### PR TITLE
Second set of ad-accounts refactor changes

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -219,6 +219,16 @@ public final class AuthenticationConstants {
         public static final String CLIENT_INFO_TRUE = "1";
 
         /**
+         * String of AAD version.
+         */
+        public static final String AAD_VERSION = "ver";
+
+        /**
+         * String of preferred user name.
+         */
+        public static final String AAD_PREFERRED_USERNAME = "preferred_username";
+
+        /**
          * String of code.
          */
         public static final String CODE = "code";

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -284,4 +284,26 @@ public final class ErrorStrings {
      * Refresh token request failed.
      */
     public static final String AUTH_REFRESH_FAILED = "Refresh token request failed";
+
+    /**
+     * STK patching failed.
+     */
+    public static final String STK_PATCHING_FAILED = "STK patching failed";
+
+    /**
+     * Primary refresh token request failed.
+     */
+    public static final String BROKER_PRT_REFRESH_FAILED = "Failed to refresh PRT";
+
+    /**
+     * Broker RT is invalid
+     */
+    public static final String INVALID_BROKER_REFRESH_TOKEN = "Broker refresh token is invalid";
+
+    /**
+     *
+     */
+    public static final String DEVICE_STATE_INVALID = "Invalid device state";
+
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -301,9 +301,13 @@ public final class ErrorStrings {
     public static final String INVALID_BROKER_REFRESH_TOKEN = "Broker refresh token is invalid";
 
     /**
-     *
+     * Device state of Joined account invalid.
      */
     public static final String DEVICE_STATE_INVALID = "Invalid device state";
 
+    /**
+     * Device registration failed.
+     */
+    public static final String DEVICE_REGISTRATION_FAILED = "Device registration failed";
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
@@ -37,7 +37,6 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
 
     private String mAuthority;
     private String mTenantId;
-    private String mPrimaryRefreshToken;
 
     @SerializedName("not_before")
     private Date mExpiresNotBefore;
@@ -45,8 +44,20 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
     @SerializedName("cloud_instance_host_name")
     private String mCloudInstanceHostName;
 
-    public BrokerTokenResponse(){
-
+    public BrokerTokenResponse(MicrosoftStsTokenResponse copy){
+        setExpiresIn(copy.getExpiresIn());
+        setAccessToken(copy.getAccessToken());
+        setTokenType(copy.getTokenType());
+        setRefreshToken(copy.getRefreshToken());
+        setScope(copy.getScope());
+        setState(copy.getState());
+        setIdToken(copy.getIdToken());
+        setResponseReceivedTime(copy.getResponseReceivedTime());
+        setExtExpiresOn(copy.getExtExpiresOn());
+        setClientInfo(copy.getClientInfo());
+        setClientId(copy.getClientId());
+        setExtExpiresIn(copy.getExtExpiresIn());
+        setFamilyId(copy.getFamilyId());
     }
 
     protected BrokerTokenResponse(Parcel in) {
@@ -66,7 +77,6 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
             setFamilyId(in.readString());
             setAuthority(in.readString());
             setTenantId(in.readString());
-            setPrimaryRefreshToken(in.readString());
             setExpiresNotBefore(new Date(in.readLong()));
             setCloudInstanceHostName(in.readString());
         }
@@ -75,7 +85,7 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         if (dest != null) {
-            dest.writeLong(getExpiresIn() != null ? getExpiresIn() : 0);
+            dest.writeLong(getExpiresIn());
             dest.writeString(getAccessToken());
             dest.writeString(getTokenType());
             dest.writeString(getRefreshToken());
@@ -90,7 +100,6 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
             dest.writeString(getFamilyId());
             dest.writeString(getAuthority());
             dest.writeString(getTenantId());
-            dest.writeString(getPrimaryRefreshToken());
             dest.writeLong(getExpiresNotBefore() != null ? getExpiresNotBefore().getTime() : 0);
             dest.writeString(getCloudInstanceHostName());
         }
@@ -127,14 +136,6 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
 
     public void setTenantId(final String tenantId) {
         mTenantId = tenantId;
-    }
-
-    public String getPrimaryRefreshToken() {
-        return mPrimaryRefreshToken;
-    }
-
-    public void setPrimaryRefreshToken(final String primaryRefreshToken) {
-        mPrimaryRefreshToken = primaryRefreshToken;
     }
 
     public Date getExpiresNotBefore() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
@@ -44,20 +44,20 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
     @SerializedName("cloud_instance_host_name")
     private String mCloudInstanceHostName;
 
-    public BrokerTokenResponse(MicrosoftStsTokenResponse copy){
-        setExpiresIn(copy.getExpiresIn());
-        setAccessToken(copy.getAccessToken());
-        setTokenType(copy.getTokenType());
-        setRefreshToken(copy.getRefreshToken());
-        setScope(copy.getScope());
-        setState(copy.getState());
-        setIdToken(copy.getIdToken());
-        setResponseReceivedTime(copy.getResponseReceivedTime());
-        setExtExpiresOn(copy.getExtExpiresOn());
-        setClientInfo(copy.getClientInfo());
-        setClientId(copy.getClientId());
-        setExtExpiresIn(copy.getExtExpiresIn());
-        setFamilyId(copy.getFamilyId());
+    public BrokerTokenResponse(MicrosoftStsTokenResponse microsoftStsTokenResponse){
+        setExpiresIn(microsoftStsTokenResponse.getExpiresIn());
+        setAccessToken(microsoftStsTokenResponse.getAccessToken());
+        setTokenType(microsoftStsTokenResponse.getTokenType());
+        setRefreshToken(microsoftStsTokenResponse.getRefreshToken());
+        setScope(microsoftStsTokenResponse.getScope());
+        setState(microsoftStsTokenResponse.getState());
+        setIdToken(microsoftStsTokenResponse.getIdToken());
+        setResponseReceivedTime(microsoftStsTokenResponse.getResponseReceivedTime());
+        setExtExpiresOn(microsoftStsTokenResponse.getExtExpiresOn());
+        setClientInfo(microsoftStsTokenResponse.getClientInfo());
+        setClientId(microsoftStsTokenResponse.getClientId());
+        setExtExpiresIn(microsoftStsTokenResponse.getExtExpiresIn());
+        setFamilyId(microsoftStsTokenResponse.getFamilyId());
     }
 
     protected BrokerTokenResponse(Parcel in) {
@@ -85,7 +85,7 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         if (dest != null) {
-            dest.writeLong(getExpiresIn());
+            dest.writeLong(getExpiresIn() != null ? getExpiresIn() : 0);
             dest.writeString(getAccessToken());
             dest.writeString(getTokenType());
             dest.writeString(getRefreshToken());

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
@@ -44,6 +44,10 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
     @SerializedName("cloud_instance_host_name")
     private String mCloudInstanceHostName;
 
+    public BrokerTokenResponse(){
+
+    }
+
     public BrokerTokenResponse(MicrosoftStsTokenResponse microsoftStsTokenResponse){
         setExpiresIn(microsoftStsTokenResponse.getExpiresIn());
         setAccessToken(microsoftStsTokenResponse.getAccessToken());

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
@@ -46,10 +46,6 @@ public class InteractiveTokenCommand extends TokenCommand {
                                    ILocalAuthenticationCallback callback) {
 
         super(context, parameters, controller, callback);
-
-        if (!(mParameters instanceof AcquireTokenOperationParameters)) {
-            throw new IllegalArgumentException("Invalid operation parameters");
-        }
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -63,10 +63,6 @@ public class TokenCommand implements TokenOperation {
         mCallback = callback;
 
         mControllers.add(controller);
-
-        if (!(mParameters instanceof AcquireTokenSilentOperationParameters)) {
-            throw new IllegalArgumentException("Invalid operation parameters");
-        }
     }
 
     public TokenCommand(@NonNull final Context context,
@@ -77,10 +73,6 @@ public class TokenCommand implements TokenOperation {
         mParameters = parameters;
         mControllers = controllers;
         mCallback = callback;
-
-        if (!(mParameters instanceof AcquireTokenSilentOperationParameters)) {
-            throw new IllegalArgumentException("Invalid operation parameters");
-        }
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationErrorResponse.java
@@ -81,6 +81,11 @@ public class MicrosoftAuthorizationErrorResponse extends AuthorizationErrorRespo
     public static final String BROKER_NEEDS_TO_BE_INSTALLED = "Device needs to have broker installed";
 
     /**
+     * Error string to indicate that the device needs to be registered
+     */
+    public static final String DEVICE_REGISTRATION_NEEDED = "Device needs to be registered to access the resource";
+
+    /**
      * Constructor of {@link MicrosoftAuthorizationErrorResponse}.
      *
      * @param error            error string returned from the Authorization Server.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
@@ -78,6 +78,21 @@ public class MicrosoftStsAuthorizationResultFactory extends AuthorizationResultF
                 result = createAuthorizationResultWithErrorResponse(AuthorizationStatus.FAIL, error, errorDescription);
                 break;
 
+            case AuthenticationConstants.UIResponse.BROKER_REQUEST_RESUME:
+                Logger.verbose(TAG, "Device needs to have broker installed, we expect the apps to call us"
+                        + "back when the broker is installed");
+                result = createAuthorizationResultWithErrorResponse(AuthorizationStatus.FAIL,
+                        MicrosoftAuthorizationErrorResponse.AUTHORIZATION_FAILED,
+                        MicrosoftAuthorizationErrorResponse.BROKER_NEEDS_TO_BE_INSTALLED);
+                break;
+
+            case AuthenticationConstants.UIResponse.BROWSER_CODE_DEVICE_REGISTER:
+                Logger.verbose(TAG, "Device Registration needed, need to start WPJ");
+                result = createAuthorizationResultWithErrorResponse(AuthorizationStatus.FAIL,
+                        MicrosoftAuthorizationErrorResponse.AUTHORIZATION_FAILED,
+                        MicrosoftAuthorizationErrorResponse.DEVICE_REGISTRATION_NEEDED);
+                break;
+
             default:
                 result = createAuthorizationResultWithErrorResponse(AuthorizationStatus.FAIL,
                         MicrosoftAuthorizationErrorResponse.UNKNOWN_ERROR, MicrosoftAuthorizationErrorResponse.UNKNOWN_RESULT_CODE);


### PR DESCRIPTION
- Added additional constants and error strings as needed
- Added a new constructor to `BrokerTokenResponse` and unused remove primary refresh token param
- Removed redundant `IllegalArgumentException` from AcquireTokenParameters
- Added missing ResponseCodes to `MicrosoftStsAuthorizationFactory`