### PR TITLE
Disambiguates AccountRecords lookups in guest scenarios

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -445,6 +445,25 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     }
 
     @Test
+    public void getAccountByLocalAccountId() throws ClientException {
+        // Save an Account into the cache
+        mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+
+        // Find it by the local_account_id
+        final AccountRecord account = mOauth2TokenCache.getAccountWithLocalAccountId(
+                ENVIRONMENT,
+                CLIENT_ID,
+                LOCAL_ACCOUNT_ID
+        );
+
+        assertNotNull(account);
+    }
+
+    @Test
     public void getAccountCacheEmpty() {
         final AccountRecord account = mOauth2TokenCache.getAccount(
                 ENVIRONMENT,

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -344,6 +344,51 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     }
 
     @Test
+    public void saveAccountDirect() {
+        mOauth2TokenCache = new MsalOAuth2TokenCache<>(
+                InstrumentationRegistry.getTargetContext(),
+                accountCredentialCache,
+                mockCredentialAdapter,
+                true
+        );
+
+        mOauth2TokenCache.save(
+                defaultTestBundle.mGeneratedAccount,
+                defaultTestBundle.mGeneratedIdToken
+        );
+
+        final AccountRecord account = mOauth2TokenCache.getAccount(
+                ENVIRONMENT,
+                CLIENT_ID,
+                HOME_ACCOUNT_ID,
+                REALM
+        );
+
+        final ICacheRecord cacheRecord = mOauth2TokenCache.load(
+                CLIENT_ID,
+                TARGET,
+                account
+        );
+
+        assertNotNull(cacheRecord);
+        assertNotNull(cacheRecord.getAccount());
+        assertNotNull(cacheRecord.getIdToken());
+
+        assertNull(cacheRecord.getAccessToken());
+        assertNull(cacheRecord.getRefreshToken());
+
+        assertEquals(
+                defaultTestBundle.mGeneratedAccount,
+                cacheRecord.getAccount()
+        );
+
+        assertEquals(
+                defaultTestBundle.mGeneratedIdToken,
+                cacheRecord.getIdToken()
+        );
+    }
+
+    @Test
     public void getAccount() throws ClientException {
         // Save an Account into the cache
         mOauth2TokenCache.save(

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -345,13 +345,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     @Test
     public void saveAccountDirect() {
-        mOauth2TokenCache = new MsalOAuth2TokenCache<>(
-                InstrumentationRegistry.getTargetContext(),
-                accountCredentialCache,
-                mockCredentialAdapter,
-                true
-        );
-
         mOauth2TokenCache.save(
                 defaultTestBundle.mGeneratedAccount,
                 defaultTestBundle.mGeneratedIdToken

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -29,7 +29,6 @@ import android.support.test.runner.AndroidJUnit4;
 import com.microsoft.identity.common.adal.internal.AndroidSecretKeyEnabledHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialAdapter;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
@@ -37,6 +36,7 @@ import com.microsoft.identity.common.internal.cache.ICacheKeyValueDelegate;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -355,7 +355,8 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final AccountRecord account = mOauth2TokenCache.getAccount(
                 ENVIRONMENT,
                 CLIENT_ID,
-                HOME_ACCOUNT_ID
+                HOME_ACCOUNT_ID,
+                REALM
         );
 
         assertNotNull(account);
@@ -372,7 +373,8 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final AccountRecord account = mOauth2TokenCache.getAccount(
                 ENVIRONMENT,
                 CLIENT_ID,
-                HOME_ACCOUNT_ID
+                HOME_ACCOUNT_ID,
+                REALM
         );
 
         assertNull(account);
@@ -473,7 +475,14 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 mockResponse
         );
 
-        assertTrue(mOauth2TokenCache.removeAccount(ENVIRONMENT, CLIENT_ID, HOME_ACCOUNT_ID));
+        assertTrue(
+                mOauth2TokenCache.removeAccount(
+                        ENVIRONMENT,
+                        CLIENT_ID,
+                        HOME_ACCOUNT_ID,
+                        REALM
+                )
+        );
     }
 
     @Test
@@ -489,14 +498,22 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 mOauth2TokenCache.removeAccount(
                         "login.chinacloudapi.cn",
                         CLIENT_ID,
-                        HOME_ACCOUNT_ID
+                        HOME_ACCOUNT_ID,
+                        REALM
                 )
         );
     }
 
     @Test
     public void removeAccountCacheEmpty() {
-        assertFalse(mOauth2TokenCache.removeAccount(ENVIRONMENT, CLIENT_ID, HOME_ACCOUNT_ID));
+        assertFalse(
+                mOauth2TokenCache.removeAccount(
+                        ENVIRONMENT,
+                        CLIENT_ID,
+                        HOME_ACCOUNT_ID,
+                        REALM
+                )
+        );
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
@@ -164,6 +165,14 @@ public class ADALOAuth2TokenCache
         }
 
         return null; // Returning null, since the ADAL cache's schema doesn't support this return type.
+    }
+
+    @Override
+    public ICacheRecord save(final AccountRecord accountRecord,
+                             final IdTokenRecord idTokenRecord) {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -194,6 +194,15 @@ public class ADALOAuth2TokenCache
     }
 
     @Override
+    public AccountRecord getAccountWithLocalAccountId(final String environment,
+                                                      final String clientId,
+                                                      final String localAccountId) {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
+    }
+
+    @Override
     public List<AccountRecord> getAccounts(final String environment,
                                            final String clientId) {
         throw new UnsupportedOperationException(

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -186,7 +186,8 @@ public class ADALOAuth2TokenCache
     @Override
     public AccountRecord getAccount(final String environment,
                                     final String clientId,
-                                    final String homeAccountId) {
+                                    final String homeAccountId,
+                                    final String realm) {
         throw new UnsupportedOperationException(
                 ERR_UNSUPPORTED_OPERATION
         );
@@ -203,7 +204,8 @@ public class ADALOAuth2TokenCache
     @Override
     public boolean removeAccount(final String environment,
                                  final String clientId,
-                                 final String homeAccountId) {
+                                 final String homeAccountId,
+                                 final String realm) {
         throw new UnsupportedOperationException(
                 ERR_UNSUPPORTED_OPERATION
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -73,8 +73,6 @@ public class MsalOAuth2TokenCache
             GenericAccount,
             GenericRefreshToken> mAccountCredentialAdapter;
 
-    private final boolean mSecondaryMode;
-
     /**
      * Constructor of MsalOAuth2TokenCache.
      *
@@ -94,41 +92,6 @@ public class MsalOAuth2TokenCache
         Logger.verbose(TAG, "Init: " + TAG);
         mAccountCredentialCache = accountCredentialCache;
         mAccountCredentialAdapter = accountCredentialAdapter;
-        mSecondaryMode = false;
-    }
-
-    /**
-     * Constructor of MsalOAuth2TokenCache.
-     *
-     * @param context                  Context
-     * @param accountCredentialCache   IAccountCredentialCache
-     * @param accountCredentialAdapter IAccountCredentialAdapter
-     * @param secondaryMode            True, if this cache is not the primary cache.
-     *                                 <p>
-     *                                 Ex: The cache is running locally inside of an app that stores
-     *                                 AT/RT pairs in the broker -- this will happen if the device
-     *                                 is WPJ'd.
-     *                                 <p>
-     *                                 Broker apps' caches should never run in secondary mode.
-     *                                 <p>
-     *                                 1st and 3rd party non-broker apps should run in secondary
-     *                                 mode when the broker is installed and enabled for auth
-     *                                 with the current application.
-     */
-    public MsalOAuth2TokenCache(final Context context,
-                                final IAccountCredentialCache accountCredentialCache,
-                                final IAccountCredentialAdapter<
-                                        GenericOAuth2Strategy,
-                                        GenericAuthorizationRequest,
-                                        GenericTokenResponse,
-                                        GenericAccount,
-                                        GenericRefreshToken> accountCredentialAdapter,
-                                final boolean secondaryMode) {
-        super(context);
-        Logger.verbose(TAG, "Init: " + TAG);
-        mAccountCredentialCache = accountCredentialCache;
-        mAccountCredentialAdapter = accountCredentialAdapter;
-        mSecondaryMode = secondaryMode;
     }
 
     @Override
@@ -463,17 +426,7 @@ public class MsalOAuth2TokenCache
                 mAccountCredentialCache.getCredentialsFilteredBy(
                         null, // homeAccountId
                         environment,
-                        // If we're running in secondary mode, apps will not cache ATs or
-                        // RTs for the Account. Instead, the broker app will maintain these
-                        // credentials. To support this case, we define the presence of an
-                        // Account by the existence of an IdToken matching it for the
-                        // current clientId.
-
-                        // If we're running in primary mode, we define the presence of an account by
-                        // the existence of a RefreshToken matching it for the current clientId.
-                        mSecondaryMode
-                                ? CredentialType.IdToken
-                                : CredentialType.RefreshToken,
+                        CredentialType.IdToken,
                         clientId,
                         null, // realm
                         null // target

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -73,6 +73,8 @@ public class MsalOAuth2TokenCache
             GenericAccount,
             GenericRefreshToken> mAccountCredentialAdapter;
 
+    private final boolean mSecondaryMode;
+
     /**
      * Constructor of MsalOAuth2TokenCache.
      *
@@ -92,6 +94,41 @@ public class MsalOAuth2TokenCache
         Logger.verbose(TAG, "Init: " + TAG);
         mAccountCredentialCache = accountCredentialCache;
         mAccountCredentialAdapter = accountCredentialAdapter;
+        mSecondaryMode = false;
+    }
+
+    /**
+     * Constructor of MsalOAuth2TokenCache.
+     *
+     * @param context                  Context
+     * @param accountCredentialCache   IAccountCredentialCache
+     * @param accountCredentialAdapter IAccountCredentialAdapter
+     * @param secondaryMode            True, if this cache is not the primary cache.
+     *                                 <p>
+     *                                 Ex: The cache is running locally inside of an app that stores
+     *                                 AT/RT pairs in the broker -- this will happen if the device
+     *                                 is WPJ'd.
+     *                                 <p>
+     *                                 Broker apps' caches should never run in secondary mode.
+     *                                 <p>
+     *                                 1st and 3rd party non-broker apps should run in secondary
+     *                                 mode when the broker is installed and enabled for auth
+     *                                 with the current application.
+     */
+    public MsalOAuth2TokenCache(final Context context,
+                                final IAccountCredentialCache accountCredentialCache,
+                                final IAccountCredentialAdapter<
+                                        GenericOAuth2Strategy,
+                                        GenericAuthorizationRequest,
+                                        GenericTokenResponse,
+                                        GenericAccount,
+                                        GenericRefreshToken> accountCredentialAdapter,
+                                final boolean secondaryMode) {
+        super(context);
+        Logger.verbose(TAG, "Init: " + TAG);
+        mAccountCredentialCache = accountCredentialCache;
+        mAccountCredentialAdapter = accountCredentialAdapter;
+        mSecondaryMode = secondaryMode;
     }
 
     @Override
@@ -183,6 +220,53 @@ public class MsalOAuth2TokenCache
         result.setAccessToken(accessTokenToSave);
         result.setRefreshToken(refreshTokenToSave);
         result.setIdToken(idTokenToSave);
+
+        return result;
+    }
+
+    @Override
+    public ICacheRecord save(@NonNull final AccountRecord accountToSave,
+                             @NonNull final IdTokenRecord idTokenToSave) {
+        final String methodName = ":save";
+
+        Logger.verbose(
+                TAG + methodName,
+                "Importing AccountRecord, IdTokenRecord (direct)"
+        );
+
+        // Validate the incoming artifacts
+        final boolean isAccountCompliant = isAccountSchemaCompliant(accountToSave);
+        final boolean isIdTokenCompliant = isIdTokenSchemaCompliant(idTokenToSave);
+
+        final CacheRecord result = new CacheRecord();
+
+        if (!(isAccountCompliant && isIdTokenCompliant)) {
+            String nonCompliantCredentials = "[";
+
+            if (!isAccountCompliant) {
+                nonCompliantCredentials += "(Account)";
+            }
+
+            if (!isIdTokenCompliant) {
+                nonCompliantCredentials += "(ID)";
+            }
+
+            nonCompliantCredentials += "]";
+
+            Logger.warn(
+                    TAG + methodName,
+                    "Skipping persistence of non-compliant credentials: "
+                            + nonCompliantCredentials
+            );
+        } else {
+            // Save the inputs
+            saveAccounts(accountToSave);
+            saveCredentials(idTokenToSave);
+
+            // Set them as the result outputs
+            result.setAccount(accountToSave);
+            result.setIdToken(idTokenToSave);
+        }
 
         return result;
     }
@@ -379,7 +463,17 @@ public class MsalOAuth2TokenCache
                 mAccountCredentialCache.getCredentialsFilteredBy(
                         null, // homeAccountId
                         environment,
-                        CredentialType.RefreshToken,
+                        // If we're running in secondary mode, apps will not cache ATs or
+                        // RTs for the Account. Instead, the broker app will maintain these
+                        // credentials. To support this case, we define the presence of an
+                        // Account by the existence of an IdToken matching it for the
+                        // current clientId.
+
+                        // If we're running in primary mode, we define the presence of an account by
+                        // the existence of a RefreshToken matching it for the current clientId.
+                        mSecondaryMode
+                                ? CredentialType.IdToken
+                                : CredentialType.RefreshToken,
                         clientId,
                         null, // realm
                         null // target

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -323,6 +323,28 @@ public class MsalOAuth2TokenCache
     }
 
     @Override
+    public AccountRecord getAccountWithLocalAccountId(@Nullable String environment,
+                                                      @NonNull String clientId,
+                                                      @NonNull String localAccountId) {
+        final String methodName = ":getAccountWithLocalAccountId";
+
+        final List<AccountRecord> accounts = getAccounts(environment, clientId);
+
+        Logger.infoPII(
+                TAG + methodName,
+                "LocalAccountId: [" + localAccountId + "]"
+        );
+
+        for (final AccountRecord account : accounts) {
+            if (localAccountId.equals(account.getLocalAccountId())) {
+                return account;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
     public List<AccountRecord> getAccounts(@Nullable final String environment,
                                            @NonNull final String clientId) {
         final String methodName = ":getAccounts";

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -275,7 +275,8 @@ public class MsalOAuth2TokenCache
     @Override
     public AccountRecord getAccount(@Nullable final String environment,
                                     @NonNull final String clientId,
-                                    @NonNull final String homeAccountId) {
+                                    @NonNull final String homeAccountId,
+                                    @Nullable final String realm) {
         final String methodName = ":getAccount";
 
         Logger.infoPII(
@@ -293,6 +294,11 @@ public class MsalOAuth2TokenCache
                 "HomeAccountId: [" + homeAccountId + "]"
         );
 
+        Logger.infoPII(
+                TAG + methodName,
+                "Realm: [" + realm + "]"
+        );
+
         final List<AccountRecord> allAccounts = getAccounts(environment, clientId);
 
         Logger.info(
@@ -300,9 +306,10 @@ public class MsalOAuth2TokenCache
                 "Found " + allAccounts.size() + " accounts"
         );
 
-        // Return the sought Account matching the supplied homeAccountId
+        // Return the sought Account matching the supplied homeAccountId and realm, if applicable
         for (final AccountRecord account : allAccounts) {
-            if (homeAccountId.equals(account.getHomeAccountId())) {
+            if (homeAccountId.equals(account.getHomeAccountId())
+                    && (null == realm || realm.equals(account.getRealm()))) {
                 return account;
             }
         }
@@ -413,7 +420,8 @@ public class MsalOAuth2TokenCache
     @Override
     public boolean removeAccount(final String environment,
                                  final String clientId,
-                                 final String homeAccountId) {
+                                 final String homeAccountId,
+                                 @Nullable final String realm) {
         final String methodName = ":removeAccount";
 
         Logger.infoPII(
@@ -431,6 +439,11 @@ public class MsalOAuth2TokenCache
                 "HomeAccountId: [" + homeAccountId + "]"
         );
 
+        Logger.infoPII(
+                TAG + methodName,
+                "Realm: [" + realm + "]"
+        );
+
         final AccountRecord targetAccount;
         if (null == environment
                 || null == clientId
@@ -439,7 +452,8 @@ public class MsalOAuth2TokenCache
                 getAccount(
                         environment,
                         clientId,
-                        homeAccountId
+                        homeAccountId,
+                        realm
                 ))) {
             return false;
         }
@@ -504,7 +518,7 @@ public class MsalOAuth2TokenCache
                         environment,
                         credentialType,
                         clientId,
-                        null, // wildcard (*) realm
+                        targetAccount.getRealm(), // wildcard (*) realm
                         null // wildcard (*) target
                 );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 
 import java.util.List;
 
@@ -60,6 +61,17 @@ public abstract class OAuth2TokenCache
     public abstract ICacheRecord save(final T oAuth2Strategy,
                                       final U request,
                                       final V response) throws ClientException;
+
+    /**
+     * Saves the supplied Account and Credential in the cache.
+     *
+     * @param accountRecord The AccountRecord to save.
+     * @param idTokenRecord The IdTokenRecord to save.
+     * @return The {@link ICacheRecord} containing the Account + Credential[s] saved to the cache.
+     */
+    public abstract ICacheRecord save(final AccountRecord accountRecord,
+                                      final IdTokenRecord idTokenRecord
+    );
 
     /**
      * Loads the tokens for the supplied Account into the result {@link ICacheRecord}.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -84,13 +84,13 @@ public abstract class OAuth2TokenCache
     public abstract boolean removeCredential(final Credential credential);
 
     /**
-     * Returns the IAccount matching the supplied criteria.
+     * Returns the AccountRecord matching the supplied criteria.
      *
-     * @param environment   The environment to which the sought IAccount is associated.
-     * @param clientId      The clientId to which the sought IAccount is associated.
-     * @param homeAccountId The homeAccountId of the sought IAccount.
+     * @param environment   The environment to which the sought AccountRecord is associated.
+     * @param clientId      The clientId to which the sought AccountRecord is associated.
+     * @param homeAccountId The homeAccountId of the sought AccountRecord.
      * @param realm         The tenant id of the targeted account (if applicable).
-     * @return The sought IAccount or null if it cannot be found.
+     * @return The sought AccountRecord or null if it cannot be found.
      */
     public abstract AccountRecord getAccount(final String environment,
                                              final String clientId,
@@ -99,11 +99,24 @@ public abstract class OAuth2TokenCache
     );
 
     /**
-     * Gets an immutable List of IAccounts for this app which have RefreshTokens in the cache.
+     * Returns the AccountRecord matching the supplied criteria.
+     *
+     * @param environment    The environment to which the sought IAccount is associated.
+     * @param clientId       The clientId to which the sought IAccount is associated.
+     * @param localAccountId The local account id of the targeted account.
+     * @return The sought AccountRecord or null if it cannot be found.
+     */
+    public abstract AccountRecord getAccountWithLocalAccountId(final String environment,
+                                                               final String clientId,
+                                                               final String localAccountId
+    );
+
+    /**
+     * Gets an immutable List of AccountRecords for this app which have RefreshTokens in the cache.
      *
      * @param clientId    The current application.
      * @param environment The current environment.
-     * @return An immutable List of IAccounts.
+     * @return An immutable List of AccountRecords.
      */
     public abstract List<AccountRecord> getAccounts(final String environment, final String clientId);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -87,13 +87,15 @@ public abstract class OAuth2TokenCache
      * Returns the IAccount matching the supplied criteria.
      *
      * @param environment   The environment to which the sought IAccount is associated.
-     * @param clientId      The clientId to which the sought IAccouct is associated.
+     * @param clientId      The clientId to which the sought IAccount is associated.
      * @param homeAccountId The homeAccountId of the sought IAccount.
+     * @param realm         The tenant id of the targeted account (if applicable).
      * @return The sought IAccount or null if it cannot be found.
      */
     public abstract AccountRecord getAccount(final String environment,
                                              final String clientId,
-                                             final String homeAccountId
+                                             final String homeAccountId,
+                                             final String realm
     );
 
     /**
@@ -111,11 +113,14 @@ public abstract class OAuth2TokenCache
      * @param environment   The environment to which the targeted Account is associated.
      * @param clientId      The clientId of this current app.
      * @param homeAccountId The homeAccountId of the Account targeted for deletion.
+     * @param realm         The tenant id of the targeted Account (if applicable).
      * @return True, if the Account was deleted. False otherwise.
      */
     public abstract boolean removeAccount(final String environment,
                                           final String clientId,
-                                          final String homeAccountId);
+                                          final String homeAccountId,
+                                          final String realm
+    );
 
     /**
      * Gets the Context used to initialize this OAuth2TokenCache.


### PR DESCRIPTION
The following method signatures have been updated. The methods which now accept a `realm` parameter do so such that they may disambiguate guest scenarios vs. not. The method which accepts a `local_account_id` is a convenience function to support broker lookups when only this value is present.

```java
/**
     * Returns the AccountRecord matching the supplied criteria.
     *
     * @param environment   The environment to which the sought AccountRecord is associated.
     * @param clientId      The clientId to which the sought AccountRecord is associated.
     * @param homeAccountId The homeAccountId of the sought AccountRecord.
     * @param realm         The tenant id of the targeted account (if applicable).
     * @return The sought AccountRecord or null if it cannot be found.
     */
    public abstract AccountRecord getAccount(final String environment,
                                             final String clientId,
                                             final String homeAccountId,
                                             final String realm
    );

    /**
     * Returns the AccountRecord matching the supplied criteria.
     *
     * @param environment    The environment to which the sought IAccount is associated.
     * @param clientId       The clientId to which the sought IAccount is associated.
     * @param localAccountId The local account id of the targeted account.
     * @return The sought AccountRecord or null if it cannot be found.
     */
    public abstract AccountRecord getAccountWithLocalAccountId(final String environment,
                                                               final String clientId,
                                                               final String localAccountId
    );

    /**
     * Removes the Account (and its associated Credentials) matching the supplied criteria.
     *
     * @param environment   The environment to which the targeted Account is associated.
     * @param clientId      The clientId of this current app.
     * @param homeAccountId The homeAccountId of the Account targeted for deletion.
     * @param realm         The tenant id of the targeted Account (if applicable).
     * @return True, if the Account was deleted. False otherwise.
     */
    public abstract boolean removeAccount(final String environment,
                                          final String clientId,
                                          final String homeAccountId,
                                          final String realm
    );
```