### PR TITLE
Adding response headers, body, and statusCode to TokenErrorResponse

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerErrorResponse.java
@@ -39,21 +39,16 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
 
     public static final String INVALID_GRANT = "invalid_grant";
 
-
     private String mOAuthError;
     private String mOAuthSubError;
     private String mOAuthErrorMetadata;
     private String mOAuthErrorDescription;
-    private int mHttpStatusCode;
-    private String mHttpResponseBody;
-    private String mHttpResponseHeaders;
 
-
-    public BrokerErrorResponse(){
+    public BrokerErrorResponse() {
 
     }
 
-    public BrokerErrorResponse(@NonNull final MicrosoftTokenErrorResponse microsoftTokenErrorResponse){
+    public BrokerErrorResponse(@NonNull final MicrosoftTokenErrorResponse microsoftTokenErrorResponse) {
         setError(microsoftTokenErrorResponse.getError());
         setErrorDescription(microsoftTokenErrorResponse.getErrorDescription());
         setErrorUri(microsoftTokenErrorResponse.getErrorUri());
@@ -61,10 +56,13 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
         setTimeStamp(microsoftTokenErrorResponse.getTimeStamp());
         setTraceId(microsoftTokenErrorResponse.getTraceId());
         setCorrelationId(microsoftTokenErrorResponse.getCorrelationId());
+        setStatusCode(microsoftTokenErrorResponse.getStatusCode());
+        setResponseHeadersJson(microsoftTokenErrorResponse.getResponseHeadersJson());
+        setResponseBody(microsoftTokenErrorResponse.getResponseBody());
     }
 
     protected BrokerErrorResponse(Parcel in) {
-        if(in!=null) {
+        if (in != null) {
             setError(in.readString());
             setErrorDescription(in.readString());
             setErrorUri(in.readString());
@@ -78,15 +76,15 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
             setOAuthSubError(in.readString());
             setOAuthErrorMetadata(in.readString());
             setOAuthErrorDescription(in.readString());
-            setHttpStatusCode(in.readInt());
-            setHttpResponseBody(in.readString());
-            setHttpResponseHeaders(in.readString());
+            setStatusCode(in.readInt());
+            setResponseHeadersJson(in.readString());
+            setResponseBody(in.readString());
         }
     }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        if(dest!=null) {
+        if (dest != null) {
             dest.writeString(getError());
             dest.writeString(getErrorDescription());
             dest.writeString(getErrorUri());
@@ -98,9 +96,9 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
             dest.writeString(getOAuthSubError());
             dest.writeString(getOAuthErrorMetadata());
             dest.writeString(getOAuthErrorDescription());
-            dest.writeInt(getHttpStatusCode());
-            dest.writeString(getHttpResponseBody());
-            dest.writeString(getHttpResponseHeaders());
+            dest.writeInt(getStatusCode());
+            dest.writeString(getResponseHeadersJson());
+            dest.writeString(getResponseBody());
         }
     }
 
@@ -159,29 +157,5 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
 
     public void setOAuthErrorDescription(String oAuthErrorDescription) {
         this.mOAuthErrorDescription = oAuthErrorDescription;
-    }
-
-    public String getHttpResponseBody() {
-        return mHttpResponseBody;
-    }
-
-    public void setHttpResponseBody(String httpResponseBody) {
-        this.mHttpResponseBody = httpResponseBody;
-    }
-
-    public String getHttpResponseHeaders() {
-        return mHttpResponseHeaders;
-    }
-
-    public void setHttpResponseHeaders(String httpResponseHeaders) {
-        this.mHttpResponseHeaders = httpResponseHeaders;
-    }
-
-    public int getHttpStatusCode() {
-        return mHttpStatusCode;
-    }
-
-    public void setHttpStatusCode(int httpStatusCode) {
-        mHttpStatusCode = httpStatusCode;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerErrorResponse.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.broker;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftTokenErrorResponse;
 
@@ -50,6 +51,16 @@ public class BrokerErrorResponse extends MicrosoftTokenErrorResponse implements 
 
     public BrokerErrorResponse(){
 
+    }
+
+    public BrokerErrorResponse(@NonNull final MicrosoftTokenErrorResponse microsoftTokenErrorResponse){
+        setError(microsoftTokenErrorResponse.getError());
+        setErrorDescription(microsoftTokenErrorResponse.getErrorDescription());
+        setErrorUri(microsoftTokenErrorResponse.getErrorUri());
+        setErrorCodes(microsoftTokenErrorResponse.getErrorCodes());
+        setTimeStamp(microsoftTokenErrorResponse.getTimeStamp());
+        setTraceId(microsoftTokenErrorResponse.getTraceId());
+        setCorrelationId(microsoftTokenErrorResponse.getCorrelationId());
     }
 
     protected BrokerErrorResponse(Parcel in) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -22,10 +22,14 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.cache;
 
+import android.text.TextUtils;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftIdToken;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
@@ -150,7 +154,12 @@ public final class SchemaUtil {
                 final Map<String, String> idTokenClaims = idToken.getTokenClaims();
 
                 if (null != idTokenClaims) {
-                    idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
+                    final String aadVersion = idTokenClaims.get(AuthenticationConstants.OAuth2.AAD_VERSION);
+                    if (!TextUtils.isEmpty(aadVersion) && aadVersion.equalsIgnoreCase("1.0")) {
+                        idp = idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
+                    } else if (!TextUtils.isEmpty(aadVersion) && aadVersion.equalsIgnoreCase("2.0")) {
+                        idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
+                    }
 
                     Logger.verbosePII(TAG + ":" + methodName, "idp: " + idp);
 
@@ -160,7 +169,7 @@ public final class SchemaUtil {
                 } else {
                     Logger.warn(TAG + ":" + methodName, "IDToken claims were null.");
                 }
-            }catch (ServiceException e){
+            } catch (ServiceException e) {
                 Logger.warn(TAG + ":" + methodName, "Exception constructing IDToken. " + e.getMessage());
             }
         } else {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -96,7 +96,7 @@ public abstract class BaseController {
 
 
     protected AuthorizationRequest getAuthorizationRequest(@NonNull final OAuth2Strategy strategy,
-                                                         @NonNull final OperationParameters parameters) {
+                                                           @NonNull final OperationParameters parameters) {
         AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
 
         List<String> msalScopes = new ArrayList<>();
@@ -120,7 +120,7 @@ public abstract class BaseController {
 
         if (parameters instanceof AcquireTokenOperationParameters) {
             AcquireTokenOperationParameters acquireTokenOperationParameters = (AcquireTokenOperationParameters) parameters;
-            if(acquireTokenOperationParameters.getExtraScopesToConsent()!=null) {
+            if (acquireTokenOperationParameters.getExtraScopesToConsent() != null) {
                 msalScopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
             }
 
@@ -142,9 +142,9 @@ public abstract class BaseController {
     }
 
     protected TokenResult performTokenRequest(final OAuth2Strategy strategy,
-                                            final AuthorizationRequest request,
-                                            final AuthorizationResponse response,
-                                            final AcquireTokenOperationParameters parameters)
+                                              final AuthorizationRequest request,
+                                              final AuthorizationResponse response,
+                                              final AcquireTokenOperationParameters parameters)
             throws IOException, ClientException {
         throwIfNetworkNotAvailable(parameters.getAppContext());
 
@@ -159,10 +159,10 @@ public abstract class BaseController {
     }
 
     protected void renewAccessToken(@NonNull final AcquireTokenSilentOperationParameters parameters,
-                                  @NonNull final AcquireTokenResult acquireTokenSilentResult,
-                                  @NonNull final OAuth2TokenCache tokenCache,
-                                  @NonNull final OAuth2Strategy strategy,
-                                  @NonNull final ICacheRecord cacheRecord)
+                                    @NonNull final AcquireTokenResult acquireTokenSilentResult,
+                                    @NonNull final OAuth2TokenCache tokenCache,
+                                    @NonNull final OAuth2Strategy strategy,
+                                    @NonNull final ICacheRecord cacheRecord)
             throws IOException, ClientException, UiRequiredException {
         final String methodName = ":renewAccessToken";
         Logger.verbose(
@@ -255,9 +255,9 @@ public abstract class BaseController {
     }
 
     protected ICacheRecord saveTokens(final OAuth2Strategy strategy,
-                                    final AuthorizationRequest request,
-                                    final TokenResponse tokenResponse,
-                                    final OAuth2TokenCache tokenCache) throws ClientException {
+                                      final AuthorizationRequest request,
+                                      final TokenResponse tokenResponse,
+                                      final OAuth2TokenCache tokenCache) throws ClientException {
         final String methodName = ":saveTokens";
         Logger.verbose(
                 TAG + methodName,

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -50,6 +50,7 @@ public class ExceptionAdapter {
 
     private static final String TAG = ExceptionAdapter.class.getSimpleName();
 
+    @Nullable
     public static BaseException exceptionFromAcquireTokenResult(final AcquireTokenResult result) {
         final String methodName = ":exceptionFromAcquireTokenResult";
         final AuthorizationResult authorizationResult = result.getAuthorizationResult();
@@ -96,33 +97,28 @@ public class ExceptionAdapter {
                 );
             }
 
+            ServiceException outErr = null;
+
             if (StringUtil.isEmpty(tokenErrorResponse.getError())) {
                 Logger.warn(
                         TAG + methodName,
                         "Received unknown error"
                 );
 
-                final ServiceException outErr = new ServiceException(
+                outErr = new ServiceException(
                         ServiceException.UNKNOWN_ERROR,
                         "Request failed, but no error returned back from service.",
                         null
                 );
-
-                applyHttpErrorResponseData(
-                        outErr,
-                        tokenErrorResponse.getStatusCode(),
-                        tokenErrorResponse.getResponseHeadersJson(),
-                        tokenErrorResponse.getResponseBody()
-                );
-
-                return outErr;
             }
 
-            final ServiceException outErr =  new ServiceException(
-                    tokenErrorResponse.getError(),
-                    tokenErrorResponse.getErrorDescription(),
-                    null
-            );
+            if (null == outErr) {
+                outErr = new ServiceException(
+                        tokenErrorResponse.getError(),
+                        tokenErrorResponse.getErrorDescription(),
+                        null
+                );
+            }
 
             applyHttpErrorResponseData(
                     outErr,

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -73,7 +73,7 @@ public class ExceptionAdapter {
         final TokenResult tokenResult = result.getTokenResult();
         final TokenErrorResponse tokenErrorResponse;
 
-        if (!result.getTokenResult().getSuccess()) {
+        if (tokenResult != null && !tokenResult.getSuccess()) {
             tokenErrorResponse = tokenResult.getErrorResponse();
 
             if (tokenErrorResponse.getError().equalsIgnoreCase(UiRequiredException.INVALID_GRANT)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -355,9 +355,13 @@ public class MicrosoftStsOAuth2Strategy
                     MicrosoftTokenErrorResponse.class
             );
             tokenErrorResponse.setStatusCode(response.getStatusCode());
-            tokenErrorResponse.setResponseHeadersJson(
-                    HeaderSerializationUtil.toJson(response.getHeaders())
-            );
+
+            if (null != response.getHeaders()) {
+                tokenErrorResponse.setResponseHeadersJson(
+                        HeaderSerializationUtil.toJson(response.getHeaders())
+                );
+            }
+
             tokenErrorResponse.setResponseBody(response.getBody());
         } else {
             tokenResponse = ObjectMapper.deserializeJsonStringToObject(

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -92,6 +92,7 @@ public class MicrosoftStsOAuth2Strategy
 
         final URL authority = request.getAuthority();
         final AzureActiveDirectoryCloud cloudEnv = AzureActiveDirectory.getAzureActiveDirectoryCloud(authority);
+
         // This map can only be consulted if the authority (cloud really) is known to Microsoft
         // If the host has a hardcoded trust, we can just use the hostname.
         if (null != cloudEnv) {
@@ -104,8 +105,10 @@ public class MicrosoftStsOAuth2Strategy
                     TAG + methodName,
                     "Preferred cache hostname: [" + preferredCacheHostName + "]"
             );
+
             return preferredCacheHostName;
         }
+
         return authority.getHost();
     }
 
@@ -113,6 +116,7 @@ public class MicrosoftStsOAuth2Strategy
         final String methodName = ":getIssuerCacheIdentifierFromAuthority";
 
         final AzureActiveDirectoryCloud cloudEnv = AzureActiveDirectory.getAzureActiveDirectoryCloud(authority);
+
         // This map can only be consulted if the cloud is known to Microsoft
         // If the host has a hardcoded trust, we can just use the hostname.
         if (null != cloudEnv) {
@@ -125,8 +129,10 @@ public class MicrosoftStsOAuth2Strategy
                     TAG + methodName,
                     "Preferred cache hostname: [" + preferredCacheHostName + "]"
             );
+
             return preferredCacheHostName;
         }
+
         return authority.getHost();
     }
 
@@ -134,10 +140,12 @@ public class MicrosoftStsOAuth2Strategy
     public MicrosoftStsAccessToken getAccessTokenFromResponse(
             @NonNull final MicrosoftStsTokenResponse response) {
         final String methodName = ":getAccessTokenFromResponse";
+
         Logger.verbose(
                 TAG + methodName,
                 "Getting AT from TokenResponse..."
         );
+
         return new MicrosoftStsAccessToken(response);
     }
 
@@ -145,10 +153,12 @@ public class MicrosoftStsOAuth2Strategy
     public MicrosoftStsRefreshToken getRefreshTokenFromResponse(
             @NonNull final MicrosoftStsTokenResponse response) {
         final String methodName = ":getRefreshTokenFromResponse";
+
         Logger.verbose(
                 TAG + methodName,
                 "Getting RT from TokenResponse..."
         );
+
         return new MicrosoftStsRefreshToken(response);
     }
 
@@ -162,12 +172,22 @@ public class MicrosoftStsOAuth2Strategy
         );
         IDToken idToken = null;
         ClientInfo clientInfo = null;
+
         try {
             idToken = new IDToken(response.getIdToken());
             clientInfo = new ClientInfo(response.getClientInfo());
         } catch (ServiceException ccse) {
-            Logger.error(TAG + methodName, "Failed to construct IDToken or ClientInfo", null);
-            Logger.errorPII(TAG + methodName, "Failed with Exception", ccse);
+            Logger.error(
+                    TAG + methodName,
+                    "Failed to construct IDToken or ClientInfo",
+                    null
+            );
+            Logger.errorPII(
+                    TAG + methodName,
+                    "Failed with Exception",
+                    ccse
+            );
+
             throw new RuntimeException();
         }
 
@@ -177,6 +197,7 @@ public class MicrosoftStsOAuth2Strategy
         // For caching purposes, this may not be the correct value due to the preferred cache identifier
         // in the InstanceDiscoveryMetadata
         URL authority = null;
+
         try {
             authority = new URL(mTokenEndpoint);
         } catch (MalformedURLException e) {
@@ -185,6 +206,7 @@ public class MicrosoftStsOAuth2Strategy
                     "Creating account from TokenResponse failed due to malformed URL (mTokenEndpoint)..."
             );
         }
+
         if (authority != null) {
             account.setEnvironment(getIssuerCacheIdentifierFromAuthority(authority));
         }
@@ -195,12 +217,15 @@ public class MicrosoftStsOAuth2Strategy
     @Override
     public MicrosoftStsAuthorizationRequest.Builder createAuthorizationRequestBuilder() {
         final String methodName = ":createAuthorizationRequestBuilder";
+
         Logger.verbose(
                 TAG + methodName,
                 "Creating AuthorizationRequestBuilder..."
         );
+
         MicrosoftStsAuthorizationRequest.Builder builder = new MicrosoftStsAuthorizationRequest.Builder();
         builder.setAuthority(mConfig.getAuthorityUrl());
+
         if (mConfig.getSlice() != null) {
             Logger.verbose(
                     TAG + methodName,
@@ -208,6 +233,7 @@ public class MicrosoftStsOAuth2Strategy
             );
             builder.setSlice(mConfig.getSlice());
         }
+
         builder.setFlightParameters(mConfig.getFlightParameters());
         builder.setMultipleCloudAware(mConfig.getMultipleCloudsSupported());
 
@@ -227,6 +253,7 @@ public class MicrosoftStsOAuth2Strategy
             final String homeAccountId = account.getHomeAccountId();
 
             final Pair<String, String> uidUtidPair = StringUtil.getTenantInfo(homeAccountId);
+
             if (!StringExtensions.isNullOrBlank(uidUtidPair.first)
                     && !StringExtensions.isNullOrBlank(uidUtidPair.second)) {
                 builder.setUid(uidUtidPair.first);
@@ -265,12 +292,24 @@ public class MicrosoftStsOAuth2Strategy
         tokenRequest.setCode(response.getCode());
         tokenRequest.setRedirectUri(request.getRedirectUri());
         tokenRequest.setClientId(request.getClientId());
+
         try {
-            tokenRequest.setCorrelationId(UUID.fromString(DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID)));
+            tokenRequest.setCorrelationId(
+                    UUID.fromString(
+                            DiagnosticContext
+                                    .getRequestContext()
+                                    .get(DiagnosticContext.CORRELATION_ID)
+                    )
+            );
         } catch (IllegalArgumentException ex) {
             //We're not setting the correlation id if we can't parse it from the diagnostic context
-            Logger.error("MicrosoftSTSOAuth2Strategy", "Correlation id on diagnostic context is not a UUID.", ex);
+            Logger.error(
+                    "MicrosoftSTSOAuth2Strategy",
+                    "Correlation id on diagnostic context is not a UUID.",
+                    ex
+            );
         }
+
         return tokenRequest;
     }
 
@@ -310,15 +349,24 @@ public class MicrosoftStsOAuth2Strategy
 
         if (response.getStatusCode() >= HttpURLConnection.HTTP_BAD_REQUEST) {
             //An error occurred
-            tokenErrorResponse = ObjectMapper.deserializeJsonStringToObject(response.getBody(), MicrosoftTokenErrorResponse.class);
+            tokenErrorResponse = ObjectMapper.deserializeJsonStringToObject(
+                    response.getBody(),
+                    MicrosoftTokenErrorResponse.class
+            );
+            tokenErrorResponse.setStatusCode(response.getStatusCode());
+            tokenErrorResponse.setResponseHeaders(response.getHeaders());
+            tokenErrorResponse.setResponseBody(response.getBody());
         } else {
-            tokenResponse = ObjectMapper.deserializeJsonStringToObject(response.getBody(), MicrosoftStsTokenResponse.class);
+            tokenResponse = ObjectMapper.deserializeJsonStringToObject(
+                    response.getBody(),
+                    MicrosoftStsTokenResponse.class
+            );
         }
 
         return new TokenResult(tokenResponse, tokenErrorResponse);
     }
 
-    private String getCloudSpecificAuthorityBasedOnAuthorizationResponse(MicrosoftStsAuthorizationResponse response) {
+    private String getCloudSpecificAuthorityBasedOnAuthorizationResponse(final MicrosoftStsAuthorizationResponse response) {
 
         final String newAuthority = Uri.parse(mTokenEndpoint).buildUpon()
                 .authority(response.getCloudInstanceHostName())

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenErrorRespons
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.util.HeaderSerializationUtil;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.net.HttpURLConnection;
@@ -354,7 +355,9 @@ public class MicrosoftStsOAuth2Strategy
                     MicrosoftTokenErrorResponse.class
             );
             tokenErrorResponse.setStatusCode(response.getStatusCode());
-            tokenErrorResponse.setResponseHeaders(response.getHeaders());
+            tokenErrorResponse.setResponseHeadersJson(
+                    HeaderSerializationUtil.toJson(response.getHeaders())
+            );
             tokenErrorResponse.setResponseBody(response.getBody());
         } else {
             tokenResponse = ObjectMapper.deserializeJsonStringToObject(

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -366,11 +366,15 @@ public class MicrosoftStsOAuth2Strategy
         return new TokenResult(tokenResponse, tokenErrorResponse);
     }
 
-    private String getCloudSpecificAuthorityBasedOnAuthorizationResponse(final MicrosoftStsAuthorizationResponse response) {
+    private String getCloudSpecificAuthorityBasedOnAuthorizationResponse(
+            @NonNull final MicrosoftStsAuthorizationResponse response) {
 
-        final String newAuthority = Uri.parse(mTokenEndpoint).buildUpon()
-                .authority(response.getCloudInstanceHostName())
-                .build().toString();
+        final String newAuthority =
+                Uri.parse(mTokenEndpoint)
+                        .buildUpon()
+                        .authority(response.getCloudInstanceHostName())
+                        .build()
+                        .toString();
 
         return newAuthority;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
@@ -24,7 +24,16 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+import java.util.Map;
+
 public class TokenErrorResponse {
+
+    private int mStatusCode;
+
+    private String mResponseBody;
+
+    private Map<String, List<String>> mResponseHeaders;
 
     @SerializedName("error")
     private String mError;
@@ -77,15 +86,71 @@ public class TokenErrorResponse {
         mErrorUri = errorUri;
     }
 
+    /**
+     * Gets the response status code.
+     *
+     * @return The status code to get.
+     */
+    public int getStatusCode() {
+        return mStatusCode;
+    }
+
+    /**
+     * Sets the response status code.
+     *
+     * @param statusCode The status code to set.
+     */
+    public void setStatusCode(final int statusCode) {
+        this.mStatusCode = statusCode;
+    }
+
+    /**
+     * Gets the response body.
+     *
+     * @return The response body to get.
+     */
+    public String getResponseBody() {
+        return mResponseBody;
+    }
+
+    /**
+     * Sets the response body.
+     *
+     * @param responseBody The response body to set.
+     */
+    public void setResponseBody(final String responseBody) {
+        this.mResponseBody = responseBody;
+    }
+
+    /**
+     * Gets the response headers.
+     *
+     * @return The response headers to get.
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return mResponseHeaders;
+    }
+
+    /**
+     * Sets the response headers.
+     *
+     * @param responseHeaders The response headers to set.
+     */
+    public void setResponseHeaders(final Map<String, List<String>> responseHeaders) {
+        this.mResponseHeaders = responseHeaders;
+    }
+
     //CHECKSTYLE:OFF
     @Override
     public String toString() {
         return "TokenErrorResponse{" +
-                "mError='" + mError + '\'' +
+                "mStatusCode=" + mStatusCode +
+                ", mResponseBody='" + mResponseBody + '\'' +
+                ", mResponseHeaders=" + mResponseHeaders +
+                ", mError='" + mError + '\'' +
                 ", mErrorDescription='" + mErrorDescription + '\'' +
                 ", mErrorUri='" + mErrorUri + '\'' +
                 '}';
     }
     //CHECKSTYLE:ON
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenErrorResponse.java
@@ -24,16 +24,13 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.util.List;
-import java.util.Map;
-
 public class TokenErrorResponse {
 
     private int mStatusCode;
 
     private String mResponseBody;
 
-    private Map<String, List<String>> mResponseHeaders;
+    private String mResponseHeadersJson;
 
     @SerializedName("error")
     private String mError;
@@ -127,17 +124,17 @@ public class TokenErrorResponse {
      *
      * @return The response headers to get.
      */
-    public Map<String, List<String>> getResponseHeaders() {
-        return mResponseHeaders;
+    public String getResponseHeadersJson() {
+        return mResponseHeadersJson;
     }
 
     /**
      * Sets the response headers.
      *
-     * @param responseHeaders The response headers to set.
+     * @param responseHeadersJson The response headers to set.
      */
-    public void setResponseHeaders(final Map<String, List<String>> responseHeaders) {
-        this.mResponseHeaders = responseHeaders;
+    public void setResponseHeadersJson(final String responseHeadersJson) {
+        this.mResponseHeadersJson = responseHeadersJson;
     }
 
     //CHECKSTYLE:OFF
@@ -146,7 +143,7 @@ public class TokenErrorResponse {
         return "TokenErrorResponse{" +
                 "mStatusCode=" + mStatusCode +
                 ", mResponseBody='" + mResponseBody + '\'' +
-                ", mResponseHeaders=" + mResponseHeaders +
+                ", mResponseHeadersJson=" + mResponseHeadersJson +
                 ", mError='" + mError + '\'' +
                 ", mErrorDescription='" + mErrorDescription + '\'' +
                 ", mErrorUri='" + mErrorUri + '\'' +

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/HeaderSerializationUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/HeaderSerializationUtil.java
@@ -1,0 +1,48 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.util;
+
+import android.support.annotation.NonNull;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HeaderSerializationUtil {
+
+    public static String toJson(@NonNull final Map<String, List<String>> headersIn) {
+        return new Gson().toJson(headersIn);
+    }
+
+    public static HashMap<String, List<String>> fromJson(@NonNull final String jsonIn) {
+        return new Gson()
+                .fromJson(
+                        jsonIn,
+                        new TypeToken<HashMap<String, List<String>>>() {
+                        }.getType()
+                );
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/HeaderSerializationUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/HeaderSerializationUtilTest.java
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.unit;
+
+import com.microsoft.identity.common.internal.util.HeaderSerializationUtil;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.microsoft.identity.common.unit.HeaderSerializationUtilTest.HeaderNames.ACCESS_CONTROL_ALLOW_METHODS;
+import static com.microsoft.identity.common.unit.HeaderSerializationUtilTest.HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static com.microsoft.identity.common.unit.HeaderSerializationUtilTest.HeaderNames.CACHE_CONTROL;
+import static com.microsoft.identity.common.unit.HeaderSerializationUtilTest.HeaderNames.CONTENT_TYPE;
+import static com.microsoft.identity.common.unit.HeaderSerializationUtilTest.HeaderNames.SERVER;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class HeaderSerializationUtilTest {
+
+    static class HeaderNames {
+        static final String CACHE_CONTROL = "Cache-Control";
+        static final String CONTENT_TYPE = "Content-Type";
+        static final String SERVER = "Server";
+        static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+        static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+    }
+
+    @Test
+    public void test_serialization() {
+        final Map<String, List<String>> testHeaders = new HashMap<>();
+
+        // Initialize the containers
+        testHeaders.put(CACHE_CONTROL, new ArrayList<String>());
+        testHeaders.put(CONTENT_TYPE, new ArrayList<String>());
+        testHeaders.put(SERVER, new ArrayList<String>());
+        testHeaders.put(ACCESS_CONTROL_ALLOW_ORIGIN, new ArrayList<String>());
+        testHeaders.put(ACCESS_CONTROL_ALLOW_METHODS, new ArrayList<String>());
+
+        // Populate some sample data...
+        testHeaders.get(CACHE_CONTROL).add("private");
+        testHeaders.get(CACHE_CONTROL).add("max-age=86400");
+
+        testHeaders.get(CONTENT_TYPE).add("application/json");
+        testHeaders.get(CONTENT_TYPE).add("charset=utf-8");
+
+        testHeaders.get(SERVER).add("Microsoft-IIS/10.0");
+
+        testHeaders.get(ACCESS_CONTROL_ALLOW_ORIGIN).add("*");
+
+        testHeaders.get(ACCESS_CONTROL_ALLOW_METHODS).add("GET");
+        testHeaders.get(ACCESS_CONTROL_ALLOW_METHODS).add("OPTIONS");
+
+        final String json = HeaderSerializationUtil.toJson(testHeaders);
+
+        final Map<String, List<String>> reserializedMap = HeaderSerializationUtil.fromJson(json);
+
+        assertEquals(
+                testHeaders.size(),
+                reserializedMap.size()
+        );
+
+        assertEquals(
+                testHeaders.get(CACHE_CONTROL).size(),
+                reserializedMap.get(CACHE_CONTROL).size()
+        );
+
+        assertEquals(
+                testHeaders.get(CONTENT_TYPE).size(),
+                reserializedMap.get(CONTENT_TYPE).size()
+        );
+
+        assertEquals(
+                testHeaders.get(SERVER).size(),
+                reserializedMap.get(SERVER).size()
+        );
+
+        assertEquals(
+                testHeaders.get(ACCESS_CONTROL_ALLOW_ORIGIN).size(),
+                reserializedMap.get(ACCESS_CONTROL_ALLOW_ORIGIN).size()
+        );
+
+        assertEquals(
+                testHeaders.get(ACCESS_CONTROL_ALLOW_METHODS).size(),
+                reserializedMap.get(ACCESS_CONTROL_ALLOW_METHODS).size()
+        );
+    }
+}


### PR DESCRIPTION
Work in progress PR to support exposing `/token` response data (such as headers, status codes, and response bodies) to clients