### PR TITLE
Closes #148

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheKeyValueDelegate.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheKeyValueDelegate.java
@@ -151,8 +151,8 @@ public class CacheKeyValueDelegate implements ICacheKeyValueDelegate {
                 && !StringExtensions.isNullOrBlank((rt = (RefreshToken) credential).getFamilyId())) {
             String familyIdForCacheKey = rt.getFamilyId();
 
-            if (!familyIdForCacheKey.startsWith(FOCI_PREFIX)) {
-                familyIdForCacheKey = FOCI_PREFIX + familyIdForCacheKey;
+            if (familyIdForCacheKey.startsWith(FOCI_PREFIX)) {
+                familyIdForCacheKey = familyIdForCacheKey.replace(FOCI_PREFIX, "");
             }
 
             cacheKey = cacheKey.replace(CLIENT_ID, familyIdForCacheKey);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheKeyValueDelegate.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheKeyValueDelegate.java
@@ -67,6 +67,7 @@ public class CacheKeyValueDelegate implements ICacheKeyValueDelegate {
      * String of cache value separator.
      */
     public static final String CACHE_VALUE_SEPARATOR = "-";
+    private static final String FOCI_PREFIX = "foci-";
 
     private final Gson mGson;
 
@@ -144,7 +145,20 @@ public class CacheKeyValueDelegate implements ICacheKeyValueDelegate {
         cacheKey = cacheKey.replace(HOME_ACCOUNT_ID, sanitizeNull(credential.getHomeAccountId()));
         cacheKey = cacheKey.replace(ENVIRONMENT, sanitizeNull(credential.getEnvironment()));
         cacheKey = cacheKey.replace(CREDENTIAL_TYPE, sanitizeNull(credential.getCredentialType()));
-        cacheKey = cacheKey.replace(CLIENT_ID, sanitizeNull(credential.getClientId()));
+
+        RefreshToken rt;
+        if ((credential instanceof RefreshToken)
+                && !StringExtensions.isNullOrBlank((rt = (RefreshToken) credential).getFamilyId())) {
+            String familyIdForCacheKey = rt.getFamilyId();
+
+            if (!familyIdForCacheKey.startsWith(FOCI_PREFIX)) {
+                familyIdForCacheKey = FOCI_PREFIX + familyIdForCacheKey;
+            }
+
+            cacheKey = cacheKey.replace(CLIENT_ID, familyIdForCacheKey);
+        } else {
+            cacheKey = cacheKey.replace(CLIENT_ID, sanitizeNull(credential.getClientId()));
+        }
 
         if (credential instanceof AccessToken) {
             final AccessToken accessToken = (AccessToken) credential;

--- a/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
@@ -494,6 +494,86 @@ public class CacheKeyValueDelegateTest {
     }
 
     @Test
+    public void refreshTokenCreateCacheKeyCompleteWithFoci() {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setFamilyId("1");
+        refreshToken.setTarget(TARGET);
+
+        final String expectedKey = "" // just for formatting
+                + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
+                + ENVIRONMENT + CACHE_VALUE_SEPARATOR
+                + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
+                + "foci-1" + CACHE_VALUE_SEPARATOR
+                + CACHE_VALUE_SEPARATOR
+                + TARGET;
+        assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
+    }
+
+    @Test
+    public void refreshTokenCreateCacheKeyCompleteWithFociPrefixed() {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setFamilyId("foci-1");
+        refreshToken.setTarget(TARGET);
+
+        final String expectedKey = "" // just for formatting
+                + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
+                + ENVIRONMENT + CACHE_VALUE_SEPARATOR
+                + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
+                + "foci-1" + CACHE_VALUE_SEPARATOR
+                + CACHE_VALUE_SEPARATOR
+                + TARGET;
+        assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
+    }
+
+    @Test
+    public void refreshTokenCreateCacheKeyCompleteWithFociAlternate() {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setFamilyId("2");
+        refreshToken.setTarget(TARGET);
+
+        final String expectedKey = "" // just for formatting
+                + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
+                + ENVIRONMENT + CACHE_VALUE_SEPARATOR
+                + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
+                + "foci-2" + CACHE_VALUE_SEPARATOR
+                + CACHE_VALUE_SEPARATOR
+                + TARGET;
+        assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
+    }
+
+    @Test
+    public void refreshTokenCreateCacheKeyCompleteWithFociPrefixedAlternate() {
+        final RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setFamilyId("foci-2");
+        refreshToken.setTarget(TARGET);
+
+        final String expectedKey = "" // just for formatting
+                + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
+                + ENVIRONMENT + CACHE_VALUE_SEPARATOR
+                + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
+                + "foci-2" + CACHE_VALUE_SEPARATOR
+                + CACHE_VALUE_SEPARATOR
+                + TARGET;
+        assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
+    }
+
+    @Test
     public void refreshTokenCreateCacheKeyNoHomeAccountId() {
         final RefreshToken refreshToken = new RefreshToken();
         refreshToken.setEnvironment(ENVIRONMENT);

--- a/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
@@ -507,7 +507,7 @@ public class CacheKeyValueDelegateTest {
                 + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
                 + ENVIRONMENT + CACHE_VALUE_SEPARATOR
                 + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
-                + "foci-1" + CACHE_VALUE_SEPARATOR
+                + "1" + CACHE_VALUE_SEPARATOR
                 + CACHE_VALUE_SEPARATOR
                 + TARGET;
         assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
@@ -527,7 +527,7 @@ public class CacheKeyValueDelegateTest {
                 + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
                 + ENVIRONMENT + CACHE_VALUE_SEPARATOR
                 + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
-                + "foci-1" + CACHE_VALUE_SEPARATOR
+                + "1" + CACHE_VALUE_SEPARATOR
                 + CACHE_VALUE_SEPARATOR
                 + TARGET;
         assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
@@ -547,7 +547,7 @@ public class CacheKeyValueDelegateTest {
                 + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
                 + ENVIRONMENT + CACHE_VALUE_SEPARATOR
                 + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
-                + "foci-2" + CACHE_VALUE_SEPARATOR
+                + "2" + CACHE_VALUE_SEPARATOR
                 + CACHE_VALUE_SEPARATOR
                 + TARGET;
         assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));
@@ -567,7 +567,7 @@ public class CacheKeyValueDelegateTest {
                 + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
                 + ENVIRONMENT + CACHE_VALUE_SEPARATOR
                 + CREDENTIAL_TYPE_REFRESH_TOKEN + CACHE_VALUE_SEPARATOR
-                + "foci-2" + CACHE_VALUE_SEPARATOR
+                + "2" + CACHE_VALUE_SEPARATOR
                 + CACHE_VALUE_SEPARATOR
                 + TARGET;
         assertEquals(expectedKey, mDelegate.generateCacheKey(refreshToken));


### PR DESCRIPTION
Bugfix to close #148 

If a `RefreshToken` has a `family_id` set, the value should be used in the cache key instead of the `client_id`