### PR TITLE
Reverting fix of auth flow bug for Huawei browser

### DIFF
--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -7,9 +7,8 @@
     <application>
         <activity
             android:name="com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
-            android:launchMode="singleTask" />
-        <!-- singleTask launchMode is required for the authorization redirect. -->
+            android:configChanges="orientation|keyboardHidden|screenSize" />
+        <!-- singleTask launchMode may be required in Huawei for the authorization redirect. -->
 
     </application>
 


### PR DESCRIPTION
Using singleTask launchMode causes other compatibility issues observed on low Android API,
specifically tested on Sony Xperia SP using API 18. The consensus is that startActivityForResult()
mustn't be used if an activity is being launched as a singleInstance or singleTask - StackOverflow:
https://stackoverflow.com/questions/7910840/android-startactivityforresult-immediately-triggering-onactivityresult
The developer can always override this in app manifest for example using:
\<activity android:name="com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity"
android:launchMode="standard" tools:replace="android:launchMode" />