### PR TITLE
Move SubError to BaseException. Refactoring some code.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/BaseException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BaseException.java
@@ -42,6 +42,8 @@ public class BaseException extends Exception {
 
     private String mErrorCode;
 
+    private String mSubErrorCode;
+
     /**
      * Default constructor.
      */
@@ -87,6 +89,22 @@ public class BaseException extends Exception {
      */
     public String getErrorCode() {
         return mErrorCode;
+    }
+
+    /**
+     * @return The sub error code for the exception, could be null. {@link BaseException} is the top level base exception, for the
+     * constants value of all the error code.
+     */
+    public String getSubErrorCode() {
+        return mSubErrorCode;
+    }
+
+    /**
+     * @@param subErrorCode - The sub error code for the exception, could be null. {@link BaseException} is the top level base exception, for the
+     * constants value of all the error code.
+     */
+    public void setSubErrorCode(@Nullable final String subErrorCode){
+        mSubErrorCode = subErrorCode;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -29,6 +29,16 @@ public final class ErrorStrings {
     }
 
     /**
+     * Access token doesn't exist and there is no refresh token can be found to redeem access token.
+     */
+    public static final String NO_TOKENS_FOUND = "no_tokens_found";
+
+    /**
+     * The supplied Account cannot be found in the cache.
+     */
+    public static final String NO_ACCOUNT_FOUND = "no_account_found";
+
+    /**
      * There are multiple cache entries found, the sdk cannot pick the correct access token
      * or refresh token from the cache. Likely it's a bug in the sdk when caching tokens or authority
      * is not proviced in the silent request and multiple tokens were found.

--- a/common/src/main/java/com/microsoft/identity/common/exception/UiRequiredException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/UiRequiredException.java
@@ -23,45 +23,23 @@
 
 package com.microsoft.identity.common.exception;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-
 /**
  * This exception indicates that UI is required for authentication to succeed.
  */
 
 public final class UiRequiredException extends BaseException {
-    /**
-     * Access token doesn't exist and there is no refresh token can be found to redeem access token.
-     */
-    public static final String NO_TOKENS_FOUND = "no_tokens_found";
 
-    /**
-     * The supplied Account cannot be found in the cache.
-     */
-    public static final String NO_ACCOUNT_FOUND = "no_account_found";
+    public UiRequiredException(BaseException e) {
+        super(e.getErrorCode(), e.getMessage(), e.getCause());
+        super.setSubErrorCode(e.getSubErrorCode());
+    }
 
-    /**
-     * Sub error code contained in the exception.
-     */
-    private String mSubErrorCode;
-
-    public UiRequiredException(final String errorCode, final String subErrorCode, final String errorMessage) {
+    public UiRequiredException(final String errorCode, final String errorMessage) {
         super(errorCode, errorMessage);
-        mSubErrorCode = subErrorCode;
     }
 
-    public UiRequiredException(final String errorCode, final String subErrorCode, final String errorMessage, final Throwable throwable) {
+    public UiRequiredException(final String errorCode, final String errorMessage, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
-        mSubErrorCode = subErrorCode;
     }
 
-    public boolean isBadTokenSubError(){
-        return getErrorCode().equalsIgnoreCase(AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT) &&
-                mSubErrorCode != null &&
-                mSubErrorCode.equalsIgnoreCase(AuthenticationConstants.OAuth2SubErrorCode.BAD_TOKEN);
-    }
-
-    public String getSubErrorCode() {
-        return mSubErrorCode;
-    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -173,7 +173,7 @@ public abstract class BaseController {
                                     @NonNull final OAuth2TokenCache tokenCache,
                                     @NonNull final OAuth2Strategy strategy,
                                     @NonNull final ICacheRecord cacheRecord)
-            throws IOException, ClientException, UiRequiredException {
+            throws IOException, ClientException, ServiceException {
         final String methodName = ":renewAccessToken";
         Logger.verbose(
                 TAG + methodName,
@@ -210,41 +210,18 @@ public abstract class BaseController {
             // Set the AuthenticationResult on the final result object
             acquireTokenSilentResult.setLocalAuthenticationResult(authenticationResult);
         } else {
-            // Log all the particulars...
-            if (null != tokenResult.getErrorResponse()) {
-                if (null != tokenResult.getErrorResponse().getError()) {
-                    Logger.warn(
-                            TAG,
-                            tokenResult.getErrorResponse().getError()
-                    );
-                }
+            ServiceException e = ExceptionAdapter.exceptionFromTokenResult(tokenResult);
 
-                if (null != tokenResult.getErrorResponse().getErrorDescription()) {
-                    Logger.warnPII(
-                            TAG,
-                            tokenResult.getErrorResponse().getErrorDescription()
-                    );
-                }
+            if (e != null){
+                Logger.warn(
+                        TAG + methodName,
+                        e.getErrorCode() + ":" + e.getSubErrorCode());
 
-                if (AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(tokenResult.getErrorResponse().getError())) {
-                    final UiRequiredException uiException = new UiRequiredException(
-                            AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT,
-                            tokenResult.getErrorResponse().getSubError(),
-                            null != tokenResult.getErrorResponse().getErrorDescription()
-                                    ? tokenResult.getErrorResponse().getErrorDescription()
-                                    : "Failed to renew access token"
-                    );
+                Logger.warnPII(
+                        TAG + methodName,
+                        e.getMessage());
 
-                    if (null != tokenResult.getCliTelemInfo()) {
-                        final CliTelemInfo cliTelemInfo = tokenResult.getCliTelemInfo();
-                        uiException.setSpeRing(cliTelemInfo.getSpeRing());
-                        uiException.setRefreshTokenAge(cliTelemInfo.getRefreshTokenAge());
-                        uiException.setCliTelemErrorCode(cliTelemInfo.getServerErrorCode());
-                        uiException.setCliTelemSubErrorCode(cliTelemInfo.getServerSubErrorCode());
-                    }
-
-                    throw uiException;
-                }
+                throw e;
             }
         }
     }


### PR DESCRIPTION
- UIRequiredInteraction will only represent any error that requires, well, UI Interaction.
- Some sub error can't be fixed by UI interaction (i.e. WPJ Device is disabled by admin), therefore I moved all of the tokenResult-based exception in the lower layer to ServiceException (and let its caller, namely acquireToken/acquireToken silent) decide if it should wrap those exception with UiRequiredException - this will be in another card)
- Remove redundant code.