### PR TITLE
 Broker Result adapter changes to centralize generating result bundle based on SDK

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -234,6 +234,16 @@ public final class AuthenticationConstants {
         public static final String AAD_VERSION = "ver";
 
         /**
+         * Constant for  v1 endpoint
+         */
+        public static final String AAD_VERSION_V1 = "1.0";
+
+        /**
+         * Constsnt for v2 endpoint
+         */
+        public static final String AAD_VERSION_V2 = "2.0";
+
+        /**
          * String of preferred user name.
          */
         public static final String AAD_PREFERRED_USERNAME = "preferred_username";

--- a/common/src/main/java/com/microsoft/identity/common/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.exception;
+
+public class IntuneAppProtectionPolicyRequiredException extends ServiceException {
+
+    private String mAccountUpn;
+    private String mAccountUserId;
+    private String mTenantId;
+    private String mAuthorityUrl;
+
+
+    public IntuneAppProtectionPolicyRequiredException(final String errorCode,
+                                                      final String errorMessage) {
+        this(errorCode, errorMessage, null);
+    }
+
+    public IntuneAppProtectionPolicyRequiredException(final String errorCode,
+                                                      final String errorMessage,
+                                                      final Throwable throwable) {
+        super(errorCode, errorMessage, throwable);
+    }
+
+
+    public String getAccountUpn() {
+        return mAccountUpn;
+    }
+
+    public void setAccountUpn(String accountUpn) {
+        mAccountUpn = accountUpn;
+    }
+
+    public String getAccountUserId() {
+        return mAccountUserId;
+    }
+
+    public void setAccountUserId(String accountUserId) {
+        mAccountUserId = accountUserId;
+    }
+
+    public String getTenantId() {
+        return mTenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        mTenantId = tenantId;
+    }
+
+    public String getAuthorityUrl() {
+        return mAuthorityUrl;
+    }
+
+    public void setAuthorityUrl(String authorityUrl) {
+        mAuthorityUrl = authorityUrl;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -42,7 +42,6 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
         super(errorCode, errorMessage, throwable);
     }
 
-
     public String getAccountUpn() {
         return mAccountUpn;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -158,21 +158,20 @@ public final class SchemaUtil {
                             AuthenticationConstants.OAuth2.AAD_VERSION
                     );
                     if (!TextUtils.isEmpty(aadVersion) &&
-                            aadVersion.equalsIgnoreCase("1.0")) {
+                            aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V1)) {
 
                         idp = idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
 
                         // For home accounts idp claim is not available, use iss claim instead.
                         if(TextUtils.isEmpty(idp)){
-                            Logger.info(
-                                    TAG + ":" + methodName,
-                                    "idp claim was null, using iss claim")
-                            ;
+                            Logger.info(TAG + ":" + methodName,
+                                    "idp claim was null, using iss claim"
+                            );
                             idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
                         }
 
                     } else if (!TextUtils.isEmpty(aadVersion) &&
-                            aadVersion.equalsIgnoreCase("2.0")) {
+                            aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V2)) {
 
                         idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
                     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -154,10 +154,26 @@ public final class SchemaUtil {
                 final Map<String, String> idTokenClaims = idToken.getTokenClaims();
 
                 if (null != idTokenClaims) {
-                    final String aadVersion = idTokenClaims.get(AuthenticationConstants.OAuth2.AAD_VERSION);
-                    if (!TextUtils.isEmpty(aadVersion) && aadVersion.equalsIgnoreCase("1.0")) {
+                    final String aadVersion = idTokenClaims.get(
+                            AuthenticationConstants.OAuth2.AAD_VERSION
+                    );
+                    if (!TextUtils.isEmpty(aadVersion) &&
+                            aadVersion.equalsIgnoreCase("1.0")) {
+
                         idp = idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
-                    } else if (!TextUtils.isEmpty(aadVersion) && aadVersion.equalsIgnoreCase("2.0")) {
+
+                        // For home accounts idp claim is not available, use iss claim instead.
+                        if(TextUtils.isEmpty(idp)){
+                            Logger.info(
+                                    TAG + ":" + methodName,
+                                    "idp claim was null, using iss claim")
+                            ;
+                            idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
+                        }
+
+                    } else if (!TextUtils.isEmpty(aadVersion) &&
+                            aadVersion.equalsIgnoreCase("2.0")) {
+
                         idp = idTokenClaims.get(MicrosoftIdToken.ISSUER);
                     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.controllers;
 
 import android.content.Intent;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Pair;
 
 import com.microsoft.identity.common.exception.BaseException;
@@ -85,7 +86,7 @@ public class ApiDispatcher {
                         }
                     }
 
-                    Handler handler = new Handler(command.getContext().getMainLooper());
+                    Handler handler = new Handler(Looper.getMainLooper());
 
                     if (baseException != null) {
                         //Post On Error
@@ -285,7 +286,7 @@ public class ApiDispatcher {
                     }
                 }
 
-                Handler handler = new Handler(command.getContext().getMainLooper());
+                Handler handler = new Handler(Looper.getMainLooper());
 
                 if (baseException != null) {
                     //Post On Error

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -22,17 +22,14 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.controllers;
 
-import android.content.Context;
 import android.content.Intent;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.adal.internal.net.HttpWebRequest;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ArgumentException;
-import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.exception.UiRequiredException;
@@ -87,24 +84,6 @@ public abstract class BaseController {
 
     public abstract AcquireTokenResult acquireTokenSilent(final AcquireTokenSilentOperationParameters request)
             throws IOException, ClientException, UiRequiredException, ArgumentException, ServiceException;
-
-    protected void throwIfNetworkNotAvailable(final Context context) throws ClientException {
-        final String methodName = ":throwIfNetworkNotAvailable";
-        final ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        final NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
-
-        if (networkInfo == null || !networkInfo.isConnected()) {
-            throw new ClientException(
-                    ClientException.DEVICE_NETWORK_NOT_AVAILABLE,
-                    "Device network connection is not available."
-            );
-        }
-
-        Logger.info(
-                TAG + methodName,
-                "Network status: connected"
-        );
-    }
 
     /**
      * Pre-filled ALL the fields in AuthorizationRequest.Builder
@@ -170,7 +149,7 @@ public abstract class BaseController {
                                               final AcquireTokenOperationParameters parameters)
             throws IOException, ClientException {
         final String methodName = ":performTokenRequest";
-        throwIfNetworkNotAvailable(parameters.getAppContext());
+        HttpWebRequest.throwIfNetworkNotAvailable(parameters.getAppContext());
 
         TokenRequest tokenRequest = strategy.createTokenRequest(request, response);
         logExposedFieldsOfObject(TAG + methodName, tokenRequest);
@@ -307,7 +286,7 @@ public abstract class BaseController {
                 "Requesting tokens..."
         );
 
-        throwIfNetworkNotAvailable(parameters.getAppContext());
+        HttpWebRequest.throwIfNetworkNotAvailable(parameters.getAppContext());
 
         // Check that the authority is known
         Authority.KnownAuthorityResult authorityResult = Authority.getKnownAuthorityResult(parameters.getAuthority());

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.controllers;
 
-import android.content.Context;
 import android.content.Intent;
 
 import com.microsoft.identity.common.exception.ArgumentException;
@@ -40,12 +39,11 @@ public class InteractiveTokenCommand extends TokenCommand {
 
     private static final String TAG = InteractiveTokenCommand.class.getSimpleName();
 
-    public InteractiveTokenCommand(Context context,
-                                   AcquireTokenOperationParameters parameters,
+    public InteractiveTokenCommand(AcquireTokenOperationParameters parameters,
                                    BaseController controller,
                                    ILocalAuthenticationCallback callback) {
 
-        super(context, parameters, controller, callback);
+        super(parameters, controller, callback);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.controllers;
 
-import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 
@@ -47,18 +46,15 @@ public class TokenCommand implements TokenOperation {
 
     protected OperationParameters mParameters;
     protected List<BaseController> mControllers;
-    protected Context mContext;
     protected ILocalAuthenticationCallback mCallback;
 
 
     public TokenCommand() {
     }
 
-    public TokenCommand(@NonNull final Context context,
-                        @NonNull final OperationParameters parameters,
+    public TokenCommand(@NonNull final OperationParameters parameters,
                         @NonNull final BaseController controller,
                         @NonNull final ILocalAuthenticationCallback callback) {
-        mContext = context;
         mParameters = parameters;
         mControllers = new ArrayList<>();
         mCallback = callback;
@@ -66,11 +62,9 @@ public class TokenCommand implements TokenOperation {
         mControllers.add(controller);
     }
 
-    public TokenCommand(@NonNull final Context context,
-                        @NonNull final OperationParameters parameters,
+    public TokenCommand(@NonNull final OperationParameters parameters,
                         @NonNull final List<BaseController> controllers,
                         @NonNull final ILocalAuthenticationCallback callback) {
-        mContext = context;
         mParameters = parameters;
         mControllers = controllers;
         mCallback = callback;
@@ -147,14 +141,6 @@ public class TokenCommand implements TokenOperation {
 
     public void setControllers(final List<BaseController> controllers) {
         this.mControllers = controllers;
-    }
-
-    public Context getContext() {
-        return mContext;
-    }
-
-    public void setContext(final Context context) {
-        this.mContext = context;
     }
 
     public ILocalAuthenticationCallback getCallback() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -110,8 +110,6 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
                 authenticationResult.getIdToken()
         );
 
-        setIdTokenClaimstoBundle(resultBundle, authenticationResult.getIdToken());
-
         resultBundle.putString(
                 SPE_RING,
                 authenticationResult.getSpeRing()
@@ -196,59 +194,6 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
             );
         }
 
-    }
-
-    /**
-     * Helper method to add idtoken claims to the bundle
-     */
-    private void setIdTokenClaimstoBundle(@NonNull final Bundle resultBundle,
-                                          @Nullable final String rawIdToken) {
-        final String methodName = "setIdTokenClaimstoBundle";
-
-        if(TextUtils.isEmpty(rawIdToken)){
-            Logger.warn(TAG + methodName, "Authentication result returned empty or null id token, " +
-                    "claims are not added to the result bundle");
-            return;
-        }
-
-        try {
-            final IDToken idToken = new IDToken(rawIdToken);
-            final Map<String, String> claims = idToken.getTokenClaims();
-
-            resultBundle.putString(
-                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
-                    claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_GIVEN_NAME)
-            );
-
-            resultBundle.putString(
-                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
-                    claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_FAMILY_NAME)
-            );
-
-            String upn = claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_UPN);
-            if (TextUtils.isEmpty(upn)) {
-                upn = claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_EMAIL);
-            }
-
-            resultBundle.putString(
-                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
-                    upn
-            );
-
-            resultBundle.putString(
-                    AuthenticationConstants.Broker.ACCOUNT_LOGIN_HINT,
-                    upn
-            );
-
-            resultBundle.putString(
-                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
-                    SchemaUtil.getIdentityProvider(rawIdToken)
-            );
-        } catch (ServiceException e) {
-            Logger.verbose(
-                    TAG + methodName,
-                    "Exception while decoding IDToken.");
-        }
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -1,0 +1,390 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.result;
+
+import android.accounts.AccountManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.microsoft.identity.common.adal.internal.ADALError;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.ArgumentException;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException;
+import com.microsoft.identity.common.exception.ServiceException;
+import com.microsoft.identity.common.exception.UserCancelException;
+import com.microsoft.identity.common.internal.cache.SchemaUtil;
+import com.microsoft.identity.common.internal.dto.IAccountRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
+import com.microsoft.identity.common.internal.util.HeaderSerializationUtil;
+
+import java.util.Map;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.RT_AGE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_SUBERROR;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SPE_RING;
+
+public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
+
+    private static final String TAG = AdalBrokerResultAdapter.class.getName();
+
+    @Override
+    public Bundle bundleFromAuthenticationResult(@NonNull final ILocalAuthenticationResult authenticationResult) {
+
+        final Bundle resultBundle = new Bundle();
+
+        IAccountRecord accountRecord = authenticationResult.getAccountRecord();
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_LOGIN_HINT,
+                accountRecord.getUsername()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,
+                accountRecord.getLocalAccountId()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
+                accountRecord.getUsername()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
+                accountRecord.getName()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
+                accountRecord.getFamilyName()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
+                SchemaUtil.getIdentityProvider(authenticationResult.getIdToken())
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID,
+                authenticationResult.getTenantId()
+        );
+
+        resultBundle.putLong(
+                AuthenticationConstants.Broker.ACCOUNT_EXPIREDATE,
+                authenticationResult.getExpiresOn().getTime()
+        );
+
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_AUTHORITY,
+                getAuthority(authenticationResult)
+        );
+
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_ACCESS_TOKEN,
+                authenticationResult.getAccessToken()
+        );
+
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_IDTOKEN,
+                authenticationResult.getIdToken()
+        );
+
+        setIdTokenClaimstoBundle(resultBundle, authenticationResult.getIdToken());
+
+        resultBundle.putString(
+                SPE_RING,
+                authenticationResult.getSpeRing()
+        );
+
+        resultBundle.putString(
+                RT_AGE,
+                authenticationResult.getRefreshTokenAge()
+        );
+
+        return resultBundle;
+    }
+
+
+    @Override
+    public Bundle bundleFromBaseException(BaseException baseException) {
+
+        final Bundle resultBundle = new Bundle();
+
+        resultBundle.putString(
+                AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,
+                baseException.getErrorCode()
+        );
+
+        resultBundle.putString(
+                AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE,
+                baseException.getMessage()
+        );
+
+        // Set the SPE Ring & Client Telemetry info, if avail...
+        resultBundle.putString(SPE_RING, baseException.getSpeRing());
+        resultBundle.putString(RT_AGE, baseException.getRefreshTokenAge());
+        resultBundle.putString(SERVER_ERROR, baseException.getCliTelemErrorCode());
+        resultBundle.putString(SERVER_SUBERROR, baseException.getCliTelemSubErrorCode());
+
+        mapExceptionToBundle(resultBundle, baseException);
+
+        return resultBundle;
+    }
+
+
+    /**
+     * Helper method to map and add errors to Adal specific constants.
+     */
+    private void mapExceptionToBundle(@NonNull final Bundle resultBundle,
+                                       @NonNull BaseException exception) {
+
+        if (exception instanceof UserCancelException) {
+
+            setErrorToResultBundle(
+                    resultBundle,
+                    AccountManager.ERROR_CODE_CANCELED,
+                    exception.getMessage());
+
+        } else if (exception instanceof ArgumentException) {
+
+            setErrorToResultBundle(
+                    resultBundle,
+                    AccountManager.ERROR_CODE_BAD_ARGUMENTS,
+                    exception.getMessage()
+            );
+
+        } else if (exception instanceof ClientException) {
+
+            setClientExceptionPropertiesToBundle(
+                    resultBundle,
+                    (ClientException) exception
+            );
+
+        } else if (exception instanceof ServiceException) {
+
+            setServiceExceptionPropertiesToBundle(
+                    resultBundle,
+                    (ServiceException) exception);
+
+        } else {
+
+            setErrorToResultBundle(
+                    resultBundle,
+                    AccountManager.ERROR_CODE_BAD_REQUEST,
+                    exception.getMessage()
+            );
+        }
+
+    }
+
+    /**
+     * Helper method to add idtoken claims to the bundle
+     */
+    private void setIdTokenClaimstoBundle(@NonNull final Bundle resultBundle,
+                                          @Nullable final String rawIdToken) {
+        final String methodName = "setIdTokenClaimstoBundle";
+
+        if(TextUtils.isEmpty(rawIdToken)){
+            Logger.warn(TAG + methodName, "Authentication result returned empty or null id token, " +
+                    "claims are not added to the result bundle");
+            return;
+        }
+
+        try {
+            final IDToken idToken = new IDToken(rawIdToken);
+            final Map<String, String> claims = idToken.getTokenClaims();
+
+            resultBundle.putString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
+                    claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_GIVEN_NAME)
+            );
+
+            resultBundle.putString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,
+                    claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_FAMILY_NAME)
+            );
+
+            String upn = claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_UPN);
+            if (TextUtils.isEmpty(upn)) {
+                upn = claims.get(AuthenticationConstants.OAuth2.ID_TOKEN_EMAIL);
+            }
+
+            resultBundle.putString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE,
+                    upn
+            );
+
+            resultBundle.putString(
+                    AuthenticationConstants.Broker.ACCOUNT_LOGIN_HINT,
+                    upn
+            );
+
+            resultBundle.putString(
+                    AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER,
+                    SchemaUtil.getIdentityProvider(rawIdToken)
+            );
+        } catch (ServiceException e) {
+            Logger.verbose(
+                    TAG + methodName,
+                    "Exception while decoding IDToken.");
+        }
+    }
+
+    /**
+     * Helper method to get result authority.
+     */
+    private String getAuthority(@NonNull final ILocalAuthenticationResult authenticationResult) {
+        final String protocol = "https";
+        Uri.Builder builder = new Uri.Builder().scheme(protocol);
+        builder.authority(authenticationResult.getAccessTokenRecord().getEnvironment());
+
+        if (!TextUtils.isEmpty(authenticationResult.getTenantId())) {
+            builder.appendPath(authenticationResult.getTenantId());
+        } else {
+            builder.appendPath("common");
+        }
+        return builder.build().toString();
+    }
+
+    private void setClientExceptionPropertiesToBundle(@NonNull final Bundle resultBundle,
+                                                      @NonNull final ClientException clientException) {
+
+        if (clientException.getErrorCode().equalsIgnoreCase(ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE)) {
+
+            setErrorToResultBundle(
+                    resultBundle,
+                    AccountManager.ERROR_CODE_NETWORK_ERROR,
+                    ADALError.DEVICE_CONNECTION_IS_NOT_AVAILABLE.getDescription()
+            );
+
+        } else if (clientException.getErrorCode().equalsIgnoreCase(
+                ErrorStrings.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION)) {
+
+            setErrorToResultBundle(
+                    resultBundle,
+                    AccountManager.ERROR_CODE_NETWORK_ERROR,
+                    ADALError.NO_NETWORK_CONNECTION_POWER_OPTIMIZATION.getDescription()
+            );
+
+        }
+    }
+
+
+    /**
+     * Helper method to set Service Exception to Bundle
+     */
+    private void setServiceExceptionPropertiesToBundle(@NonNull final Bundle resultBundle,
+                                                       @NonNull final ServiceException serviceException) {
+
+        if (null != serviceException.getHttpResponseBody()) {
+            resultBundle.putString(
+                    AuthenticationConstants.OAuth2.HTTP_RESPONSE_BODY,
+                    serviceException.getHttpResponseBody().toString()
+            );
+        }
+
+        if (null != serviceException.getHttpResponseHeaders()) {
+            resultBundle.putString(
+                    AuthenticationConstants.OAuth2.HTTP_RESPONSE_HEADER,
+                    HeaderSerializationUtil.toJson(
+                            serviceException.getHttpResponseHeaders()
+                    )
+            );
+        }
+        resultBundle.putInt(
+                AuthenticationConstants.OAuth2.HTTP_STATUS_CODE,
+                serviceException.getHttpStatusCode()
+        );
+
+        if (serviceException instanceof IntuneAppProtectionPolicyRequiredException) {
+            setIntuneAppProtectionPropertiesToBundle(
+                    resultBundle,
+                    (IntuneAppProtectionPolicyRequiredException) serviceException
+            );
+        }
+
+        if (serviceException.getErrorCode().equalsIgnoreCase(
+                AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT) ||
+                serviceException.getErrorCode().equalsIgnoreCase(
+                        AuthenticationConstants.OAuth2ErrorCode.INTERACTION_REQUIRED)) {
+
+            resultBundle.putString(
+                    AuthenticationConstants.OAuth2.ERROR,
+                    ADALError.AUTH_REFRESH_FAILED_PROMPT_NOT_ALLOWED.getDescription()
+            );
+
+            resultBundle.putString(
+                    AuthenticationConstants.OAuth2.ERROR_DESCRIPTION,
+                    serviceException.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Helper method to IntuneAppProtectionPolicyRequiredException properties to bundle
+     *
+     * @param resultBundle
+     * @param exception
+     */
+    private void setIntuneAppProtectionPropertiesToBundle(@NonNull final Bundle resultBundle,
+                                                          @NonNull final IntuneAppProtectionPolicyRequiredException exception) {
+
+        resultBundle.putString(
+                AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,
+                ADALError.AUTH_FAILED_INTUNE_POLICY_REQUIRED.getDescription()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID,
+                exception.getTenantId()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_AUTHORITY,
+                exception.getAuthorityUrl()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID,
+                exception.getAccountUserId()
+        );
+        resultBundle.putString(
+                AuthenticationConstants.Broker.ACCOUNT_NAME,
+                exception.getAccountUpn()
+        );
+    }
+
+    /**
+     * Helper method to set Bundle with Account manager error keys as expected by Adal
+     */
+    private void setErrorToResultBundle(@NonNull final Bundle resultBundle,
+                                        @NonNull int error,
+                                        @NonNull final String errorDescription) {
+        resultBundle.putInt(
+                AccountManager.KEY_ERROR_CODE,
+                error
+        );
+        resultBundle.putString(
+                AccountManager.KEY_ERROR_MESSAGE,
+                errorDescription
+        );
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -26,7 +26,6 @@ import android.accounts.AccountManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.adal.internal.ADALError;
@@ -41,10 +40,7 @@ import com.microsoft.identity.common.exception.UserCancelException;
 import com.microsoft.identity.common.internal.cache.SchemaUtil;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
-import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 import com.microsoft.identity.common.internal.util.HeaderSerializationUtil;
-
-import java.util.Map;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.RT_AGE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CliTelemInfo.SERVER_ERROR;
@@ -57,6 +53,8 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
 
     @Override
     public Bundle bundleFromAuthenticationResult(@NonNull final ILocalAuthenticationResult authenticationResult) {
+
+        Logger.verbose(TAG , "Constructing success bundle from Authentication Result.");
 
         final Bundle resultBundle = new Bundle();
 
@@ -127,6 +125,8 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
     @Override
     public Bundle bundleFromBaseException(BaseException baseException) {
 
+        Logger.verbose(TAG , "Constructing error bundle from exception.");
+
         final Bundle resultBundle = new Bundle();
 
         resultBundle.putString(
@@ -159,6 +159,7 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
 
         if (exception instanceof UserCancelException) {
 
+            Logger.verbose(TAG , "Setting Bundle result from UserCancelException.");
             setErrorToResultBundle(
                     resultBundle,
                     AccountManager.ERROR_CODE_CANCELED,
@@ -166,6 +167,7 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
 
         } else if (exception instanceof ArgumentException) {
 
+            Logger.verbose(TAG , "Setting Bundle result from ArgumentException.");
             setErrorToResultBundle(
                     resultBundle,
                     AccountManager.ERROR_CODE_BAD_ARGUMENTS,
@@ -186,7 +188,7 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
                     (ServiceException) exception);
 
         } else {
-
+            Logger.verbose(TAG , "Setting Bundle result for Unknown Exception/Bad result.");
             setErrorToResultBundle(
                     resultBundle,
                     AccountManager.ERROR_CODE_BAD_REQUEST,
@@ -215,6 +217,8 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
     private void setClientExceptionPropertiesToBundle(@NonNull final Bundle resultBundle,
                                                       @NonNull final ClientException clientException) {
 
+        Logger.verbose(TAG , "Setting properties from ClientException.");
+
         if (clientException.getErrorCode().equalsIgnoreCase(ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE)) {
 
             setErrorToResultBundle(
@@ -241,6 +245,8 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
      */
     private void setServiceExceptionPropertiesToBundle(@NonNull final Bundle resultBundle,
                                                        @NonNull final ServiceException serviceException) {
+
+        Logger.verbose(TAG , "Setting properties from ServiceException.");
 
         if (null != serviceException.getHttpResponseBody()) {
             resultBundle.putString(
@@ -294,6 +300,8 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
      */
     private void setIntuneAppProtectionPropertiesToBundle(@NonNull final Bundle resultBundle,
                                                           @NonNull final IntuneAppProtectionPolicyRequiredException exception) {
+
+        Logger.verbose(TAG , "Setting properties from IntuneAppProtectionPolicyRequiredException.");
 
         resultBundle.putString(
                 AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/BrokerResultAdapterFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/BrokerResultAdapterFactory.java
@@ -1,0 +1,40 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.result;
+
+import com.microsoft.identity.common.internal.request.SdkType;
+
+/**
+ * Class which returns creates {@link IBrokerResultAdapter }  based on {@link SdkType}
+ */
+public class BrokerResultAdapterFactory {
+
+    public static IBrokerResultAdapter getBrokerResultAdapter(final SdkType sdkType) {
+
+        if (sdkType == SdkType.ADAL) {
+            return new AdalBrokerResultAdapter();
+        } else {
+            return new MsalBrokerResultAdapter();
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/IBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/IBrokerResultAdapter.java
@@ -1,0 +1,44 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.result;
+
+import android.os.Bundle;
+
+import com.microsoft.identity.common.exception.BaseException;
+
+public interface IBrokerResultAdapter {
+
+    /**
+     * Returns a success bundle with properties from Authenticator Result.
+     * @param authenticationResult
+     * @return Bundle
+     */
+    Bundle bundleFromAuthenticationResult(ILocalAuthenticationResult authenticationResult);
+
+    /**
+     * Returns an error bundle with properties from Exception.
+     * @param exception
+     * @return
+     */
+    Bundle bundleFromBaseException(BaseException exception);
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -1,0 +1,42 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.result;
+
+import android.os.Bundle;
+
+import com.microsoft.identity.common.exception.BaseException;
+
+
+// TODO : To be implemented.
+public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
+
+ @Override
+ public Bundle bundleFromAuthenticationResult(ILocalAuthenticationResult authenticationResult) {
+  return null;
+ }
+
+ @Override
+ public Bundle bundleFromBaseException(BaseException exception) {
+  return null;
+ }
+}


### PR DESCRIPTION
- Added new `IBrokerResultAdapter` and corresponding `AdalBrokerResultAdapter` and `MsalBrokerResultAdapter` to consolidate result bundle based on the SDK
- Added `IntuneAppProtectionPolicyRequiredException` to support intune's `PROTECTION_POLICY_REQUIRED` sub error.
- Removed `context` from `TokenCommand` as it's being staticly held which can potentially lead to garbage collection issues.
- Replaced `throwIfNetworkNotAvailable` to more comprehensive `HttpWebRequest.throwIfNetworkNotAvailable`.
- Added logic to add `iss` claim as identity provider for V1 token if `idp` is not available