### PR TITLE
Remove INVALID_GRANT omission in TokenCommand.execute()

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -81,25 +81,17 @@ public class TokenCommand implements TokenOperation {
         final String methodName = ":execute";
 
         for(BaseController controller : mControllers) {
-            try {
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Executing with controller: " + controller.getClass().getSimpleName()
+            );
+            result = controller.acquireTokenSilent((AcquireTokenSilentOperationParameters) getParameters());
+            if(result.getSucceeded()){
                 com.microsoft.identity.common.internal.logging.Logger.verbose(
                         TAG + methodName,
-                        "Executing with controller: " + controller.getClass().getSimpleName()
+                        "Executing with controller: " + controller.getClass().getSimpleName() + ": Succeeded"
                 );
-                result = controller.acquireTokenSilent((AcquireTokenSilentOperationParameters) getParameters());
-                if(result.getSucceeded()){
-                    com.microsoft.identity.common.internal.logging.Logger.verbose(
-                            TAG + methodName,
-                            "Executing with controller: " + controller.getClass().getSimpleName() + ": Succeeded"
-                    );
-                    return result;
-                }
-            }catch(UiRequiredException e){
-                if(e.getErrorCode().equals(UiRequiredException.INVALID_GRANT)){
-                    continue;
-                }else{
-                    throw e;
-                }
+                return result;
             }
         }
 


### PR DESCRIPTION
When INVALID_GRANT was received, it was silently consumed hence there is no exception thrown, and the null result object is returned.

This crashes ad-accounts as it's expecting result object to not be null.