### PR TITLE
Counterpart changes to adal/#1044

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -13,7 +13,6 @@ import java.util.Map;
  */
 public class AzureActiveDirectoryAccount extends Account {
 
-
     private String mDisplayableId;
     private String mName;
     private String mIdentityProvider;
@@ -21,11 +20,16 @@ public class AzureActiveDirectoryAccount extends Account {
     private String mUtid;
     private IDToken mIDToken;
 
+    public AzureActiveDirectoryAccount() {
+        // Default constructor.
+    }
+
     /**
      * Private constructor for AzureActiveDirectoryAccount object
+     *
      * @param idToken Returned as part of the TokenResponse
-     * @param uid Returned via clientInfo of TokenResponse
-     * @param uTid Returned via ClientInfo of Token Response
+     * @param uid     Returned via clientInfo of TokenResponse
+     * @param uTid    Returned via ClientInfo of Token Response
      */
     AzureActiveDirectoryAccount(IDToken idToken, String uid, final String uTid) {
         Map<String, String> claims = idToken.getTokenClaims();
@@ -39,6 +43,7 @@ public class AzureActiveDirectoryAccount extends Account {
     /**
      * Creates an AzureActiveDirectoryAccount based on the contents of the IDToken and based on the contents of the ClientInfo JSON
      * returned as part of the TokenResponse
+     *
      * @param idToken
      * @return
      */
@@ -93,31 +98,70 @@ public class AzureActiveDirectoryAccount extends Account {
      *
      * @param displayableId
      */
-    void setDisplayableId(final String displayableId) {
+    public void setDisplayableId(final String displayableId) {
         mDisplayableId = displayableId;
     }
 
+    /**
+     * Gets the uid.
+     *
+     * @return The uid to get.
+     */
     String getUid() {
         return mUid;
     }
 
-    void setUid(final String uid) {
+    /**
+     * Sets the uid.
+     *
+     * @param uid The uid to set.
+     */
+    public void setUid(final String uid) {
         mUid = uid;
     }
 
-    void setUtid(final String uTid) {
+    /**
+     * Sets the utid.
+     *
+     * @param uTid The utid to set.
+     */
+    public void setUtid(final String uTid) {
         mUtid = uTid;
     }
 
+    /**
+     * Sets the name.
+     *
+     * @param name The name to set.
+     */
+    public void setName(final String name) {
+        mName = name;
+    }
+
+    /**
+     * Sets the identity provider.
+     *
+     * @param idp The identity provider to set.
+     */
+    public void setIdentityProvider(final String idp) {
+        mIdentityProvider = idp;
+    }
+
+    /**
+     * Gets the utid.
+     *
+     * @return The utid to get.
+     */
     String getUtid() {
         return mUtid;
     }
 
     /**
      * Return the unique identifier for the account...
+     *
      * @return
      */
-    public String getUniqueIdentifier(){
+    public String getUniqueIdentifier() {
         return StringExtensions.base64UrlEncodeToString(mUid) + "." + StringExtensions.base64UrlEncodeToString(mUtid);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -142,6 +142,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
 
     /**
      * Gets the response foci.
+     *
      * @return The foci to get.
      */
     public String getFoci() {
@@ -150,6 +151,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
 
     /**
      * Sets the response foci.
+     *
      * @param foci The foci to set.
      */
     public void setFoci(String foci) {
@@ -158,6 +160,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
 
     /**
      * Gets the response spe ring (x-ms-clitelem)
+     *
      * @return The spe ring.
      */
     public String getSpeRing() {
@@ -166,7 +169,8 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
 
     /**
      * Sets the response spe ring (x-ms-clitelem)
-     * @param speRing
+     *
+     * @param speRing The spe ring to set.
      */
     public void setSpeRing(String speRing) {
         this.mSpeRing = speRing;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -40,6 +40,17 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
     protected String mClientInfo;
 
     /**
+     * Field use to indicate if the issued token is valid for the Microsoft 1st party
+     * 'family' of client ids.
+     */
+    protected String mFoci;
+
+    /**
+     * The SPE Ring from which this token was issued.
+     */
+    protected String mSpeRing;
+
+    /**
      * Gets the response expires_on.
      *
      * @return The expires_on to get.
@@ -127,5 +138,37 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      */
     public void setClientInfo(String clientInfo) {
         this.mClientInfo = clientInfo;
+    }
+
+    /**
+     * Gets the response foci.
+     * @return The foci to get.
+     */
+    public String getFoci() {
+        return mFoci;
+    }
+
+    /**
+     * Sets the response foci.
+     * @param foci The foci to set.
+     */
+    public void setFoci(String foci) {
+        this.mFoci = foci;
+    }
+
+    /**
+     * Gets the response spe ring (x-ms-clitelem)
+     * @return The spe ring.
+     */
+    public String getSpeRing() {
+        return mSpeRing;
+    }
+
+    /**
+     * Sets the response spe ring (x-ms-clitelem)
+     * @param speRing
+     */
+    public void setSpeRing(String speRing) {
+        this.mSpeRing = speRing;
     }
 }


### PR DESCRIPTION
These changes accompany [`adal/#1044`](https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1044) - a default constructor has been added to `AzureActiveDirectoryAccount` to allow for object transformations in `CoreAdapter`, some setters have had their access modifiers increased to `public`