### PR TITLE
Add support to interrupt flow

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -132,7 +132,11 @@ public abstract class BaseController {
                     acquireTokenOperationParameters.getExtraQueryStringParameters()
             ).setPrompt(
                     acquireTokenOperationParameters.getOpenIdConnectPromptParameter().toString()
-            ).setClaims(parameters.getClaimsRequestJson());
+            ).setClaims(
+                    parameters.getClaimsRequestJson()
+            ).setRequestHeaders(
+                    acquireTokenOperationParameters.getRequestHeaders()
+            );
         }
 
         request.setScope(TextUtils.join(" ", parameters.getScopes()));

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -101,11 +101,11 @@ public abstract class BaseController {
         );
     }
 
-
-    protected AuthorizationRequest getAuthorizationRequest(@NonNull final OAuth2Strategy strategy,
-                                                           @NonNull final OperationParameters parameters) {
-        AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
-
+    /**
+     * Pre-filled ALL the fields in AuthorizationRequest.Builder
+     */
+    protected final AuthorizationRequest.Builder initializeAuthorizationRequestBuilder(@NonNull final AuthorizationRequest.Builder builder,
+                                                                                        @NonNull final OperationParameters parameters){
         UUID correlationId = null;
 
         try {
@@ -114,8 +114,7 @@ public abstract class BaseController {
             Logger.error(TAG, "correlation id from diagnostic context is not a UUID", ex);
         }
 
-        AuthorizationRequest.Builder request = builder
-                .setClientId(parameters.getClientId())
+        builder.setClientId(parameters.getClientId())
                 .setRedirectUri(parameters.getRedirectUri())
                 .setCorrelationId(correlationId);
 
@@ -126,7 +125,7 @@ public abstract class BaseController {
             }
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
-            request.setLoginHint(
+            builder.setLoginHint(
                     acquireTokenOperationParameters.getLoginHint()
             ).setExtraQueryParams(
                     acquireTokenOperationParameters.getExtraQueryStringParameters()
@@ -139,9 +138,16 @@ public abstract class BaseController {
             );
         }
 
-        request.setScope(TextUtils.join(" ", parameters.getScopes()));
+        builder.setScope(TextUtils.join(" ", parameters.getScopes()));
 
-        return request.build();
+        return builder;
+    }
+
+    protected AuthorizationRequest getAuthorizationRequest(@NonNull final OAuth2Strategy strategy,
+                                                           @NonNull final OperationParameters parameters) {
+        AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
+        initializeAuthorizationRequestBuilder(builder, parameters);
+        return builder.build();
     }
 
     protected TokenResult performTokenRequest(final OAuth2Strategy strategy,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.internal.net.ObjectMapper;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -92,6 +93,11 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
     @SerializedName("claims")
     private String mClaims;
 
+    /**
+     * Header of the request.
+     */
+    private transient HashMap<String, String> mRequestHeaders;
+
     private transient List<Pair<String, String>> mExtraQueryParams;
 
     /**
@@ -105,6 +111,7 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         mScope = builder.mScope;
         mExtraQueryParams = builder.mExtraQueryParams;
         mClaims = builder.mClaims;
+        mRequestHeaders = builder.mRequestHeaders;
     }
 
     public static final class ResponseType {
@@ -118,6 +125,7 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         private String mState;
         private String mScope;
         private String mClaims;
+        private HashMap<String, String> mRequestHeaders;
 
         /**
          * Can be used to pre-fill the username/email address field of the sign-in page for the user, if you know their username ahead of time.
@@ -186,6 +194,11 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
             return self();
         }
 
+        public B setRequestHeaders(HashMap<String, String> requestHeaders){
+            mRequestHeaders = requestHeaders;
+            return self();
+        }
+
         public abstract B self();
 
         public abstract AuthorizationRequest build();
@@ -220,12 +233,18 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
     }
 
     /**
+     * @return mRequestHeaders of the authorization request.
+     */
+    public HashMap<String, String> getRequestHeaders() {
+        return mRequestHeaders;
+    }
+
+    /**
      * @return mRedirectUri of the authorization request.
      */
     public String getRedirectUri() {
         return mRedirectUri;
     }
-
     /**
      * @return mState of the authorization request.
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -28,6 +28,11 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 public enum OpenIdConnectPromptParameter {
 
     /**
+     * No prompt parameter will be injected into the request.
+     */
+    NONE,
+
+    /**
      * acquireToken will send prompt=select_account to the authorize endpoint. Shows a list of users from which can be
      * selected for authentication.
      */
@@ -47,6 +52,10 @@ public enum OpenIdConnectPromptParameter {
 
     @Override
     public String toString() {
+        if (this == NONE) {
+            return null;
+        }
+
         return this.name().toLowerCase();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
@@ -28,6 +28,7 @@ import android.util.Pair;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 
+import java.util.HashMap;
 import java.util.List;
 
 public class AcquireTokenOperationParameters extends OperationParameters {
@@ -37,6 +38,7 @@ public class AcquireTokenOperationParameters extends OperationParameters {
     private List<Pair<String, String>> mExtraQueryStringParameters;
     private List<String> mExtraScopesToConsent;
     private OpenIdConnectPromptParameter mOpenIdConnectPromptParameter;
+    private HashMap<String, String> mRequestHeaders;
 
     public AuthorizationAgent getAuthorizationAgent() {
         return mAuthorizationAgent;
@@ -86,5 +88,13 @@ public class AcquireTokenOperationParameters extends OperationParameters {
 
     public void setOpenIdConnectPromptParameter(OpenIdConnectPromptParameter openIdConnectPromptParameter) {
         mOpenIdConnectPromptParameter = openIdConnectPromptParameter;
+    }
+
+    public HashMap<String, String> getRequestHeaders() {
+        return mRequestHeaders;
+    }
+
+    public void setRequestHeaders(HashMap<String, String> requestHeaders) {
+        this.mRequestHeaders = requestHeaders;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -102,6 +102,7 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
                         mResultIntent,
                         requestUrl.toString(),
                         mAuthorizationRequest.getRedirectUri(),
+                        mAuthorizationRequest.getRequestHeaders(),
                         AuthorizationAgent.BROWSER));
 
         return mAuthorizationResultFuture;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -82,6 +82,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
                 mResultIntent,
                 requestUrl.toString(),
                 mAuthorizationRequest.getRedirectUri(),
+                mAuthorizationRequest.getRequestHeaders(),
                 AuthorizationAgent.WEBVIEW);
         mReferencedActivity.get().startActivity(authIntent);
         return mAuthorizationResultFuture;


### PR DESCRIPTION
- Allow header injection in the webView request.
- Add NONE in OpenIdConnectPromptParameter. If this is set, no "prompt" parameter will be passed in the request.
- Extract initializeAuthorizationRequestBuilder in the BaseController (Instead of having to set the same value for AuthorizationRequest.Builder in 2 functions as of today).