### PR TITLE
Added a new error string for socket timeout

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -56,6 +56,11 @@ public final class ErrorStrings {
     public static final String IO_ERROR = "io_error";
 
     /**
+     * SocketTimeoutException happened, connection flow timed out, stalled or broken.
+     */
+    public static final String SOCKET_TIMEOUT = "socket_timeout";
+
+    /**
      * The url is malformed.  Likely caused when constructing the auth request, authority, or redirect URI.
      */
     public static final String MALFORMED_URL = "malformed_url";


### PR DESCRIPTION
String required for this PR in ADAL : https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1296