### PR TITLE
 Changes to accommodate Joined Account Caching changes in ad-accounts

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -108,7 +108,7 @@ public abstract class BaseController {
         defaultScopes.add("offline_access");
 
         List<String> scopes  = parameters.getScopes();
-        if(scopes.containsAll(defaultScopes)){
+        if(!scopes.containsAll(defaultScopes)){
             scopes.addAll(defaultScopes);
         }
         scopes.removeAll(Arrays.asList("", null));

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -60,6 +60,7 @@ import com.microsoft.identity.common.internal.util.DateUtilities;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -101,7 +102,17 @@ public abstract class BaseController {
                                                            @NonNull final OperationParameters parameters) {
         AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
 
+        List<String> defaultScopes = new ArrayList<>();
+        defaultScopes.add("openid");
+        defaultScopes.add("profile");
+        defaultScopes.add("offline_access");
+
         List<String> scopes  = parameters.getScopes();
+        if(scopes.containsAll(defaultScopes)){
+            scopes.addAll(defaultScopes);
+        }
+        scopes.removeAll(Arrays.asList("", null));
+
 
         UUID correlationId = null;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -40,6 +40,8 @@ import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
@@ -58,11 +60,11 @@ import com.microsoft.identity.common.internal.util.DateUtilities;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public abstract class BaseController {
 
@@ -99,11 +101,7 @@ public abstract class BaseController {
                                                            @NonNull final OperationParameters parameters) {
         AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
 
-        List<String> msalScopes = new ArrayList<>();
-        msalScopes.add("openid");
-        msalScopes.add("profile");
-        msalScopes.add("offline_access");
-        msalScopes.addAll(parameters.getScopes());
+        List<String> scopes  = parameters.getScopes();
 
         UUID correlationId = null;
 
@@ -121,7 +119,7 @@ public abstract class BaseController {
         if (parameters instanceof AcquireTokenOperationParameters) {
             AcquireTokenOperationParameters acquireTokenOperationParameters = (AcquireTokenOperationParameters) parameters;
             if (acquireTokenOperationParameters.getExtraScopesToConsent() != null) {
-                msalScopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
+                scopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
             }
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
@@ -135,8 +133,8 @@ public abstract class BaseController {
         }
 
         //Remove empty strings and null values
-        msalScopes.removeAll(Arrays.asList("", null));
-        request.setScope(StringUtil.join(' ', msalScopes));
+        scopes.removeAll(Arrays.asList("", null));
+        request.setScope(StringUtil.join(' ', scopes));
 
         return request.build();
     }
@@ -275,7 +273,7 @@ public abstract class BaseController {
     }
 
     public static AccessTokenRecord getAccessTokenRecord(@NonNull final MicrosoftStsTokenResponse tokenResponse,
-                                                         @NonNull final String authority) {
+                                                         @NonNull final OperationParameters requestParameters) {
         final String methodName = ":getAccessTokenRecord";
 
         final AccessTokenRecord accessTokenRecord = new AccessTokenRecord();
@@ -284,17 +282,38 @@ public abstract class BaseController {
             final ClientInfo clientInfo = new ClientInfo(tokenResponse.getClientInfo());
             accessTokenRecord.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             accessTokenRecord.setRealm(clientInfo.getUtid());
+            final AzureActiveDirectoryCloud cloudEnv = AzureActiveDirectory.
+                    getAzureActiveDirectoryCloud(
+                            requestParameters.getAuthority().getAuthorityURL()
+                    );
+            if (cloudEnv != null) {
+                Logger.info(TAG, "Using preferred cache host name...");
+                accessTokenRecord.setEnvironment(cloudEnv.getPreferredCacheHostName());
+            } else {
+                accessTokenRecord.setEnvironment(
+                        requestParameters.getAuthority().getAuthorityURL().getHost()
+                );
+            }
         } catch (final ServiceException e) {
             Logger.error(TAG + methodName, "ClientInfo construction failed ", e);
         }
-
+        accessTokenRecord.setClientId(requestParameters.getClientId());
         accessTokenRecord.setSecret(tokenResponse.getAccessToken());
-        accessTokenRecord.setAuthority(tokenResponse.getTokenType());
-        accessTokenRecord.setAuthority(authority);
+        accessTokenRecord.setAccessTokenType(tokenResponse.getTokenType());
+        accessTokenRecord.setAuthority(
+                requestParameters.getAuthority().getAuthorityURL().toString()
+        );
         accessTokenRecord.setTarget(tokenResponse.getScope());
         accessTokenRecord.setCredentialType(CredentialType.AccessToken.name());
-        accessTokenRecord.setExpiresOn(String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExpiresIn())));
-        accessTokenRecord.setExtendedExpiresOn(String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExtExpiresIn())));
+        accessTokenRecord.setExpiresOn(
+                String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExpiresIn()))
+        );
+        accessTokenRecord.setExtendedExpiresOn(
+                String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExtExpiresIn()))
+        );
+        accessTokenRecord.setCachedAt(
+                String.valueOf(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
+        );
         return accessTokenRecord;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
@@ -32,6 +32,13 @@ public class MicrosoftTokenRequest extends TokenRequest {
     public static final String CODE_VERIFIER = "code_verifier";
     public static final String CLIENT_INFO = "client_info";
     public static final String CORRELATION_ID = "client-request-id";
+    public static final String ID_TOKEN_VERSIOM = "itver";
+    public static final String MAM_VERSION = "mamver";
+    public static final String CLAIMS = "claims";
+    public static final String INSTANCE_AWARE = "instance_aware";
+    public static final String CLIENT_APP_NAME = "x-app-name";
+    public static final String CLIENT_APP_VERSION = "x-app-ver";
+
 
     public MicrosoftTokenRequest() {
         mClientInfoEnabled = "1";
@@ -45,6 +52,25 @@ public class MicrosoftTokenRequest extends TokenRequest {
 
     @SerializedName(CORRELATION_ID)
     private UUID mCorrelationId;
+
+    @SerializedName(ID_TOKEN_VERSIOM)
+    private String mIdTokenVersion;
+
+    @SerializedName(MAM_VERSION)
+    private String mMamVersion;
+
+    @SerializedName(CLAIMS)
+    private String mClaims;
+
+    @SerializedName(INSTANCE_AWARE)
+    private String mInstanceAware;
+
+    @SerializedName(CLIENT_APP_NAME)
+    private String mClientAppName;
+
+    @SerializedName(CLIENT_APP_VERSION)
+    private String mClientAppVersion;
+
 
     public String getCodeVerifier() {
         return this.mCodeVerifier;
@@ -64,5 +90,53 @@ public class MicrosoftTokenRequest extends TokenRequest {
 
     public UUID getCorrelationId() {
         return mCorrelationId;
+    }
+
+    public String getIdTokenVersion() {
+        return mIdTokenVersion;
+    }
+
+    public void setIdTokenVersion(final String mIdTokenVersion) {
+        this.mIdTokenVersion = mIdTokenVersion;
+    }
+
+    public String getClaims() {
+        return mClaims;
+    }
+
+    public void setClaims(final String claims) {
+        this.mClaims = claims;
+    }
+
+    public String getInstanceAware() {
+        return mInstanceAware;
+    }
+
+    public void setInstanceAware(final String instanceAware) {
+        this.mInstanceAware = instanceAware;
+    }
+
+    public String getClientAppName() {
+        return mClientAppName;
+    }
+
+    public void setClientAppName(String clientAppName) {
+        this.mClientAppName = clientAppName;
+    }
+
+    public String getClientAppVersion() {
+        return mClientAppVersion;
+    }
+
+    public void setClientAppVersion(final String clientAppVersion) {
+        this.mClientAppVersion = clientAppVersion;
+    }
+
+    public String getMamVersion() {
+        return mMamVersion;
+    }
+
+    public void setMamversion(final String mamVersion) {
+        this.mMamVersion = mamVersion;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAccount.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
@@ -63,10 +64,15 @@ public class MicrosoftStsAccount extends MicrosoftAccount {
 
     @Override
     protected String getDisplayableId(final Map<String, String> claims) {
+
         if (!StringExtensions.isNullOrBlank(claims.get(MicrosoftStsIdToken.PREFERRED_USERNAME))) {
             return claims.get(MicrosoftStsIdToken.PREFERRED_USERNAME);
         } else if (!StringExtensions.isNullOrBlank(claims.get(MicrosoftStsIdToken.EMAIL))) {
             return claims.get(MicrosoftStsIdToken.EMAIL);
+        } else if(!StringExtensions.isNullOrBlank(claims.get(AzureActiveDirectoryIdToken.UPN))){
+
+            // TODO : Temporary Hack to read and store V1 id token in Cache for V2 request
+            return claims.get(AzureActiveDirectoryIdToken.UPN);
         } else {
             Logger.warn(TAG, "The preferred username is not returned from the IdToken.");
             return "Missing from the token response";

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/LocalAuthenticationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/LocalAuthenticationResult.java
@@ -40,20 +40,24 @@ import java.util.concurrent.TimeUnit;
 public class LocalAuthenticationResult implements ILocalAuthenticationResult {
 
 
-    private final String mRawIdToken;
-    private final AccessTokenRecord mAccessTokenRecord;
-    private final IAccountRecord mAccountRecord;
-    private final String mRefreshToken;
+    private String mRawIdToken = null;
+    private AccessTokenRecord mAccessTokenRecord;
+    private IAccountRecord mAccountRecord;
+    private String mRefreshToken = null;
 
     public LocalAuthenticationResult(@NonNull final ICacheRecord cacheRecord) {
         mAccessTokenRecord = cacheRecord.getAccessToken();
-        mRawIdToken = cacheRecord.getIdToken().getSecret();
         mAccountRecord = cacheRecord.getAccount();
-        mRefreshToken = cacheRecord.getRefreshToken().getSecret();
+        if(cacheRecord.getIdToken() != null) {
+            mRawIdToken = cacheRecord.getIdToken().getSecret();
+        }
+        if(cacheRecord.getRefreshToken() != null) {
+            mRefreshToken = cacheRecord.getRefreshToken().getSecret();
+        }
     }
 
     public LocalAuthenticationResult(@NonNull AccessTokenRecord accessTokenRecord,
-                                     @NonNull String refreshToken,
+                                     @Nullable String refreshToken,
                                      @Nullable String rawIdToken,
                                      @NonNull IAccountRecord accountRecord) {
         mAccessTokenRecord = accessTokenRecord;


### PR DESCRIPTION
- Also fixed issue where default scopes could be added multiple times.
- Added Additional Extra query params related to Broker to `MicrosoftTokenRequest`
- (Temporary hack) TBD : added to parse V1 idtoken `upn` in `MicrosoftStsRequest` to store the right value of displayable id in cache

Related ad-accounts PR : https://github.com/AzureAD/ad-accounts-for-android/pull/811