### PR TITLE
Implementing cache writing for ADALOAuth2TokenCache

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     })
     compile 'com.android.support:appcompat-v7:25.3.1'
     testCompile 'junit:junit:4.12'
+    compile 'com.google.code.gson:gson:2.8.1'
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/DateTimeAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/DateTimeAdapter.java
@@ -1,0 +1,118 @@
+package com.microsoft.identity.common.adal.internal.cache;
+
+import android.util.Log;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import com.microsoft.identity.common.adal.error.ADALError;
+
+import java.lang.reflect.Type;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public final class DateTimeAdapter implements JsonDeserializer<Date>, JsonSerializer<Date> {
+
+    private static final String TAG = "DateTimeAdapter";
+
+    private final DateFormat mEnUsFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
+            DateFormat.DEFAULT, Locale.US);
+
+    private final DateFormat mLocalFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT,
+            DateFormat.DEFAULT);
+
+    private final DateFormat mISO8601Format = buildIso8601Format();
+    private final DateFormat mEnUs24HourFormat = buildEnUs24HourDateFormat();
+    private final DateFormat mLocal24HourFormat = buildLocal24HourDateFormat();
+
+    private static DateFormat buildIso8601Format() {
+        DateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return iso8601Format;
+    }
+
+    /**
+     * Add new en-us date format for parsing date string if it doesn't contain AM/PM.
+     */
+    private static DateFormat buildEnUs24HourDateFormat() {
+        return new SimpleDateFormat("MMM dd, yyyy HH:mm:ss", Locale.US);
+    }
+
+    /**
+     * Add new local date format when parsing date string if it doesn't contain AM/PM.
+     */
+    private static DateFormat buildLocal24HourDateFormat() {
+        return new SimpleDateFormat("MMM dd, yyyy HH:mm:ss", Locale.getDefault());
+    }
+
+    /**
+     * Default constructor for {@link DateTimeAdapter}.
+     */
+    public DateTimeAdapter() {
+        // Default constructor, intentionally empty.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized Date deserialize(JsonElement json, Type typeOfT,
+                                         JsonDeserializationContext context) throws JsonParseException {
+        String jsonString = json.getAsString();
+
+        // Datetime string is serialized with iso8601 format by default, should
+        // always try to deserialize with iso8601. But to support the backward
+        // compatibility, we also need to deserialize with old format if failing
+        // with iso8601.
+        try {
+            return mISO8601Format.parse(jsonString);
+        } catch (final ParseException ignored) {
+            Log.v(TAG, "Cannot parse with ISO8601, try again with local format.");
+        }
+
+        // fallback logic for old date format parsing.
+        try {
+            return mLocalFormat.parse(jsonString);
+        } catch (final ParseException ignored) {
+            Log.v(TAG, "Cannot parse with local format, try again with local 24 hour format.");
+        }
+
+        try {
+            return mLocal24HourFormat.parse(jsonString);
+        } catch (final ParseException ignored) {
+            Log.v(TAG, "Cannot parse with local 24 hour format, try again with en us format.");
+        }
+
+        try {
+            return mEnUsFormat.parse(jsonString);
+        } catch (final ParseException ignored) {
+            Log.v(TAG, "Cannot parse with en us format, try again with en us 24 hour format.");
+        }
+
+        try {
+            return mEnUs24HourFormat.parse(jsonString);
+        } catch (final ParseException e) {
+            Log.e(TAG, "Could not parse date: " + e.getMessage(), e);
+        }
+
+        throw new JsonParseException("Could not parse date: " + jsonString);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized JsonElement serialize(Date src, Type typeOfSrc,
+                                              JsonSerializationContext context) {
+        return new JsonPrimitive(mISO8601Format.format(src));
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -132,7 +132,7 @@ public class StorageHelper {
      * @param context The {@link Context} to create {@link StorageHelper}.
      */
     public StorageHelper(Context context) {
-        mContext = context;
+        mContext = context.getApplicationContext();
         mRandom = new SecureRandom();
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -7,22 +7,18 @@ import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import com.microsoft.identity.common.Account;
 import com.microsoft.identity.common.adal.error.ADALError;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.cache.CacheKey;
-import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.DateTimeAdapter;
+import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
-import com.microsoft.identity.common.internal.providers.oauth2.AccessToken;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
-
-
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -86,7 +82,7 @@ public class ADALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
 
         ListIterator<IShareSingleSignOnState> otherCaches = mSharedSSOCaches.listIterator();
 
-        while(otherCaches.hasNext()){
+        while (otherCaches.hasNext()) {
             otherCaches.next().setSingleSignOnState(account, refreshToken);
         }
 
@@ -99,17 +95,17 @@ public class ADALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
 
         setItem(CacheKey.createCacheKeyForRTEntry(issuer, resource, clientId, userId), cacheItem);
 
-        if(cacheItem.getIsMultiResourceRefreshToken()){
+        if (cacheItem.getIsMultiResourceRefreshToken()) {
             setItem(CacheKey.createCacheKeyForMRRT(issuer, clientId, userId), cacheItem);
         }
 
-        if(!StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())){
+        if (!StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())) {
             setItem(CacheKey.createCacheKeyForFRT(issuer, clientId, userId), cacheItem);
         }
 
     }
 
-    private void setItem(String key, ADALTokenCacheItem cacheItem){
+    private void setItem(String key, ADALTokenCacheItem cacheItem) {
 
         String json = mGson.toJson(cacheItem);
         String encrypted = encrypt(json);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -1,8 +1,20 @@
 package com.microsoft.identity.common.internal.cache;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import com.microsoft.identity.common.Account;
+import com.microsoft.identity.common.adal.error.ADALError;
+import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
+import com.microsoft.identity.common.adal.internal.cache.CacheKey;
+import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
+import com.microsoft.identity.common.adal.internal.cache.DateTimeAdapter;
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.providers.oauth2.AccessToken;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
@@ -10,6 +22,12 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
+
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Date;
+import java.util.List;
 import java.util.ListIterator;
 
 /**
@@ -20,10 +38,22 @@ public class ADALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
 
     SharedPreferencesFileManager mSharedPreferencesFileManager;
     final static String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
+    private static final String TAG = "ADALOAuth2TokenCache";
+    @SuppressLint("StaticFieldLeak")
+    private static StorageHelper sHelper;
+    private static final Object LOCK = new Object();
+    private Gson mGson = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new DateTimeAdapter())
+            .create();
 
-    public ADALOAuth2TokenCache(Context context, SharedPreferencesFileManager mSharedPreferencesFileManager) {
+    private List<IShareSingleSignOnState> mSharedSSOCaches;
+
+
+    public ADALOAuth2TokenCache(Context context, SharedPreferencesFileManager mSharedPreferencesFileManager, List<IShareSingleSignOnState> sharedSSOCaches) {
         super(context);
+        validateSecretKeySetting();
         initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
+        mSharedSSOCaches = sharedSSOCaches;
     }
 
     protected void initializeSharedPreferencesFileManager(String fileName) {
@@ -33,24 +63,31 @@ public class ADALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
     /**
      * Method responsible for saving tokens contained in the TokenResponse to storage.
      *
-     * @param oAuth2Strategy
+     * @param strategy
      * @param request
      * @param response
      */
     @Override
-    public void saveTokens(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) {
+    public void saveTokens(OAuth2Strategy strategy, AuthorizationRequest request, TokenResponse response) {
 
-        Account account = oAuth2Strategy.createAccount(response);
-        String issuerCacheIdentifier = oAuth2Strategy.getIssuerCacheIdentifier(request);
-        AccessToken accessToken = oAuth2Strategy.getAccessTokenFromResponse(response);
-        RefreshToken refreshToken = oAuth2Strategy.getRefreshTokenFromResponse(response);
+        Account account = strategy.createAccount(response);
+        String issuerCacheIdentifier = strategy.getIssuerCacheIdentifier(request);
+        RefreshToken refreshToken = strategy.getRefreshTokenFromResponse(response);
+
+        ADALTokenCacheItem cacheItem = new ADALTokenCacheItem(strategy, request, response);
 
         //There is more than one valid user identifier for some accounts... AAD Accounts as of this writing have 3
-        ListIterator<String> cacheIds = account.getCacheIdentifiers().listIterator();
+        ListIterator<String> accountCacheIds = account.getCacheIdentifiers().listIterator();
 
-        while (cacheIds.hasNext()) {
+        while (accountCacheIds.hasNext()) {
             //Azure AD Uses Resource and Not Scope... but we didn't override... heads up
-            setItemToCacheForUser(issuerCacheIdentifier, request.getScope(), request.getClientId(), accessToken, refreshToken, cacheIds.next());
+            setItemToCacheForUser(issuerCacheIdentifier, request.getScope(), request.getClientId(), cacheItem, accountCacheIds.next());
+        }
+
+        ListIterator<IShareSingleSignOnState> otherCaches = mSharedSSOCaches.listIterator();
+
+        while(otherCaches.hasNext()){
+            otherCaches.next().setSingleSignOnState(account, refreshToken);
         }
 
         // TODO: I'd like to know exactly why this is here before I put this back in.... i'm assuming for ADFS v3.
@@ -58,40 +95,88 @@ public class ADALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
     }
 
 
-    private void setItemToCacheForUser(final String issuer, final String resource, final String clientId, final AccessToken accessToken, final RefreshToken refreshToken, final String userId) {
+    private void setItemToCacheForUser(final String issuer, final String resource, final String clientId, final ADALTokenCacheItem cacheItem, final String userId) {
 
+        setItem(CacheKey.createCacheKeyForRTEntry(issuer, resource, clientId, userId), cacheItem);
 
-
-/*
-        // new tokens will only be saved into preferred cache location
-        mTokenCacheStore.setItem(CacheKey.createCacheKeyForRTEntry(issuer, resource, clientId, userId),
-                TokenCacheItem.createRegularTokenCacheItem(issuer, resource, clientId, result));
-
-
-        if (result.getIsMultiResourceRefreshToken()) {
-            Log.v(TAG, "Save Multi Resource Refresh token to cache");
-            mTokenCacheStore.setItem(CacheKey.createCacheKeyForMRRT(issuer, clientId, userId),
-                    TokenCacheItem.createMRRTTokenCacheItem(issuer, clientId, result));
+        if(cacheItem.getIsMultiResourceRefreshToken()){
+            setItem(CacheKey.createCacheKeyForMRRT(issuer, clientId, userId), cacheItem);
         }
 
-        // Store separate entries for FRT.
-        if (!StringExtensions.isNullOrBlank(result.getFamilyClientId()) && !StringExtensions.isNullOrBlank(userId)) {
-            Log.v(TAG, "Save Family Refresh token into cache");
-            final TokenCacheItem familyTokenCacheItem = TokenCacheItem.createFRRTTokenCacheItem(issuer, result);
-            mTokenCacheStore.setItem(CacheKey.createCacheKeyForFRT(issuer, result.getFamilyClientId(), userId), familyTokenCacheItem);
+        if(!StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())){
+            setItem(CacheKey.createCacheKeyForFRT(issuer, clientId, userId), cacheItem);
         }
-        */
+
+    }
+
+    private void setItem(String key, ADALTokenCacheItem cacheItem){
+
+        String json = mGson.toJson(cacheItem);
+        String encrypted = encrypt(json);
+        if (encrypted != null) {
+            mSharedPreferencesFileManager.putString(key, encrypted);
+        } else {
+            Log.e(TAG, "Encrypted output is null");
+        }
 
     }
 
 
+    /**
+     * Method that allows to mock StorageHelper class and use custom encryption in UTs.
+     */
+    protected StorageHelper getStorageHelper() {
+        synchronized (LOCK) {
+            if (sHelper == null) {
+                Log.v(TAG, "Started to initialize storage helper");
+                sHelper = new StorageHelper(mContext);
+                Log.v(TAG, "Finished to initialize storage helper");
+            }
+        }
+        return sHelper;
+    }
+
+    private String encrypt(String value) {
+        try {
+            return getStorageHelper().encrypt(value);
+        } catch (GeneralSecurityException | IOException e) {
+            Log.e(TAG, ADALError.ENCRYPTION_ERROR.toString(), e);
+        }
+
+        return null;
+    }
+
+    private String decrypt(final String key, final String value) {
+        if (StringExtensions.isNullOrBlank(key)) {
+            throw new IllegalArgumentException("encryption key is null or blank");
+        }
+
+        try {
+            return getStorageHelper().decrypt(value);
+        } catch (GeneralSecurityException | IOException e) {
+            Log.e(TAG, ADALError.DECRYPTION_FAILED.toString(), e);
+            //TODO: Implement remove item in this case... not sure I actually want to do this
+            //removeItem(key);
+        }
+
+        return null;
+    }
+
+    private void validateSecretKeySetting() {
+        final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+        if (secretKeyData == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            throw new IllegalArgumentException("Secret key must be provided for API < 18. "
+                    + "Use AuthenticationSettings.INSTANCE.setSecretKey()");
+        }
+    }
+
     @Override
-    public void setSingleSignOnState(Account account, String refreshToken) {
+    public void setSingleSignOnState(Account account, RefreshToken refreshToken) {
 
     }
 
     @Override
-    public String getSingleSignOnState(Account account) {
+    public RefreshToken getSingleSignOnState(Account account) {
         return null;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
@@ -1,7 +1,10 @@
 package com.microsoft.identity.common.internal.cache;
 
 import com.microsoft.identity.common.Account;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryAccessToken;
 import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryAccount;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryRefreshToken;
+import com.microsoft.identity.common.internal.providers.azureactivedirectory.AzureActiveDirectoryTokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.AccessToken;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
@@ -58,7 +61,7 @@ public class ADALTokenCacheItem {
         mSpeRing = tokenCacheItem.getSpeRing();
     }
 
-    ADALTokenCacheItem(OAuth2Strategy strategy, TokenResponse response, AuthorizationRequest request) {
+    ADALTokenCacheItem(OAuth2Strategy strategy, AuthorizationRequest request, TokenResponse response) {
 
         Account account = strategy.createAccount(response);
         String issuerCacheIdentifier = strategy.getIssuerCacheIdentifier(request);
@@ -73,19 +76,22 @@ public class ADALTokenCacheItem {
         mRawIdToken = response.getIdToken();
         if (account instanceof AzureActiveDirectoryAccount) {
             mUserInfo = new ADALUserInfo((AzureActiveDirectoryAccount) account);
+            mTenantId = ((AzureActiveDirectoryAccount) account).getTenantId();
         }
 
-        /*
         if(accessToken instanceof AzureActiveDirectoryAccessToken){
-            mExpiresOn = ((AzureActiveDirectoryAccessToken)accessToken).getExpiresOn()
+            mExpiresOn = ((AzureActiveDirectoryAccessToken)accessToken).getExpiresOn();
+            mExtendedExpiresOn = ((AzureActiveDirectoryAccessToken)accessToken).getExtendedExpiresOn();
         }
 
         if(refreshToken instanceof AzureActiveDirectoryRefreshToken){
-            mExpiresOn = ((AzureActiveDirectoryTokenResponse)response).getExpiresOn();
+            mIsMultiResourceRefreshToken = ((AzureActiveDirectoryRefreshToken)refreshToken).getIsFamilyRefreshToken();
+            mFamilyClientId = ((AzureActiveDirectoryRefreshToken)refreshToken).getFamilyId();
         }
 
-        */
-
+        if(response instanceof AzureActiveDirectoryTokenResponse){
+            mSpeRing = ((AzureActiveDirectoryTokenResponse)response).getSpeRing();
+        }
 
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
@@ -79,18 +79,18 @@ public class ADALTokenCacheItem {
             mTenantId = ((AzureActiveDirectoryAccount) account).getTenantId();
         }
 
-        if(accessToken instanceof AzureActiveDirectoryAccessToken){
-            mExpiresOn = ((AzureActiveDirectoryAccessToken)accessToken).getExpiresOn();
-            mExtendedExpiresOn = ((AzureActiveDirectoryAccessToken)accessToken).getExtendedExpiresOn();
+        if (accessToken instanceof AzureActiveDirectoryAccessToken) {
+            mExpiresOn = ((AzureActiveDirectoryAccessToken) accessToken).getExpiresOn();
+            mExtendedExpiresOn = ((AzureActiveDirectoryAccessToken) accessToken).getExtendedExpiresOn();
         }
 
-        if(refreshToken instanceof AzureActiveDirectoryRefreshToken){
-            mIsMultiResourceRefreshToken = ((AzureActiveDirectoryRefreshToken)refreshToken).getIsFamilyRefreshToken();
-            mFamilyClientId = ((AzureActiveDirectoryRefreshToken)refreshToken).getFamilyId();
+        if (refreshToken instanceof AzureActiveDirectoryRefreshToken) {
+            mIsMultiResourceRefreshToken = ((AzureActiveDirectoryRefreshToken) refreshToken).getIsFamilyRefreshToken();
+            mFamilyClientId = ((AzureActiveDirectoryRefreshToken) refreshToken).getFamilyId();
         }
 
-        if(response instanceof AzureActiveDirectoryTokenResponse){
-            mSpeRing = ((AzureActiveDirectoryTokenResponse)response).getSpeRing();
+        if (response instanceof AzureActiveDirectoryTokenResponse) {
+            mSpeRing = ((AzureActiveDirectoryTokenResponse) response).getSpeRing();
         }
 
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IShareSingleSignOnState.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IShareSingleSignOnState.java
@@ -1,15 +1,15 @@
 package com.microsoft.identity.common.internal.cache;
 
 import com.microsoft.identity.common.Account;
+import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 
 /**
- * Created by shoatman on 11/22/2017.
+ * Interface that defines methods allowing refresh token cache state to be shared between Cache Implementations
+ * The assumption being that in order for a client to avoid prompting a user to sign in they need a refresh token (effectively SSO state)
  */
-
 public interface IShareSingleSignOnState {
 
-    void setSingleSignOnState(Account account, String refreshToken);
-
-    String getSingleSignOnState(Account account);
+    void setSingleSignOnState(Account account, RefreshToken refreshToken);
+    RefreshToken getSingleSignOnState(Account account);
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IShareSingleSignOnState.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IShareSingleSignOnState.java
@@ -10,6 +10,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 public interface IShareSingleSignOnState {
 
     void setSingleSignOnState(Account account, RefreshToken refreshToken);
+
     RefreshToken getSingleSignOnState(Account account);
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MSALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MSALOAuth2TokenCache.java
@@ -6,6 +6,7 @@ import com.microsoft.identity.common.Account;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
+import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
 
@@ -16,12 +17,12 @@ public class MSALOAuth2TokenCache extends OAuth2TokenCache implements IShareSing
     }
 
     @Override
-    public void setSingleSignOnState(Account account, String refreshToken) {
+    public void setSingleSignOnState(Account account, RefreshToken refreshToken) {
 
     }
 
     @Override
-    public String getSingleSignOnState(Account account) {
+    public RefreshToken getSingleSignOnState(Account account) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccessToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccessToken.java
@@ -3,11 +3,13 @@ package com.microsoft.identity.common.internal.providers.azureactivedirectory;
 import com.microsoft.identity.common.internal.providers.oauth2.AccessToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
+import java.util.Date;
+
 
 public class AzureActiveDirectoryAccessToken extends AccessToken {
 
-    String mExpiresOn;
-    String mExtendedExpiresOn;
+    Date mExpiresOn;
+    Date mExtendedExpiresOn;
 
     public AzureActiveDirectoryAccessToken(TokenResponse response) {
         super(response);
@@ -22,9 +24,10 @@ public class AzureActiveDirectoryAccessToken extends AccessToken {
         }
     }
 
-    public String getExpiresOn() {
+    public Date getExpiresOn() {
         return mExpiresOn;
     }
+    public Date getExtendedExpiresOn() { return mExtendedExpiresOn;}
 
     //TODO: Need to add override for IsExpired() to address extended token expires on
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccessToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccessToken.java
@@ -27,7 +27,10 @@ public class AzureActiveDirectoryAccessToken extends AccessToken {
     public Date getExpiresOn() {
         return mExpiresOn;
     }
-    public Date getExtendedExpiresOn() { return mExtendedExpiresOn;}
+
+    public Date getExtendedExpiresOn() {
+        return mExtendedExpiresOn;
+    }
 
     //TODO: Need to add override for IsExpired() to address extended token expires on
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -127,7 +127,9 @@ public class AzureActiveDirectoryAccount extends Account {
     }
 
 
-    public String getTenantId() { return mTenantId; }
+    public String getTenantId() {
+        return mTenantId;
+    }
 
     public String getGivenName() {
         return mGivenName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -32,6 +32,7 @@ public class AzureActiveDirectoryAccount extends Account {
     private IDToken mIDToken;
     private Uri mPasswordChangeUrl;
     private Date mPasswordExpiresOn;
+    private String mTenantId; // Tenant Id of the authority that issued the idToken... not necessarily the home tenant of the account
 
     private String mGivenName;
     private String mFamilyName;
@@ -55,6 +56,7 @@ public class AzureActiveDirectoryAccount extends Account {
         mIdentityProvider = claims.get(AzureActiveDirectoryIdTokenClaims.ISSUER);
         mGivenName = claims.get(StandardIdTokenClaims.GIVEN_NAME);
         mFamilyName = claims.get(StandardIdTokenClaims.FAMILY_NAME);
+        mTenantId = claims.get(AzureActiveDirectoryIdTokenClaims.TENANT_ID);
         mUid = uid;
         mUtid = uTid;
 
@@ -124,6 +126,8 @@ public class AzureActiveDirectoryAccount extends Account {
         return null;
     }
 
+
+    public String getTenantId() { return mTenantId; }
 
     public String getGivenName() {
         return mGivenName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -2,6 +2,8 @@ package com.microsoft.identity.common.internal.providers.azureactivedirectory;
 
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
+import java.util.Date;
+
 /**
  * {@link TokenResponse} subclass for Azure AD.
  */
@@ -14,7 +16,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      *
      * @See <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code">Authorize access to web applications using OAuth 2.0 and Azure Active Directory</a>
      */
-    protected String mExpiresOn;
+    protected Date mExpiresOn;
 
     /**
      * The App ID URI of the web API (secured resource).
@@ -27,7 +29,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      * Optionally extended access_token TTL. In the event of STS outage, this field may be used to
      * extend the valid lifetime of an access_token.
      */
-    protected String mExtExpiresOn;
+    protected Date mExtExpiresOn;
 
     /**
      * The time after which the issued access_token may be used.
@@ -79,7 +81,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      *
      * @return The expires_on to get.
      */
-    public String getExpiresOn() {
+    public Date getExpiresOn() {
         return mExpiresOn;
     }
 
@@ -88,7 +90,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      *
      * @param expiresOn The expires_on to set.
      */
-    public void setExpiresOn(String expiresOn) {
+    public void setExpiresOn(Date expiresOn) {
         this.mExpiresOn = expiresOn;
     }
 
@@ -115,7 +117,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      *
      * @return The ext_expires_in to get.
      */
-    public String getExtExpiresOn() {
+    public Date getExtExpiresOn() {
         return mExtExpiresOn;
     }
 
@@ -124,7 +126,7 @@ public class AzureActiveDirectoryTokenResponse extends TokenResponse {
      *
      * @param extExpiresOn The ext_expires_in to set.
      */
-    public void setExtExpiresOn(String extExpiresOn) {
+    public void setExtExpiresOn(Date extExpiresOn) {
         this.mExtExpiresOn = extExpiresOn;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -10,7 +10,7 @@ public abstract class OAuth2TokenCache {
     protected Context mContext;
 
     public OAuth2TokenCache(Context context) {
-        mContext = context;
+        mContext = context.getApplicationContext();
     }
 
     /**


### PR DESCRIPTION
Closes #35 

No tests yet for this.... want to chat about what state is necessary when writing refresh tokens from ADAL to MSAL and the reverse.  I suspect the reverse... will require significantly more state... so we need to think about whether we should add a new ADAL cache item entry for just the user.... a user SSO refresh token entry instead of an MRRT / FRT, etc.... that would require us to modify the ADAL cache lookup code... to use this.