### PR TITLE
Moved IBrokerAccountService.aidl to com.microsoft.aad.adal

### DIFF
--- a/common/src/main/aidl/com/microsoft/aad/adal/IBrokerAccountService.aidl
+++ b/common/src/main/aidl/com/microsoft/aad/adal/IBrokerAccountService.aidl
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.internal.broker;
+package com.microsoft.aad.adal;
 
 /**
  * Broker Account service APIs provided by the broker app. Those APIs will be responsible for interacting with the


### PR DESCRIPTION
- Both client and server AIDL files need to be in the package, so moved it to be backwards compat with ADAL