### PR TITLE
Implements isExpired() for access tokens

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessToken.java
@@ -23,6 +23,10 @@
 package com.microsoft.identity.common.internal.dto;
 
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
+
+import java.util.Calendar;
+import java.util.Date;
 
 import static com.microsoft.identity.common.internal.dto.AccessToken.SerializedNames.ACCESS_TOKEN_TYPE;
 import static com.microsoft.identity.common.internal.dto.AccessToken.SerializedNames.AUTHORITY;
@@ -240,5 +244,17 @@ public class AccessToken extends Credential {
      */
     public void setExpiresOn(final String expiresOn) {
         mExpiresOn = expiresOn;
+    }
+
+    @Override
+    public boolean isExpired() {
+        // Init a Calendar for the current time/date
+        final Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, AuthenticationSettings.INSTANCE.getExpirationBuffer());
+        final Date validity = calendar.getTime();
+        // Init a Date for the accessToken's expiry
+        long epoch = Long.valueOf(getExpiresOn());
+        final Date expiresOn = new Date(epoch * 1000);
+        return expiresOn.before(validity);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/Credential.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/Credential.java
@@ -230,6 +230,13 @@ public abstract class Credential extends AccountCredentialBase {
         mCachedAt = cachedAt;
     }
 
+    /**
+     * Checks if the current Credentials is expired.
+     *
+     * @return True, if expired. False otherwise.
+     */
+    public abstract boolean isExpired();
+
     //CHECKSTYLE:OFF
     // This method is generated. Checkstyle and/or PMD has been disabled.
     // This method *must* be regenerated if the class' structural definition changes through the

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/IdToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/IdToken.java
@@ -88,6 +88,11 @@ public class IdToken extends Credential {
         mRealm = realm;
     }
 
+    @Override
+    public boolean isExpired() {
+        return false;
+    }
+
     //CHECKSTYLE:OFF
     // This method is generated. Checkstyle and/or PMD has been disabled.
     // This method *must* be regenerated if the class' structural definition changes through the

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshToken.java
@@ -121,6 +121,11 @@ public class RefreshToken extends Credential {
         mFamilyId = familyId;
     }
 
+    @Override
+    public boolean isExpired() {
+        return false;
+    }
+
     //CHECKSTYLE:OFF
     // This method is generated. Checkstyle and/or PMD has been disabled.
     // This method *must* be regenerated if the class' structural definition changes through the


### PR DESCRIPTION
Matches the [soon-to-be-removed implementation in `AccessTokenCacheItem`](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/cache/java/com/microsoft/identity/client/AccessTokenCacheItem.java#L133-L143).

Credential types other than AT return `false`, as expiry is not tracked for these types.