### PR TITLE
Update StorageHelper to detect when running inside of broker and provide the correct SecretKeys

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -27,6 +27,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
+import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;
 
@@ -287,8 +288,23 @@ public class StorageHelper implements IStorageHelper {
     @Override
     public synchronized SecretKey loadSecretKeyForEncryption() throws IOException,
             GeneralSecurityException {
-        final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+        final String pkgName = mContext.getPackageName();
+        final byte[] secretKeyData = getSecretKeyData(pkgName);
         return loadSecretKeyForEncryption(secretKeyData == null ? VERSION_ANDROID_KEY_STORE : VERSION_USER_DEFINED);
+    }
+
+    @Nullable
+    private byte[] getSecretKeyData(@Nullable final String pkgName) {
+        byte[] secretKeyData;
+
+        if (AuthenticationSettings.INSTANCE.getBrokerSecretKeys().containsKey(pkgName)) {
+            // The current app runtime is the broker; load its secret keys...
+            secretKeyData = AuthenticationSettings.INSTANCE.getBrokerSecretKeys().get(pkgName);
+        } else { // We are not the broker, proceed as usual.
+            secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+        }
+
+        return secretKeyData;
     }
 
     @Override
@@ -351,7 +367,7 @@ public class StorageHelper implements IStorageHelper {
     private synchronized SecretKey getKey(final String keyVersion) throws GeneralSecurityException, IOException {
         switch (keyVersion) {
             case VERSION_USER_DEFINED:
-                return getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
+                return getSecretKey(getSecretKeyData(mContext.getPackageName()));
             case VERSION_ANDROID_KEY_STORE:
 
                 if (mSecretKeyFromAndroidKeyStore != null) {


### PR DESCRIPTION
ADAL & Unity shipped different versions of ADAL’s encryption utility `StorageHelper` – the Unity version contains fallback logic for attempting different keys that the broker knows about, while the ADAL version does not – this nuance apparently got missed in the ADAL-Unity merge work.

ADAL Version: https://github.com/AzureAD/azure-activedirectory-library-for-android/blob/master/adal/src/main/java/com/microsoft/aad/adal/StorageHelper.java
Unity Version: https://github.com/AzureAD/azure-activedirectory-library-for-android-unity-fork/blob/master/adal-unity-fork/src/main/java/com/microsoft/aad/adal/unity/StorageHelper.java