### PR TITLE
Closes #274 - Removes client_info from CredentialRecord types, adds to AccountRecord

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -161,6 +161,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         when(mockAccount.getName()).thenReturn(MOCK_NAME);
         when(mockAccount.getMiddleName()).thenReturn(MOCK_MIDDLE_NAME);
         when(mockAccount.getFamilyName()).thenReturn(MOCK_FAMILY_NAME);
+        when(mockAccount.getClientInfo()).thenReturn(MOCK_CLIENT_INFO);
         when(mockRequest.getScope()).thenReturn(MOCK_SCOPE);
         when(mockResponse.getExpiresIn()).thenReturn(MOCK_EXPIRES_IN);
         when(mockResponse.getExtExpiresIn()).thenReturn(MOCK_EXT_EXPIRES_IN);
@@ -175,6 +176,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         assertNotNull(account);
         assertEquals(MOCK_UID + "." + MOCK_UTID, account.getHomeAccountId());
         assertEquals(MOCK_ENVIRONMENT, account.getEnvironment());
+        assertEquals(MOCK_CLIENT_INFO, account.getClientInfo());
         assertEquals(MOCK_TID, account.getRealm());
         assertEquals(MOCK_OID, account.getLocalAccountId());
         assertEquals(MOCK_PREFERRED_USERNAME, account.getUsername());
@@ -193,7 +195,6 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         assertNotNull(accessToken.getCachedAt());
         assertNotNull(accessToken.getExpiresOn());
         assertNotNull(accessToken.getExpiresOn());
-        assertEquals(MOCK_CLIENT_INFO, accessToken.getClientInfo());
         assertEquals(MOCK_TID, accessToken.getRealm());
         assertEquals(MOCK_AUTHORITY, accessToken.getAuthority());
         assertEquals(MOCK_ENVIRONMENT, accessToken.getEnvironment());
@@ -207,7 +208,6 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         assertNotNull(refreshToken);
         assertEquals(MOCK_SCOPE, refreshToken.getTarget());
         assertNotNull(refreshToken.getCachedAt());
-        assertEquals(MOCK_CLIENT_INFO, refreshToken.getClientInfo());
         assertEquals(MOCK_FAMILY_ID, refreshToken.getFamilyId());
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -93,7 +93,6 @@ public class MicrosoftStsAccountCredentialAdapter
             // Optional fields
             accessToken.setExtendedExpiresOn(getExtendedExpiresOn(response));
             accessToken.setAuthority(request.getAuthority().toString());
-            accessToken.setClientInfo(response.getClientInfo());
             accessToken.setAccessTokenType(response.getTokenType());
 
             return accessToken;
@@ -123,7 +122,6 @@ public class MicrosoftStsAccountCredentialAdapter
             // Optional
             refreshToken.setFamilyId(response.getFamilyId());
             refreshToken.setTarget(request.getScope());
-            refreshToken.setClientInfo(response.getClientInfo());
 
             // TODO are these needed? Expected?
             refreshToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
@@ -176,7 +174,6 @@ public class MicrosoftStsAccountCredentialAdapter
         // Optional fields
         refreshTokenOut.setTarget(refreshTokenIn.getTarget());
         refreshTokenOut.setCachedAt(String.valueOf(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())));
-        refreshTokenOut.setClientInfo(refreshTokenIn.getClientInfo().getRawClientInfo());
         refreshTokenOut.setFamilyId(refreshTokenIn.getFamilyId());
 
         return refreshTokenOut;

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.ACCESS_TOKEN_TYPE;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.AUTHORITY;
-import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.CLIENT_INFO;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.EXTENDED_EXPIRES_ON;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.REALM;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.TARGET;
@@ -48,11 +47,6 @@ public class AccessTokenRecord extends Credential {
          * String of authority.
          */
         public static final String AUTHORITY = "authority";
-
-        /**
-         * String of client info.
-         */
-        public static final String CLIENT_INFO = "client_info";
 
         /**
          * String of extended expires on.
@@ -83,13 +77,6 @@ public class AccessTokenRecord extends Credential {
      */
     @SerializedName(AUTHORITY)
     private String mAuthority;
-
-    /**
-     * Full base64 encoded client info received from ESTS, if available. STS returns the clientInfo 
-     * on both v1 and v2 for AAD. This field is used for extensibility purposes.
-     */
-    @SerializedName(CLIENT_INFO)
-    private String mClientInfo;
 
     /**
      * Additional extended expiry time until when token is valid in case of server-side outage.
@@ -154,24 +141,6 @@ public class AccessTokenRecord extends Credential {
      */
     public void setTarget(final String target) {
         mTarget = target;
-    }
-
-    /**
-     * Gets the client_info.
-     *
-     * @return The client_info to get.
-     */
-    public String getClientInfo() {
-        return mClientInfo;
-    }
-
-    /**
-     * Sets the client_info.
-     *
-     * @param clientInfo The clent_info to set.
-     */
-    public void setClientInfo(final String clientInfo) {
-        mClientInfo = clientInfo;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccountRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccountRecord.java
@@ -27,6 +27,7 @@ import com.google.gson.annotations.SerializedName;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.ALTERNATIVE_ACCOUNT_ID;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.AUTHORITY_TYPE;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.AVATAR_URL;
+import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.CLIENT_INFO;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.ENVIRONMENT;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.FAMILY_NAME;
 import static com.microsoft.identity.common.internal.dto.AccountRecord.SerializedNames.FIRST_NAME;
@@ -109,6 +110,10 @@ public class AccountRecord extends AccountCredentialBase implements IAccountReco
          * JSON name of the avatar url.
          */
         public static final String AVATAR_URL = "avatar_url";
+        /**
+         * String of client info.
+         */
+        public static final String CLIENT_INFO = "client_info";
     }
 
     /**
@@ -133,6 +138,7 @@ public class AccountRecord extends AccountCredentialBase implements IAccountReco
         setAuthorityType(copy.getAuthorityType());
 
         // Optional
+        setClientInfo(copy.getClientInfo());
         setAlternativeAccountId(copy.getAlternativeAccountId());
         setFirstName(copy.getFirstName());
         setFamilyName(copy.getFamilyName());
@@ -220,6 +226,14 @@ public class AccountRecord extends AccountCredentialBase implements IAccountReco
      */
     @SerializedName(AVATAR_URL)
     private String mAvatarUrl;
+
+
+    /**
+     * Full base64 encoded client info received from ESTS, if available. STS returns the clientInfo 
+     * on both v1 and v2 for AAD. This field is used for extensibility purposes.
+     */
+    @SerializedName(CLIENT_INFO)
+    private String mClientInfo;
 
     @Override
     public String getHomeAccountId() {
@@ -387,6 +401,25 @@ public class AccountRecord extends AccountCredentialBase implements IAccountReco
      */
     public void setAvatarUrl(final String avatarUrl) {
         mAvatarUrl = avatarUrl;
+    }
+
+
+    /**
+     * Gets the client_info.
+     *
+     * @return The client_info to get.
+     */
+    public String getClientInfo() {
+        return mClientInfo;
+    }
+
+    /**
+     * Sets the client_info.
+     *
+     * @param clientInfo The clent_info to set.
+     */
+    public void setClientInfo(final String clientInfo) {
+        mClientInfo = clientInfo;
     }
 
     //CHECKSTYLE:OFF

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccountRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccountRecord.java
@@ -409,6 +409,7 @@ public class AccountRecord extends AccountCredentialBase implements IAccountReco
      *
      * @return The client_info to get.
      */
+    @Override
     public String getClientInfo() {
         return mClientInfo;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/IAccountRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/IAccountRecord.java
@@ -107,4 +107,11 @@ public interface IAccountRecord {
      * @return The avatar_url to get.
      */
     String getAvatarUrl();
+
+    /**
+     * Gets the client_info.
+     *
+     * @return The client_info to get.
+     */
+    String getClientInfo();
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/IAccountRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/IAccountRecord.java
@@ -109,7 +109,8 @@ public interface IAccountRecord {
     String getAvatarUrl();
 
     /**
-     * Gets the client_info.
+     * Gets the client_info as a base64 encoded String of JSON.
+     * Decoded JSON has the format of {"uid":"<UUID>", "utid":"<UUID>"}.
      *
      * @return The client_info to get.
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/RefreshTokenRecord.java
@@ -24,17 +24,12 @@ package com.microsoft.identity.common.internal.dto;
 
 import com.google.gson.annotations.SerializedName;
 
-import static com.microsoft.identity.common.internal.dto.RefreshTokenRecord.SerializedNames.CLIENT_INFO;
 import static com.microsoft.identity.common.internal.dto.RefreshTokenRecord.SerializedNames.FAMILY_ID;
 import static com.microsoft.identity.common.internal.dto.RefreshTokenRecord.SerializedNames.TARGET;
 
 public class RefreshTokenRecord extends Credential {
 
     public static class SerializedNames extends Credential.SerializedNames {
-        /**
-         * String of client info.
-         */
-        public static final String CLIENT_INFO = "client_info";
         /**
          * String of family id.
          */
@@ -44,13 +39,6 @@ public class RefreshTokenRecord extends Credential {
          */
         public static final String TARGET = "target";
     }
-
-    /**
-     * Full base64 encoded client info received from ESTS, if available. STS returns the clientInfo 
-     * on both v1 and v2 for AAD. This field is used for extensibility purposes.
-     */
-    @SerializedName(CLIENT_INFO)
-    private String mClientInfo;
 
     /**
      * 1st Party Application Family ID.
@@ -83,24 +71,6 @@ public class RefreshTokenRecord extends Credential {
      */
     public void setTarget(final String target) {
         mTarget = target;
-    }
-
-    /**
-     * Gets the client_info.
-     *
-     * @return The client_info to get.
-     */
-    public String getClientInfo() {
-        return mClientInfo;
-    }
-
-    /**
-     * Sets the client_info.
-     *
-     * @param clientInfo The clent_info to set.
-     */
-    public void setClientInfo(final String clientInfo) {
-        mClientInfo = clientInfo;
     }
 
     /**
@@ -139,8 +109,6 @@ public class RefreshTokenRecord extends Credential {
 
         RefreshTokenRecord that = (RefreshTokenRecord) o;
 
-        if (mClientInfo != null ? !mClientInfo.equals(that.mClientInfo) : that.mClientInfo != null)
-            return false;
         if (mFamilyId != null ? !mFamilyId.equals(that.mFamilyId) : that.mFamilyId != null)
             return false;
         return mTarget != null ? mTarget.equals(that.mTarget) : that.mTarget == null;
@@ -155,7 +123,6 @@ public class RefreshTokenRecord extends Credential {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (mClientInfo != null ? mClientInfo.hashCode() : 0);
         result = 31 * result + (mFamilyId != null ? mFamilyId.hashCode() : 0);
         result = 31 * result + (mTarget != null ? mTarget.hashCode() : 0);
         return result;
@@ -170,8 +137,7 @@ public class RefreshTokenRecord extends Credential {
     @Override
     public String toString() {
         return "RefreshToken{" +
-                "mClientInfo='" + mClientInfo + '\'' +
-                ", mFamilyId='" + mFamilyId + '\'' +
+                "mFamilyId='" + mFamilyId + '\'' +
                 ", mTarget='" + mTarget + '\'' +
                 "} " + super.toString();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2Account.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2Account.java
@@ -105,4 +105,9 @@ public class ActiveDirectoryFederationServices2012R2Account extends BaseAccount 
     public String getAvatarUrl() {
         throw new UnsupportedOperationException("Method stub!");
     }
+
+    @Override
+    public String getClientInfo() {
+        throw new UnsupportedOperationException("Method stub!");
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016Account.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016Account.java
@@ -101,4 +101,9 @@ public class ActiveDirectoryFederationServices2016Account extends BaseAccount {
     public String getAvatarUrl() {
         throw new UnsupportedOperationException("Method stub!");
     }
+
+    @Override
+    public String getClientInfo() {
+        throw new UnsupportedOperationException("Method stub!");
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryAccount.java
@@ -48,33 +48,13 @@ public class AzureActiveDirectoryAccount extends MicrosoftAccount {
     /**
      * Constructor for AzureActiveDirectoryAccount object.
      *
-     * @param idToken Returned as part of the TokenResponse
-     * @param uid     Returned via clientInfo of TokenResponse
-     * @param uTid    Returned via ClientInfo of Token Response
+     * @param idToken    Returned as part of the TokenResponse
+     * @param clientInfo Returned via TokenResponse
      */
     public AzureActiveDirectoryAccount(@NonNull final IDToken idToken,
-                                       final String uid,
-                                       final String uTid) {
-        super(idToken, uid, uTid);
+                                       @NonNull final ClientInfo clientInfo) {
+        super(idToken, clientInfo);
         Logger.verbose(TAG, "Init: " + TAG);
-    }
-
-    /**
-     * Creates an AzureActiveDirectoryAccount based on the contents of the IDToken.
-     * And based on the contents of the ClientInfo JSON returned as part of the TokenResponse
-     *
-     * @param idToken    IDToken
-     * @param clientInfo ClientInfo
-     * @return AzureActiveDirectoryAccount
-     */
-    public static AzureActiveDirectoryAccount create(@NonNull final IDToken idToken,
-                                                     @NonNull final ClientInfo clientInfo) {
-        final String uid = clientInfo.getUid();
-        final String uTid = clientInfo.getUtid();
-
-        AzureActiveDirectoryAccount acct = new AzureActiveDirectoryAccount(idToken, uid, uTid);
-
-        return acct;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -181,10 +181,10 @@ public class AzureActiveDirectoryOAuth2Strategy
         } catch (ServiceException ccse) {
             Logger.error(TAG + ":" + methodName, "Failed to construct IDToken or ClientInfo", null);
             Logger.errorPII(TAG + ":" + methodName, "Failed with Exception", ccse);
-            // TODO: Should we bail?
+            throw new RuntimeException();
         }
 
-        final AzureActiveDirectoryAccount account = AzureActiveDirectoryAccount.create(idToken, clientInfo);
+        final AzureActiveDirectoryAccount account = new AzureActiveDirectoryAccount(idToken, clientInfo);
 
         Logger.info(TAG, "Account created");
         Logger.infoPII(TAG, account.toString());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2CAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2CAccount.java
@@ -101,4 +101,9 @@ public class AzureActiveDirectoryB2CAccount extends BaseAccount {
     public String getAvatarUrl() {
         throw new UnsupportedOperationException("Method stub!");
     }
+
+    @Override
+    public String getClientInfo() {
+        throw new UnsupportedOperationException("Method stub!");
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -39,30 +39,13 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
     /**
      * Constructor of MicrosoftStsAccount.
      *
-     * @param idToken IDToken
-     * @param uid     String
-     * @param uTid    String
+     * @param idToken    IDToken
+     * @param clientInfo clientInfo
      */
-    public MicrosoftStsAccount(IDToken idToken, String uid, final String uTid) {
-        super(idToken, uid, uTid);
+    public MicrosoftStsAccount(@NonNull final IDToken idToken,
+                               @NonNull final ClientInfo clientInfo) {
+        super(idToken, clientInfo);
         Logger.verbose(TAG, "Init: " + TAG);
-    }
-
-    /**
-     * Creates an MicrosoftStsAccount based on the contents of the IDToken and based on the contents of the ClientInfo JSON returned as part of the TokenResponse.
-     *
-     * @param idToken    The IDToken for this Account.
-     * @param clientInfo The ClientInfo for this Account.
-     * @return The newly created MicrosoftStsAccount.
-     */
-    public static MicrosoftStsAccount create(@NonNull final IDToken idToken,
-                                             @NonNull final ClientInfo clientInfo) {
-        final String uid = clientInfo.getUid();
-        final String uTid = clientInfo.getUtid();
-
-        MicrosoftStsAccount acct = new MicrosoftStsAccount(idToken, uid, uTid);
-
-        return acct;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -31,7 +31,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAutho
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
 import java.util.Map;
 
 public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequest<MicrosoftStsAuthorizationRequest> {
@@ -166,8 +165,7 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
 
     @Override
     public String getAuthorizationEndpoint() {
-
-        Uri authorityUri = Uri.parse(this.getAuthority().toString());
+        final Uri authorityUri = Uri.parse(this.getAuthority().toString());
         Uri endpointUri = authorityUri.buildUpon()
                 .appendPath(AUTHORIZATION_ENDPOINT)
                 .build();

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -145,11 +145,12 @@ public class MicrosoftStsOAuth2Strategy
             idToken = new IDToken(response.getIdToken());
             clientInfo = new ClientInfo(response.getClientInfo());
         } catch (ServiceException ccse) {
-            // TODO: Add a log here
-            // TODO: Should we bail?
+            Logger.error(TAG + methodName, "Failed to construct IDToken or ClientInfo", null);
+            Logger.errorPII(TAG + methodName, "Failed with Exception", ccse);
+            throw new RuntimeException();
         }
 
-        return MicrosoftStsAccount.create(idToken, clientInfo);
+        return new MicrosoftStsAccount(idToken, clientInfo);
     }
 
     @Override


### PR DESCRIPTION
See #274 

Updated `AccountRecord` format below (data is scrubbed/replaced with random GUIDS):
```json
{
    "authority_type": "MSSTS",
    "client_info": "eyJ1aWQiOiJjYjQ2MzJjYi02OTkyLTQzNzktOGIwMS1jNmFlMzg1NmIxOGYiLCJ1dGlkIjoiMTljNTJmZDEtZDA4Ny00N2UwLTgxZjctOGQ4OTE2ZTFjZDhmIn0=",
    "environment": "login.windows.net",
    "home_account_id": "2380adc0-8eeb-4b76-bfb4-b3547afcb809.66182264-8579-4c2b-aed1-9a81359ec708",
    "local_account_id": "03a21d16-f1ae-4df9-ac69-7f5bff3832d6",
    "name": "DevEx Admin",
    "realm": "66182264-8579-4c2b-aed1-9a81359ec708",
    "username": "user@contoso.onmicrosoft.com"
}
```

**Summary of changes:**
- Removes `client_info` from `AccessTokenRecord`, `RefreshTokenRecord`
- Adds `client_info` to `AccountRecord`
- Relocates `@SerializedName#CLIENT_INFO` constant to `AccountRecord.SerializedNames`
- Updates `MicrosoftStsAccountCredentialAdapterTest` to remove getter calls on `Credential` subtypes and modify the test behavior of `createAccount()`
- Removes static constructors on classes `AzureActiveDirectoryAccount` and `MicrosoftStsAccount`