### PR TITLE
Relocating google() repo -- jcenter appears to have removed support libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Looks like support libs were pulled from `jcenter` - weird