### PR TITLE
Fix the fragment parameter when extracting the redirect url

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@ Version 0.0.8
 -------------
 - Bugfix: Resolves COMMON/#343
     * Fix the discrepancy on idToken claim of Account object in v1.15.1.
+- Bugfix: Resolves MSAL/#517
+	* Fix the bug caused by fragment parameter when extracting the redirect url.
 
 Version 0.0.7
 -------------

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationResultFactoryTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAuthorizationResultFactoryTest.java
@@ -52,6 +52,7 @@ public class MicrosoftStsAuthorizationResultFactoryTest {
 
     private static final String REDIRECT_URI = "msauth-clientid://packagename/";
     private static final String AUTH_CODE_AND_STATE = "code=authorization_code&state=state";
+    private static final String FRAGMENT_STRING = "#_=_";
     private static final String MOCK_AUTH_CODE = "authorization_code";
     private static final String MOCK_STATE = "state";
     private static final String ERROR_MESSAGE = "access_denied";
@@ -196,4 +197,33 @@ public class MicrosoftStsAuthorizationResultFactoryTest {
         assertEquals(errorResponse.getErrorDescription(), ERROR_DESCRIPTION);
     }
 
+    @Test
+    public void testUrlWithValidAuthCodeAndFragmentParas() {
+        Intent intent = new Intent();
+        MicrosoftStsAuthorizationRequest testRequest = getMstsAuthorizationRequest();
+        intent.putExtra(AuthorizationStrategy.AUTHORIZATION_FINAL_URL,
+                REDIRECT_URI
+                        + "?" + "code=authorization_code&state=" + testRequest.getState()
+                        + FRAGMENT_STRING);
+        AuthorizationResult result = mAuthorizationResultFactory.createAuthorizationResult(
+                AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent, testRequest);
+        assertNotNull(result);
+        assertNotNull(result.getAuthorizationResponse());
+        assertEquals(AuthorizationStatus.SUCCESS, result.getAuthorizationStatus());
+        assertNotNull(result.getAuthorizationResponse().getCode());
+    }
+
+    @Test
+    public void testUrlWithInvalidAuthCodeAndFragmentParas() {
+        Intent intent = new Intent();
+        intent.putExtra(AuthorizationStrategy.AUTHORIZATION_FINAL_URL, REDIRECT_URI  + "?" + FRAGMENT_STRING);
+        AuthorizationResult result = mAuthorizationResultFactory.createAuthorizationResult(
+                AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, intent, getMstsAuthorizationRequest());
+        assertNotNull(result);
+        assertNotNull(result.getAuthorizationErrorResponse());
+        assertEquals(AuthorizationStatus.FAIL, result.getAuthorizationStatus());
+        AuthorizationErrorResponse errorResponse = result.getAuthorizationErrorResponse();
+        assertEquals(errorResponse.getError(), MicrosoftAuthorizationErrorResponse.AUTHORIZATION_FAILED);
+        assertEquals(errorResponse.getErrorDescription(), MicrosoftAuthorizationErrorResponse.AUTHORIZATION_SERVER_INVALID_RESPONSE);
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/util/StringExtensions.java
@@ -27,6 +27,7 @@ import android.util.Base64;
 import android.util.Log;
 
 import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.logging.Logger;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -149,14 +150,12 @@ public final class StringExtensions {
      */
     public static HashMap<String, String> getUrlParameters(String finalUrl) {
         Uri response = Uri.parse(finalUrl);
-        String fragment = response.getFragment();
-        HashMap<String, String> parameters = HashMapExtensions.urlFormDecode(fragment);
-
-        if (parameters == null || parameters.isEmpty()) {
-            String queryParameters = response.getEncodedQuery();
-            parameters = HashMapExtensions.urlFormDecode(queryParameters);
+        if (!HashMapExtensions.urlFormDecode(response.getFragment()).isEmpty()) {
+            Logger.warn(TAG, "Received url contains unexpected fragment parameters.");
+            Logger.warnPII(TAG, "Unexpected fragment: " + response.getFragment());
         }
-        return parameters;
+
+        return HashMapExtensions.urlFormDecode(response.getEncodedQuery());
     }
 
     /**

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=0.0.8-rc
+versionName=0.0.8-rc2
 versionCode=1


### PR DESCRIPTION
During the interactive auth code flow, MSAL extracts the auth code from the redirect URI's query parameters. And the fragment parameter is expected to be null. However, the B2C bug we encountered is, Facebook returns both query parameter and fragment parameter “_=_”.

For AAD V1(Section: OAuth 2.0 auth code grant) and V2 (Section: request an authorization code), the query is set as default for “response_mode”. And in MSAL, at least in Android platform, we actually did not have the property to set the “response_mode” value of the auth request. That is we always use the default value of “response_mode” set by the server. 

And the B2C service cannot delete the fragment para sent by Facebook. To fix this issue, we can simply skip the fragment para when extracting the auth response from redirect_uri
