### PR TITLE
[B2C] Workaround for "realm" and "username" missing in IdToken

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
@@ -59,7 +59,7 @@ public class MicrosoftStsAuthorizationRequestTests {
     private static final String DEFAULT_TEST_DISPLAYABLEID = "user@contoso.com";
     private static final String DEFAULT_TEST_SLICE_PARAMETER = "slice=myslice";
     private static final String DEFAULT_TEST_AUTHORITY_STRING = "https://login.microsoftonline.com/common";
-    private static final String DEFAULT_TEST_LIBRARY_NAME = "MSAL.Android";
+    private static final String DEFAULT_TEST_LIBRARY_NAME = "Test.Android";
 
     static URL getValidRequestUrl() throws MalformedURLException {
         return new URL(DEFAULT_TEST_AUTHORITY_STRING);
@@ -73,8 +73,9 @@ public class MicrosoftStsAuthorizationRequestTests {
                 .setAuthority(getValidRequestUrl())
                 .setScope(DEFAULT_TEST_SCOPE)
                 .setLoginHint(DEFAULT_TEST_LOGIN_HINT)
-                .setCorrelationId(DEFAULT_TEST_CORRELATION_ID);
-
+                .setCorrelationId(DEFAULT_TEST_CORRELATION_ID)
+                .setLibraryVersion(DEFAULT_TEST_VERSION)
+                .setLibraryName(DEFAULT_TEST_LIBRARY_NAME);
     }
 
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
@@ -52,7 +52,7 @@ public class MicrosoftStsAuthorizationRequestTests {
         add(new Pair<>("extra", "1"));
         add(new Pair<>("haschrome", "1"));
     }};
-    private static final String DEFAULT_TEST_VERSION = "0.2.0";
+    private static final String DEFAULT_TEST_VERSION = "test.version";
     private static final String DEFAULT_TEST_PROMPT = MicrosoftStsAuthorizationRequest.Prompt.CONSENT;
     private static final String DEFAULT_TEST_UID = "1";
     private static final String DEFAULT_TEST_UTID = "1234-5678-90abcdefg";

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
@@ -52,14 +52,12 @@ public class MicrosoftStsAuthorizationRequestTests {
         add(new Pair<>("extra", "1"));
         add(new Pair<>("haschrome", "1"));
     }};
-    private static final String DEFAULT_TEST_VERSION = "test.version";
     private static final String DEFAULT_TEST_PROMPT = MicrosoftStsAuthorizationRequest.Prompt.CONSENT;
     private static final String DEFAULT_TEST_UID = "1";
     private static final String DEFAULT_TEST_UTID = "1234-5678-90abcdefg";
     private static final String DEFAULT_TEST_DISPLAYABLEID = "user@contoso.com";
     private static final String DEFAULT_TEST_SLICE_PARAMETER = "slice=myslice";
     private static final String DEFAULT_TEST_AUTHORITY_STRING = "https://login.microsoftonline.com/common";
-    private static final String DEFAULT_TEST_LIBRARY_NAME = "Test.Android";
 
     static URL getValidRequestUrl() throws MalformedURLException {
         return new URL(DEFAULT_TEST_AUTHORITY_STRING);
@@ -73,9 +71,7 @@ public class MicrosoftStsAuthorizationRequestTests {
                 .setAuthority(getValidRequestUrl())
                 .setScope(DEFAULT_TEST_SCOPE)
                 .setLoginHint(DEFAULT_TEST_LOGIN_HINT)
-                .setCorrelationId(DEFAULT_TEST_CORRELATION_ID)
-                .setLibraryVersion(DEFAULT_TEST_VERSION)
-                .setLibraryName(DEFAULT_TEST_LIBRARY_NAME);
+                .setCorrelationId(DEFAULT_TEST_CORRELATION_ID);
     }
 
 
@@ -88,7 +84,6 @@ public class MicrosoftStsAuthorizationRequestTests {
         assertTrue("Matching login hint", actualCodeRequestUrlWithLoginHint.contains("login_hint=" + DEFAULT_TEST_LOGIN_HINT));
         assertTrue("Matching response type", actualCodeRequestUrlWithLoginHint.contains("response_type=code"));
         assertTrue("Matching correlation id", actualCodeRequestUrlWithLoginHint.contains("&client-request-id=" + DEFAULT_TEST_CORRELATION_ID.toString()));
-        assertTrue("Matching library version", actualCodeRequestUrlWithLoginHint.contains("&x-client-Ver=" + DEFAULT_TEST_VERSION));
 
     }
 
@@ -112,10 +107,6 @@ public class MicrosoftStsAuthorizationRequestTests {
 
         final String actualCodeRequestUrl = request.getAuthorizationRequestAsHttpRequest().toString();
         assertTrue("Prompt", actualCodeRequestUrl.contains("&prompt=" + MicrosoftStsAuthorizationRequest.Prompt.SELECT_ACCOUNT));
-        assertTrue("Matching message",
-                actualCodeRequestUrl.contains("&x-client-SKU=" + DEFAULT_TEST_LIBRARY_NAME));
-        assertTrue("Matching message",
-                actualCodeRequestUrl.contains("&x-client-Ver=" + DEFAULT_TEST_VERSION));
     }
 
     @Test

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationRequestTests.java
@@ -52,7 +52,7 @@ public class MicrosoftStsAuthorizationRequestTests {
         add(new Pair<>("extra", "1"));
         add(new Pair<>("haschrome", "1"));
     }};
-    private static final String DEFAULT_TEST_VERSION = "0.1.3";
+    private static final String DEFAULT_TEST_VERSION = "0.2.0";
     private static final String DEFAULT_TEST_PROMPT = MicrosoftStsAuthorizationRequest.Prompt.CONSENT;
     private static final String DEFAULT_TEST_UID = "1";
     private static final String DEFAULT_TEST_UTID = "1234-5678-90abcdefg";

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -682,7 +682,8 @@ public class MsalOAuth2TokenCache
                 {AccountRecord.SerializedNames.ENVIRONMENT, account.getEnvironment()},
                 {AccountRecord.SerializedNames.REALM, account.getRealm()},
                 {AccountRecord.SerializedNames.LOCAL_ACCOUNT_ID, account.getLocalAccountId()},
-                {AccountRecord.SerializedNames.USERNAME, account.getUsername()},
+                //TODO MSA server side will fix the bug where username is not returned in the id token.
+                //{AccountRecord.SerializedNames.USERNAME, account.getUsername()},
                 {AccountRecord.SerializedNames.AUTHORITY_TYPE, account.getAuthorityType()},
         };
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -682,8 +682,6 @@ public class MsalOAuth2TokenCache
                 {AccountRecord.SerializedNames.ENVIRONMENT, account.getEnvironment()},
                 {AccountRecord.SerializedNames.REALM, account.getRealm()},
                 {AccountRecord.SerializedNames.LOCAL_ACCOUNT_ID, account.getLocalAccountId()},
-                //TODO MSA server side will fix the bug where username is not returned in the id token.
-                //{AccountRecord.SerializedNames.USERNAME, account.getUsername()},
                 {AccountRecord.SerializedNames.AUTHORITY_TYPE, account.getAuthorityType()},
         };
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -682,6 +682,7 @@ public class MsalOAuth2TokenCache
                 {AccountRecord.SerializedNames.ENVIRONMENT, account.getEnvironment()},
                 {AccountRecord.SerializedNames.REALM, account.getRealm()},
                 {AccountRecord.SerializedNames.LOCAL_ACCOUNT_ID, account.getLocalAccountId()},
+                {AccountRecord.SerializedNames.USERNAME, account.getUsername()},
                 {AccountRecord.SerializedNames.AUTHORITY_TYPE, account.getAuthorityType()},
         };
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.common.internal.cache.SchemaUtil;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -90,7 +91,15 @@ public abstract class MicrosoftAccount extends BaseAccount {
         mGivenName = claims.get(AzureActiveDirectoryIdToken.GIVEN_NAME);
         mFamilyName = claims.get(AzureActiveDirectoryIdToken.FAMILY_NAME);
         mMiddleName = claims.get(AzureActiveDirectoryIdToken.MIDDLE_NAME);
-        mTenantId = claims.get(AzureActiveDirectoryIdToken.TENANT_ID);
+        if (!StringUtil.isEmpty(claims.get(AzureActiveDirectoryIdToken.TENANT_ID))) {
+            mTenantId = claims.get(AzureActiveDirectoryIdToken.TENANT_ID);
+        } else {
+            // This if-else check will be removed this after the server
+            // test slice goes to production. Use a placeholder for the
+            // tid now.
+            Logger.warn(TAG, "TenantID is not returned from server.");
+            mTenantId = "tid not return from server";
+        }
         mUid = uid;
         mUtid = utid;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -116,8 +116,8 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
 
         //TODO: Need to figure out how to flow this information down
         //builder.setLibraryVersion(PublicClientApplication.getSdkVersion());
-        mLibraryVersion = "0.2.0";
-        mLibraryName = "Common.Android";
+        mLibraryVersion = "0.1.3";
+        mLibraryName = "MSAL.Android";
         mDiagnosticOS = String.valueOf(Build.VERSION.SDK_INT);
         mDiagnosticDM = android.os.Build.MODEL;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -116,8 +116,8 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
 
         //TODO: Need to figure out how to flow this information down
         //builder.setLibraryVersion(PublicClientApplication.getSdkVersion());
-        mLibraryVersion = "0.1.3";
-        mLibraryName = "MSAL.Android";
+        mLibraryVersion = "0.2.0";
+        mLibraryName = "Common.Android";
         mDiagnosticOS = String.valueOf(Build.VERSION.SDK_INT);
         mDiagnosticDM = android.os.Build.MODEL;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -115,9 +115,8 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
         //Initialize the diagnostic properties.
 
         //TODO: Need to figure out how to flow this information down
-        //builder.setLibraryVersion(PublicClientApplication.getSdkVersion());
-        mLibraryVersion = "0.1.3";
-        mLibraryName = "MSAL.Android";
+        mLibraryVersion =  builder.mLibraryVersion;
+        mLibraryName = builder.mLibraryName;
         mDiagnosticOS = String.valueOf(Build.VERSION.SDK_INT);
         mDiagnosticDM = android.os.Build.MODEL;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAuthorizationRequest.java
@@ -141,6 +141,8 @@ public class AzureActiveDirectoryAuthorizationRequest extends MicrosoftAuthoriza
         }
 
         public AzureActiveDirectoryAuthorizationRequest build() {
+            this.setLibraryName("ADAL.Android");
+            this.setLibraryVersion("1.15.2");
             return new AzureActiveDirectoryAuthorizationRequest(this);
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -76,11 +76,10 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
             return claims.get(MicrosoftStsIdToken.PREFERRED_USERNAME);
         } else if (!StringExtensions.isNullOrBlank(claims.get(MicrosoftStsIdToken.EMAIL))) {
             return claims.get(MicrosoftStsIdToken.EMAIL);
+        } else {
+            Logger.warn(TAG, "The preferred username is not returned from the IdToken.");
+            return "Username not return from server";
         }
-
-        Logger.warn(TAG, "The preferred username is not returned from the IdToken.");
-
-        return null;
     }
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -78,6 +78,8 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
             return claims.get(MicrosoftStsIdToken.EMAIL);
         }
 
+        Logger.warn(TAG, "The preferred username is not returned from the IdToken.");
+
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -116,6 +116,8 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         }
 
         public MicrosoftStsAuthorizationRequest build() {
+            this.setLibraryName("MSAL.Android");
+            this.setLibraryVersion("0.2.0");
             return new MicrosoftStsAuthorizationRequest(this);
         }
     }


### PR DESCRIPTION
• Preferred_username is mandatory filed. Use placeholder if it is missing in the id_token.

• Tid id required according to the spec. The fix is in the serve's test slice. Add the workaround with place holder string. Will remove it after the test slice becoming production.

• Fix the lib versioning for MSAL and ADAL.