### PR TITLE
Updating buildToolsVersion to minimum supported by Gradle plugin 3.2.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,7 +13,7 @@ project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") 
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Gradle plugin 3.2.1 ([used by ad-accounts](https://github.com/AzureAD/ad-accounts-for-android/blob/dev/build.gradle#L23)) requires `buildToolsVersion` > = `28.0.3`