### PR TITLE
Adding partial key support for Accounts & Credentials

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class AccountCredentialCacheTest {
@@ -33,6 +35,8 @@ public class AccountCredentialCacheTest {
     private static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
     private static final String TARGET = "user.read user.write https://graph.windows.net";
     private static final String REALM = "3c62ac97-29eb-4aed-a3c8-add0298508d";
+    private static final String REALM2 = "20d3e9fa-982a-40bc-bea4-26bbe3fd332e";
+    private static final String REALM3 = "fc5171ec-2889-4ba6-bd1f-216fe87a8613";
     private static final String CREDENTIAL_TYPE_ACCESS_TOKEN = CredentialType.AccessToken.name().toLowerCase(Locale.US);
     private static final String CREDENTIAL_TYPE_REFRESH_TOKEN = CredentialType.RefreshToken.name().toLowerCase(Locale.US);
 
@@ -318,6 +322,168 @@ public class AccountCredentialCacheTest {
     }
 
     @Test
+    public void getAccountsNullEnvironment() throws Exception {
+        try {
+            mAccountCredentialCache.getAccounts(UNIQUE_ID, null, REALM);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void getAccountsComplete() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account.setUniqueId(UNIQUE_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Save the Account
+        mAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(UNIQUE_ID, ENVIRONMENT, REALM);
+        assertEquals(1, accounts.size());
+        final Account retrievedAccount = accounts.get(0);
+        assertEquals(UNIQUE_ID, retrievedAccount.getUniqueId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoUniqueId() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account.setUniqueId(UNIQUE_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Save the Account
+        mAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(null, ENVIRONMENT, REALM);
+        assertEquals(1, accounts.size());
+        final Account retrievedAccount = accounts.get(0);
+        assertEquals(UNIQUE_ID, retrievedAccount.getUniqueId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoUniqueIdNoRealm() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account.setUniqueId(UNIQUE_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Save the Account
+        mAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(null, ENVIRONMENT, null);
+        assertEquals(1, accounts.size());
+        final Account retrievedAccount = accounts.get(0);
+        assertEquals(UNIQUE_ID, retrievedAccount.getUniqueId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoRealm() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account.setUniqueId(UNIQUE_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Save the Account
+        mAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(UNIQUE_ID, ENVIRONMENT, null);
+        assertEquals(1, accounts.size());
+        final Account retrievedAccount = accounts.get(0);
+        assertEquals(UNIQUE_ID, retrievedAccount.getUniqueId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsWithMatchingUniqueIdEnvironment() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account1
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account1.setUniqueId(UNIQUE_ID);
+        account1.setEnvironment(ENVIRONMENT);
+        account1.setRealm(REALM);
+
+        final com.microsoft.identity.common.internal.dto.Account account2
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account2.setUniqueId(UNIQUE_ID);
+        account2.setEnvironment(ENVIRONMENT);
+        account2.setRealm(REALM2);
+
+        final com.microsoft.identity.common.internal.dto.Account account3
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account3.setUniqueId(UNIQUE_ID);
+        account3.setEnvironment(ENVIRONMENT);
+        account3.setRealm(REALM3);
+
+        final com.microsoft.identity.common.internal.dto.Account account4
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account4.setUniqueId(UNIQUE_ID);
+        account4.setEnvironment("Foo");
+        account4.setRealm(REALM);
+
+        // Save the Accounts
+        mAccountCredentialCache.saveAccount(account1);
+        mAccountCredentialCache.saveAccount(account2);
+        mAccountCredentialCache.saveAccount(account3);
+        mAccountCredentialCache.saveAccount(account4);
+
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(UNIQUE_ID, ENVIRONMENT, null);
+        assertEquals(3, accounts.size());
+    }
+
+    @Test
+    public void getAccountsWithMatchingEnvironmentRealm() throws Exception {
+        final com.microsoft.identity.common.internal.dto.Account account1
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account1.setUniqueId("Foo");
+        account1.setEnvironment(ENVIRONMENT);
+        account1.setRealm(REALM);
+
+        final com.microsoft.identity.common.internal.dto.Account account2
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account2.setUniqueId("Bar");
+        account2.setEnvironment(ENVIRONMENT);
+        account2.setRealm(REALM);
+
+        final com.microsoft.identity.common.internal.dto.Account account3
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account3.setUniqueId("Baz");
+        account3.setEnvironment(ENVIRONMENT);
+        account3.setRealm(REALM);
+
+        final com.microsoft.identity.common.internal.dto.Account account4
+                = new com.microsoft.identity.common.internal.dto.Account();
+        account4.setUniqueId("qux");
+        account4.setEnvironment(ENVIRONMENT);
+        account4.setRealm("quz");
+
+        // Save the Accounts
+        mAccountCredentialCache.saveAccount(account1);
+        mAccountCredentialCache.saveAccount(account2);
+        mAccountCredentialCache.saveAccount(account3);
+        mAccountCredentialCache.saveAccount(account4);
+
+        final List<Account> accounts = mAccountCredentialCache.getAccounts(null, ENVIRONMENT, REALM);
+        assertEquals(3, accounts.size());
+    }
+
+    @Test
     public void getCredentials() throws Exception {
         // Save an Account into the cache
         final com.microsoft.identity.common.internal.dto.Account account
@@ -347,6 +513,372 @@ public class AccountCredentialCacheTest {
         // Verify getCredentials() returns two matching elements
         final List<Credential> credentials = mAccountCredentialCache.getCredentials();
         assertTrue(credentials.size() == 2);
+    }
+
+    @Test
+    public void getCredentialsNoEnvironment() throws Exception {
+        try {
+            mAccountCredentialCache.getCredentials(
+                    UNIQUE_ID,
+                    null,
+                    CredentialType.RefreshToken,
+                    CLIENT_ID,
+                    REALM,
+                    TARGET
+            );
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void getCredentialsNoCredentialType() throws Exception {
+        try {
+            mAccountCredentialCache.getCredentials(
+                    UNIQUE_ID,
+                    ENVIRONMENT,
+                    null,
+                    CLIENT_ID,
+                    REALM,
+                    TARGET
+            );
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void getCredentialsNoClientId() throws Exception {
+        try {
+            mAccountCredentialCache.getCredentials(
+                    UNIQUE_ID,
+                    ENVIRONMENT,
+                    CredentialType.RefreshToken,
+                    null,
+                    REALM,
+                    TARGET
+            );
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void getCredentialsComplete() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId(UNIQUE_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId(UNIQUE_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                UNIQUE_ID,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                REALM,
+                TARGET
+        );
+        assertEquals(1, credentials.size());
+        final Credential retrievedCredential = credentials.get(0);
+        assertEquals(
+                CredentialType.RefreshToken.name(),
+                retrievedCredential.getCredentialType()
+        );
+    }
+
+    @Test
+    public void getCredentialsNoUniqueId() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                null,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                REALM,
+                TARGET
+        );
+        assertEquals(1, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoUniqueIdNoRealm() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId("Baz");
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                null,
+                TARGET
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoUniqueIdNoRealmNoTarget() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId("Baz");
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget("qux");
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                null,
+                null
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoTarget() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId(UNIQUE_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId(UNIQUE_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId(UNIQUE_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget("qux");
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                UNIQUE_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                REALM,
+                null
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoRealm() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId(UNIQUE_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId(UNIQUE_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId(UNIQUE_ID);
+        accessToken2.setRealm("Bar");
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                UNIQUE_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                null,
+                TARGET
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoRealmNoTarget() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId(UNIQUE_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId(UNIQUE_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId(UNIQUE_ID);
+        accessToken2.setRealm("Bar");
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget("qux");
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                UNIQUE_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                null,
+                null
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoUniqueIdNoTarget() throws Exception {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUniqueId(UNIQUE_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessToken accessToken = new AccessToken();
+        accessToken.setUniqueId("Quz");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        final AccessToken accessToken2 = new AccessToken();
+        accessToken2.setUniqueId(UNIQUE_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mAccountCredentialCache.saveCredential(refreshToken);
+        mAccountCredentialCache.saveCredential(accessToken);
+        mAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mAccountCredentialCache.getCredentials(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                REALM,
+                null
+        );
+        assertEquals(2, credentials.size());
     }
 
     @Test

--- a/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
@@ -377,7 +377,7 @@ public class AccountCredentialCacheTest {
         mAccountCredentialCache.saveCredential(refreshToken);
 
         // Call clearAccounts()
-        mAccountCredentialCache.clearAccounts();
+        mAccountCredentialCache.removeAccount(account.getUniqueId(), account.getEnvironment());
 
         // Verify getAccounts() returns zero items
         assertTrue(mAccountCredentialCache.getAccounts().isEmpty());
@@ -415,7 +415,8 @@ public class AccountCredentialCacheTest {
         mAccountCredentialCache.saveCredential(refreshToken);
 
         // Call clearCredentials()
-        mAccountCredentialCache.clearCredentials();
+        mAccountCredentialCache.removeCredential(accessToken);
+        mAccountCredentialCache.removeCredential(refreshToken);
 
         // Verify getAccounts() returns 1 item
         assertEquals(1, mAccountCredentialCache.getAccounts().size());

--- a/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
@@ -12,6 +12,7 @@ import com.microsoft.identity.common.internal.dto.AccessToken;
 import com.microsoft.identity.common.internal.dto.Account;
 import com.microsoft.identity.common.internal.dto.Credential;
 import com.microsoft.identity.common.internal.dto.CredentialType;
+import com.microsoft.identity.common.internal.dto.IdToken;
 import com.microsoft.identity.common.internal.dto.RefreshToken;
 
 import org.junit.After;
@@ -134,6 +135,29 @@ public class AccountCredentialCacheTest {
         final com.microsoft.identity.common.internal.dto.Account restoredAccount
                 = mAccountCredentialCache.getAccount(accountCacheKey);
         assertTrue(account.equals(restoredAccount));
+    }
+
+    @Test
+    public void saveIdToken() throws Exception {
+        final IdToken idToken = new IdToken();
+        idToken.setUniqueId(UNIQUE_ID);
+        idToken.setEnvironment(ENVIRONMENT);
+        idToken.setCredentialType(CredentialType.IdToken.name());
+        idToken.setClientId(CLIENT_ID);
+
+        // Save the Credential
+        mAccountCredentialCache.saveCredential(idToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(idToken);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mAccountCredentialCache.getCredential(credentialCacheKey);
+        assertEquals(idToken.getUniqueId(), restoredIdToken.getUniqueId());
+        assertEquals(idToken.getEnvironment(), restoredIdToken.getEnvironment());
+        assertEquals(idToken.getCredentialType(), restoredIdToken.getCredentialType());
+        assertEquals(idToken.getClientId(), restoredIdToken.getClientId());
+        assertTrue(idToken.equals(restoredIdToken));
     }
 
     @Test

--- a/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/AccountCredentialCacheTest.java
@@ -909,7 +909,7 @@ public class AccountCredentialCacheTest {
         mAccountCredentialCache.saveCredential(refreshToken);
 
         // Call clearAccounts()
-        mAccountCredentialCache.removeAccount(account.getUniqueId(), account.getEnvironment());
+        mAccountCredentialCache.removeAccount(account);
 
         // Verify getAccounts() returns zero items
         assertTrue(mAccountCredentialCache.getAccounts().isEmpty());

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -214,6 +214,14 @@ public class AccountCredentialCache implements IAccountCredentialCache {
 
     @Override
     public boolean removeAccount(final String uniqueId, final String environment) {
+        if (StringExtensions.isNullOrBlank(uniqueId)) {
+            throw new IllegalArgumentException("Param [uniqueId] cannot be null.");
+        }
+
+        if (StringExtensions.isNullOrBlank(environment)) {
+            throw new IllegalArgumentException("Param [environment] cannot be null.");
+        }
+
         final Map<String, Account> accounts = getAccountsWithKeys();
 
         for (final Map.Entry<String, Account> entry : accounts.entrySet()) {
@@ -231,6 +239,10 @@ public class AccountCredentialCache implements IAccountCredentialCache {
 
     @Override
     public boolean removeCredential(final Credential credentialToClear) {
+        if (null == credentialToClear) {
+            throw new IllegalArgumentException("Param [credentialToClear] cannot be null.");
+        }
+
         final Map<String, Credential> credentials = getCredentialsWithKeys();
 
         for (final Map.Entry<String, Credential> entry : credentials.entrySet()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -237,9 +237,9 @@ public class AccountCredentialCache implements IAccountCredentialCache {
                 uniqueId,
                 environment,
                 CredentialType.AccessToken,
-                null,
-                null,
-                null
+                null, // clientId
+                null, // realm
+                null // target
         );
 
         credentialsToRemove.addAll(
@@ -247,9 +247,9 @@ public class AccountCredentialCache implements IAccountCredentialCache {
                         uniqueId,
                         environment,
                         CredentialType.RefreshToken,
-                        null,
-                        null,
-                        null
+                        null, // clientId
+                        null, // realm
+                        null // target
                 )
         );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -291,21 +291,6 @@ public class AccountCredentialCache implements IAccountCredentialCache {
         return credentialClass;
     }
 
-    interface Evaluator<T> {
-        boolean evaluate(final T t);
-    }
-
-    private void clearCacheValuesOfType(final Evaluator<String> evaluator) {
-        final Map<String, ?> cacheEntries = mSharedPreferencesFileManager.getAll();
-
-        for (Map.Entry<String, ?> cacheEntry : cacheEntries.entrySet()) {
-            final String cacheKey = cacheEntry.getKey();
-            if (evaluator.evaluate(cacheKey)) {
-                mSharedPreferencesFileManager.remove(cacheKey);
-            }
-        }
-    }
-
     private CredentialType getCredentialTypeForCredentialCacheKey(final String cacheKey) {
         final Set<String> credentialTypesLowerCase = new HashSet<>();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -258,44 +258,6 @@ public class AccountCredentialCache implements IAccountCredentialCache {
     }
 
     @Override
-    public int removeAll(final String uniqueId, final String environment) {
-        int entriesRemoved = removeAccount(uniqueId, environment) ? 1 : 0;
-
-        final List<Credential> credentialsToRemove = getCredentials(
-                uniqueId,
-                environment,
-                CredentialType.AccessToken,
-                null, // clientId
-                null, // realm
-                null // target
-        );
-
-        credentialsToRemove.addAll(
-                getCredentials(
-                        uniqueId,
-                        environment,
-                        CredentialType.RefreshToken,
-                        null, // clientId
-                        null, // realm
-                        null // target
-                )
-        );
-
-        final Map<String, Credential> allCredentialsAndKeys = getCredentialsWithKeys();
-
-        for (final Map.Entry<String, Credential> entry : allCredentialsAndKeys.entrySet()) {
-            final Credential credential = entry.getValue();
-
-            if (credentialsToRemove.contains(credential)) {
-                entriesRemoved++;
-                mSharedPreferencesFileManager.remove(entry.getKey());
-            }
-        }
-
-        return entriesRemoved;
-    }
-
-    @Override
     public void clearAll() {
         mSharedPreferencesFileManager.clear();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -213,13 +213,9 @@ public class AccountCredentialCache implements IAccountCredentialCache {
     }
 
     @Override
-    public boolean removeAccount(final String uniqueId, final String environment) {
-        if (StringExtensions.isNullOrBlank(uniqueId)) {
-            throw new IllegalArgumentException("Param [uniqueId] cannot be null.");
-        }
-
-        if (StringExtensions.isNullOrBlank(environment)) {
-            throw new IllegalArgumentException("Param [environment] cannot be null.");
+    public boolean removeAccount(final Account accountToRemove) {
+        if (null == accountToRemove) {
+            throw new IllegalArgumentException("Param [accountToRemove] cannot be null.");
         }
 
         final Map<String, Account> accounts = getAccountsWithKeys();
@@ -227,8 +223,7 @@ public class AccountCredentialCache implements IAccountCredentialCache {
         for (final Map.Entry<String, Account> entry : accounts.entrySet()) {
             final Account currentAccount = entry.getValue();
 
-            if (uniqueId.equalsIgnoreCase(currentAccount.getUniqueId())
-                    && environment.equalsIgnoreCase(currentAccount.getEnvironment())) {
+            if (currentAccount.equals(accountToRemove)) {
                 mSharedPreferencesFileManager.remove(entry.getKey());
                 return true;
             }
@@ -238,9 +233,9 @@ public class AccountCredentialCache implements IAccountCredentialCache {
     }
 
     @Override
-    public boolean removeCredential(final Credential credentialToClear) {
-        if (null == credentialToClear) {
-            throw new IllegalArgumentException("Param [credentialToClear] cannot be null.");
+    public boolean removeCredential(final Credential credentialToRemove) {
+        if (null == credentialToRemove) {
+            throw new IllegalArgumentException("Param [credentialToRemove] cannot be null.");
         }
 
         final Map<String, Credential> credentials = getCredentialsWithKeys();
@@ -248,7 +243,7 @@ public class AccountCredentialCache implements IAccountCredentialCache {
         for (final Map.Entry<String, Credential> entry : credentials.entrySet()) {
             final Credential currentCredential = entry.getValue();
 
-            if (currentCredential.equals(credentialToClear)) {
+            if (currentCredential.equals(credentialToRemove)) {
                 mSharedPreferencesFileManager.remove(entry.getKey());
                 return true;
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -110,7 +110,6 @@ public class AccountCredentialCache implements IAccountCredentialCache {
                 matches = uniqueId.equalsIgnoreCase(account.getUniqueId());
             }
 
-            // test environment
             matches = matches && environment.equalsIgnoreCase(account.getEnvironment());
 
             if (mustMatchOnRealm) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCache.java
@@ -98,6 +98,10 @@ public class AccountCredentialCache implements IAccountCredentialCache {
             final @Nullable String uniqueId,
             final String environment,
             final @Nullable String realm) {
+        if (StringExtensions.isNullOrBlank(environment)) {
+            throw new IllegalArgumentException("Param [environment] cannot be null.");
+        }
+
         final boolean mustMatchOnUniqueId = !StringExtensions.isNullOrBlank(uniqueId);
         final boolean mustMatchOnRealm = !StringExtensions.isNullOrBlank(realm);
         final List<Account> allAccounts = getAccounts();
@@ -156,6 +160,18 @@ public class AccountCredentialCache implements IAccountCredentialCache {
             final String clientId,
             final @Nullable String realm,
             final @Nullable String target) {
+        if (StringExtensions.isNullOrBlank(environment)) {
+            throw new IllegalArgumentException("Param [environment] cannot be null.");
+        }
+
+        if (null == credentialType) {
+            throw new IllegalArgumentException("Param [credentialType] cannot be null.");
+        }
+
+        if (StringExtensions.isNullOrBlank(clientId)) {
+            throw new IllegalArgumentException("Param [clientId] cannot be null.");
+        }
+
         final boolean mustMatchOnUniqueId = !StringExtensions.isNullOrBlank(uniqueId);
         final boolean mustMatchOnRealm = !StringExtensions.isNullOrBlank(realm);
         final boolean mustMatchOnTarget = !StringExtensions.isNullOrBlank(target);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCacheKeyValueDelegate.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCacheKeyValueDelegate.java
@@ -1,6 +1,7 @@
 package com.microsoft.identity.common.internal.cache;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.dto.AccessToken;
 import com.microsoft.identity.common.internal.dto.Account;
@@ -87,6 +88,10 @@ public class AccountCredentialCacheKeyValueDelegate implements IAccountCredentia
     @Override
     public <T> T fromCacheValue(String string, Class<T> t) {
         // TODO serialize extra fields?
-        return mGson.fromJson(string, t);
+        try {
+            return mGson.fromJson(string, t);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCacheKeyValueDelegate.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AccountCredentialCacheKeyValueDelegate.java
@@ -5,6 +5,7 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.dto.AccessToken;
 import com.microsoft.identity.common.internal.dto.Account;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.IdToken;
 import com.microsoft.identity.common.internal.dto.RefreshToken;
 
 import java.util.ArrayList;
@@ -70,6 +71,8 @@ public class AccountCredentialCacheKeyValueDelegate implements IAccountCredentia
             keyComponents.add(((AccessToken) credential).getTarget());
         } else if (credential instanceof RefreshToken) {
             keyComponents.add(((RefreshToken) credential).getTarget());
+        } else if (credential instanceof IdToken) {
+            keyComponents.add(((IdToken) credential).getRealm());
         }
 
         return collapseKeyComponents(keyComponents);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
@@ -41,8 +41,6 @@ public interface IAccountCredentialCache {
 
     boolean removeCredential(final Credential credentialToClear);
 
-    int removeAll(final String uniqueId, final String environment);
-
     void clearAll();
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
@@ -1,7 +1,10 @@
 package com.microsoft.identity.common.internal.cache;
 
+import android.support.annotation.Nullable;
+
 import com.microsoft.identity.common.internal.dto.Account;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
 
 import java.util.List;
 
@@ -17,11 +20,28 @@ public interface IAccountCredentialCache {
 
     List<Account> getAccounts();
 
+    List<Account> getAccounts(
+            @Nullable final String uniqueId,
+            final String environment,
+            @Nullable final String realm
+    );
+
     List<Credential> getCredentials();
 
-    void clearAccounts();
+    List<Credential> getCredentials(
+            @Nullable final String uniqueId,
+            final String environment,
+            final CredentialType credentialType,
+            final String clientId,
+            @Nullable final String realm,
+            @Nullable final String target
+    );
 
-    void clearCredentials();
+    boolean removeAccount(final String uniqueId, final String environment);
+
+    boolean removeCredential(final Credential credentialToClear);
+
+    int removeAll(final String uniqueId, final String environment);
 
     void clearAll();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
@@ -92,21 +92,20 @@ public interface IAccountCredentialCache {
     );
 
     /**
-     * Removes the Account matching the supplied criteria.
+     * Removes the supplied Account from the cache.
      *
-     * @param uniqueId    The uniqueId used to match Account cache keys.
-     * @param environment The environment used to match Account cache keys.
+     * @param accountToRemove The Account to delete.
      * @return True if the Account was deleted. False otherwise.
      */
-    boolean removeAccount(final String uniqueId, final String environment);
+    boolean removeAccount(final Account accountToRemove);
 
     /**
-     * REmoves the supplied Credential from the cache.
+     * Removes the supplied Credential from the cache.
      *
-     * @param credentialToClear The Credential to delete.
+     * @param credentialToRemove The Credential to delete.
      * @return True if the Credential was deleted. False otherwise.
      */
-    boolean removeCredential(final Credential credentialToClear);
+    boolean removeCredential(final Credential credentialToRemove);
 
     /**
      * Clear the contents of the cache.

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
@@ -8,26 +8,80 @@ import com.microsoft.identity.common.internal.dto.CredentialType;
 
 import java.util.List;
 
+/**
+ * Account & Credential cache interface.
+ */
 public interface IAccountCredentialCache {
 
+    /**
+     * Saves the supplied Account in the cache.
+     *
+     * @param account The Account to save.
+     */
     void saveAccount(final Account account);
 
+    /**
+     * Saves the supplied Credential in the cache.
+     *
+     * @param credential The Credential to save.
+     */
     void saveCredential(final Credential credential);
 
+    /**
+     * Gets the Account saved for the supplied cache key.
+     *
+     * @param cacheKey The cache key to use when consulting the cache.
+     * @return The saved Account or null if no cache entry exists.
+     */
     Account getAccount(final String cacheKey);
 
+    /**
+     * Gets the Credential saved for the supplied cache key.
+     *
+     * @param cacheKey The cache key to use when consulting the cache.
+     * @return The saved Credential or null if no cache entry exists.
+     */
     Credential getCredential(final String cacheKey);
 
+    /**
+     * Returns all of the Accounts saved in the cache.
+     *
+     * @return The saved Accounts.
+     */
     List<Account> getAccounts();
 
+    /**
+     * Returns all of the Accounts matching the supplied criteria.
+     *
+     * @param uniqueId    The uniqueId used to match Account cache keys.
+     * @param environment The environment used to match Account cache keys.
+     * @param realm       The realm used to match Account cache keys.
+     * @return A List of Accounts matching the supplied criteria.
+     */
     List<Account> getAccounts(
             @Nullable final String uniqueId,
             final String environment,
             @Nullable final String realm
     );
 
+    /**
+     * Returns all of the Credentials saved in the cache.
+     *
+     * @return The saved Credentials.
+     */
     List<Credential> getCredentials();
 
+    /**
+     * Returns all of the Credentials matching the supplied criteria.
+     *
+     * @param uniqueId       The uniqueId used to match Credential cache keys.
+     * @param environment    The environment used to match Credential cache keys.
+     * @param credentialType The sought CredentialType.
+     * @param clientId       The clientId used to match Credential cache keys.
+     * @param realm          The realm used to match Credential cache keys.
+     * @param target         The target used to match Credential cache keys.
+     * @return A List of Credentials matching the supplied criteria.
+     */
     List<Credential> getCredentials(
             @Nullable final String uniqueId,
             final String environment,
@@ -37,10 +91,26 @@ public interface IAccountCredentialCache {
             @Nullable final String target
     );
 
+    /**
+     * Removes the Account matching the supplied criteria.
+     *
+     * @param uniqueId    The uniqueId used to match Account cache keys.
+     * @param environment The environment used to match Account cache keys.
+     * @return True if the Account was deleted. False otherwise.
+     */
     boolean removeAccount(final String uniqueId, final String environment);
 
+    /**
+     * REmoves the supplied Credential from the cache.
+     *
+     * @param credentialToClear The Credential to delete.
+     * @return True if the Credential was deleted. False otherwise.
+     */
     boolean removeCredential(final Credential credentialToClear);
 
+    /**
+     * Clear the contents of the cache.
+     */
     void clearAll();
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCacheKeyValueDelegate.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCacheKeyValueDelegate.java
@@ -13,6 +13,6 @@ public interface IAccountCredentialCacheKeyValueDelegate {
 
     String generateCacheValue(final Credential credential);
 
-    <T> T fromCacheValue(final String string, Class<T> t);
+    <T> T fromCacheValue(final String string, Class<T> t); // TODO consider throwing an Exception if parsing fails
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/IdToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/IdToken.java
@@ -27,4 +27,22 @@ public class IdToken extends Credential {
     public void setRealm(final String realm) {
         mRealm = realm;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        IdToken idToken = (IdToken) o;
+
+        return mRealm != null ? mRealm.equals(idToken.mRealm) : idToken.mRealm == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (mRealm != null ? mRealm.hashCode() : 0);
+        return result;
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshToken.java
@@ -110,6 +110,7 @@ public class RefreshToken extends Credential {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
 
         RefreshToken that = (RefreshToken) o;
 
@@ -123,7 +124,8 @@ public class RefreshToken extends Credential {
 
     @Override
     public int hashCode() {
-        int result = mClientInfo != null ? mClientInfo.hashCode() : 0;
+        int result = super.hashCode();
+        result = 31 * result + (mClientInfo != null ? mClientInfo.hashCode() : 0);
         result = 31 * result + (mFamilyId != null ? mFamilyId.hashCode() : 0);
         result = 31 * result + (mTarget != null ? mTarget.hashCode() : 0);
         result = 31 * result + (mUsername != null ? mUsername.hashCode() : 0);


### PR DESCRIPTION
This pull request updates the `IAccountCredentialCache` interface to support partial-key queries