### PR TITLE
App/FOCI/UID Metadata Caching

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
@@ -78,8 +78,6 @@ public class SharedPreferencesBrokerApplicationMetadataCacheTest {
                 mMetadataCache.getAll().size()
         );
 
-        final List<BrokerApplicationMetadata> metadata = mMetadataCache.getAll();
-
         assertEquals(
                 randomMetadata,
                 mMetadataCache
@@ -120,8 +118,6 @@ public class SharedPreferencesBrokerApplicationMetadataCacheTest {
                 1,
                 mMetadataCache.getAll().size()
         );
-
-        final List<BrokerApplicationMetadata> metadata = mMetadataCache.getAll();
 
         assertEquals(
                 randomMetadata,

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.microsoft.identity.common.internal.cache.BrokerApplicationMetadata;
+import com.microsoft.identity.common.internal.cache.IBrokerApplicationMetadataCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesBrokerApplicationMetadataCache;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class SharedPreferencesBrokerApplicationMetadataCacheTest {
+
+    private IBrokerApplicationMetadataCache mMetadataCache;
+
+    @Before
+    public void setUp() {
+        mMetadataCache = new SharedPreferencesBrokerApplicationMetadataCache(
+                InstrumentationRegistry.getContext()
+        );
+    }
+
+    @After
+    public void tearDown() {
+        mMetadataCache.clear();
+    }
+
+    @Test
+    public void testEmptyCacheReturnsList() {
+        final List<BrokerApplicationMetadata> applicationMetadata = mMetadataCache.getAll();
+        assertNotNull(applicationMetadata);
+        assertTrue(applicationMetadata.isEmpty());
+    }
+
+    @Test
+    public void testInsert() {
+        final BrokerApplicationMetadata randomMetadata = generateRandomMetadata();
+
+        mMetadataCache.insert(randomMetadata);
+
+        assertEquals(
+                1,
+                mMetadataCache.getAll().size()
+        );
+
+        final List<BrokerApplicationMetadata> metadata = mMetadataCache.getAll();
+
+        assertEquals(
+                randomMetadata,
+                mMetadataCache
+                        .getAll()
+                        .get(0)
+        );
+    }
+
+    @Test
+    public void testInsertMultiple() {
+        final int expected = 10;
+        final List<BrokerApplicationMetadata> metadataList = new ArrayList<>();
+
+        for (int ii = 0; ii < expected; ii++) {
+            metadataList.add(generateRandomMetadata());
+        }
+
+        for (final BrokerApplicationMetadata metadata : metadataList) {
+            mMetadataCache.insert(metadata);
+        }
+
+        final List<BrokerApplicationMetadata> cacheContents = mMetadataCache.getAll();
+
+        for (final BrokerApplicationMetadata metadata : cacheContents) {
+            assertTrue(
+                    metadataList.contains(metadata)
+            );
+        }
+    }
+
+    @Test
+    public void testRemove() {
+        final BrokerApplicationMetadata randomMetadata = generateRandomMetadata();
+
+        mMetadataCache.insert(randomMetadata);
+
+        assertEquals(
+                1,
+                mMetadataCache.getAll().size()
+        );
+
+        final List<BrokerApplicationMetadata> metadata = mMetadataCache.getAll();
+
+        assertEquals(
+                randomMetadata,
+                mMetadataCache
+                        .getAll()
+                        .get(0)
+        );
+
+        assertTrue(mMetadataCache.remove(randomMetadata));
+    }
+
+    @Test
+    public void testRemoveMultiple() {
+        final int expected = 10;
+        final List<BrokerApplicationMetadata> metadataList = new ArrayList<>();
+
+        for (int ii = 0; ii < expected; ii++) {
+            metadataList.add(generateRandomMetadata());
+        }
+
+        for (final BrokerApplicationMetadata metadata : metadataList) {
+            mMetadataCache.insert(metadata);
+        }
+
+        final List<BrokerApplicationMetadata> cacheContents = mMetadataCache.getAll();
+
+        for (final BrokerApplicationMetadata metadata : cacheContents) {
+            assertTrue(
+                    mMetadataCache.remove(metadata)
+            );
+        }
+
+        assertTrue(mMetadataCache.getAll().isEmpty());
+    }
+
+    @Test
+    public void testRemoveNone() {
+        assertTrue(
+                mMetadataCache.remove(
+                        generateRandomMetadata()
+                )
+        );
+    }
+
+    @Test
+    public void testClear() {
+        final int expected = 10;
+
+        for (int ii = 0; ii < expected; ii++) {
+            mMetadataCache.insert(generateRandomMetadata());
+        }
+
+        assertEquals(
+                expected,
+                mMetadataCache.getAll().size()
+        );
+
+        assertTrue(
+                mMetadataCache.clear()
+        );
+
+        assertEquals(
+                0,
+                mMetadataCache.getAll().size()
+        );
+    }
+
+    private static BrokerApplicationMetadata generateRandomMetadata() {
+        final BrokerApplicationMetadata randomMetadata = new BrokerApplicationMetadata();
+
+        randomMetadata.setClientId(UUID.randomUUID().toString());
+        randomMetadata.setEnvironment(UUID.randomUUID().toString());
+        randomMetadata.setFoci(UUID.randomUUID().toString());
+        randomMetadata.setUid(new Random().nextInt());
+
+        return randomMetadata;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerApplicationMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerApplicationMetadata.java
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import com.google.gson.annotations.SerializedName;
+
+public class BrokerApplicationMetadata {
+
+    private static final class SerializedNames {
+        public static final String CLIENT_ID = "client_id";
+        static final String ENVIRONMENT = "environment";
+        static final String FOCI = "foci";
+        static final String APPLICATION_UID = "application_uid";
+    }
+
+    @SerializedName(SerializedNames.CLIENT_ID)
+    private String mClientId;
+
+    @SerializedName(SerializedNames.ENVIRONMENT)
+    private String mEnvironment;
+
+    @SerializedName(SerializedNames.FOCI)
+    private String mFoci;
+
+    @SerializedName(SerializedNames.APPLICATION_UID)
+    private int mUid;
+
+    public String getClientId() {
+        return mClientId;
+    }
+
+    public void setClientId(final String mClientId) {
+        this.mClientId = mClientId;
+    }
+
+    public String getEnvironment() {
+        return mEnvironment;
+    }
+
+    public void setEnvironment(final String mEnvironment) {
+        this.mEnvironment = mEnvironment;
+    }
+
+    public String getFoci() {
+        return mFoci;
+    }
+
+    public void setFoci(final String mFoci) {
+        this.mFoci = mFoci;
+    }
+
+    public int getUid() {
+        return mUid;
+    }
+
+    public void setUid(final int mUid) {
+        this.mUid = mUid;
+    }
+
+    //CHECKSTYLE:OFF
+    // This method is generated. Checkstyle and/or PMD has been disabled.
+    // This method *must* be regenerated if the class' structural definition changes through the
+    // addition/subtraction of fields.
+    @SuppressWarnings("PMD")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BrokerApplicationMetadata that = (BrokerApplicationMetadata) o;
+
+        if (mUid != that.mUid) return false;
+        if (mClientId != null ? !mClientId.equals(that.mClientId) : that.mClientId != null)
+            return false;
+        if (mEnvironment != null ? !mEnvironment.equals(that.mEnvironment) : that.mEnvironment != null)
+            return false;
+        return mFoci != null ? mFoci.equals(that.mFoci) : that.mFoci == null;
+    }
+    //CHECKSTYLE:ON
+
+    //CHECKSTYLE:OFF
+    // This method is generated. Checkstyle and/or PMD has been disabled.
+    // This method *must* be regenerated if the class' structural definition changes through the
+    // addition/subtraction of fields.
+    @SuppressWarnings("PMD")
+    @Override
+    public int hashCode() {
+        int result = mClientId != null ? mClientId.hashCode() : 0;
+        result = 31 * result + (mEnvironment != null ? mEnvironment.hashCode() : 0);
+        result = 31 * result + (mFoci != null ? mFoci.hashCode() : 0);
+        result = 31 * result + mUid;
+        return result;
+    }
+    //CHECKSTYLE:ON
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IBrokerApplicationMetadataCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IBrokerApplicationMetadataCache.java
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import java.util.List;
+
+public interface IBrokerApplicationMetadataCache {
+
+    /**
+     * Inserts a new entry in the cache.
+     *
+     * @param metadata The metadata to save.
+     * @return True, if saved. False otherwise.
+     */
+    boolean insert(BrokerApplicationMetadata metadata);
+
+    /**
+     * Removes an existing entry in the cache.
+     *
+     * @param metadata The metadata to remove.
+     * @return True if removed or does not exist. False otherwise.
+     */
+    boolean remove(BrokerApplicationMetadata metadata);
+
+    /**
+     * Returns all entries in the app metadata cache.
+     *
+     * @return A List of {@link BrokerApplicationMetadata}.
+     */
+    List<BrokerApplicationMetadata> getAll();
+
+    /**
+     * Removes all entries in the app metadata cache.
+     *
+     * @return True if the cache has been successfully cleared. False otherwise.
+     */
+    boolean clear();
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
@@ -133,6 +133,7 @@ public class SharedPreferencesBrokerApplicationMetadataCache
                     TAG + methodName,
                     "Nothing to delete -- cache entry is missing!"
             );
+
             return true;
         } else {
             final String json = mGson.toJson(allMetadata);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.microsoft.identity.common.internal.logging.Logger;
+
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SharedPreferencesBrokerApplicationMetadataCache
+        implements IBrokerApplicationMetadataCache {
+
+    private static final String TAG = SharedPreferencesBrokerApplicationMetadataCache.class.getSimpleName();
+
+    private static final String DEFAULT_APP_METADATA_CACHE_NAME = "com.microsoft.identity.app-meta-cache";
+
+    private static final String KEY_CACHE_LIST = "app-meta-cache";
+    private static final String EMPTY_ARRAY = "[]";
+
+    private final SharedPreferences mSharedPrefs;
+
+    private final Gson mGson = new Gson();
+
+    public SharedPreferencesBrokerApplicationMetadataCache(@NonNull final Context context) {
+        Logger.verbose(
+                TAG + "::ctor",
+                "Init"
+        );
+        mSharedPrefs = context.getSharedPreferences(
+                DEFAULT_APP_METADATA_CACHE_NAME,
+                Context.MODE_PRIVATE
+        );
+    }
+
+    @Override
+    public synchronized boolean insert(@NonNull final BrokerApplicationMetadata metadata) {
+        final Set<BrokerApplicationMetadata> allMetadata = new HashSet<>(getAll());
+        allMetadata.add(metadata);
+
+        final String json = mGson.toJson(allMetadata);
+
+        return mSharedPrefs.edit().putString(KEY_CACHE_LIST, json).commit();
+    }
+
+    @Override
+    public synchronized boolean remove(@NonNull final BrokerApplicationMetadata metadata) {
+        final Set<BrokerApplicationMetadata> allMetadata = new HashSet<>(getAll());
+        final boolean removed = allMetadata.remove(metadata);
+
+        if (!removed) {
+            // Nothing to do, wasn't cached in the first place!
+            return true;
+        } else {
+            final String json = mGson.toJson(allMetadata);
+            return mSharedPrefs.edit().putString(KEY_CACHE_LIST, json).commit();
+        }
+    }
+
+    @Override
+    public synchronized List<BrokerApplicationMetadata> getAll() {
+        final String jsonList = mSharedPrefs.getString(KEY_CACHE_LIST, EMPTY_ARRAY);
+
+        final Type listType = new TypeToken<List<BrokerApplicationMetadata>>() {
+        }.getType();
+
+        return mGson.fromJson(
+                jsonList,
+                listType
+        );
+    }
+
+    @Override
+    public synchronized boolean clear() {
+        return mSharedPrefs.edit().clear().commit();
+    }
+}


### PR DESCRIPTION
Implements and integrates a FOCI, application, and uid metadata caching for `BrokerOAuth2TokenCache`

**Usage with cache:**
When ADAL is calling broker:
```java
        final BrokerOAuth2TokenCache brokerOAuth2TokenCache2 = new BrokerOAuth2TokenCache(
                context,
                TEST_APP_UID,
                new SharedPreferencesBrokerApplicationMetadataCache(context),
                true // allow vis into other apps' caches
        );
```

When MSAL is calling broker:
```java
        final BrokerOAuth2TokenCache brokerOAuth2TokenCache2 = new BrokerOAuth2TokenCache(
                context,
                TEST_APP_UID,
                new SharedPreferencesBrokerApplicationMetadataCache(context),
                false // disallow vis into other apps' caches
        );
```