### PR TITLE
Put null check on tokenResponse.getExpiresIn and getExtExpiresIn

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -400,12 +400,19 @@ public abstract class BaseController {
         );
         accessTokenRecord.setTarget(TextUtils.join(" ", requestParameters.getScopes()));
         accessTokenRecord.setCredentialType(CredentialType.AccessToken.name());
-        accessTokenRecord.setExpiresOn(
-                String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExpiresIn()))
-        );
-        accessTokenRecord.setExtendedExpiresOn(
-                String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExtExpiresIn()))
-        );
+
+        if (tokenResponse.getExpiresIn() != null) {
+            accessTokenRecord.setExpiresOn(
+                    String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExpiresIn()))
+            );
+        }
+
+        if (tokenResponse.getExtExpiresIn() != null) {
+            accessTokenRecord.setExtendedExpiresOn(
+                    String.valueOf(DateUtilities.getExpiresOn(tokenResponse.getExtExpiresIn()))
+            );
+        }
+
         accessTokenRecord.setCachedAt(
                 String.valueOf(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
         );


### PR DESCRIPTION
The BRT update response in the interrupt flow doesn't contain these fields.