### PR TITLE
Relocates HTTP related classes to common. Fixes imports.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1,6 +1,5 @@
 package com.microsoft.identity.common.adal.internal;
 
-
 /**
  * {@link AuthenticationConstants} contains all the constant value the SDK is using.
  */
@@ -151,50 +150,50 @@ public final class AuthenticationConstants {
         public static final String TOKEN_TYPE = "token_type";
 
         /** String of id token. */
-        static final String ID_TOKEN = "id_token";
+        public static final String ID_TOKEN = "id_token";
 
         /** String of sub in the id token. */
-        static final String ID_TOKEN_SUBJECT = "sub";
+        public static final String ID_TOKEN_SUBJECT = "sub";
 
         /** String of tenant id in the id token. */
-        static final String ID_TOKEN_TENANTID = "tid";
+        public static final String ID_TOKEN_TENANTID = "tid";
 
         /** String of UPN in the id token claim. */
-        static final String ID_TOKEN_UPN = "upn";
+        public static final String ID_TOKEN_UPN = "upn";
 
         /** String of given name in the id token claim. */
-        static final String ID_TOKEN_GIVEN_NAME = "given_name";
+        public static final String ID_TOKEN_GIVEN_NAME = "given_name";
 
         /** String of family name in the id token claim. */
-        static final String ID_TOKEN_FAMILY_NAME = "family_name";
+        public static final String ID_TOKEN_FAMILY_NAME = "family_name";
 
         /** String of unique name. */
-        static final String ID_TOKEN_UNIQUE_NAME = "unique_name";
+        public static final String ID_TOKEN_UNIQUE_NAME = "unique_name";
 
         /** String of email in the id token. */
-        static final String ID_TOKEN_EMAIL = "email";
+        public static final String ID_TOKEN_EMAIL = "email";
 
         /** String of identity provider in the id token claim. */
-        static final String ID_TOKEN_IDENTITY_PROVIDER = "idp";
+        public static final String ID_TOKEN_IDENTITY_PROVIDER = "idp";
 
         /** String of oid in the id token claim. */
-        static final String ID_TOKEN_OBJECT_ID = "oid";
+        public static final String ID_TOKEN_OBJECT_ID = "oid";
 
         /** String of password expiration in the id token claim. */
-        static final String ID_TOKEN_PASSWORD_EXPIRATION = "pwd_exp";
+        public static final String ID_TOKEN_PASSWORD_EXPIRATION = "pwd_exp";
 
         /** String of password change url in the id token claim. */
-        static final String ID_TOKEN_PASSWORD_CHANGE_URL = "pwd_url";
+        public static final String ID_TOKEN_PASSWORD_CHANGE_URL = "pwd_url";
 
         /** String of FoCI field returned in the JSON response from token endpoint. */
-        static final String ADAL_CLIENT_FAMILY_ID = "foci";
+        public static final String ADAL_CLIENT_FAMILY_ID = "foci";
 
         /** String of has_chrome sent as extra query param to hide back button in the webview. */
-        static final String HAS_CHROME = "haschrome";
+        public static final String HAS_CHROME = "haschrome";
 
-        static final String EXT_EXPIRES_IN = "ext_expires_in";
+        public static final String EXT_EXPIRES_IN = "ext_expires_in";
 
-        static final String CLAIMS = "claims";
+        public static final String CLAIMS = "claims";
     }
 
     /**
@@ -504,37 +503,37 @@ public final class AuthenticationConstants {
     /**
      * Represents the oauth2 error code.
      */
-    protected static final class OAuth2ErrorCode {
+    public static final class OAuth2ErrorCode {
         /**
          * Oauth2 error code invalid_grant.
          */
-        static final String INVALID_GRANT = "invalid_grant";
+        public static final String INVALID_GRANT = "invalid_grant";
     }
 
     /**
      * HTTP header fields.
      */
-    static final class HeaderField {
+    public static final class HeaderField {
 
         /**
          * @see <a href="https://tools.ietf.org/html/rfc1945#appendix-D.2.1">RFC-1945</a>
          */
-        static final String ACCEPT = "Accept";
+        public static final String ACCEPT = "Accept";
 
         /**
          * Header used to track SPE Ring for telemetry.
          */
-        static final String X_MS_CLITELEM = "x-ms-clitelem";
+        public static final String X_MS_CLITELEM = "x-ms-clitelem";
     }
 
     /**
      * Identifiers for file formats and format contents.
      */
-    static final class MediaType {
+    public static final class MediaType {
 
         /**
          * @see <a href="https://tools.ietf.org/html/rfc7159">RFC-7159</a>
          */
-        static final String APPLICATION_JSON = "application/json";
+        public static final String APPLICATION_JSON = "application/json";
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapper.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.adal.internal;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.os.PowerManager;
+
+/**
+ * Wrapper class for PowerManager.
+ */
+
+public class PowerManagerWrapper {
+
+    private static PowerManagerWrapper sInstance;
+
+    public static void setInstance(final PowerManagerWrapper wrapper) {
+        sInstance = wrapper;
+    }
+
+    /**
+     * Singleton implementation for PowerManagerWrapper.
+     *
+     * @return PowerManagerWrapper singleton instance
+     */
+    public static synchronized PowerManagerWrapper getInstance() {
+        if (sInstance == null) {
+            sInstance = new PowerManagerWrapper();
+        }
+        return sInstance;
+    }
+
+    /**
+     * Wrap the calling to method isDeviceIdleMode() of final class PowerManager.
+     *
+     * @param connectionContext Context used to query if app is in idle mode
+     * @return true if the device is in doze/idle mode
+     */
+    @TargetApi(Build.VERSION_CODES.M)
+    public boolean isDeviceIdleMode(final Context connectionContext) {
+        return ((PowerManager) connectionContext.getSystemService(Context.POWER_SERVICE)).isDeviceIdleMode();
+    }
+
+    /**
+     * Wrap the calling to method isIgnoringBatteryOptimizations() of final class PowerManager.
+     *
+     * @param connectionContext Context used to query if app is ignoring battery optimizations
+     * @return true if the given application package name is on the device's power whitelist
+     */
+    @TargetApi(Build.VERSION_CODES.M)
+    public boolean isIgnoringBatteryOptimizations(final Context connectionContext) {
+        return ((PowerManager) connectionContext.getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(connectionContext.getPackageName());
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/UsageStatsManagerWrapper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/UsageStatsManagerWrapper.java
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.adal.internal;
+
+import android.annotation.TargetApi;
+import android.app.usage.UsageStatsManager;
+import android.content.Context;
+import android.os.Build;
+
+/**
+ * Wrapper class for UsageStatsManager.
+ */
+
+public class UsageStatsManagerWrapper {
+
+    private static UsageStatsManagerWrapper sInstance;
+
+    public static synchronized void setInstance(final UsageStatsManagerWrapper instance) {
+        sInstance = instance;
+    }
+
+    /**
+     * Singleton implementation for UsageStatsManagerWrapper.
+     *
+     * @return UsageStatsManagerWrapper singleton instance
+     */
+    public static synchronized UsageStatsManagerWrapper getInstance() {
+        if (sInstance == null) {
+            sInstance = new UsageStatsManagerWrapper();
+        }
+        return sInstance;
+    }
+
+    /**
+     * Wrap the final class function UsageStatsManager.isAppInactive(). And make the code testable.
+     *
+     * @param connectionContext Context used to query app active state
+     * @return true if the app is inactive
+     */
+    @TargetApi(Build.VERSION_CODES.M)
+    public boolean isAppInactive(final Context connectionContext) {
+        return ((UsageStatsManager) connectionContext.getSystemService(Context.USAGE_STATS_SERVICE)).isAppInactive(connectionContext.getPackageName());
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.adal.internal.net;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.Build;
+
+import com.microsoft.identity.common.adal.internal.PowerManagerWrapper;
+import com.microsoft.identity.common.adal.internal.UsageStatsManagerWrapper;
+
+/**
+ * Default connection service check network connectivity. 
+ * TODO: No need for {@link IConnectionService}. Interface was created for testing purpose. 
+ * Same purpose could be achieved via mocking the context. Since it's a public interface, should
+ * be removed in the next major version update. 
+ * https://github.com/AzureAD/azure-activedirectory-library-for-android/issues/626
+ */
+class DefaultConnectionService implements IConnectionService {
+
+    private final Context mConnectionContext;
+
+    private static final String TAG = "DefaultConnectionService";
+
+    DefaultConnectionService(Context ctx) {
+        mConnectionContext = ctx;
+    }
+
+    public boolean isConnectionAvailable() {
+        ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.isConnectedOrConnecting() && !isNetworkDisabledFromOptimizations();
+    }
+
+    /**
+     * Determines if the client app cannot access the network due to power saving optimizations introduced in API 23.
+     *
+     * @return true if the device is API23 and one or both of the following is true: the device is in doze or the company
+     * portal is in standby, false otherwise.
+     */
+    @TargetApi(Build.VERSION_CODES.M)
+    public boolean isNetworkDisabledFromOptimizations() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final UsageStatsManagerWrapper usageStatsManagerWrapper = UsageStatsManagerWrapper.getInstance();
+            if (usageStatsManagerWrapper.isAppInactive(mConnectionContext)) {
+                return true;
+            }
+
+            final PowerManagerWrapper powerManagerWrapper = PowerManagerWrapper.getInstance();
+            if (powerManagerWrapper.isDeviceIdleMode(mConnectionContext) && !powerManagerWrapper.isIgnoringBatteryOptimizations(mConnectionContext)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.adal.internal.net;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Debug;
+
+import com.microsoft.identity.common.adal.error.ADALError;
+import com.microsoft.identity.common.adal.error.AuthenticationException;
+import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Webrequest are called in background thread from API level. HttpWebRequest
+ * does not create another thread.
+ */
+public class HttpWebRequest {
+    static final String REQUEST_METHOD_POST = "POST";
+    static final String REQUEST_METHOD_GET = "GET";
+
+    private static final String TAG = "HttpWebRequest";
+    private static final int DEBUG_SIMULATE_DELAY = 0;
+    private static final int CONNECT_TIME_OUT = AuthenticationSettings.INSTANCE.getConnectTimeOut();
+    private static final int READ_TIME_OUT = AuthenticationSettings.INSTANCE.getReadTimeOut();
+    private final String mRequestMethod;
+    private final URL mUrl;
+    private final byte[] mRequestContent;
+    private final String mRequestContentType;
+    private final Map<String, String> mRequestHeaders;
+
+    public HttpWebRequest(URL requestURL, String requestMethod, Map<String, String> headers) {
+        this(requestURL, requestMethod, headers, null, null);
+    }
+
+    public HttpWebRequest(
+            URL requestURL,
+            String requestMethod,
+            Map<String, String> headers,
+            byte[] requestContent,
+            String requestContentType) {
+        mUrl = requestURL;
+        mRequestMethod = requestMethod;
+        mRequestHeaders = new HashMap<>();
+        if (mUrl != null) {
+            mRequestHeaders.put("Host", mUrl.getAuthority());
+        }
+        mRequestHeaders.putAll(headers);
+        mRequestContent = requestContent;
+        mRequestContentType = requestContentType;
+    }
+
+    /**
+     * setupConnection before sending the request.
+     */
+    private HttpURLConnection setupConnection() throws IOException {
+        if (mUrl == null) {
+            throw new IllegalArgumentException("requestURL");
+        }
+        if (!mUrl.getProtocol().equalsIgnoreCase("http")
+                && !mUrl.getProtocol().equalsIgnoreCase("https")) {
+            throw new IllegalArgumentException("requestURL");
+        }
+        HttpURLConnection.setFollowRedirects(true);
+        final HttpURLConnection connection = HttpUrlConnectionFactory.createHttpUrlConnection(mUrl);
+        connection.setConnectTimeout(CONNECT_TIME_OUT);
+        // To prevent EOF exception.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB_MR2) {
+            connection.setRequestProperty("Connection", "close");
+        }
+
+        // Apply the request headers
+        final Set<Map.Entry<String, String>> headerEntries = mRequestHeaders.entrySet();
+        for (final Map.Entry<String, String> entry : headerEntries) {
+            connection.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+
+        connection.setReadTimeout(READ_TIME_OUT);
+        connection.setInstanceFollowRedirects(true);
+        connection.setUseCaches(false);
+        connection.setRequestMethod(mRequestMethod);
+        connection.setDoInput(true); // it will at least read status
+        // code. Default is true.
+        setRequestBody(connection, mRequestContent, mRequestContentType);
+
+        return connection;
+    }
+
+    /**
+     * send the request.
+     */
+    public HttpWebResponse send() throws IOException {
+        final HttpURLConnection connection = setupConnection();
+        final HttpWebResponse response;
+        InputStream responseStream = null;
+        try {
+            try {
+                responseStream = connection.getInputStream();
+            } catch (IOException ex) {
+                // If it does not get the error stream, it will return
+                // exception in the httpresponse
+                responseStream = connection.getErrorStream();
+                if (responseStream == null) {
+                    throw ex;
+                }
+            }
+            // GET request should read status after getInputStream to make
+            // this work for different SDKs
+            final int statusCode = connection.getResponseCode();
+            final String responseBody = convertStreamToString(responseStream);
+
+            // It will only run in debugger and set from outside for testing
+            if (Debug.isDebuggerConnected() && DEBUG_SIMULATE_DELAY > 0) {
+                // sleep background thread in debugging mode
+                try {
+                    Thread.sleep(DEBUG_SIMULATE_DELAY);
+                } catch (InterruptedException e) {
+                    // Do nothing.
+                }
+            }
+
+            response = new HttpWebResponse(statusCode, responseBody, connection.getHeaderFields());
+        } finally {
+            safeCloseStream(responseStream);
+            // We are not disconnecting from network to allow connection to be returned into the
+            // connection pool. If we call disconnect due to buggy implementation we are not reusing
+            // connections.
+            //if (connection != null) {
+            //	connection.disconnect();
+            //}
+        }
+
+        return response;
+    }
+
+    public static void throwIfNetworkNotAvailable(final Context context) throws AuthenticationException {
+        final DefaultConnectionService connectionService = new DefaultConnectionService(context);
+        if (!connectionService.isConnectionAvailable()) {
+            if (connectionService.isNetworkDisabledFromOptimizations()) {
+                final AuthenticationException authenticationException = new AuthenticationException(
+                        ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION,
+                        "Connection is not available to refresh token because power optimization is "
+                                + "enabled. And the device is in doze mode or the app is standby"
+                                + ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription());
+                throw authenticationException;
+            } else {
+                final AuthenticationException authenticationException = new AuthenticationException(
+                        ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE,
+                        "Connection is not available to refresh token");
+                throw authenticationException;
+            }
+        }
+    }
+
+    /**
+     * Convert stream into the string.
+     *
+     * @param inputStream {@link InputStream} to be converted to be a string.
+     * @return The converted string
+     * @throws IOException Thrown when failing to access inputStream stream.
+     */
+    private static String convertStreamToString(InputStream inputStream) throws IOException {
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(inputStream));
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (sb.length() > 0) {
+                    sb.append('\n');
+                }
+                sb.append(line);
+            }
+
+            return sb.toString();
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+    }
+
+    private static void setRequestBody(HttpURLConnection connection, byte[] contentRequest, String requestContentType) throws IOException {
+        if (null != contentRequest) {
+            connection.setDoOutput(true);
+
+            if (null != requestContentType && !requestContentType.isEmpty()) {
+                connection.setRequestProperty("Content-Type", requestContentType);
+            }
+
+            connection.setRequestProperty("Content-Length",
+                    Integer.toString(contentRequest.length));
+            connection.setFixedLengthStreamingMode(contentRequest.length);
+
+            OutputStream out = null;
+            try {
+                out = connection.getOutputStream();
+                out.write(contentRequest);
+            } finally {
+                safeCloseStream(out);
+            }
+        }
+    }
+
+    /**
+     * Close the stream safely.
+     *
+     * @param stream stream to be closed
+     */
+    private static void safeCloseStream(Closeable stream) {
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (IOException e) {
+                // swallow error in this case
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/IConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/IConnectionService.java
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.adal.internal.net;
+
+/**
+ * exposed interface for testing.
+ */
+public interface IConnectionService {
+
+    /**
+     * Gets status for connection status.
+     * 
+     * @return connection status
+     */
+    boolean isConnectionAvailable();
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/IWebRequestHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/IWebRequestHandler.java
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.adal.internal.net;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Webrequest interface to send web requests.
+ */
+public interface IWebRequestHandler {
+    /**
+     * Send the http GET request.
+     * @param url {@link URL} for the GET request.
+     * @param headers Non-null, and mutable Map of headers sent in the GET request.
+     * @return {@link HttpWebResponse} containing the status code and response headers.
+     * @throws IOException when error occurs on reading the http response.
+     */
+    HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException;
+
+    /**
+     * Send the HTTP POST request.
+     * @param url {@link URL} for the POST request.
+     * @param headers Non-null, and mutable Map of headers sent int the POST request.
+     * @param content The content sent as POST message.
+     * @param contentType Content type of the POST request.
+     * @return {@link HttpWebResponse} containing the status code and response header.
+     * @throws IOException when error occurs on reading the http response.
+     */
+    HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
+            String contentType) throws IOException;
+
+    /**
+     * Set the correlation id for the web request.
+     * @param requestCorrelationId {@link UUID} of the correlation id to set in the web request.
+     */
+    void setRequestCorrelationId(UUID requestCorrelationId);
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/WebRequestHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/WebRequestHandler.java
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.adal.internal.net;
+
+import android.os.Build;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.HeaderField;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.MediaType;
+
+/**
+ * It uses one time async task. WebRequest are wrapped here to prevent multiple
+ * reuses for same tasks. Each request returns a handler for cancel action. Call
+ * this from UI thread to correctly create async task and execute.
+ */
+public class WebRequestHandler implements IWebRequestHandler {
+
+    private static final String TAG = "WebRequestHandler";
+
+    /**
+     * Header for accept.
+     */
+    public static final String HEADER_ACCEPT = HeaderField.ACCEPT;
+
+    /**
+     * Header for json type.
+     */
+    public static final String HEADER_ACCEPT_JSON = MediaType.APPLICATION_JSON;
+
+    private UUID mRequestCorrelationId = null;
+
+    @Override
+    public HttpWebResponse sendGet(URL url, Map<String, String> headers) throws IOException {
+        final HttpWebRequest request = new HttpWebRequest(url, HttpWebRequest.REQUEST_METHOD_GET, updateHeaders(headers));
+        return request.send();
+    }
+
+    @Override
+    public HttpWebResponse sendPost(URL url, Map<String, String> headers, byte[] content,
+                                    String contentType) throws IOException {
+        final HttpWebRequest request = new HttpWebRequest(
+                url,
+                HttpWebRequest.REQUEST_METHOD_POST,
+                updateHeaders(headers),
+                content,
+                contentType);
+        return request.send();
+    }
+
+    private Map<String, String> updateHeaders(final Map<String, String> headers) {
+
+        if (mRequestCorrelationId != null) {
+            headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, mRequestCorrelationId.toString());
+        }
+
+        headers.put(AuthenticationConstants.AAD.ADAL_ID_PLATFORM, "Android");
+        // TODO don't make this dependency circular
+        //headers.put(AuthenticationConstants.AAD.ADAL_ID_VERSION, AuthenticationContext.getVersionName());
+        headers.put(AuthenticationConstants.AAD.ADAL_ID_OS_VER, "" + Build.VERSION.SDK_INT);
+        headers.put(AuthenticationConstants.AAD.ADAL_ID_DM, android.os.Build.MODEL);
+
+        return headers;
+    }
+
+    /**
+     * Sets correlationId.
+     *
+     * @param requestCorrelationId {@link UUID}
+     */
+    public void setRequestCorrelationId(UUID requestCorrelationId) {
+        this.mRequestCorrelationId = requestCorrelationId;
+    }
+}


### PR DESCRIPTION
This change relocates HTTP/networking related classes and utilities to `:common`.

See changes in `:adal` [here](https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1054).