### PR TITLE
Introduces generic return & arg types to Future/controller api

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.microsoft.activedirectoryfederationservices;
 
-import android.net.Uri;
-
 import com.microsoft.identity.common.Account;
 import com.microsoft.identity.common.internal.net.HttpResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.AccessToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.net.HttpResponse;
 import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftTokenErrorResponse;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
@@ -47,6 +48,7 @@ public class AzureActiveDirectoryOAuth2Strategy
         AzureActiveDirectoryAccessToken,
         AzureActiveDirectoryAccount,
         AzureActiveDirectoryAuthorizationRequest,
+        AuthorizationResponse,
         AuthorizationStrategy,
         AzureActiveDirectoryOAuth2Configuration,
         AzureActiveDirectoryRefreshToken,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftToken
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
@@ -48,6 +49,7 @@ public class MicrosoftStsOAuth2Strategy
         <MicrosoftStsAccessToken,
                 MicrosoftStsAccount,
                 MicrosoftStsAuthorizationRequest,
+                AuthorizationResponse,
                 AuthorizationStrategy,
                 MicrosoftStsOAuth2Configuration,
                 MicrosoftStsRefreshToken,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationResultFuture.java
@@ -6,10 +6,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class AuthorizationResultFuture implements Future<AuthorizationResult> {
+public class AuthorizationResultFuture<GenericAuthorizationResult extends AuthorizationResult> implements Future<GenericAuthorizationResult> {
 
     private final CountDownLatch mCountDownLatch = new CountDownLatch(1);
-    private AuthorizationResult mAuthorizationResult;
+    private GenericAuthorizationResult mAuthorizationResult;
 
     @Override
     public boolean cancel(boolean b) {
@@ -27,22 +27,22 @@ public class AuthorizationResultFuture implements Future<AuthorizationResult> {
     }
 
     @Override
-    public AuthorizationResult get() throws InterruptedException, ExecutionException {
+    public GenericAuthorizationResult get() throws InterruptedException, ExecutionException {
         mCountDownLatch.await();
         return mAuthorizationResult;
     }
 
     @Override
-    public AuthorizationResult get(long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
-        if(mCountDownLatch.await(l, timeUnit)){
+    public GenericAuthorizationResult get(long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (mCountDownLatch.await(l, timeUnit)) {
             return mAuthorizationResult;
-        }else {
+        } else {
             throw new TimeoutException();
         }
 
     }
 
-    public void setAuthorizationResult(AuthorizationResult result){
+    public void setAuthorizationResult(GenericAuthorizationResult result) {
         mAuthorizationResult = result;
         mCountDownLatch.countDown();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
@@ -32,15 +32,15 @@ import java.util.concurrent.Future;
  * and/or authentication information (OIDC)
  * Possible implementations include: EmbeddedWebViewAuthorizationStrategy, SystemWebViewAuthorizationStrategy, Device Code, etc...
  */
-public abstract class AuthorizationStrategy <GenericAuthorizationRequest extends AuthorizationRequest,
-                                             GenericAuthorizationResult extends AuthorizationResult> {
+public abstract class AuthorizationStrategy<GenericAuthorizationRequest extends AuthorizationRequest,
+        GenericAuthorizationResult extends AuthorizationResult> {
     /**
      * Perform the authorization request.
      *
      * @param request authorization request
      * @return AuthorizationResult
      */
-    public abstract Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request) throws UnsupportedEncodingException;
+    public abstract Future<GenericAuthorizationResult> requestAuthorization(GenericAuthorizationRequest request) throws UnsupportedEncodingException;
 
     public abstract void completeAuthorization(int requestCode, int resultCode, final Intent data);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -46,6 +46,7 @@ public abstract class OAuth2Strategy
         <GenericAccessToken extends AccessToken,
                 GenericAccount extends Account,
                 GenericAuthorizationRequest extends AuthorizationRequest,
+                GenericAuthorizationResponse extends AuthorizationResponse,
                 GenericAuthorizationStrategy extends AuthorizationStrategy,
                 GenericOAuth2Configuration extends OAuth2Configuration,
                 GenericRefreshToken extends RefreshToken,
@@ -74,12 +75,12 @@ public abstract class OAuth2Strategy
      * @param authorizationStrategy generic authorization strategy.
      * @return GenericAuthorizationResponse
      */
-    public Future<AuthorizationResult> requestAuthorization(
+    public Future<GenericAuthorizationResponse> requestAuthorization(
             final GenericAuthorizationRequest request,
             final GenericAuthorizationStrategy authorizationStrategy) {
         validateAuthorizationRequest(request);
 
-        Future<AuthorizationResult> future = null;
+        Future<GenericAuthorizationResponse> future = null;
 
         try {
             future = authorizationStrategy.requestAuthorization(request); //NOPMD Suppressing PMD warning for unused variable

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/embeddedwebview/EmbeddedWebViewAuthorizationStrategy.java
@@ -23,11 +23,7 @@
 package com.microsoft.identity.common.internal.ui.embeddedwebview;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
@@ -48,7 +44,7 @@ import java.util.concurrent.Future;
 /**
  * Serve as a class to do the OAuth2 auth code grant flow with Android embedded web view.
  */
-public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends OAuth2WebViewClient,
+public class EmbeddedWebViewAuthorizationStrategy<GenericWebViewClient extends OAuth2WebViewClient,
         GenericAuthorizationRequest extends AuthorizationRequest,
         GenericAuthorizationResult extends AuthorizationResult>
         extends AuthorizationStrategy<GenericAuthorizationRequest, GenericAuthorizationResult> {
@@ -56,14 +52,14 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
     private static final String TAG = StringExtensions.class.getSimpleName();
     private WebView mWebView;
     private String mStartUrl;
-    private AuthorizationResultFuture mFuture;
+    private AuthorizationResultFuture<GenericAuthorizationResult> mFuture;
 
     /**
      * Constructor of EmbeddedWebViewAuthorizationStrategy.
      *
      * @param webViewClient Generic WebViewClient
      * @throws UnsupportedEncodingException thrown when the Character Encoding is not supported
-     * @throws ClientException throw when error happens during the authorization
+     * @throws ClientException              throw when error happens during the authorization
      */
     public EmbeddedWebViewAuthorizationStrategy(final GenericWebViewClient webViewClient, final WebView webView)
             throws UnsupportedEncodingException, ClientException {
@@ -74,6 +70,7 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
 
     /**
      * Set up the web view configurations.
+     *
      * @param webViewClient AzureActiveDirectoryWebViewClient
      */
     @SuppressLint({"SetJavaScriptEnabled", "ClickableViewAccessibility"})
@@ -124,7 +121,7 @@ public class EmbeddedWebViewAuthorizationStrategy <GenericWebViewClient extends 
     }
 
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request) throws UnsupportedEncodingException {
+    public Future<GenericAuthorizationResult> requestAuthorization(GenericAuthorizationRequest request) {
 
 
         Logger.verbose(TAG, "Perform the authorization request with embedded webView.");


### PR DESCRIPTION
`Futures` can now return a specific subclass (or not) of `AuthorizationResult`.