### PR TITLE
 Changes to make scopes type as Set

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1022,6 +1022,30 @@ public final class AuthenticationConstants {
         }
     }
 
+    public static final class OAuth2Scopes{
+
+        /**
+         * Scope to get get open id connect ID token
+         */
+        public static final String OPEN_ID_SCOPE = "openid";
+
+        /**
+         * Scope to give the app access to get resources on behalf of user for an extended time.
+         * App can receive refresh tokens using this scope.
+         */
+        public static final String OFFLINE_ACCESS_SCOPE = "offline_access";
+
+        /**
+         * Scope to get user profile information as a part Id token
+         */
+        public static final String PROFILE_SCOPE = "profile";
+
+        /**
+         * Custom scope used to get PRT
+         */
+        public static final String AZA_SCOPE = "aza";
+    }
+
     /**
      * Represents the oauth2 error code.
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -27,8 +27,8 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
-import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.ClientException;
@@ -62,12 +62,10 @@ import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.internal.telemetry.CliTelemInfo;
 import com.microsoft.identity.common.internal.util.DateUtilities;
-import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +73,10 @@ import java.util.concurrent.TimeUnit;
 public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();
+
+    private static final String OPEN_ID_SCOPE = "openid";
+    private static final String OFFLINE_ACCESS_SCOPE = "offline_access";
+    private static final String PROFILE_SCOPE = "profile";
 
     public abstract AcquireTokenResult acquireToken(final AcquireTokenOperationParameters request)
             throws ExecutionException, InterruptedException, ClientException, IOException, ArgumentException, ServiceException;
@@ -107,18 +109,6 @@ public abstract class BaseController {
                                                            @NonNull final OperationParameters parameters) {
         AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
 
-        List<String> defaultScopes = new ArrayList<>();
-        defaultScopes.add("openid");
-        defaultScopes.add("profile");
-        defaultScopes.add("offline_access");
-
-        List<String> scopes = parameters.getScopes();
-        if (!scopes.containsAll(defaultScopes)) {
-            scopes.addAll(defaultScopes);
-        }
-        scopes.removeAll(Arrays.asList("", null));
-
-
         UUID correlationId = null;
 
         try {
@@ -135,7 +125,7 @@ public abstract class BaseController {
         if (parameters instanceof AcquireTokenOperationParameters) {
             AcquireTokenOperationParameters acquireTokenOperationParameters = (AcquireTokenOperationParameters) parameters;
             if (acquireTokenOperationParameters.getExtraScopesToConsent() != null) {
-                scopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
+                parameters.getScopes().addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
             }
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
@@ -148,9 +138,7 @@ public abstract class BaseController {
             ).setClaims(parameters.getClaimsRequestJson());
         }
 
-        //Remove empty strings and null values
-        scopes.removeAll(Arrays.asList("", null));
-        request.setScope(StringUtil.join(' ', scopes));
+        request.setScope(TextUtils.join(" ", parameters.getScopes()));
 
         return request.build();
     }
@@ -332,7 +320,7 @@ public abstract class BaseController {
 
         final TokenRequest refreshTokenRequest = strategy.createRefreshTokenRequest();
         refreshTokenRequest.setClientId(parameters.getClientId());
-        refreshTokenRequest.setScope(StringUtil.join(' ', parameters.getScopes()));
+        refreshTokenRequest.setScope(TextUtils.join(" ", parameters.getScopes()));
         refreshTokenRequest.setRefreshToken(parameters.getRefreshToken().getSecret());
         refreshTokenRequest.setRedirectUri(parameters.getRedirectUri());
 
@@ -364,6 +352,16 @@ public abstract class BaseController {
 
     protected boolean accessTokenIsNull(ICacheRecord cacheRecord) {
         return null == cacheRecord.getAccessToken();
+    }
+
+    protected void addDefaultScopes(final OperationParameters operationParameters){
+        final Set<String> requestScopes = operationParameters.getScopes();
+        requestScopes.add(OPEN_ID_SCOPE);
+        requestScopes.add(OFFLINE_ACCESS_SCOPE);
+        requestScopes.add(PROFILE_SCOPE);
+        // sanatize empty and null scopes
+        requestScopes.removeAll(Arrays.asList("", null));
+        operationParameters.setScopes(requestScopes);
     }
 
     public static AccessTokenRecord getAccessTokenRecord(@NonNull final MicrosoftStsTokenResponse tokenResponse,

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -361,7 +361,7 @@ public abstract class BaseController {
         requestScopes.add(OPEN_ID_SCOPE);
         requestScopes.add(OFFLINE_ACCESS_SCOPE);
         requestScopes.add(PROFILE_SCOPE);
-        // sanatize empty and null scopes
+        // sanitize empty and null scopes
         requestScopes.removeAll(Arrays.asList("", null));
         operationParameters.setScopes(requestScopes);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -63,6 +63,8 @@ import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.internal.telemetry.CliTelemInfo;
 import com.microsoft.identity.common.internal.util.DateUtilities;
 
+import junit.framework.TestResult;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
@@ -395,7 +397,7 @@ public abstract class BaseController {
         accessTokenRecord.setAuthority(
                 requestParameters.getAuthority().getAuthorityURL().toString()
         );
-        accessTokenRecord.setTarget(tokenResponse.getScope());
+        accessTokenRecord.setTarget(TextUtils.join(" ", requestParameters.getScopes()));
         accessTokenRecord.setCredentialType(CredentialType.AccessToken.name());
         accessTokenRecord.setExpiresOn(
                 String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExpiresIn()))

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -75,10 +75,6 @@ public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();
 
-    private static final String OPEN_ID_SCOPE = "openid";
-    private static final String OFFLINE_ACCESS_SCOPE = "offline_access";
-    private static final String PROFILE_SCOPE = "profile";
-
     public abstract AcquireTokenResult acquireToken(final AcquireTokenOperationParameters request)
             throws ExecutionException, InterruptedException, ClientException, IOException, ArgumentException, ServiceException;
 
@@ -358,9 +354,9 @@ public abstract class BaseController {
 
     protected void addDefaultScopes(final OperationParameters operationParameters){
         final Set<String> requestScopes = operationParameters.getScopes();
-        requestScopes.add(OPEN_ID_SCOPE);
-        requestScopes.add(OFFLINE_ACCESS_SCOPE);
-        requestScopes.add(PROFILE_SCOPE);
+        requestScopes.add(AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE);
+        requestScopes.add(AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE);
+        requestScopes.add(AuthenticationConstants.OAuth2Scopes.PROFILE_SCOPE);
         // sanitize empty and null scopes
         requestScopes.removeAll(Arrays.asList("", null));
         operationParameters.setScopes(requestScopes);

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
@@ -30,17 +30,16 @@ import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 
 public class OperationParameters {
 
     private static final String TAG = OperationParameters.class.getSimpleName();
 
-
     private transient Context mAppContext;
     private transient OAuth2TokenCache mTokenCache;
-    private ArrayList<String> mScopes;
+    private Set<String> mScopes;
     protected IAccountRecord mAccount;
     private String clientId;
     private String redirectUri;
@@ -55,11 +54,11 @@ public class OperationParameters {
         this.mAppContext = mAppContext;
     }
 
-    public ArrayList<String> getScopes() {
+    public Set<String> getScopes() {
         return mScopes;
     }
 
-    public void setScopes(ArrayList<String> mScopes) {
+    public void setScopes(Set<String> mScopes) {
         this.mScopes = mScopes;
     }
 


### PR DESCRIPTION
- Also added `addDefaultScopes` util method to base controller
- Setting accesstoken target from request scopes.
- Fixes : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/384