### PR TITLE
First draft api for OAuth2TokenCache extensions

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.common.adal.internal.cache.CacheKey;
 import com.microsoft.identity.common.adal.internal.cache.DateTimeAdapter;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.dto.Credential;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
@@ -56,6 +57,7 @@ import java.util.List;
 public class ADALOAuth2TokenCache
         extends OAuth2TokenCache<AzureActiveDirectoryOAuth2Strategy, AzureActiveDirectoryAuthorizationRequest, AzureActiveDirectoryTokenResponse>
         implements IShareSingleSignOnState {
+    private static final String ERR_UNSUPPORTED_OPERATION = "This method is unsupported by the ADALOAuth2TokenCache";
     private ISharedPreferencesFileManager mISharedPreferencesFileManager;
 
     private static final String TAG = ADALOAuth2TokenCache.class.getSimpleName();
@@ -115,7 +117,7 @@ public class ADALOAuth2TokenCache
      * @param response
      */
     @Override
-    public void saveTokens(
+    public ISaveTokenResult saveTokens(
             final AzureActiveDirectoryOAuth2Strategy strategy,
             final AzureActiveDirectoryAuthorizationRequest request,
             final AzureActiveDirectoryTokenResponse response) {
@@ -155,6 +157,22 @@ public class ADALOAuth2TokenCache
         for (final IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken> sharedSsoCache : mSharedSSOCaches) {
             sharedSsoCache.setSingleSignOnState(account, refreshToken);
         }
+
+        return null; // Returning null, since the ADAL cache's schema doesn't support this return type.
+    }
+
+    @Override
+    public ISaveTokenResult loadTokens(com.microsoft.identity.common.internal.dto.Account account) {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
+    }
+
+    @Override
+    public boolean removeCredential(Credential credential) {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
     }
 
     @Override
@@ -162,7 +180,7 @@ public class ADALOAuth2TokenCache
                                                                          final String clientId,
                                                                          final String homeAccountId) {
         throw new UnsupportedOperationException(
-                "This method is unsupported by the ADALOAuth2TokenCache"
+                ERR_UNSUPPORTED_OPERATION
         );
     }
 
@@ -170,7 +188,7 @@ public class ADALOAuth2TokenCache
     public List<com.microsoft.identity.common.internal.dto.Account> getAccounts(final String environment,
                                                                                 final String clientId) {
         throw new UnsupportedOperationException(
-                "This method is unsupported by the ADALOAuth2TokenCache"
+                ERR_UNSUPPORTED_OPERATION
         );
     }
 
@@ -179,7 +197,7 @@ public class ADALOAuth2TokenCache
                                  final String clientId,
                                  final String homeAccountId) {
         throw new UnsupportedOperationException(
-                "This method is unsupported by the ADALOAuth2TokenCache"
+                ERR_UNSUPPORTED_OPERATION
         );
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ISaveTokenResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ISaveTokenResult.java
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import com.microsoft.identity.common.internal.dto.AccessToken;
+import com.microsoft.identity.common.internal.dto.Account;
+import com.microsoft.identity.common.internal.dto.IdToken;
+import com.microsoft.identity.common.internal.dto.RefreshToken;
+
+/**
+ * Result container for Account and Credential - usually the result of a save or load operation.
+ */
+public interface ISaveTokenResult {
+
+    /**
+     * Gets the {@link Account}.
+     *
+     * @return The Account to get.
+     */
+    Account getAccount();
+
+    /**
+     * Gets the {@link AccessToken}.
+     *
+     * @return The AccessToken to get.
+     */
+    AccessToken getAccessToken();
+
+    /**
+     * Gets the {@link RefreshToken}.
+     *
+     * @return The RefreshToken to get.
+     */
+    RefreshToken getRefreshToken();
+
+    /**
+     * Gets the {@link IdToken}.
+     *
+     * @return The IdToken to get.
+     */
+    IdToken getIdToken();
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -113,7 +113,7 @@ public class MsalOAuth2TokenCache
     }
 
     @Override
-    public void saveTokens(
+    public ISaveTokenResult saveTokens(
             final MicrosoftStsOAuth2Strategy oAuth2Strategy,
             final MicrosoftStsAuthorizationRequest request,
             final MicrosoftStsTokenResponse response) throws ClientException {
@@ -160,6 +160,26 @@ public class MsalOAuth2TokenCache
         // Save the Account and Credentials...
         saveAccounts(accountToSave);
         saveCredentials(accessTokenToSave, refreshTokenToSave, idTokenToSave);
+
+        final SaveTokenResult result = new SaveTokenResult();
+        result.setAccount(accountToSave);
+        result.setAccessToken(accessTokenToSave);
+        result.setRefreshToken(refreshTokenToSave);
+        result.setIdToken(idTokenToSave);
+
+        return result;
+    }
+
+    @Override
+    public ISaveTokenResult loadTokens(Account account) {
+        // TODO
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public boolean removeCredential(Credential credential) {
+        // TODO
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SaveTokenResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SaveTokenResult.java
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import com.microsoft.identity.common.internal.dto.AccessToken;
+import com.microsoft.identity.common.internal.dto.Account;
+import com.microsoft.identity.common.internal.dto.IdToken;
+import com.microsoft.identity.common.internal.dto.RefreshToken;
+
+class SaveTokenResult implements ISaveTokenResult {
+
+    private Account mAccount;
+    private AccessToken mAccessToken;
+    private RefreshToken mRefreshToken;
+    private IdToken mIdToken;
+
+    void setAccount(final Account account) {
+        mAccount = account;
+    }
+
+    @Override
+    public Account getAccount() {
+        return mAccount;
+    }
+
+    void setAccessToken(final AccessToken accesToken) {
+        mAccessToken = accesToken;
+    }
+
+    @Override
+    public AccessToken getAccessToken() {
+        return mAccessToken;
+    }
+
+    void setRefreshToken(final RefreshToken refreshToken) {
+        mRefreshToken = refreshToken;
+    }
+
+    @Override
+    public RefreshToken getRefreshToken() {
+        return mRefreshToken;
+    }
+
+    void setIdToken(final IdToken idToken) {
+        mIdToken = idToken;
+    }
+
+    @Override
+    public IdToken getIdToken() {
+        return mIdToken;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -25,7 +25,9 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 import android.content.Context;
 
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.cache.ISaveTokenResult;
 import com.microsoft.identity.common.internal.dto.Account;
+import com.microsoft.identity.common.internal.dto.Credential;
 
 import java.util.List;
 
@@ -52,11 +54,28 @@ public abstract class OAuth2TokenCache
      * @param oAuth2Strategy The strategy used to create the token request.
      * @param request        The request used to acquire tokens and credentials.
      * @param response       The response received from the IdP/STS.
+     * @return The {@link ISaveTokenResult} containing the Account + Credentials saved to the cache.
      * @throws ClientException If tokens cannot be successfully saved.
      */
-    public abstract void saveTokens(final T oAuth2Strategy,
-                                    final U request,
-                                    final V response) throws ClientException;
+    public abstract ISaveTokenResult saveTokens(final T oAuth2Strategy,
+                                                final U request,
+                                                final V response) throws ClientException;
+
+    /**
+     * Loads the tokens for the supplied Account into the result {@link ISaveTokenResult}.
+     *
+     * @param account The Account whose Credentials should be loaded.
+     * @return The resulting ISaveTokenResult. Entries may be empty if not present in the cache.
+     */
+    public abstract ISaveTokenResult loadTokens(final Account account);
+
+    /**
+     * Removes the supplied Credential from the cache.
+     *
+     * @param credential The Credential to remove.
+     * @return True, if the Credential was removed. False otherwise.
+     */
+    public abstract boolean removeCredential(final Credential credential);
 
     /**
      * Returns the IAccount matching the supplied criteria.
@@ -92,6 +111,11 @@ public abstract class OAuth2TokenCache
                                           final String clientId,
                                           final String homeAccountId);
 
+    /**
+     * Gets the Context used to initialize this OAuth2TokenCache.
+     *
+     * @return The Context.
+     */
     protected final Context getContext() {
         return mContext;
     }


### PR DESCRIPTION
Extensions for the `OAuth2TokenCache` interface to support cool new stuff like:

- Get out of the cache exactly what goes in when tokens are saved
- Get the `AccessToken`, `RefreshToken`, and `Idtoken` of a supplied `Account`
- Delete a provided `Credential` (This functionality already exists, but is only exposed through `IAccountCredentialCache`)