### PR TITLE
Token endpoint authority and PPE support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 0.0.4
 --------------
+Add authority AzureActiveDirectoryOAuth2 Configuration and Strategy for Sovereign and PPE cloud support.
 Fix for PPE Null Cloud when discovery metadata is malformed.
 
 Version 0.0.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 0.0.4
+--------------
+Fix for PPE Null Cloud when discovery metadata is malformed.
+
 Version 0.0.3
 --------------
 - First release: Hello, World!

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
-        versionName "0.0.3"
+        versionName "0.0.4-cp"
         project.archivesBaseName = "common"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,7 +16,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
-        versionName "0.0.4-cp"
+        versionName "0.0.4-RC"
         project.archivesBaseName = "common"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Configuration.java
@@ -24,7 +24,12 @@ package com.microsoft.identity.common.internal.providers.microsoft.azureactivedi
 
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Configuration;
 
+import java.net.URL;
+
 public class AzureActiveDirectoryOAuth2Configuration extends OAuth2Configuration {
+
+    private boolean mAuthorityHostValidationEnabled = true;
+    private URL mAuthorityUrl;
 
     /**
      * @return True if authority host validation enabled, false otherwise.
@@ -40,21 +45,17 @@ public class AzureActiveDirectoryOAuth2Configuration extends OAuth2Configuration
         mAuthorityHostValidationEnabled = authorityHostValidationEnabled;
     }
 
-    private boolean mAuthorityHostValidationEnabled = true;
-
     /**
-     * @return The authority if configured, empty string otherwise.
+     * @return The authority URL if configured, null otherwise.
      */
-    public String getAuthority() {
-        return mAuthority;
+    public URL getAuthorityUrl() {
+        return this.mAuthorityUrl;
     }
     
     /**
-     * Sets an authority to use as a base for URIs as appropriate.
+     * Sets an authority URL to use for URIs as appropriate.
      */
-    public void setAuthority(String authority) {
-        mAuthority = authority;
+    public void setAuthorityUrl(URL authorityUrl) {
+        this.mAuthorityUrl = authorityUrl;
     }
-    
-    private String mAuthority = "";
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -74,11 +74,21 @@ public class AzureActiveDirectoryOAuth2Strategy
         final String methodName = "getIssuerCacheIdentifier";
 
         final AzureActiveDirectoryCloud cloud = AzureActiveDirectory.getAzureActiveDirectoryCloud(authRequest.getAuthority());
+        if (cloud == null && !getOAuth2Configuration().isAuthorityHostValidationEnabled()) {
+            Logger.warn(TAG + ":" + methodName, "Discovery data does not include cloud authority and validation is off."
+                + " Returning passed in Authority: "
+                + authRequest.getAuthority().toString());
+            return authRequest.getAuthority().toString();
+        }
 
         if (!cloud.isValidated() && getOAuth2Configuration().isAuthorityHostValidationEnabled()) {
             Logger.warn(TAG + ":" + methodName, "Authority host validation has been enabled. This data hasn't been validated, though.");
             // We have invalid cloud data... and authority host validation is enabled....
             // TODO: Throw an exception in this case... need to see what ADAL does in this case.
+            // If Cloud is null, e.g. Authority is PPE and AAD PE doesn't include it in the discovery data, this will similarly throw:
+            // java.lang.NullPointerException: Attempt to invoke virtual method
+            // 'boolean com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.isValidated()'
+            // on a null object reference
         }
 
         if (!cloud.isValidated() && !getOAuth2Configuration().isAuthorityHostValidationEnabled()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -67,10 +67,10 @@ public class AzureActiveDirectoryOAuth2Strategy
     public AzureActiveDirectoryOAuth2Strategy(final AzureActiveDirectoryOAuth2Configuration config) {
         super(config);
         Logger.verbose(TAG, "Init: " + TAG);
-        if (TextUtils.isEmpty(config.getAuthority())) {
-            setTokenEndpoint("https://login.microsoftonline.com/microsoft.com/oauth2/token");
+        if (null != config.getAuthorityUrl()) {
+            setTokenEndpoint(config.getAuthorityUrl().toString() + "/oauth2/token");
         } else {
-            setTokenEndpoint(config.getAuthority() + "/oauth2/token");
+            setTokenEndpoint("https://login.microsoftonline.com/microsoft.com/oauth2/token");
         }
     }
 


### PR DESCRIPTION
Updating version to 0.0.4-RC
Adding Token Endpoint Authority configuration support for Sovereign Clouds and PPE
Adding support for null cloud from AAD discovery with authority validation disabled