### PR TITLE
Adding temporary AndroidX Custom Tab support

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -30,7 +30,6 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.customtabs.CustomTabsService;
 
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
@@ -118,7 +117,9 @@ public class BrowserSelector {
     }
 
     private static boolean isCustomTabsServiceSupported(@NonNull final Context context, @NonNull final PackageInfo packageInfo) {
-        Intent serviceIntent = new Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+        // https://issuetracker.google.com/issues/119183822
+        // When above AndroidX issue is fixed, switch back to CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
+        Intent serviceIntent = new Intent(new StringBuilder("android").append(".support.customtabs.action.CustomTabsService").toString());
         serviceIntent.setPackage(packageInfo.packageName);
         List<ResolveInfo> resolveInfos = context.getPackageManager().queryIntentServices(serviceIntent, 0);
         return !(resolveInfos == null || resolveInfos.isEmpty());


### PR DESCRIPTION
Adding temporary AndroidX Custom Tab support until https://issuetracker.google.com/issues/119183822 is properly fixed, see issue #300 