### PR TITLE
Moving Google's maven repo 'higher' on the resolution list.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -250,9 +250,9 @@ afterEvaluate {
 
 // Repositories from which Gradle can fetch dependencies
 repositories {
+    google()
     mavenLocal()
     jcenter()
-    google()
     maven {
         name "vsts-maven-adal-android"
         url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"


### PR DESCRIPTION
Working around a bug in the latest version of Android Studio....was failing to resolve `vector-drawable` and other deps unless `google()` is the first artifact stream...

Another related PR will follow for MSAL & ADAL