### PR TITLE
Update version to 0.0.3-RC1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 0.0.1
+Version 0.0.3
 --------------
 - First release: Hello, World!
 - Implementation of new unified cache schema

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
-        versionName "0.0.2"
+        versionName "0.0.3-RC1"
         project.archivesBaseName = "common"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Incorporates fixes from
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/179
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/181

Updates changelog
Revs version to `0.0.3-RC1` (cannot use `0.0.2`, as this name was used to publish to the VSTS maven stream)