### PR TITLE
Adding Logging to ADALOAuth2TokenCache

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -89,7 +89,10 @@ public class ADALOAuth2TokenCache
     }
 
     protected void initializeSharedPreferencesFileManager(final String fileName) {
+        final String methodName = "initializeSharedPreferencesFileManager";
+        Logger.entering(TAG, methodName, fileName);
         mISharedPreferencesFileManager = new SharedPreferencesFileManager(mContext, fileName);
+        Logger.exiting(TAG, methodName);
     }
 
     /**
@@ -104,6 +107,8 @@ public class ADALOAuth2TokenCache
             final AzureActiveDirectoryOAuth2Strategy strategy,
             final AzureActiveDirectoryAuthorizationRequest request,
             final AzureActiveDirectoryTokenResponse response) {
+        final String methodName = "saveTokens";
+        Logger.entering(TAG, methodName, strategy, request, response);
 
         Account account = strategy.createAccount(response);
         String issuerCacheIdentifier = strategy.getIssuerCacheIdentifier(request);
@@ -124,6 +129,8 @@ public class ADALOAuth2TokenCache
 
         // TODO: I'd like to know exactly why this is here before I put this back in.... i'm assuming for ADFS v3.
         //setItemToCacheForUser(resource, clientId, result, null);
+
+        Logger.exiting(TAG, methodName);
     }
 
 
@@ -132,6 +139,9 @@ public class ADALOAuth2TokenCache
                                        final String clientId,
                                        final ADALTokenCacheItem cacheItem,
                                        final String userId) {
+        final String methodName = "setItemToCacheForUser";
+        Logger.entering(TAG, methodName, issuer, resource, clientId, cacheItem, userId);
+
         setItem(CacheKey.createCacheKeyForRTEntry(issuer, resource, clientId, userId), cacheItem);
 
         if (cacheItem.getIsMultiResourceRefreshToken()) {
@@ -141,9 +151,14 @@ public class ADALOAuth2TokenCache
         if (!StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())) {
             setItem(CacheKey.createCacheKeyForFRT(issuer, cacheItem.getFamilyClientId(), userId), cacheItem);
         }
+
+        Logger.exiting(TAG, methodName);
     }
 
     private void setItem(final String key, final ADALTokenCacheItem cacheItem) {
+        final String methodName = "setItem";
+        Logger.entering(TAG, methodName, key, cacheItem);
+
         String json = mGson.toJson(cacheItem);
         String encrypted = encrypt(json);
 
@@ -152,6 +167,8 @@ public class ADALOAuth2TokenCache
         } else {
             Log.e(TAG, "Encrypted output is null");
         }
+
+        Logger.exiting(TAG, methodName);
     }
 
 
@@ -159,59 +176,99 @@ public class ADALOAuth2TokenCache
      * Method that allows to mock StorageHelper class and use custom encryption in UTs.
      */
     protected StorageHelper getStorageHelper() {
+        final String methodName = "getStorageHelper";
+        Logger.entering(TAG, methodName);
+
         synchronized (LOCK) {
             if (sHelper == null) {
-                Log.v(TAG, "Started to initialize storage helper");
+                Log.v(TAG, "Initializing StorageHelper");
                 sHelper = new StorageHelper(mContext);
-                Log.v(TAG, "Finished to initialize storage helper");
+                Log.v(TAG, "Finished initializing StorageHelper");
             }
         }
+
+        Logger.exiting(TAG, methodName, sHelper);
 
         return sHelper;
     }
 
-    private String encrypt(String value) {
+    private String encrypt(final String value) {
+        final String methodName = "encrypt";
+        Logger.entering(TAG, methodName, value);
+
+        String encryptedResult;
+
         try {
-            return getStorageHelper().encrypt(value);
+            encryptedResult = getStorageHelper().encrypt(value);
         } catch (GeneralSecurityException | IOException e) {
             Log.e(TAG, ErrorStrings.ENCRYPTION_ERROR, e);
+            encryptedResult = null;
         }
 
-        return null;
+        Logger.exiting(TAG, methodName, encryptedResult);
+
+        return encryptedResult;
     }
 
     private String decrypt(final String key, final String value) {
+        final String methodName = "decrypt";
+        Logger.entering(TAG, methodName, key, value);
+
         if (StringExtensions.isNullOrBlank(key)) {
             throw new IllegalArgumentException("encryption key is null or blank");
         }
 
+        String decryptedResult;
+
         try {
-            return getStorageHelper().decrypt(value);
+            decryptedResult = getStorageHelper().decrypt(value);
         } catch (GeneralSecurityException | IOException e) {
             Log.e(TAG, ErrorStrings.DECRYPTION_ERROR, e);
+            decryptedResult = null;
+
             //TODO: Implement remove item in this case... not sure I actually want to do this
             //removeItem(key);
         }
 
-        return null;
+        Logger.exiting(TAG, methodName, decryptedResult);
+
+        return decryptedResult;
     }
 
     private void validateSecretKeySetting() {
+        final String methodName = "validateSecretKeySetting";
+        Logger.entering(TAG, methodName);
+
         final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
 
         if (secretKeyData == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
             throw new IllegalArgumentException("Secret key must be provided for API < 18. "
                     + "Use AuthenticationSettings.INSTANCE.setSecretKey()");
         }
+
+        Logger.exiting(TAG, methodName);
     }
 
     @Override
     public void setSingleSignOnState(final Account account, final RefreshToken refreshToken) {
+        final String methodName = "setSingleSignOnState";
+        Logger.entering(TAG, methodName, account, refreshToken);
+
         // Unimplemented
+
+        Logger.exiting(TAG, methodName);
     }
 
     @Override
     public RefreshToken getSingleSignOnState(final Account account) {
-        return null;
+        final String methodName = "getSingleSignOnState";
+        Logger.entering(TAG, methodName, account);
+
+        // Unimplemented
+        final RefreshToken refreshToken = null;
+
+        Logger.exiting(TAG, methodName, refreshToken);
+
+        return refreshToken;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -57,12 +57,14 @@ public class ADALOAuth2TokenCache
         extends OAuth2TokenCache<AzureActiveDirectoryOAuth2Strategy, AzureActiveDirectoryAuthorizationRequest, AzureActiveDirectoryTokenResponse>
         implements IShareSingleSignOnState {
 
-    ISharedPreferencesFileManager mISharedPreferencesFileManager;
-    final static String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
-    private static final String TAG = "ADALOAuth2TokenCache";
+    private static final String TAG = ADALOAuth2TokenCache.class.getSimpleName();
+    private static final String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
+    private static final Object LOCK = new Object();
+
     @SuppressLint("StaticFieldLeak")
     private static StorageHelper sHelper;
-    private static final Object LOCK = new Object();
+
+    private ISharedPreferencesFileManager mISharedPreferencesFileManager;
     private Gson mGson = new GsonBuilder()
             .registerTypeAdapter(Date.class, new DateTimeAdapter())
             .create();

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -129,8 +129,11 @@ public class ADALOAuth2TokenCache
     }
 
 
-    private void setItemToCacheForUser(final String issuer, final String resource, final String clientId, final ADALTokenCacheItem cacheItem, final String userId) {
-
+    private void setItemToCacheForUser(final String issuer,
+                                       final String resource,
+                                       final String clientId,
+                                       final ADALTokenCacheItem cacheItem,
+                                       final String userId) {
         setItem(CacheKey.createCacheKeyForRTEntry(issuer, resource, clientId, userId), cacheItem);
 
         if (cacheItem.getIsMultiResourceRefreshToken()) {
@@ -140,19 +143,17 @@ public class ADALOAuth2TokenCache
         if (!StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())) {
             setItem(CacheKey.createCacheKeyForFRT(issuer, cacheItem.getFamilyClientId(), userId), cacheItem);
         }
-
     }
 
-    private void setItem(String key, ADALTokenCacheItem cacheItem) {
-
+    private void setItem(final String key, final ADALTokenCacheItem cacheItem) {
         String json = mGson.toJson(cacheItem);
         String encrypted = encrypt(json);
+
         if (encrypted != null) {
             mISharedPreferencesFileManager.putString(key, encrypted);
         } else {
             Log.e(TAG, "Encrypted output is null");
         }
-
     }
 
 
@@ -167,6 +168,7 @@ public class ADALOAuth2TokenCache
                 Log.v(TAG, "Finished to initialize storage helper");
             }
         }
+
         return sHelper;
     }
 
@@ -198,6 +200,7 @@ public class ADALOAuth2TokenCache
 
     private void validateSecretKeySetting() {
         final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+
         if (secretKeyData == null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
             throw new IllegalArgumentException("Secret key must be provided for API < 18. "
                     + "Use AuthenticationSettings.INSTANCE.setSecretKey()");
@@ -205,12 +208,12 @@ public class ADALOAuth2TokenCache
     }
 
     @Override
-    public void setSingleSignOnState(Account account, RefreshToken refreshToken) {
-
+    public void setSingleSignOnState(final Account account, final RefreshToken refreshToken) {
+        // Unimplemented
     }
 
     @Override
-    public RefreshToken getSingleSignOnState(Account account) {
+    public RefreshToken getSingleSignOnState(final Account account) {
         return null;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -47,7 +47,6 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.ListIterator;
 
 /**
  * Class responsible for saving oAuth2 Tokens for use in future requests.  Ideally this class would
@@ -110,18 +109,14 @@ public class ADALOAuth2TokenCache
         ADALTokenCacheItem cacheItem = new ADALTokenCacheItem(strategy, request, response);
 
         //There is more than one valid user identifier for some accounts... AAD Accounts as of this writing have 3
-        ListIterator<String> accountCacheIds = account.getCacheIdentifiers().listIterator();
-
-        while (accountCacheIds.hasNext()) {
+        for (final String cacheIdentifier : account.getCacheIdentifiers()) {
             //Azure AD Uses Resource and Not Scope... but we didn't override... heads up
-            setItemToCacheForUser(issuerCacheIdentifier, request.getScope(), request.getClientId(), cacheItem, accountCacheIds.next());
+            setItemToCacheForUser(issuerCacheIdentifier, request.getScope(), request.getClientId(), cacheItem, cacheIdentifier);
         }
 
-        ListIterator<IShareSingleSignOnState> otherCaches = mSharedSSOCaches.listIterator();
-
         // TODO At some point, the type-safety of this call needs to get beefed-up
-        while (otherCaches.hasNext()) {
-            otherCaches.next().setSingleSignOnState(account, refreshToken);
+        for (final IShareSingleSignOnState sharedSsoCache : mSharedSSOCaches) {
+            sharedSsoCache.setSingleSignOnState(account, refreshToken);
         }
 
         // TODO: I'd like to know exactly why this is here before I put this back in.... i'm assuming for ADFS v3.

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.adal.internal.cache.DateTimeAdapter;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryTokenResponse;
@@ -72,6 +73,7 @@ public class ADALOAuth2TokenCache
 
     public ADALOAuth2TokenCache(final Context context) {
         super(context);
+        Logger.verbose(TAG, "Init: " + TAG);
         validateSecretKeySetting();
         initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
         mSharedSSOCaches = new ArrayList<>();
@@ -80,13 +82,14 @@ public class ADALOAuth2TokenCache
     public ADALOAuth2TokenCache(final Context context,
                                 final List<IShareSingleSignOnState> sharedSSOCaches) {
         super(context);
+        Logger.verbose(TAG, "Init: " + TAG);
         validateSecretKeySetting();
         initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
         mSharedSSOCaches = sharedSSOCaches;
     }
 
     protected void initializeSharedPreferencesFileManager(final String fileName) {
-        mISharedPreferencesFileManager = new SharedPreferencesFileManager(super.mContext, fileName);
+        mISharedPreferencesFileManager = new SharedPreferencesFileManager(mContext, fileName);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -71,6 +71,12 @@ public class ADALOAuth2TokenCache
 
     private List<IShareSingleSignOnState> mSharedSSOCaches;
 
+    public ADALOAuth2TokenCache(final Context context) {
+        super(context);
+        validateSecretKeySetting();
+        initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
+        mSharedSSOCaches = new ArrayList<>();
+    }
 
     public ADALOAuth2TokenCache(final Context context,
                                 final List<IShareSingleSignOnState> sharedSSOCaches) {
@@ -78,13 +84,6 @@ public class ADALOAuth2TokenCache
         validateSecretKeySetting();
         initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
         mSharedSSOCaches = sharedSSOCaches;
-    }
-
-    public ADALOAuth2TokenCache(final Context context) {
-        super(context);
-        validateSecretKeySetting();
-        initializeSharedPreferencesFileManager(ADALOAuth2TokenCache.SHARED_PREFERENCES_FILENAME);
-        mSharedSSOCaches = new ArrayList<>();
     }
 
     protected void initializeSharedPreferencesFileManager(final String fileName) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALTokenCacheItem.java
@@ -343,4 +343,22 @@ public class ADALTokenCacheItem {
         return DateUtilities.createCopy(mExtendedExpiresOn);
     }
 
+    @Override
+    public String toString() {
+        return "ADALTokenCacheItem{" +
+                "mUserInfo=" + mUserInfo +
+                ", mResource='" + mResource + '\'' +
+                ", mAuthority='" + mAuthority + '\'' +
+                ", mClientId='" + mClientId + '\'' +
+                ", mAccessToken='" + mAccessToken + '\'' +
+                ", mRefreshtoken='" + mRefreshtoken + '\'' +
+                ", mRawIdToken='" + mRawIdToken + '\'' +
+                ", mExpiresOn=" + mExpiresOn +
+                ", mIsMultiResourceRefreshToken=" + mIsMultiResourceRefreshToken +
+                ", mTenantId='" + mTenantId + '\'' +
+                ", mFamilyClientId='" + mFamilyClientId + '\'' +
+                ", mExtendedExpiresOn=" + mExtendedExpiresOn +
+                ", mSpeRing='" + mSpeRing + '\'' +
+                '}';
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALUserInfo.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALUserInfo.java
@@ -131,4 +131,17 @@ public class ADALUserInfo {
     public Date getPasswordExpiresOn() {
         return DateExtensions.createCopy(mPasswordExpiresOn);
     }
+
+    @Override
+    public String toString() {
+        return "ADALUserInfo{" +
+                "mUniqueId='" + mUniqueId + '\'' +
+                ", mDisplayableId='" + mDisplayableId + '\'' +
+                ", mGivenName='" + mGivenName + '\'' +
+                ", mFamilyName='" + mFamilyName + '\'' +
+                ", mIdentityProvider='" + mIdentityProvider + '\'' +
+                ", mPasswordChangeUrl=" + mPasswordChangeUrl +
+                ", mPasswordExpiresOn=" + mPasswordExpiresOn +
+                '}';
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/HttpResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/HttpResponse.java
@@ -29,6 +29,7 @@ import java.util.Map;
  * Internal class to wrap the raw server response, headers and status code.
  */
 public final class HttpResponse {
+
     private final int mStatusCode;
     private final String mResponseBody;
     private final Map<String, List<String>> mResponseHeaders;
@@ -67,5 +68,14 @@ public final class HttpResponse {
      */
     public Map<String, List<String>> getHeaders() {
         return mResponseHeaders;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpResponse{" +
+                "mStatusCode=" + mStatusCode +
+                ", mResponseBody='" + mResponseBody + '\'' +
+                ", mResponseHeaders=" + mResponseHeaders +
+                '}';
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
@@ -57,6 +57,11 @@ public abstract class MicrosoftAccount extends Account {
     protected String mGivenName;
     protected String mFamilyName;
 
+    public MicrosoftAccount() {
+        super();
+        Logger.verbose(TAG, "Init: " + TAG);
+    }
+
     public MicrosoftAccount(final IDToken idToken, final String uid, final String utid) {
         Logger.verbose(TAG, "Init: " + TAG);
         mIDToken = idToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenResponse.java
@@ -30,4 +30,10 @@ public class MicrosoftTokenResponse extends TokenResponse {
     @SerializedName("ext_expires_in")
     protected Long mExtendedExpiresIn;
 
+    @Override
+    public String toString() {
+        return "MicrosoftTokenResponse{" +
+                "mExtendedExpiresIn=" + mExtendedExpiresIn +
+                "} " + super.toString();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -37,6 +37,10 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
 
     private static final String TAG = AzureActiveDirectoryAccount.class.getSimpleName();
 
+    public AzureActiveDirectoryAccount() {
+        super();
+    }
+
     /**
      * Constructor for AzureActiveDirectoryAccount object
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
@@ -34,6 +35,8 @@ import java.util.Map;
  */
 public class AzureActiveDirectoryAccount extends MicrosoftAccount {
 
+    private static final String TAG = AzureActiveDirectoryAccount.class.getSimpleName();
+
     /**
      * Constructor for AzureActiveDirectoryAccount object
      *
@@ -43,6 +46,7 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
      */
     public AzureActiveDirectoryAccount(IDToken idToken, String uid, final String uTid) {
         super(idToken, uid, uTid);
+        Logger.verbose(TAG, "Init: " + TAG);
     }
 
     /**
@@ -53,6 +57,8 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
      * @return
      */
     public static AzureActiveDirectoryAccount create(final IDToken idToken, ClientInfo clientInfo) {
+        final String methodName = "create";
+        Logger.entering(TAG, methodName, idToken, clientInfo);
 
         final String uid;
         final String uTid;
@@ -64,7 +70,11 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
             uTid = clientInfo.getUtid();
         }
 
-        return new AzureActiveDirectoryAccount(idToken, uid, uTid);
+        AzureActiveDirectoryAccount acct = new AzureActiveDirectoryAccount(idToken, uid, uTid);
+
+        Logger.exiting(TAG, methodName, acct);
+
+        return acct;
     }
 
     @Override
@@ -74,13 +84,22 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
 
     @Override
     protected String getDisplayableId(Map<String, String> claims) {
+        final String methodName = "getDisplayableId";
+        Logger.entering(TAG, methodName, claims);
+
+        String displayableId = null;
+
         if (!StringExtensions.isNullOrBlank(claims.get(AzureActiveDirectoryIdToken.UPN))) {
-            return claims.get(AzureActiveDirectoryIdToken.UPN);
+            Logger.info(TAG + ":" + methodName, "Returning upn as displayableId");
+            displayableId = claims.get(AzureActiveDirectoryIdToken.UPN);
         } else if (!StringExtensions.isNullOrBlank(claims.get(AzureActiveDirectoryIdToken.EMAIL))) {
-            return claims.get(AzureActiveDirectoryIdToken.EMAIL);
+            Logger.info(TAG + ":" + methodName, "Returning email as displayableId");
+            displayableId = claims.get(AzureActiveDirectoryIdToken.EMAIL);
         }
 
-        return null;
+        Logger.exiting(TAG, methodName, displayableId);
+
+        return displayableId;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -34,10 +34,6 @@ import java.util.Map;
  */
 public class AzureActiveDirectoryAccount extends MicrosoftAccount {
 
-    public AzureActiveDirectoryAccount() {
-        super();
-    }
-
     /**
      * Constructor for AzureActiveDirectoryAccount object
      *
@@ -61,10 +57,8 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
         final String uid;
         final String uTid;
 
-        //TODO: objC code throws an exception when uid/utid is null.... something for us to consider
         if (clientInfo == null) {
-            uid = "";
-            uTid = "";
+            throw new IllegalArgumentException("ClientInfo cannot be null");
         } else {
             uid = clientInfo.getUid();
             uTid = clientInfo.getUtid();
@@ -87,5 +81,10 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
         }
 
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureActiveDirectoryAccount{} " + super.toString();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -64,15 +64,12 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
         final String methodName = "create";
         Logger.entering(TAG, methodName, idToken, clientInfo);
 
-        final String uid;
-        final String uTid;
-
-        if (clientInfo == null) {
+        if (null == clientInfo) {
             throw new IllegalArgumentException("ClientInfo cannot be null");
-        } else {
-            uid = clientInfo.getUid();
-            uTid = clientInfo.getUtid();
         }
+
+        final String uid = clientInfo.getUid();
+        final String uTid = clientInfo.getUtid();
 
         AzureActiveDirectoryAccount acct = new AzureActiveDirectoryAccount(idToken, uid, uTid);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
@@ -38,4 +38,10 @@ public class AzureActiveDirectoryAuthorizationRequest extends AuthorizationReque
         this.mAuthority = mAuthority;
     }
 
+    @Override
+    public String toString() {
+        return "AzureActiveDirectoryAuthorizationRequest{" +
+                "mAuthority=" + mAuthority +
+                "} " + super.toString();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
@@ -28,7 +28,7 @@ import java.net.URL;
 
 public class AzureActiveDirectoryAuthorizationRequest extends AuthorizationRequest {
 
-    URL mAuthority;
+    private URL mAuthority;
 
     public URL getAuthority() {
         return mAuthority;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -144,7 +144,6 @@ public class AzureActiveDirectoryOAuth2Strategy
         } catch (ServiceException ccse) {
             Logger.error(TAG + ":" + methodName, "Failed to construct IDToken or ClientInfo", null);
             Logger.errorPII(TAG + ":" + methodName, "Failed with Exception", ccse);
-            // TODO: Add a log here
             // TODO: Should we bail?
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTokenResponse.java
@@ -221,4 +221,18 @@ public class AzureActiveDirectoryTokenResponse extends MicrosoftTokenResponse {
     public void setClientId(final String clientId) {
         mClientId = clientId;
     }
+
+    @Override
+    public String toString() {
+        return "AzureActiveDirectoryTokenResponse{" +
+                "mExpiresOn=" + mExpiresOn +
+                ", mResource='" + mResource + '\'' +
+                ", mExtExpiresOn=" + mExtExpiresOn +
+                ", mNotBefore='" + mNotBefore + '\'' +
+                ", mClientInfo='" + mClientInfo + '\'' +
+                ", mFamilyId='" + mFamilyId + '\'' +
+                ", mClientId='" + mClientId + '\'' +
+                ", mSpeRing='" + mSpeRing + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -44,18 +44,12 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
      * @return The newly created MicrosoftStsAccount.
      */
     public static MicrosoftStsAccount create(final IDToken idToken, ClientInfo clientInfo) {
-
-        final String uid;
-        final String uTid;
-
-        //TODO: objC code throws an exception when uid/utid is null.... something for us to consider
-        if (clientInfo == null) {
-            uid = "";
-            uTid = "";
-        } else {
-            uid = clientInfo.getUid();
-            uTid = clientInfo.getUtid();
+        if (null == clientInfo) {
+            throw new IllegalArgumentException("ClientInfo cannot be null");
         }
+
+        final String uid = clientInfo.getUid();
+        final String uTid = clientInfo.getUtid();
 
         return new MicrosoftStsAccount(idToken, uid, uTid);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -76,4 +76,14 @@ public class AuthorizationRequest {
         this.mState = mState;
     }
 
+    @Override
+    public String toString() {
+        return "AuthorizationRequest{" +
+                "mResponseType='" + mResponseType + '\'' +
+                ", mClientId='" + mClientId + '\'' +
+                ", mRedirectUri='" + mRedirectUri + '\'' +
+                ", mScope='" + mScope + '\'' +
+                ", mState='" + mState + '\'' +
+                '}';
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -52,14 +52,15 @@ public abstract class OAuth2Strategy
                 GenericTokenResponse extends TokenResponse,
                 GenericTokenResult extends TokenResult> {
 
+    protected static final String TOKEN_REQUEST_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
+    protected final GenericOAuth2Configuration mConfig;
     protected String mTokenEndpoint;
     protected String mAuthorizationEndpoint;
     protected Uri mIssuer;
 
-    protected static final String TOKEN_REQUEST_CONTENT_TYPE = "application/x-www-form-urlencoded";
-
     public OAuth2Strategy(GenericOAuth2Configuration config) {
-
+        mConfig = config;
     }
 
     /**
@@ -80,13 +81,11 @@ public abstract class OAuth2Strategy
         return (GenericAuthorizationResponse) response;
     }
 
-
     public GenericTokenResult requestToken(final GenericTokenRequest request) throws IOException {
         validateTokenRequest(request);
         HttpResponse response = performTokenRequest(request);
         return getTokenResultFromHttpResponse(response);
     }
-
 
     protected HttpResponse performTokenRequest(final GenericTokenRequest request) throws IOException {
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
@@ -59,4 +59,13 @@ public class TokenErrorResponse {
     public void setErrorUri(String errorUri) {
         this.mErrorUri = errorUri;
     }
+
+    @Override
+    public String toString() {
+        return "TokenErrorResponse{" +
+                "mError='" + mError + '\'' +
+                ", mErrorDescription='" + mErrorDescription + '\'' +
+                ", mErrorUri='" + mErrorUri + '\'' +
+                '}';
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResponse.java
@@ -251,4 +251,17 @@ public class TokenResponse {
         return this.mResponseReceivedTime;
     }
 
+    @Override
+    public String toString() {
+        return "TokenResponse{" +
+                "mExpiresIn=" + mExpiresIn +
+                ", mAccessToken='" + mAccessToken + '\'' +
+                ", mTokenType='" + mTokenType + '\'' +
+                ", mRefreshToken='" + mRefreshToken + '\'' +
+                ", mScope='" + mScope + '\'' +
+                ", mState='" + mState + '\'' +
+                ", mIdToken='" + mIdToken + '\'' +
+                ", mResponseReceivedTime=" + mResponseReceivedTime +
+                '}';
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenResult.java
@@ -22,18 +22,21 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2;
 
+import com.microsoft.identity.common.internal.logging.Logger;
+
 /**
  * Holds the request of a token request.  The request will either contain the success result or the error result.
  */
 public class TokenResult {
 
-    private boolean mSuccess = false;
+    private static final String TAG = TokenResult.class.getSimpleName();
 
     private TokenResponse mTokenResponse;
     private TokenErrorResponse mTokenErrorResponse;
+    private boolean mSuccess = false;
 
-    public TokenResult(TokenResponse response, TokenErrorResponse errorResponse) {
-
+    public TokenResult(final TokenResponse response, final TokenErrorResponse errorResponse) {
+        Logger.verbose(TAG, "Init: " + TAG);
         this.mTokenResponse = response;
         this.mTokenErrorResponse = errorResponse;
 
@@ -49,7 +52,7 @@ public class TokenResult {
      * @return TokenResponse
      */
     public TokenResponse getTokenResponse() {
-        return this.mTokenResponse;
+        return mTokenResponse;
     }
 
     /**
@@ -58,7 +61,7 @@ public class TokenResult {
      * @return TokenErrorResponse
      */
     public TokenErrorResponse getErrorResponse() {
-        return this.mTokenErrorResponse;
+        return mTokenErrorResponse;
     }
 
     /**
@@ -67,7 +70,15 @@ public class TokenResult {
      * @return boolean
      */
     public boolean getSuccess() {
-        return this.mSuccess;
+        return mSuccess;
     }
 
+    @Override
+    public String toString() {
+        return "TokenResult{" +
+                "mTokenResponse=" + mTokenResponse +
+                ", mTokenErrorResponse=" + mTokenErrorResponse +
+                ", mSuccess=" + mSuccess +
+                '}';
+    }
 }


### PR DESCRIPTION
Adds logging to `ADALOAuth2TokenCache`, also cleans up some hairy formatting I spotted while doing this work. The occasional constructor or method argument has been made final. Some line wrappings were added to fit a 100 char terminal