### PR TITLE
Making constructor public so that ADAL can call it

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -32,7 +32,7 @@ import java.util.List;
  * as a service is available in multiple clouds.  World wide is the default; however their are sovereign clouds
  * available for Germany, China, etc....
  */
-public class git commAzureActiveDirectoryCloud {
+public class AzureActiveDirectoryCloud {
 
     @SerializedName("preferred_network")
     private final String mPreferredNetworkHostName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -32,7 +32,7 @@ import java.util.List;
  * as a service is available in multiple clouds.  World wide is the default; however their are sovereign clouds
  * available for Germany, China, etc....
  */
-public class AzureActiveDirectoryCloud {
+public class git commAzureActiveDirectoryCloud {
 
     @SerializedName("preferred_network")
     private final String mPreferredNetworkHostName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -45,7 +45,7 @@ public class AzureActiveDirectoryCloud {
 
     private boolean mIsValidated;
 
-    AzureActiveDirectoryCloud(boolean isValidated) {
+    public AzureActiveDirectoryCloud(boolean isValidated) {
         mIsValidated = isValidated;
 
         mPreferredNetworkHostName = null;


### PR DESCRIPTION
Making constructor for AzureActiveDirectoryCloud public so that it can be called from ADAL.