### PR TITLE
Adds the ClientInfo object + fields to TokenResponse

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -24,15 +24,6 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
     protected String mResource;
 
     /**
-     * An unsigned JSON Web Token (JWT). The app can base64Url decode the segments of this token
-     * to request information about the user who signed in. The app can cache the values and
-     * display them, but it should not rely on them for any authorization or security boundaries.
-     *
-     * @See <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code">Authorize access to web applications using OAuth 2.0 and Azure Active Directory</a>
-     */
-    protected String mIdToken;
-
-    /**
      * Optionally extended access_token TTL. In the event of STS outage, this field may be used to
      * extend the valid lifetime of an access_token.
      */
@@ -82,24 +73,6 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      */
     public void setResource(String resource) {
         this.mResource = resource;
-    }
-
-    /**
-     * Gets the response id_token.
-     *
-     * @return The id_token to get.
-     */
-    public String getIdToken() {
-        return mIdToken;
-    }
-
-    /**
-     * Sets the response id_token.
-     *
-     * @param idToken The id_token to set.
-     */
-    public void setIdToken(String idToken) {
-        this.mIdToken = idToken;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -33,6 +33,22 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
     protected String mIdToken;
 
     /**
+     * Optionally extended access_token TTL. In the event of STS outage, this field may be used to
+     * extend the valid lifetime of an access_token.
+     */
+    protected String mExtExpiresIn;
+
+    /**
+     * The time after which the issued access_token may be used.
+     */
+    protected String mNotBefore;
+
+    /**
+     * Information to uniquely identify the tenant and the user _within_ that tenant.
+     */
+    protected String mClientInfo;
+
+    /**
      * Gets the response expires_on.
      *
      * @return The expires_on to get.
@@ -84,5 +100,59 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      */
     public void setIdToken(String idToken) {
         this.mIdToken = idToken;
+    }
+
+    /**
+     * Gets the response ext_expires_in.
+     *
+     * @return The ext_expires_in to get.
+     */
+    public String getExtExpiresIn() {
+        return mExtExpiresIn;
+    }
+
+    /**
+     * Sets the response ext_expires_in.
+     *
+     * @param extExpiresIn The ext_expires_in to set.
+     */
+    public void setExtExpiresIn(String extExpiresIn) {
+        this.mExtExpiresIn = extExpiresIn;
+    }
+
+    /**
+     * Gets the response not_before.
+     *
+     * @return The not_before to get.
+     */
+    public String getNotBefore() {
+        return mNotBefore;
+    }
+
+    /**
+     * Set the response not_before.
+     *
+     * @param notBefore The not_before to set.
+     */
+    public void setNotBefore(String notBefore) {
+        this.mNotBefore = notBefore;
+    }
+
+    /**
+     * Gets the response client_info.
+     *
+     * @return The client_info to get.
+     */
+    public String getClientInfo() {
+        return mClientInfo;
+    }
+
+    /**
+     * Sets the response client_info.
+     *
+     * @param clientInfo The client_info to set.
+     */
+    public void setClientInfo(String clientInfo) {
+        this.mClientInfo = clientInfo;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/ClientInfo.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/ClientInfo.java
@@ -1,0 +1,53 @@
+package com.microsoft.identity.common.internal.providers.azureactivedirectory;
+
+/**
+ * Object representation of client_info returned by AAD's Token Endpoint.
+ */
+public class ClientInfo {
+
+    /**
+     * Unique identifier for a user in the current tenant.
+     */
+    protected String mUid;
+
+    /**
+     * Unique identifier for a tenant.
+     */
+    protected String mUtid;
+
+    /**
+     * Gets the user unique id.
+     *
+     * @return The user unique id to get.
+     */
+    public String getUid() {
+        return mUid;
+    }
+
+    /**
+     * Sets the user unique id.
+     *
+     * @param uid The user unique id to set.
+     */
+    public void setUid(String uid) {
+        this.mUid = uid;
+    }
+
+    /**
+     * Gets the tenant unique id.
+     *
+     * @return The tenant unique id to get.
+     */
+    public String getUtid() {
+        return mUtid;
+    }
+
+    /**
+     * Sets the tenant unique id.
+     *
+     * @param utid The tenant unique id to set.
+     */
+    public void setUtid(String utid) {
+        this.mUtid = utid;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResponse.java
@@ -63,6 +63,15 @@ public class TokenResponse {
     protected String mState;
 
     /**
+     * An unsigned JSON Web Token (JWT). The app can base64Url decode the segments of this token
+     * to request information about the user who signed in. The app can cache the values and
+     * display them, but it should not rely on them for any authorization or security boundaries.
+     *
+     * @See <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code">Authorize access to web applications using OAuth 2.0 and Azure Active Directory</a>
+     */
+    protected String mIdToken;
+
+    /**
      * Gets the response expires_in.
      *
      * @return The expires_in to get.
@@ -168,5 +177,23 @@ public class TokenResponse {
      */
     public void setState(String state) {
         this.mState = state;
+    }
+
+    /**
+     * Gets the response id_token.
+     *
+     * @return The id_token to get.
+     */
+    public String getIdToken() {
+        return mIdToken;
+    }
+
+    /**
+     * Sets the response id_token.
+     *
+     * @param idToken The id_token to set.
+     */
+    public void setIdToken(String idToken) {
+        this.mIdToken = idToken;
     }
 }


### PR DESCRIPTION
Creates the POJO for `ClientInfo`, adds it as a field on `AzureActiveDirectoryTokenResponse`