### PR TITLE
to keep only one AuthticationConstants

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/AndroidTestHelper.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/AndroidTestHelper.java
@@ -72,7 +72,7 @@ public class AndroidTestHelper {
         }
         AuthenticationSettings.INSTANCE.setBrokerSignature(mTestTag);
         AuthenticationSettings.INSTANCE
-                .setBrokerPackageName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
+                .setBrokerPackageName(BaseAuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME);
         Log.d(TAG, "mTestSignature is set");
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -25,11 +25,11 @@ package com.microsoft.identity.common.adal.internal;
 /**
  * {@link AuthenticationConstants} contains all the constant value the SDK is using.
  */
-public final class AuthenticationConstants {
+public class AuthenticationConstants {
     /**
-     * Private constructor to prevent an utility class from being initiated.
+     * protected constructor to prevent an utility class from being initiated and make it still inheritable.
      */
-    private AuthenticationConstants() {
+    protected AuthenticationConstants() {
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -43,9 +43,9 @@ public enum AuthenticationSettings {
 
     private AtomicReference<byte[]> mSecretKeyData = new AtomicReference<>();
 
-    private String mBrokerPackageName = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+    private String mBrokerPackageName = BaseAuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 
-    private String mBrokerSignature = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE;
+    private String mBrokerSignature = BaseAuthenticationConstants.Broker.COMPANY_PORTAL_APP_SIGNATURE;
 
     private Class<?> mClazzDeviceCertProxy;
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/BaseAuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/BaseAuthenticationConstants.java
@@ -23,13 +23,13 @@
 package com.microsoft.identity.common.adal.internal;
 
 /**
- * {@link AuthenticationConstants} contains all the constant value the SDK is using.
+ * {@link BaseAuthenticationConstants} contains all the constant value the SDK is using.
  */
-public class AuthenticationConstants {
+public class BaseAuthenticationConstants {
     /**
      * protected constructor to prevent an utility class from being initiated and make it still inheritable.
      */
-    protected AuthenticationConstants() {
+    protected BaseAuthenticationConstants() {
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -30,7 +30,7 @@ import android.security.KeyPairGeneratorSpec;
 import android.util.Base64;
 import android.util.Log;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ErrorStrings;
@@ -175,8 +175,8 @@ public class StorageHelper implements IStorageHelper {
         mHMACKey = getHMacKey(mKey);
 
         Log.v(TAG, "Encrypt version:" + mBlobVersion);
-        final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.ENCODING_UTF8);
-        final byte[] bytes = clearText.getBytes(AuthenticationConstants.ENCODING_UTF8);
+        final byte[] blobVersion = mBlobVersion.getBytes(BaseAuthenticationConstants.ENCODING_UTF8);
+        final byte[] bytes = clearText.getBytes(BaseAuthenticationConstants.ENCODING_UTF8);
 
         // IV: Initialization vector that is needed to start CBC
         final byte[] iv = new byte[DATA_KEY_LENGTH];
@@ -211,7 +211,7 @@ public class StorageHelper implements IStorageHelper {
                 + encrypted.length + iv.length, macDigest.length);
 
         final String encryptedText = new String(Base64.encode(blobVerAndEncryptedDataAndIVAndMacDigest,
-                Base64.NO_WRAP), AuthenticationConstants.ENCODING_UTF8);
+                Base64.NO_WRAP), BaseAuthenticationConstants.ENCODING_UTF8);
         Log.v(TAG, "Finished encryption");
 
         return getEncodeVersionLengthPrefix() + ENCODE_VERSION + encryptedText;
@@ -244,7 +244,7 @@ public class StorageHelper implements IStorageHelper {
         // get key version used for this data. If user upgraded to different
         // API level, data needs to be updated
         final String keyVersion = new String(bytes, 0, KEY_VERSION_BLOB_LENGTH,
-                AuthenticationConstants.ENCODING_UTF8);
+                BaseAuthenticationConstants.ENCODING_UTF8);
         Log.v(TAG, "Encrypt version:" + keyVersion);
 
         final SecretKey secretKey = getKey(keyVersion);
@@ -279,7 +279,7 @@ public class StorageHelper implements IStorageHelper {
 
         // Decrypt data bytes from 0 to ivindex
         final String decrypted = new String(cipher.doFinal(bytes, KEY_VERSION_BLOB_LENGTH,
-                encryptedLength), AuthenticationConstants.ENCODING_UTF8);
+                encryptedLength), BaseAuthenticationConstants.ENCODING_UTF8);
         Log.v(TAG, "Finished decryption");
         return decrypted;
     }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/WebRequestHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/WebRequestHandler.java
@@ -24,7 +24,7 @@ package com.microsoft.identity.common.adal.internal.net;
 
 import android.os.Build;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.io.IOException;
@@ -32,8 +32,8 @@ import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.HeaderField;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.MediaType;
+import static com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants.HeaderField;
+import static com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants.MediaType;
 
 /**
  * It uses one time async task. WebRequest are wrapped here to prevent multiple
@@ -77,14 +77,14 @@ public class WebRequestHandler implements IWebRequestHandler {
     private Map<String, String> updateHeaders(final Map<String, String> headers) {
 
         if (mRequestCorrelationId != null) {
-            headers.put(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, mRequestCorrelationId.toString());
+            headers.put(BaseAuthenticationConstants.AAD.CLIENT_REQUEST_ID, mRequestCorrelationId.toString());
         }
 
-        headers.put(AuthenticationConstants.AAD.ADAL_ID_PLATFORM, "Android");
+        headers.put(BaseAuthenticationConstants.AAD.ADAL_ID_PLATFORM, "Android");
         // TODO don't make this dependency circular
-        headers.put(AuthenticationConstants.AAD.ADAL_ID_VERSION, mCurrentClientVersion);
-        headers.put(AuthenticationConstants.AAD.ADAL_ID_OS_VER, "" + Build.VERSION.SDK_INT);
-        headers.put(AuthenticationConstants.AAD.ADAL_ID_DM, android.os.Build.MODEL);
+        headers.put(BaseAuthenticationConstants.AAD.ADAL_ID_VERSION, mCurrentClientVersion);
+        headers.put(BaseAuthenticationConstants.AAD.ADAL_ID_OS_VER, "" + Build.VERSION.SDK_INT);
+        headers.put(BaseAuthenticationConstants.AAD.ADAL_ID_DM, android.os.Build.MODEL);
 
         return headers;
     }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
@@ -26,7 +26,7 @@ import android.net.Uri;
 import android.util.Base64;
 import android.util.Log;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants;
 import com.microsoft.identity.common.exception.ErrorStrings;
 
 import java.io.UnsupportedEncodingException;
@@ -78,9 +78,9 @@ public final class StringExtensions {
             UnsupportedEncodingException {
         if (!isNullOrBlank(msg)) {
             MessageDigest digester = MessageDigest.getInstance(TOKEN_HASH_ALGORITHM);
-            final byte[] msgInBytes = msg.getBytes(AuthenticationConstants.ENCODING_UTF8);
+            final byte[] msgInBytes = msg.getBytes(BaseAuthenticationConstants.ENCODING_UTF8);
             return new String(Base64.encode(digester.digest(msgInBytes), Base64.NO_WRAP),
-                    AuthenticationConstants.ENCODING_UTF8);
+                    BaseAuthenticationConstants.ENCODING_UTF8);
         }
         return msg;
     }
@@ -120,7 +120,7 @@ public final class StringExtensions {
             throws UnsupportedEncodingException {
         return new String(
                 Base64.encode(bytes, Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE),
-                AuthenticationConstants.ENCODING_UTF8);
+                BaseAuthenticationConstants.ENCODING_UTF8);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -30,7 +30,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
 import android.util.Base64;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
@@ -118,7 +118,7 @@ public class BrokerValidator {
             // Check the hash for signer cert is the same as what we hardcoded.
             final String signatureHash = Base64.encodeToString(messageDigest.digest(), Base64.NO_WRAP);
             if (mCompanyPortalSignature.equals(signatureHash)
-                    || AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_SIGNATURE.equals(signatureHash)) {
+                    || BaseAuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_SIGNATURE.equals(signatureHash)) {
                 return;
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.logging;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.BaseAuthenticationConstants;
 
 public final class DiagnosticContext {
 
@@ -36,7 +36,7 @@ public final class DiagnosticContext {
                 @Override // This is the default value for the RequestContext if it's unset
                 protected RequestContext initialValue() {
                     final RequestContext defaultRequestContext = new RequestContext();
-                    defaultRequestContext.put(AuthenticationConstants.AAD.CORRELATION_ID, "UNSET");
+                    defaultRequestContext.put(BaseAuthenticationConstants.AAD.CORRELATION_ID, "UNSET");
                     return defaultRequestContext;
                 }
             };


### PR DESCRIPTION
to keep only one AuthticationConstants, make the one in ADAL inherit from the one in common-core, so updating the common-core Authentication to non-final class with protected ctor for subclass to inherit