### PR TITLE
Adding new constants to support ad-accounts, userappwithbroker testing

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -219,6 +219,16 @@ public final class AuthenticationConstants {
         public static final String CLIENT_INFO_TRUE = "1";
 
         /**
+         * String of AAD version.
+         */
+        public static final String AAD_VERSION = "ver";
+
+        /**
+         * String of preferred user name.
+         */
+        public static final String AAD_PREFERRED_USERNAME = "preferred_username";
+
+        /**
          * String of code.
          */
         public static final String CODE = "code";


### PR DESCRIPTION
These changes support https://github.com/AzureAD/ad-accounts-for-android/pull/791

See additional notes documented here: https://github.com/AzureAD/ad-accounts-for-android/pull/792