### PR TITLE
Adds support for MRRTs in common cache on v1/v2 endpoints

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 import com.microsoft.identity.common.internal.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
@@ -153,6 +154,10 @@ public class MsalOAuth2TokenCache
     public ICacheRecord load(@NonNull final String clientId,
                              @Nullable final String target,
                              @NonNull final AccountRecord account) {
+        final boolean isMultiResourceCapable = MicrosoftAccount.AUTHORITY_TYPE_V1_V2.equals(
+                account.getAuthorityType()
+        );
+
         // Load the AccessTokens
         final List<Credential> accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
                 account.getHomeAccountId(),
@@ -169,8 +174,12 @@ public class MsalOAuth2TokenCache
                 account.getEnvironment(),
                 CredentialType.RefreshToken,
                 clientId,
-                account.getRealm(),
-                target
+                isMultiResourceCapable
+                        ? null // wildcard (*)
+                        : account.getRealm(),
+                isMultiResourceCapable
+                        ? null // wildcard (*)
+                        : target
         );
 
         // Load the IdTokens

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -105,7 +106,7 @@ public class ActiveDirectoryFederationServices2012R2OAuth2Strategy extends OAuth
     }
 
     @Override
-    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken) {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken, List scopes) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -102,7 +103,7 @@ public class ActiveDirectoryFederationServices2016OAuth2Strategy extends OAuth2S
     }
 
     @Override
-    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken) {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken, List scopes) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
 
 import java.net.HttpURLConnection;
+import java.util.List;
 
 /**
  * The Azure Active Directory OAuth 2.0 Strategy.
@@ -207,7 +208,7 @@ public class AzureActiveDirectoryOAuth2Strategy
     }
 
     @Override
-    public AzureActiveDirectoryTokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken) {
+    public AzureActiveDirectoryTokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken, List<String> scopes) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
 
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -104,7 +105,7 @@ public class AzureActiveDirectoryB2COAuth2Strategy extends OAuth2Strategy {
 
 
     @Override
-    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken) {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRecord refreshToken, List scopes) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -44,9 +44,11 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenErrorRespons
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.List;
 
 public class MicrosoftStsOAuth2Strategy
         extends OAuth2Strategy
@@ -166,10 +168,12 @@ public class MicrosoftStsOAuth2Strategy
     }
 
     @Override
-    public MicrosoftStsTokenRequest createRefreshTokenRequest(@NonNull final RefreshTokenRecord refreshToken) {
+    public MicrosoftStsTokenRequest createRefreshTokenRequest(@NonNull final RefreshTokenRecord refreshToken,
+                                                              @NonNull final List<String> scopes) {
         final MicrosoftStsTokenRequest request = new MicrosoftStsTokenRequest();
         request.setRefreshToken(refreshToken.getSecret());
         request.setGrantType(TokenRequest.GrantTypes.REFRESH_TOKEN);
+        request.setScope(StringUtil.join(' ', scopes));
         return request;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.internal.platform.Device;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -204,7 +205,7 @@ public abstract class OAuth2Strategy
      * @param refreshToken The refresh token to use.
      * @return TokenRequest.
      */
-    public abstract GenericTokenRequest createRefreshTokenRequest(final RefreshTokenRecord refreshToken);
+    public abstract GenericTokenRequest createRefreshTokenRequest(final RefreshTokenRecord refreshToken, final List<String> scopes);
 
     /**
      * Abstract method for validating the authorization request.  In the case of AAD this is the method


### PR DESCRIPTION
Also updates the save() logic to delete RTs for the current account if there are some already in the cache.