### PR TITLE
Fix the bugs for Embedded WebView Intergration

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -40,6 +40,7 @@ android {
         disable 'GradleDependency'
         disable 'GradleOverrides'
         disable 'OldTargetApi'
+        disable 'RtlHardcoded'
     }
 
     testOptions {

--- a/common/src/androidTest/java/com/microsoft/identity/common/AzureActiveDirectoryAuthorizationResultFactoryTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/AzureActiveDirectoryAuthorizationResultFactoryTest.java
@@ -189,7 +189,7 @@ public class AzureActiveDirectoryAuthorizationResultFactoryTest {
     public void testUrlWithEmptyParams() {
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
-        bundle.putString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, REDIRECT_URI);
+        bundle.putString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, REDIRECT_URI);
         intent.putExtras(bundle);
         AuthorizationResult result = mAuthorizationResultFactory.createAuthorizationResult(
                 AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent);
@@ -206,7 +206,7 @@ public class AzureActiveDirectoryAuthorizationResultFactoryTest {
     public void testUrlWithInvalidParams() {
         Intent intent = new Intent();
         Bundle bundle = new Bundle();
-        bundle.putString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, REDIRECT_URI + "?some_random_error=accessdenied");
+        bundle.putString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, REDIRECT_URI + "?some_random_error=accessdenied");
         intent.putExtras(bundle);
         AuthorizationResult result = mAuthorizationResultFactory.createAuthorizationResult(
                 AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent);
@@ -225,7 +225,7 @@ public class AzureActiveDirectoryAuthorizationResultFactoryTest {
         Bundle bundle = new Bundle();
         String responseUrl = REDIRECT_URI + "?" + AUTH_CODE_AND_STATE + "&"
                 + AuthenticationConstants.AAD.CORRELATION_ID + "=" + CORRELATION_ID;
-        bundle.putString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, responseUrl);
+        bundle.putString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, responseUrl);
         bundle.putString(AuthenticationConstants.AAD.CORRELATION_ID, CORRELATION_ID);
         intent.putExtras(bundle);
         intent.putExtra(MicrosoftAuthorizationResult.REQUEST_STATE_PARAMETER, STATE);
@@ -246,7 +246,7 @@ public class AzureActiveDirectoryAuthorizationResultFactoryTest {
         Bundle bundle = new Bundle();
         String responseUrl = REDIRECT_URI + "?" + AUTH_CODE_AND_STATE + "&"
                 + AuthenticationConstants.AAD.CORRELATION_ID + "=" + CORRELATION_ID;
-        bundle.putString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, responseUrl);
+        bundle.putString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, responseUrl);
         bundle.putString(AuthenticationConstants.AAD.CORRELATION_ID, CORRELATION_ID);
         intent.putExtras(bundle);
         intent.putExtra(MicrosoftAuthorizationResult.REQUEST_STATE_PARAMETER, STATE);
@@ -267,7 +267,7 @@ public class AzureActiveDirectoryAuthorizationResultFactoryTest {
         Bundle bundle = new Bundle();
         String responseUrl = REDIRECT_URI + "?error=" + ERROR_MESSAGE + "&error_description="
                 + ERROR_DESCRIPTION + "&error_codes=" + ERROR_CODES;
-        bundle.putString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, responseUrl);
+        bundle.putString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, responseUrl);
         intent.putExtras(bundle);
         AzureActiveDirectoryAuthorizationResult result = mAuthorizationResultFactory.createAuthorizationResult(
                 AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent);

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
@@ -104,7 +104,7 @@ public class MicrosoftStsAuthorizationRequestTests {
         final String actualCodeRequestUrl = request.getAuthorizationStartUrl();
         assertTrue("Prompt", actualCodeRequestUrl.contains("&prompt=consent"));
         assertTrue("Auth endpoint", actualCodeRequestUrl.contains(DEFAULT_TEST_AUTHORIZATION_ENDPOINT));
-        assertTrue("scope", actualCodeRequestUrl.contains("scope=offline_access%2Bprofile%2Bscope1%2Bopenid%2Bscope2"));
+        assertTrue("scope", actualCodeRequestUrl.contains("scope=offline_access%20profile%20scope1%20openid%20scope2"));
         assertTrue("Client id", actualCodeRequestUrl.contains("client_id=some-client-id"));
     }
 
@@ -119,8 +119,9 @@ public class MicrosoftStsAuthorizationRequestTests {
         final String actualCodeRequestUrlWithLoginHint = requestWithLoginHint.getAuthorizationStartUrl();
         assertTrue("Matching login hint", actualCodeRequestUrlWithLoginHint.contains("login_hint=someLoginHint"));
         assertTrue("Matching response type", actualCodeRequestUrlWithLoginHint.contains("response_type=code"));
-        assertTrue("Matching correlation id", actualCodeRequestUrlWithLoginHint.contains("&correlation_id=" + DEFAULT_TEST_CORRELATION_ID.toString()));
+        assertTrue("Matching correlation id", actualCodeRequestUrlWithLoginHint.contains("&client-request-id=" + DEFAULT_TEST_CORRELATION_ID.toString()));
         assertTrue("Matching library version", actualCodeRequestUrlWithLoginHint.contains("&x-client-Ver=0.1"));
+
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -65,37 +65,37 @@ public final class AuthenticationConstants {
         /**
          * Represents the request object used to construct request sent to authorize endpoint.
          */
-        public static final String REQUEST_MESSAGE = "com.microsoft.aad.adal:BrowserRequestMessage";
+        public static final String REQUEST_MESSAGE = "com.microsoft.identity.browser.request.message";
 
         /**
          * Represents the request object returned from webview.
          */
-        public static final String RESPONSE_REQUEST_INFO = "com.microsoft.aad.adal:BrowserRequestInfo";
+        public static final String RESPONSE_REQUEST_INFO = "com.microsoft.identity.browser.request.info";
 
         /**
          * Represents the error code returned from webview.
          */
-        public static final String RESPONSE_ERROR_CODE = "com.microsoft.aad.adal:BrowserErrorCode";
+        public static final String RESPONSE_ERROR_CODE = "com.microsoft.identity.browser.error.code";
 
         /**
          * Represents the error message returned from webview.
          */
-        public static final String RESPONSE_ERROR_MESSAGE = "com.microsoft.aad.adal:BrowserErrorMessage";
+        public static final String RESPONSE_ERROR_MESSAGE = "com.microsoft.identity.browser.error.message";
 
         /**
          * Represents the exception returned from webview.
          */
-        public static final String RESPONSE_AUTHENTICATION_EXCEPTION = "com.microsoft.aad.adal:AuthenticationException";
+        public static final String RESPONSE_AUTHENTICATION_EXCEPTION = "com.microsoft.identity.authorization.exception";
 
         /**
          * Represents the final url that webview receives.
          */
-        public static final String RESPONSE_FINAL_URL = "com.microsoft.aad.adal:BrowserFinalUrl";
+        public static final String AUTHORIZATION_FINAL_URL = "com.microsoft.identity.client.final.url";
 
         /**
          * Represents the response returned from broker.
          */
-        public static final String RESPONSE = "com.microsoft.aad.adal:BrokerResponse";
+        public static final String RESPONSE = "com.microsoft.identity.broker.response";
 
         /**
          * Represent the error code of invalid request returned from webview.
@@ -105,12 +105,12 @@ public final class AuthenticationConstants {
         /**
          * Used by LocalBroadcastReceivers to filter the intent string of request cancellation.
          */
-        public static final String ACTION_CANCEL = "com.microsoft.aad.adal:BrowserCancel";
+        public static final String ACTION_CANCEL = "com.microsoft.identity.browser.cancel";
 
         /**
          * Used as the key to send back request id.
          */
-        public static final String REQUEST_ID = "com.microsoft.aad.adal:RequestId";
+        public static final String REQUEST_ID = "com.microsoft.identity.request.id";
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
@@ -268,7 +268,7 @@ public final class StringExtensions {
 
         Uri.Builder builtUri = Uri.parse(url).buildUpon();
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
-            builtUri.appendQueryParameter(entry.getKey(), urlFormEncode(entry.getValue()));
+            builtUri.appendQueryParameter(entry.getKey(), entry.getValue());
         }
 
         return builtUri.build().toString();

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public final class Logger {
@@ -504,7 +505,7 @@ public final class Logger {
     }
 
     private static String getUTCDateTimeAsString() {
-        final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+        final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT, Locale.getDefault());
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         return dateFormat.format(new Date());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -62,6 +62,7 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
     public static final String LIB_ID_CPU = "x-client-CPU";
     public static final String LIB_ID_OS_VER = "x-client-OS";
     public static final String LIB_ID_DM = "x-client-DM";
+    private static final long serialVersionUID = 6873634931996113294L;
 
     /**
      * Required.
@@ -127,6 +128,13 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
         mPkceChallenge = pkceChallenge;
         mExtraQueryParam = extraQueryParam;
         mLibraryVersion = libraryVersion;
+    }
+
+    /**
+     * Default constructor of {@link MicrosoftAuthorizationRequest}
+     */
+    public MicrosoftAuthorizationRequest() {
+        super();
     }
 
     public URL getAuthority() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +112,6 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
                                          final String extraQueryParam,
                                          final String libraryVersion) {
         super(responseType, clientId, redirectUri, state, scope);
-        setState(generateState());
 
         if (StringUtil.isEmpty(redirectUri)) {
             throw new IllegalArgumentException("redirect Uri is empty");
@@ -210,10 +210,20 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
         }
     }
 
-    protected String generateState() {
+    public String generateEncodedState() throws UnsupportedEncodingException {
         final UUID stateUUID1 = UUID.randomUUID();
         final UUID stateUUID2 = UUID.randomUUID();
-        return stateUUID1.toString() + "-" + stateUUID2.toString();
+        final String state = stateUUID1.toString() + "-" + stateUUID2.toString();
+        return Base64.encodeToString(state.getBytes("UTF-8"), Base64.NO_PADDING | Base64.URL_SAFE);
+    }
+
+    public String decodeState(final String encodedState) {
+        if (StringUtil.isEmpty(encodedState)) {
+            return null;
+        }
+
+        final byte[] stateBytes = Base64.decode(encodedState, Base64.NO_PADDING | Base64.URL_SAFE);
+        return new String(stateBytes, Charset.defaultCharset());
     }
 
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -49,6 +49,11 @@ import static com.microsoft.identity.common.adal.internal.util.StringExtensions.
 import static com.microsoft.identity.common.adal.internal.util.StringExtensions.urlFormDecode;
 
 public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest {
+    /**
+     * Serial version id.
+     */
+    private static final long serialVersionUID = 6873634931996113294L;
+
     /* Constants */
     private static final String TAG = MicrosoftAuthorizationRequest.class.getSimpleName();
     public static final String ENCODING_UTF8 = "UTF_8";
@@ -63,7 +68,6 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
     public static final String LIB_ID_CPU = "x-client-CPU";
     public static final String LIB_ID_OS_VER = "x-client-OS";
     public static final String LIB_ID_DM = "x-client-DM";
-    private static final long serialVersionUID = 6873634931996113294L;
 
     /**
      * Required.
@@ -219,6 +223,7 @@ public abstract class MicrosoftAuthorizationRequest extends AuthorizationRequest
 
     public String decodeState(final String encodedState) {
         if (StringUtil.isEmpty(encodedState)) {
+            Logger.warn(TAG, "Decode state failed because the input state is empty.");
             return null;
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationResultFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationResultFactory.java
@@ -70,7 +70,7 @@ public class AzureActiveDirectoryAuthorizationResultFactory extends Authorizatio
                 break;
 
             case AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE:
-                final String url = extras.getString(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, "");
+                final String url = extras.getString(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, "");
                 result = parseUrlAndCreateAuthorizationResult(url, data.getStringExtra(MicrosoftAuthorizationResult.REQUEST_STATE_PARAMETER));
                 break;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -45,6 +45,11 @@ import java.util.UUID;
 public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequest {
     private static final String TAG = MicrosoftStsAuthorizationRequest.class.getSimpleName();
 
+    /**
+     * Serial version id.
+     */
+    private static final long serialVersionUID = 6545759826515911472L;
+
     /* Constants */
     private static final String CORRELATION_ID = "client-request-id";
     private static final String LOGIN_REQ = "login_req";
@@ -54,7 +59,6 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     private static final String PLATFORM_VALUE = "MSAL.Android";
     private static final String PROMPT_SELECT_ACCOUNT = "select_account";
     private static final String PROMPT_CONSENT = "consent";
-    private static final long serialVersionUID = 6545759826515911472L;
 
     /**
      * Indicates the type of user interaction that is required. The only valid values at this time are 'login', 'none', and 'consent'.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -54,6 +54,7 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     private static final String PLATFORM_VALUE = "MSAL.Android";
     private static final String PROMPT_SELECT_ACCOUNT = "select_account";
     private static final String PROMPT_CONSENT = "consent";
+    private static final long serialVersionUID = 6545759826515911472L;
 
     /**
      * Indicates the type of user interaction that is required. The only valid values at this time are 'login', 'none', and 'consent'.
@@ -99,6 +100,13 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         mDisplayableId = displayableId;
         mSliceParameters = sliceParameters;
         mExtraScopesToConsent = extraScopesToConsent;
+    }
+
+    /**
+     * Default constructor of {@link MicrosoftStsAuthorizationRequest}
+     */
+    public MicrosoftStsAuthorizationRequest() {
+        super();
     }
 
     public Set<String> getExtraScopesToConsent() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -46,7 +46,7 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     private static final String TAG = MicrosoftStsAuthorizationRequest.class.getSimpleName();
 
     /* Constants */
-    private static final String CORRELATION_ID = "correlation_id";
+    private static final String CORRELATION_ID = "client-request-id";
     private static final String LOGIN_REQ = "login_req";
     private static final String DOMAIN_REQ = "domain_req";
     private static final String SCOPE_PROFILE = "profile";
@@ -277,7 +277,10 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     // Add PKCE Challenge
     private void addPkceChallengeToRequestParameters(@NonNull final Map<String, String> requestParameters) throws ClientException {
         // Create our Challenge
-        setPkceChallenge(PkceChallenge.newPkceChallenge());
+        if (getPkceChallenge() == null) {
+            Logger.verbose(TAG, "PKCE challenge is null. Set the PKCE challenge.");
+            setPkceChallenge(PkceChallenge.newPkceChallenge());
+        }
 
         // Add it to our Authorization request
         requestParameters.put(CODE_CHALLENGE, getPkceChallenge().getCodeChallenge());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * This should provide an extension point for additional parameters to be set
  */
 public abstract class AuthorizationRequest implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 6171895895590170062L;
 
     /**
      * A required value and must be set to "code".
@@ -94,6 +94,12 @@ public abstract class AuthorizationRequest implements Serializable {
         mRedirectUri = redirectUri;
         mState = state;
         mScope = scope;
+    }
+
+    /**
+     * Default constructor of AuthorizationRequest.
+     */
+    public AuthorizationRequest() {
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -39,6 +39,9 @@ import java.util.Set;
  * This should provide an extension point for additional parameters to be set
  */
 public abstract class AuthorizationRequest implements Serializable {
+    /**
+     * Serial version id.
+     */
     private static final long serialVersionUID = 6171895895590170062L;
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PkceChallenge.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PkceChallenge.java
@@ -27,6 +27,7 @@ import android.util.Base64;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -49,12 +50,13 @@ import java.security.SecureRandom;
  * @see <a href="https://tools.ietf.org/html/rfc7636#page-17">RFC-7636</a>
  */
 
-public class PkceChallenge {
+public class PkceChallenge implements Serializable {
     private static final int CODE_VERIFIER_BYTE_SIZE = 32;
     private static final int ENCODE_MASK = Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP;
     private static final String DIGEST_ALGORITHM = "SHA-256";
     private static final String ISO_8859_1 = "ISO_8859_1";
     private static final String CHALLENGE_SHA256 = "S256";
+    private static final long serialVersionUID = 8549806628675994235L;
 
     /**
      * A cryptographically random string that is used to correlate the

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/AzureActiveDirectoryWebViewClient.java
@@ -64,7 +64,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
 
-    AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
+    public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                       @NonNull final MicrosoftAuthorizationRequest request,
                                       @NonNull final IChallengeCompletionCallback callback) {
         super(activity, request, callback);
@@ -107,7 +107,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (isPkeyAuthUrl(formattedURL)) {
             Logger.verbose(TAG, "WebView detected request for pkeyauth challenge.");
             try {
-                final PKeyAuthChallenge pKeyAuthChallenge = new PKeyAuthChallenge(formattedURL);
+                final PKeyAuthChallenge pKeyAuthChallenge = new PKeyAuthChallenge(url);
                 final PKeyAuthChallengeHandler pKeyAuthChallengeHandler = new PKeyAuthChallengeHandler(view, getRequest(), getCompletionCallback());
                 pKeyAuthChallengeHandler.processChallenge(pKeyAuthChallenge);
             } catch (final ClientException exception) {
@@ -119,13 +119,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             return true;
         } else if (isRedirectUrl(formattedURL)) {
             Logger.verbose(TAG, "Navigation starts with the redirect uri.");
-            return processRedirectUrl(view, formattedURL);
+            return processRedirectUrl(view, url);
         } else if (isWebsiteRequestUrl(formattedURL)) {
             Logger.verbose(TAG, "It is an external website request");
-            return processWebsiteRequest(view, formattedURL);
+            return processWebsiteRequest(view, url);
         } else if (isInstallRequestUrl(formattedURL)) {
             Logger.verbose(TAG, "It is an install request");
-            return processInstallRequest(view, formattedURL);
+            return processInstallRequest(view, url);
         } else {
             Logger.verbose(TAG, "It is an invalid redirect uri.");
             return processInvalidUrl(view, url);
@@ -167,7 +167,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         } else {
             Logger.verbose(TAG, "It is pointing to redirect. Final url can be processed to get the code or error.");
             Intent resultIntent = new Intent();
-            resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_FINAL_URL, url);
+            resultIntent.putExtra(AuthenticationConstants.Browser.AUTHORIZATION_FINAL_URL, url);
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_REQUEST_INFO,
                     getRequest());
             getCompletionCallback().onChallengeResponseReceived(

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.embeddedwebview;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.view.MotionEvent;
@@ -59,10 +60,12 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
      * @return generic AuthorizationResult
      */
     public GenericAuthorizationResult requestAuthorization(final GenericAuthorizationRequest request) {
+        Logger.verbose(TAG, "Perform the authorization request with embedded webView.");
         loadStartUrl();
-        // TODO : Add state parameter from the AuthorizationRequest to the Intent parameter like below
-        // intent.putExtra(MicrosoftAuthorizationResult.REQUEST_STATE_PARAMETER, request.getState());
-        throw new UnsupportedOperationException("Not implemented yet.");
+        // requestAuthorization could not return the authorization result
+        // The activity result is set in AuthenticationActivity.setResult()
+        // And AuthenticationActivity in ADAL/MSAL is not moved into common
+        return null;
     }
 
     /**
@@ -84,7 +87,6 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
      * @param webViewClient AzureActiveDirectoryWebViewClient
      */
     private void createWebView(final GenericWebViewClient webViewClient, final WebView webView) {
-        final Activity activity = webViewClient.getActivity();
         // Create the Web View to show the page
         mWebView = webView;
         WebSettings userAgentSetting = mWebView.getSettings();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
@@ -22,9 +22,11 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.embeddedwebview;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
@@ -59,7 +61,7 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
      * @param request authorization request
      * @return generic AuthorizationResult
      */
-    public GenericAuthorizationResult requestAuthorization(final GenericAuthorizationRequest request) {
+    public GenericAuthorizationResult requestAuthorization(@Nullable final GenericAuthorizationRequest request) {
         Logger.verbose(TAG, "Perform the authorization request with embedded webView.");
         loadStartUrl();
         // requestAuthorization could not return the authorization result
@@ -78,7 +80,7 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
     public EmbeddedWebViewAuthorizationStrategy(final GenericWebViewClient webViewClient, final WebView webView)
             throws UnsupportedEncodingException, ClientException {
         //TODO validate auth request in OAuth2Strategy.
-        createWebView(webViewClient, webView);
+        setUpWebView(webViewClient, webView);
         mStartUrl = webViewClient.getRequest().getAuthorizationStartUrl();
     }
 
@@ -86,7 +88,8 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
      * Set up the web view configurations.
      * @param webViewClient AzureActiveDirectoryWebViewClient
      */
-    private void createWebView(final GenericWebViewClient webViewClient, final WebView webView) {
+    @SuppressLint({"SetJavaScriptEnabled", "ClickableViewAccessibility"})
+    private void setUpWebView(final GenericWebViewClient webViewClient, final WebView webView) {
         // Create the Web View to show the page
         mWebView = webView;
         WebSettings userAgentSetting = mWebView.getSettings();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
@@ -26,6 +26,7 @@ import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.view.MotionEvent;
 import android.view.View;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -71,25 +72,25 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
      * @throws UnsupportedEncodingException thrown when the Character Encoding is not supported
      * @throws ClientException throw when error happens during the authorization
      */
-    public EmbeddedWebViewAuthorizationStrategy(final GenericWebViewClient webViewClient)
+    public EmbeddedWebViewAuthorizationStrategy(final GenericWebViewClient webViewClient, final WebView webView)
             throws UnsupportedEncodingException, ClientException {
         //TODO validate auth request in OAuth2Strategy.
-        createWebView(webViewClient);
+        createWebView(webViewClient, webView);
         mStartUrl = webViewClient.getRequest().getAuthorizationStartUrl();
     }
 
     /**
      * Set up the web view configurations.
-     * @param activity  AuthenticationActivity
      * @param webViewClient AzureActiveDirectoryWebViewClient
      */
-    private void createWebView(final GenericWebViewClient webViewClient) {
+    private void createWebView(final GenericWebViewClient webViewClient, final WebView webView) {
         final Activity activity = webViewClient.getActivity();
         // Create the Web View to show the page
-        mWebView = (WebView) activity.findViewById(activity.getResources().getIdentifier("webView1", "id",
-                activity.getPackageName()));
+        mWebView = webView;
+        WebSettings userAgentSetting = mWebView.getSettings();
+        final String userAgent = userAgentSetting.getUserAgentString();
         mWebView.getSettings().setUserAgentString(
-                mWebView.getSettings().getUserAgentString() + AuthenticationConstants.Broker.USER_AGENT_VALUE_PKEY_AUTH);
+                userAgent + AuthenticationConstants.Broker.USER_AGENT_VALUE_PKEY_AUTH);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.requestFocus(View.FOCUS_DOWN);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/challengehandlers/PKeyAuthChallenge.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/challengehandlers/PKeyAuthChallenge.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ClientException;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -12,11 +13,15 @@ import java.util.Map;
 
 import static com.microsoft.identity.common.exception.ErrorStrings.DEVICE_CERTIFICATE_REQUEST_INVALID;
 
-public class PKeyAuthChallenge {
+public class PKeyAuthChallenge implements Serializable {
     /**
      * Certificate authorities are passed with delimiter.
      */
     private static final String CHALLENGE_REQUEST_CERT_AUTH_DELIMITER = ";";
+    /**
+     * Serial version id.
+     */
+    private static final long serialVersionUID = 1035116074451575588L;
 
     private String mNonce = "";
 

--- a/common/src/main/res/layout/http_auth_dialog.xml
+++ b/common/src/main/res/layout/http_auth_dialog.xml
@@ -8,6 +8,7 @@
     android:paddingRight="@dimen/http_auth_dialog_padding_right" >
 
     <EditText
+        android:inputType="text"
         android:id="@+id/editUserName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
* Add default constructor for authorization request
* Add serialVersionUID for auth request.
* Fix the encoding for the auth start url
* Fix the finding webview. As the webview is defined in MSAL.AuthenticationActivity. MSAL should be responsible to find the webview by id and passes it to common's webviewclient.
* Fix the bug where auth code is case-sensitive
* Add null check to PKCE challenge
* Update the constants for auth request.
* Fix the unit tests.
* Fix PMD issue
* Resolve the lint warning
* Rename the createWebView to setUpWebView
* Add javadoc to serialVersionUID