### PR TITLE
Implements and tests the new BrokerOAuth2TokenCache 3-arg save() API

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -789,4 +789,120 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         );
     }
 
+    @Test
+    public void testWPJSaveNonFoci() throws ClientException {
+        final ICacheRecord saveResult = mBrokerOAuth2TokenCache.save(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                null
+        );
+
+        assertNotNull(saveResult);
+        assertNotNull(saveResult.getAccount());
+        assertNotNull(saveResult.getIdToken());
+        assertNotNull(saveResult.getAccessToken());
+        assertNull(saveResult.getRefreshToken());
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                saveResult.getAccount()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                saveResult.getIdToken()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                saveResult.getAccessToken()
+        );
+
+        final ICacheRecord retrievedResult = mBrokerOAuth2TokenCache.load(
+                mDefaultAppUidTestBundle.mGeneratedIdToken.getClientId(),
+                mDefaultAppUidTestBundle.mGeneratedAccessToken.getTarget(),
+                mDefaultAppUidTestBundle.mGeneratedAccount
+        );
+
+        assertNotNull(retrievedResult);
+        assertNotNull(retrievedResult.getAccount());
+        assertNotNull(retrievedResult.getIdToken());
+        assertNotNull(retrievedResult.getAccessToken());
+        assertNull(retrievedResult.getRefreshToken());
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                retrievedResult.getAccount()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                retrievedResult.getIdToken()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                retrievedResult.getAccessToken()
+        );
+    }
+
+    @Test
+    public void testWPJSaveFoci() throws ClientException {
+        final ICacheRecord saveResult = mBrokerOAuth2TokenCache.save(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                "1"
+        );
+
+        assertNotNull(saveResult);
+        assertNotNull(saveResult.getAccount());
+        assertNotNull(saveResult.getIdToken());
+        assertNotNull(saveResult.getAccessToken());
+        assertNull(saveResult.getRefreshToken());
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                saveResult.getAccount()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                saveResult.getIdToken()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                saveResult.getAccessToken()
+        );
+
+        final ICacheRecord retrievedResult = mBrokerOAuth2TokenCache.load(
+                mDefaultAppUidTestBundle.mGeneratedIdToken.getClientId(),
+                mDefaultAppUidTestBundle.mGeneratedAccessToken.getTarget(),
+                mDefaultAppUidTestBundle.mGeneratedAccount
+        );
+
+        assertNotNull(retrievedResult);
+        assertNotNull(retrievedResult.getAccount());
+        assertNotNull(retrievedResult.getIdToken());
+        assertNotNull(retrievedResult.getAccessToken());
+        assertNull(retrievedResult.getRefreshToken());
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccount,
+                retrievedResult.getAccount()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedIdToken,
+                retrievedResult.getIdToken()
+        );
+
+        assertEquals(
+                mDefaultAppUidTestBundle.mGeneratedAccessToken,
+                retrievedResult.getAccessToken()
+        );
+    }
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -94,6 +94,53 @@ public class MsalOAuth2TokenCache
         mAccountCredentialAdapter = accountCredentialAdapter;
     }
 
+    /**
+     * @param accountRecord     The {@link AccountRecord} to store.
+     * @param idTokenRecord     The {@link IdTokenRecord} to store.
+     * @param accessTokenRecord The {@link AccessTokenRecord} to store.
+     * @return The {@link ICacheRecord} result of this save action.
+     * @throws ClientException If the supplied Accounts or Credentials are schema invalid.
+     * @see BrokerOAuth2TokenCache#save(AccountRecord, IdTokenRecord, AccessTokenRecord, String)
+     */
+    ICacheRecord save(@NonNull AccountRecord accountRecord,
+                      @NonNull IdTokenRecord idTokenRecord,
+                      @NonNull AccessTokenRecord accessTokenRecord) throws ClientException {
+        final String methodName = ":save (broker 3 arg)";
+
+        // Validate the supplied Accounts/Credentials
+        final boolean isAccountValid = isAccountSchemaCompliant(accountRecord);
+        final boolean isIdTokenValid = isIdTokenSchemaCompliant(idTokenRecord);
+        final boolean isAccessTokenValid = isAccessTokenSchemaCompliant(accessTokenRecord);
+
+        if (!isAccountValid) {
+            throw new ClientException(ACCOUNT_IS_SCHEMA_NONCOMPLIANT);
+        }
+
+        if (!isIdTokenValid) {
+            throw new ClientException(CREDENTIAL_IS_SCHEMA_NONCOMPLIANT, "[(ID)]");
+        }
+
+        if (!isAccessTokenValid) {
+            throw new ClientException(CREDENTIAL_IS_SCHEMA_NONCOMPLIANT, "[(AT)]");
+
+        }
+
+        Logger.verbose(
+                TAG + methodName,
+                "Accounts/Credentials are valid.... proceeding"
+        );
+
+        saveAccounts(accountRecord);
+        saveCredentials(idTokenRecord, accessTokenRecord);
+
+        final CacheRecord result = new CacheRecord();
+        result.setAccount(accountRecord);
+        result.setIdToken(idTokenRecord);
+        result.setAccessToken(accessTokenRecord);
+
+        return result;
+    }
+
     @Override
     public ICacheRecord save(@NonNull final GenericOAuth2Strategy oAuth2Strategy,
                              @NonNull final GenericAuthorizationRequest request,

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -122,7 +122,6 @@ public class MsalOAuth2TokenCache
 
         if (!isAccessTokenValid) {
             throw new ClientException(CREDENTIAL_IS_SCHEMA_NONCOMPLIANT, "[(AT)]");
-
         }
 
         Logger.verbose(


### PR DESCRIPTION
This is a feature request on the `BrokerOAuth2TokenCache`: allow it to save WPJ'd Accounts, IdTokens, AccessTokens (but RefreshTokens will not be present).

API Design:
The BrokerOAuth2TokenCache will get a new API with approx. the following functionality

```java
public ICacheRecord save(@NonNull AccountRecord account,
                         @NonNull IdTokenRecord idToken,
                         @NonNull AccessTokenRecord accessToken,
                         @Nullable String familyId) {
    if (null != familyId) {
        // Save the passed-in Account/Credentials to the FOCI cache
    } else {
        // Save the passed-in Account/Credentials to the processUid cache
    }

    // Update the BrokerApplicationMetadataCache with the new record
}
```