### PR TITLE
Closes #146

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/Account.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/Account.java
@@ -178,7 +178,7 @@ public class Account extends AccountCredentialBase implements IAccount {
     private String mUsername;
 
     /**
-     * Account’s authority type as string (ex: AAD, MSA, MSSTS, Other).
+     * Account’s authority type as string (ex: MSA, MSSTS, Other).
      * Set of account types is extensible.
      */
     @SerializedName(AUTHORITY_TYPE)

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
@@ -41,6 +41,9 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class MicrosoftAccount extends Account {
+
+    protected static final String AUTHORITY_TYPE_V1_V2 = "MSSTS";
+
     private static final String TAG = MicrosoftAccount.class.getSimpleName();
 
     private String mDisplayableId; // Legacy Identifier -  UPN (preferred) or Email

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -79,7 +79,7 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
 
     @Override
     public String getAuthorityType() {
-        return "AAD";
+        return AUTHORITY_TYPE_V1_V2;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -67,7 +67,7 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
 
     @Override
     public String getAuthorityType() {
-        return "MSSTS";
+        return AUTHORITY_TYPE_V1_V2;
     }
 
     @Override


### PR DESCRIPTION
Common cache will no longer distinguish between the `v1` and `v2` endpoints -- as a result, the `Account#authority_type` will now use `MSSTS` to represent both