### PR TITLE
Add sovereign cloud support for V2 broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerTokenResponse.java
@@ -34,8 +34,6 @@ import java.util.Date;
  * Encapsulates the broker token response
  */
 public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Parcelable{
-
-    private String mAuthority;
     private String mTenantId;
 
     @SerializedName("not_before")
@@ -62,6 +60,7 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
         setClientId(microsoftStsTokenResponse.getClientId());
         setExtExpiresIn(microsoftStsTokenResponse.getExtExpiresIn());
         setFamilyId(microsoftStsTokenResponse.getFamilyId());
+        setAuthority(microsoftStsTokenResponse.getAuthority());
     }
 
     protected BrokerTokenResponse(Parcel in) {
@@ -125,14 +124,6 @@ public class BrokerTokenResponse extends MicrosoftStsTokenResponse implements Pa
             return new BrokerTokenResponse[size];
         }
     };
-
-    public String getAuthority() {
-        return mAuthority;
-    }
-
-    public void setAuthority(final String authority) {
-        mAuthority = authority;
-    }
 
     public String getTenantId() {
         return mTenantId;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -93,7 +93,11 @@ public class MicrosoftStsAccountCredentialAdapter
 
             // Optional fields
             accessToken.setExtendedExpiresOn(getExtendedExpiresOn(response));
-            accessToken.setAuthority(response.getAuthority());
+            if (!StringUtil.isEmpty(response.getAuthority())) {
+                accessToken.setAuthority(response.getAuthority());
+            } else {
+                accessToken.setAuthority(request.getAuthority().toString());
+            }
             accessToken.setAccessTokenType(response.getTokenType());
 
             return accessToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.support.annotation.NonNull;
 
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -39,7 +40,10 @@ import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.M
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 public class MicrosoftStsAccountCredentialAdapter
@@ -76,7 +80,11 @@ public class MicrosoftStsAccountCredentialAdapter
             accessToken.setCredentialType(CredentialType.AccessToken.name());
             accessToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             accessToken.setRealm(getRealm(strategy, response));
-            accessToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            if (!StringUtil.isEmpty(response.getAuthority())) {
+                accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
+            } else {
+                accessToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            }
             accessToken.setClientId(request.getClientId());
             accessToken.setTarget(request.getScope());
             accessToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
@@ -85,11 +93,11 @@ public class MicrosoftStsAccountCredentialAdapter
 
             // Optional fields
             accessToken.setExtendedExpiresOn(getExtendedExpiresOn(response));
-            accessToken.setAuthority(request.getAuthority().toString());
+            accessToken.setAuthority(response.getAuthority());
             accessToken.setAccessTokenType(response.getTokenType());
 
             return accessToken;
-        } catch (ServiceException e) {
+        } catch (ServiceException | MalformedURLException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }
@@ -107,7 +115,12 @@ public class MicrosoftStsAccountCredentialAdapter
             final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
             // Required
             refreshToken.setCredentialType(CredentialType.RefreshToken.name());
-            refreshToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            if (null != response.getAuthority()) {
+                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
+            } else {
+                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            }
+
             refreshToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             refreshToken.setClientId(request.getClientId());
             refreshToken.setSecret(response.getRefreshToken());
@@ -120,7 +133,7 @@ public class MicrosoftStsAccountCredentialAdapter
             refreshToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
 
             return refreshToken;
-        } catch (ServiceException e) {
+        } catch (ServiceException | MalformedURLException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }
@@ -137,17 +150,21 @@ public class MicrosoftStsAccountCredentialAdapter
             final IdTokenRecord idToken = new IdTokenRecord();
             // Required fields
             idToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
-            idToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            if (null != response.getAuthority()) {
+                idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
+            } else {
+                idToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+            }
             idToken.setRealm(getRealm(strategy, response));
             idToken.setCredentialType(CredentialType.IdToken.name());
             idToken.setClientId(request.getClientId());
             idToken.setSecret(response.getIdToken());
 
             // Optional fields
-            idToken.setAuthority(request.getAuthority().toString());
+            idToken.setAuthority(response.getAuthority());
 
             return idToken;
-        } catch (ServiceException e) {
+        } catch (ServiceException | MalformedURLException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenResponse.java
@@ -54,6 +54,19 @@ public class MicrosoftTokenResponse extends TokenResponse {
      */
     private String mFamilyId;
 
+    private String mAuthority;
+
+    // The token returned is cached with this authority as key.
+    // We expect the subsequent requests to AcquireToken will use this authority as the authority parameter,
+    // otherwise the AcquireTokenSilent will fail
+    public final String getAuthority() {
+        return mAuthority;
+    }
+
+    public void setAuthority(final String authority) {
+        mAuthority = authority;
+    }
+
     /**
      * Gets the ext_expires_in.
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -284,9 +284,12 @@ public class MicrosoftStsOAuth2Strategy
                 "Creating TokenRequest..."
         );
 
-        if (mConfig.getMultipleCloudsSupported()) {
+        if (mConfig.getMultipleCloudsSupported() || request.getMultipleCloudAware()) {
+            Logger.verbose(TAG, "get cloud specific authority based on authorization response.");
             setTokenEndpoint(getCloudSpecificAuthorityBasedOnAuthorizationResponse(response));
         }
+
+
 
         MicrosoftStsTokenRequest tokenRequest = new MicrosoftStsTokenRequest();
         tokenRequest.setCodeVerifier(request.getPkceChallenge().getCodeVerifier());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -289,8 +289,6 @@ public class MicrosoftStsOAuth2Strategy
             setTokenEndpoint(getCloudSpecificAuthorityBasedOnAuthorizationResponse(response));
         }
 
-
-
         MicrosoftStsTokenRequest tokenRequest = new MicrosoftStsTokenRequest();
         tokenRequest.setCodeVerifier(request.getPkceChallenge().getCodeVerifier());
         tokenRequest.setCode(response.getCode());
@@ -338,7 +336,7 @@ public class MicrosoftStsOAuth2Strategy
 
     @Override
     protected void validateTokenRequest(MicrosoftStsTokenRequest request) {
-
+        //TODO implement
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -113,7 +113,7 @@ public class MicrosoftStsOAuth2Strategy
         return authority.getHost();
     }
 
-    private String getIssuerCacheIdentifierFromAuthority(URL authority) {
+    public String getIssuerCacheIdentifierFromAuthority(URL authority) {
         final String methodName = ":getIssuerCacheIdentifierFromAuthority";
 
         final AzureActiveDirectoryCloud cloudEnv = AzureActiveDirectory.getAzureActiveDirectoryCloud(authority);


### PR DESCRIPTION
1. Fixed the cloud authority for the sovereign token request
2. Fixed the broken back compatibility on BrokerAuthenticationResult.authority between V1 broker and V2 broker
3. Add the extraqp filtering and mapping
4. Add cloud host name authority into broker token result.
5. Fix the unit tests

TODO.

2. Add unit tests