### PR TITLE
Adds support for guest accounts to MSAL cache migration

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/AdalMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/AdalMigrationAdapter.java
@@ -32,7 +32,6 @@ import android.util.Pair;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.microsoft.identity.common.adal.internal.ADALUserInfo;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.cache.ADALTokenCacheItem;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -40,7 +39,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccou
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryAccount;
-import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
@@ -48,11 +46,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+
+import static com.microsoft.identity.common.internal.migration.TokenCacheItemMigrationAdapter.migrateTokens;
 
 /**
  * Adapts tokens from the ADAL cache format to the MSAL (common schema) format.
@@ -68,16 +66,6 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
      * The log tag of this class.
      */
     private static final String TAG = AdalMigrationAdapter.class.getSimpleName();
-
-    /**
-     * The cache-key component, unique to MRRT tokens.
-     */
-    private static final String MRRT_FLAG = "$y$";
-
-    /**
-     * The cache-key component, unique to FOCI tokens.
-     */
-    private static final String FOCI_FLAG = "$foci-";
 
     /**
      * The name of the SharedPreferences file used by this class for tracking migration state.
@@ -100,6 +88,8 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
      */
     private final boolean mForceMigration;
 
+    private final Map<String, String> mRedirectsMap;
+
     /**
      * Constructs a new AdalMigrationAdapter.
      *
@@ -107,8 +97,10 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
      * @param force   Force migration to occur, even if it has run before.
      */
     public AdalMigrationAdapter(final Context context,
+                                final Map<String, String> redirects,
                                 final boolean force) {
         mSharedPrefs = context.getSharedPreferences(MIGRATION_STATUS_SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        mRedirectsMap = redirects;
         mForceMigration = force;
     }
 
@@ -125,29 +117,13 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
                 final boolean cloudMetadataLoaded = loadCloudDiscoveryMetadata();
 
                 if (cloudMetadataLoaded) {
-                    final List<String> commonEndpoints = getCommonEndpoints();
-                    Logger.verbose(
-                            TAG + methodName,
-                            "Identified [" + commonEndpoints.size() + "] common endpoints"
-                    );
-
                     // Convert the JSON to native ADALTokenCacheItem representation, original keys used to key the Map
                     Map<String, ADALTokenCacheItem> nativeCacheItems = deserialize(cacheItems);
-                    nativeCacheItems = filterByEndpoint(commonEndpoints, nativeCacheItems);
-                    Logger.verbose(
-                            TAG + methodName,
-                            "Found [" + nativeCacheItems.size() + "] common tokens."
+
+                    result.addAll(
+                            migrateTokens(mRedirectsMap, nativeCacheItems.values())
                     );
 
-                    // Split these by clientId, key is client id - secondary key is original TKI key
-                    Map<String, Map<String, ADALTokenCacheItem>> nativeCacheItemByClientId = segmentByClientId(nativeCacheItems);
-
-                    for (final Map.Entry<String, Map<String, ADALTokenCacheItem>> entry : nativeCacheItemByClientId.entrySet()) {
-                        final Map<String, ADALTokenCacheItem> tokensForClientId = entry.getValue();
-                        result.addAll(selectTokensByUser(segmentByUser(tokensForClientId)));
-                    }
-
-                    // Update the migrated status
                     setMigrationStatus(true);
                 }
             }
@@ -173,134 +149,6 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
      */
     public boolean getMigrationStatus() {
         return mSharedPrefs.getBoolean(KEY_MIGRATION_STATUS, false);
-    }
-
-    /**
-     * Splits the provided credentials into a Map, keyed on the clientId of the application to which
-     * they are associated.
-     *
-     * @param nativeCacheItems The cache items to inspect.
-     * @return A Map of the provided Credentials, keyed by clientId.
-     */
-    private Map<String, Map<String, ADALTokenCacheItem>> segmentByClientId(@NonNull final Map<String, ADALTokenCacheItem> nativeCacheItems) {
-        // Declare a List to hold the result
-        Map<String, Map<String, ADALTokenCacheItem>> result = new HashMap<>();
-
-        // Iterate over the supplied entries
-        for (final Map.Entry<String, ADALTokenCacheItem> entry : nativeCacheItems.entrySet()) {
-            // Grab the clientId of the current credential.
-            final String currentClientId = entry.getValue().getClientId();
-
-            // If this is the first time we have seen it, create a secondary Map for the destination
-            // of this credential
-            if (null == result.get(currentClientId)) {
-                result.put(currentClientId, new HashMap<String, ADALTokenCacheItem>());
-            }
-
-            // Add the current credential to the token map
-            result.get(currentClientId).put(entry.getKey(), entry.getValue());
-        }
-
-        return result;
-    }
-
-    private Collection<? extends Pair<MicrosoftAccount, MicrosoftRefreshToken>> selectTokensByUser(@NonNull final Map<String, Map<String, ADALTokenCacheItem>> cacheItemsByUniqueId) {
-        final List<Pair<MicrosoftAccount, MicrosoftRefreshToken>> result = new ArrayList<>();
-
-        for (final Map.Entry<String, Map<String, ADALTokenCacheItem>> entry : cacheItemsByUniqueId.entrySet()) {
-            MicrosoftAccount account;
-            MicrosoftRefreshToken msRt;
-            Pair<String, ADALTokenCacheItem> refreshTokenPair = null;
-            boolean isFrt = true;
-
-            // Try to find the FRT
-            refreshTokenPair = findFrt(entry.getValue());
-
-            // If no FRT found, try to find MRRT
-            if (null == refreshTokenPair) {
-                isFrt = false;
-                refreshTokenPair = findMrrt(entry.getValue());
-            }
-
-            // If no MRRT found, fallback to RT
-            if (null == refreshTokenPair) {
-                refreshTokenPair = findRt(entry.getValue());
-            }
-
-            if (null != refreshTokenPair) {
-                // Create the account to 'own' this RT
-                account = createAccount(refreshTokenPair.second);
-
-                if (null != account) {
-                    // If we were able to create the account, create the associated RT
-                    msRt = createMicrosoftRefreshToken(account, isFrt, refreshTokenPair);
-
-                    if (null != msRt) {
-                        // If we have the account and RT, we're done. Move on...
-                        result.add(new Pair<>(account, msRt));
-                    }
-                }
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * Creates a {@link MicrosoftRefreshToken} from the supplied credential data.
-     *
-     * @param account          The account which will 'own' this token.
-     * @param isFrt            True, if the supplied token is an FRT. False otherwise.
-     * @param refreshTokenPair The 'legacy' format pair -- the key & value.
-     * @return The resulting MicrosoftRefreshToken.
-     */
-    public static MicrosoftRefreshToken createMicrosoftRefreshToken(@NonNull final MicrosoftAccount account,
-                                                                    final boolean isFrt,
-                                                                    @NonNull final Pair<String, ADALTokenCacheItem> refreshTokenPair) {
-        final String methodName = ":createMicrosoftRefreshToken";
-
-        try {
-            final String legacyCacheKey = refreshTokenPair.first;
-            final String rawRt = refreshTokenPair.second.getRefreshToken();
-            final String clientInfoStr = account.getClientInfo();
-            final ClientInfo clientInfo = new ClientInfo(clientInfoStr);
-            final String scope = "openid profile offline_access"; // default scopes
-            final String clientId = refreshTokenPair.second.getClientId();
-            final String environment = new URL(refreshTokenPair.second.getAuthority()).getHost();
-            String familyId = null;
-
-            if (isFrt) {
-                familyId = legacyCacheKey.substring(
-                        legacyCacheKey.lastIndexOf(FOCI_FLAG),
-                        legacyCacheKey.length()
-                );
-
-                familyId = familyId.replace(FOCI_FLAG, "");
-            }
-
-            return new MicrosoftRefreshToken(
-                    rawRt,
-                    clientInfo,
-                    scope,
-                    clientId,
-                    isFrt,
-                    environment,
-                    familyId
-            );
-        } catch (ServiceException | MalformedURLException e) {
-            final String errMsg = "Failed to create RefreshToken";
-            Logger.error(
-                    TAG + methodName,
-                    errMsg,
-                    null
-            );
-            Logger.errorPII(
-                    TAG + methodName,
-                    errMsg,
-                    e
-            );
-            return null;
-        }
     }
 
     /**
@@ -348,106 +196,6 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
     }
 
     /**
-     * Selects a non-null RT from the supplied cache items. Order is nondeterministic.
-     *
-     * @param cacheItems The cache items to inspect.
-     * @return A non-null RT and its associated key.
-     */
-    private Pair<String, ADALTokenCacheItem> findRt(@NonNull final Map<String, ADALTokenCacheItem> cacheItems) {
-        for (Map.Entry<String, ADALTokenCacheItem> entry : cacheItems.entrySet()) {
-            if (null != entry.getValue().getRefreshToken()) {
-                return new Pair<>(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Selects a non-null MRRT from the supplied cache items. Order is nondeterministic.
-     *
-     * @param cacheItems The cache items to inspect.
-     * @return A non-null RT and its associated key.
-     */
-    private Pair<String, ADALTokenCacheItem> findMrrt(@NonNull final Map<String, ADALTokenCacheItem> cacheItems) {
-        return findRtKeyVariant(MRRT_FLAG, cacheItems);
-    }
-
-    /**
-     * Selects a non-null FRT from the supplied cache items. Order is nondeterministic.
-     *
-     * @param cacheItems The cache items to inspect.
-     * @return A non-null RT and its associated key.
-     */
-    private Pair<String, ADALTokenCacheItem> findFrt(@NonNull final Map<String, ADALTokenCacheItem> cacheItems) {
-        return findRtKeyVariant(FOCI_FLAG, cacheItems);
-    }
-
-    /**
-     * Utility method for finding various token types, based on key metadata.
-     *
-     * @param keyVariant The key component used to search the supplied cache items.
-     * @param cacheItems The cache items to inspect.
-     * @return A refresh token matching the specified criteria (and its key).
-     */
-    private Pair<String, ADALTokenCacheItem> findRtKeyVariant(@NonNull final String keyVariant,
-                                                              @NonNull final Map<String, ADALTokenCacheItem> cacheItems) {
-        for (Map.Entry<String, ADALTokenCacheItem> entry : cacheItems.entrySet()) {
-            if (entry.getKey().contains(keyVariant)) {
-                return new Pair<>(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns a copy of the supplied native cache items, keyed by the oid of the account to which
-     * those entries will be associated.
-     *
-     * @param nativeCacheItems The cache items to inspect.
-     * @return The supplied cache items, keyed by oid.
-     */
-    private Map<String, Map<String, ADALTokenCacheItem>> segmentByUser(@NonNull final Map<String, ADALTokenCacheItem> nativeCacheItems) {
-        final Map<String, Map<String, ADALTokenCacheItem>> result = new HashMap<>();
-
-        ADALTokenCacheItem currentTokenCacheItem;
-        ADALUserInfo currentUserInfo;
-        for (final Map.Entry<String, ADALTokenCacheItem> entry : nativeCacheItems.entrySet()) {
-            currentTokenCacheItem = entry.getValue();
-            currentUserInfo = currentTokenCacheItem.getUserInfo();
-
-            if (null == result.get(currentUserInfo.getUserId())) {
-                result.put(currentUserInfo.getUserId(), new HashMap<String, ADALTokenCacheItem>());
-            }
-
-            result.get(currentUserInfo.getUserId()).put(entry.getKey(), entry.getValue());
-        }
-
-        return result;
-    }
-
-    /**
-     * Filters the supplied list of credentials relative to a List of supplied endpoints.
-     *
-     * @param endpoints        The endpoints to search for.
-     * @param nativeCacheItems The credentials to inspect.
-     * @return The filtered credential Map.
-     */
-    private Map<String, ADALTokenCacheItem> filterByEndpoint(@NonNull final List<String> endpoints,
-                                                             @NonNull final Map<String, ADALTokenCacheItem> nativeCacheItems) {
-        final Map<String, ADALTokenCacheItem> result = new HashMap<>();
-
-        for (final Map.Entry<String, ADALTokenCacheItem> cacheItemEntry : nativeCacheItems.entrySet()) {
-            if (endpoints.contains(cacheItemEntry.getValue().getAuthority())) {
-                result.put(cacheItemEntry.getKey(), cacheItemEntry.getValue());
-            }
-        }
-
-        return result;
-    }
-
-    /**
      * Converts the supplied Map of key/value JSON credentials into a Map of key/POJO.
      *
      * @param tokenCacheItems The credentials to inspect.
@@ -465,46 +213,6 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
         }
 
         return result;
-    }
-
-    /**
-     * Loads the comprehensive list of 'common' endpoints, based on the loaded InstanceDiscoveryMetadata.
-     *
-     * @return The complete list of known common endpoints.
-     */
-    public static List<String> getCommonEndpoints() {
-        final String protocol = "https://";
-        final String pathSeparator = "/";
-        final String commonPathSegment = "common";
-
-        // List of our result endpoints...
-        final List<String> commonEndpoints = new ArrayList<>();
-
-        // Declare a List to hold the associated Cloud instances
-        final List<AzureActiveDirectoryCloud> clouds = AzureActiveDirectory.getClouds();
-
-        String commonHostAlias;
-        for (final AzureActiveDirectoryCloud cloud : clouds) {
-            for (final String hostAlias : cloud.getHostAliases()) {
-                commonHostAlias = hostAlias;
-
-                if (!commonHostAlias.startsWith(protocol)) {
-                    commonHostAlias = protocol + commonHostAlias;
-                }
-
-                if (!commonHostAlias.endsWith(pathSeparator)) {
-                    commonHostAlias = commonHostAlias + pathSeparator;
-                }
-
-                if (!commonHostAlias.endsWith(commonPathSegment)) {
-                    commonHostAlias = commonHostAlias + commonPathSegment;
-                }
-
-                commonEndpoints.add(commonHostAlias);
-            }
-        }
-
-        return commonEndpoints;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/AdalMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/AdalMigrationAdapter.java
@@ -106,7 +106,6 @@ public class AdalMigrationAdapter implements IMigrationAdapter<MicrosoftAccount,
 
     @Override
     public List<Pair<MicrosoftAccount, MicrosoftRefreshToken>> adapt(Map<String, String> cacheItems) {
-        final String methodName = ":adapt";
         final List<Pair<MicrosoftAccount, MicrosoftRefreshToken>> result = new ArrayList<>();
 
         synchronized (sLock) { // To prevent multiple threads from potentially running migration

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
@@ -1,0 +1,281 @@
+package com.microsoft.identity.common.internal.migration;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Pair;
+
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.cache.ADALTokenCacheItem;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.microsoft.identity.common.internal.migration.AdalMigrationAdapter.loadCloudDiscoveryMetadata;
+
+public class TokenCacheItemMigrationAdapter {
+
+    private static final String TAG = TokenCacheItemMigrationAdapter.class.getSimpleName();
+    public static final String COMMON = "/common";
+
+    private final Context mContext;
+
+    public TokenCacheItemMigrationAdapter(@NonNull final Context context) {
+        mContext = context;
+    }
+
+    /**
+     * For a list of supplied tokens, filter them to find the 'most preferred' when migrating.
+     * Renew those tokens and provide them as the result in the v2 format.
+     *
+     * @param redirects  The mapping of clientIds to redirect_uris.
+     * @param cacheItems The cache items to migrate.
+     * @return The result.
+     */
+    public List<Pair<MicrosoftAccount, MicrosoftRefreshToken>> migrateTokens(
+            @NonNull final Map<String, String> redirects,
+            @NonNull final List<ADALTokenCacheItem> cacheItems) {
+        final List<Pair<MicrosoftAccount, MicrosoftRefreshToken>> result = new ArrayList<>();
+
+        final boolean cloudMetadataLoaded = loadCloudDiscoveryMetadata();
+
+        if (cloudMetadataLoaded) {
+            final List<ADALTokenCacheItem> cacheItemsWithoutDuplicates = filterDuplicateTokens(
+                    cacheItems
+            );
+
+            final Map<String, List<ADALTokenCacheItem>> tokensByClientId = splitTokensByClientId(
+                    cacheItemsWithoutDuplicates
+            );
+
+            final Map<String, List<ADALTokenCacheItem>> filteredTokens = preferentiallySelectTokens(
+                    tokensByClientId
+            );
+
+            // TODO renew these tokens...
+        }
+
+        return result;
+    }
+
+    @NonNull
+    public static List<ADALTokenCacheItem> filterDuplicateTokens(
+            @NonNull final List<ADALTokenCacheItem> cacheItems) {
+        final List<ADALTokenCacheItem> cacheItemsFiltered = new ArrayList<>();
+
+        // Key is the rt secret value
+        final Map<String, ADALTokenCacheItem> cacheItemMap = new HashMap<>();
+
+        for (final ADALTokenCacheItem cacheItem : cacheItems) {
+            if (null == cacheItem.getResource()) {
+                Logger.warn(
+                        TAG,
+                        "Skipping resourceless token."
+                );
+
+                continue;
+            }
+
+            if (null == cacheItemMap.get(cacheItem.getRefreshToken())) {
+                cacheItemMap.put(cacheItem.getRefreshToken(), cacheItem);
+            }
+
+            if (null != cacheItemMap.get(cacheItem.getRefreshToken())
+                    && cacheItem.getAuthority().contains(COMMON)) {
+                // Prefer the home-tenant token over the tenanted...
+                cacheItemMap.put(cacheItem.getRefreshToken(), cacheItem);
+            }
+        }
+
+        cacheItemsFiltered.addAll(cacheItemMap.values());
+
+        return cacheItemsFiltered;
+    }
+
+    /**
+     * For the supplied List of {@link ADALTokenCacheItem}, sort it into a Map keyed on the
+     * clientId of the contained tokens.
+     *
+     * @param cacheItemsIn The cache items to inspect.
+     * @return The input cache items, sorted into 'buckets' based on clientId.
+     */
+    @NonNull
+    public static Map<String, List<ADALTokenCacheItem>> splitTokensByClientId(
+            @NonNull final List<ADALTokenCacheItem> cacheItemsIn) {
+        final String methodName = ":splitTokensByClientId";
+
+        Logger.verbose(
+                TAG + methodName,
+                "Splitting ["
+                        + cacheItemsIn.size()
+                        + "] cache items."
+        );
+
+        final Map<String, List<ADALTokenCacheItem>> cacheItemsOut = new HashMap<>();
+
+        for (final ADALTokenCacheItem cacheItem : cacheItemsIn) {
+            if (null == cacheItemsOut.get(cacheItem.getClientId())) {
+                cacheItemsOut.put(
+                        cacheItem.getClientId(),
+                        new ArrayList<ADALTokenCacheItem>()
+                );
+            }
+
+            cacheItemsOut.get(cacheItem.getClientId()).add(cacheItem);
+        }
+
+        return cacheItemsOut;
+    }
+
+    /**
+     * Given the supplied Map of tokens (keyed by clientId), iterate over the list of tokens to
+     * select the 'most preferred' one to migrate. Preference order is:
+     * 1. FRT
+     * 2. MRRT
+     * 3. Regular RT
+     *
+     * @param tokensByClientId The candidate tokens to inspect.
+     * @return The reduced Map of input tokens, contain only the most preferred tokens to migrate.
+     */
+    public static Map<String, List<ADALTokenCacheItem>> preferentiallySelectTokens(
+            @NonNull final Map<String, List<ADALTokenCacheItem>> tokensByClientId) {
+        final String methodName = ":preferentiallySelectTokens";
+        // Key is client id
+        final Map<String, List<ADALTokenCacheItem>> result = new HashMap<>();
+
+        for (final Map.Entry<String, List<ADALTokenCacheItem>> entry : tokensByClientId.entrySet()) {
+            final String clientId = entry.getKey();
+            final List<ADALTokenCacheItem> tokens = entry.getValue();
+
+            ADALTokenCacheItem refreshToken = findFrt(tokens);
+
+            if (null == refreshToken) {
+                Logger.verbose(
+                        TAG + methodName,
+                        "FRT was null. Try MRRT."
+                );
+
+                refreshToken = findMrrt(tokens);
+            }
+
+            if (null == refreshToken) {
+                Logger.verbose(
+                        TAG + methodName,
+                        "MRRT was null. Try RT."
+                );
+
+                refreshToken = findRt(tokens);
+            }
+
+            if (null != refreshToken) {
+                // We've selected the 'best' token. Stick it in the result...
+                if (null == result.get(clientId)) {
+                    result.put(clientId, new ArrayList<ADALTokenCacheItem>());
+                }
+
+                result.get(clientId).add(refreshToken);
+            } else {
+                Logger.warn(
+                        TAG + methodName,
+                        "Refresh token could not be located."
+                );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * For the supplied List of ADALTokenCacheItems, return the first item which is an RT or
+     * null, if none exists.
+     *
+     * @param cacheItems The List of ADALTokenCacheItems to inspect.
+     * @return The first occurring RT or null, if none can be found.
+     */
+    @Nullable
+    public static ADALTokenCacheItem findRt(
+            @NonNull final List<ADALTokenCacheItem> cacheItems) {
+        final String methodName = ":findRt";
+        ADALTokenCacheItem result = null;
+
+        for (final ADALTokenCacheItem cacheItem : cacheItems) {
+            if (!StringExtensions.isNullOrBlank(cacheItem.getRefreshToken())) {
+                result = cacheItem;
+
+                Logger.verbose(
+                        TAG + methodName,
+                        "RT found."
+                );
+
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * For the supplied List of ADALTokenCacheItems, return the first item which is an MRRT or
+     * null, if none exists.
+     *
+     * @param cacheItems The List of ADALTokenCacheItems to inspect.
+     * @return The first occurring MRRT or null, if none can be found.
+     */
+    @Nullable
+    public static ADALTokenCacheItem findMrrt(
+            @NonNull final List<ADALTokenCacheItem> cacheItems) {
+        final String methodName = ":findMrrt";
+        ADALTokenCacheItem result = null;
+
+        for (final ADALTokenCacheItem cacheItem : cacheItems) {
+            if (!StringExtensions.isNullOrBlank(cacheItem.getRefreshToken())
+                    && cacheItem.getIsMultiResourceRefreshToken()) {
+                result = cacheItem;
+
+                Logger.verbose(
+                        TAG + methodName,
+                        "Mrrt found."
+                );
+
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * For the supplied List of ADALTokenCacheItems, return the first item which is an FRT or
+     * null, if none exists.
+     *
+     * @param cacheItems The List of ADALTokenCacheItems to inspect.
+     * @return The first occurring FRT or null, if none can be found.
+     */
+    @Nullable
+    public static ADALTokenCacheItem findFrt(
+            @NonNull final List<ADALTokenCacheItem> cacheItems) {
+        final String methodName = ":findFrt";
+        ADALTokenCacheItem result = null;
+
+        for (final ADALTokenCacheItem cacheItem : cacheItems) {
+            if (!StringExtensions.isNullOrBlank(cacheItem.getRefreshToken())
+                    && !StringExtensions.isNullOrBlank(cacheItem.getFamilyClientId())) {
+                result = cacheItem;
+
+                Logger.verbose(
+                        TAG + methodName,
+                        "Frt found."
+                );
+
+                break;
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This PR increases code sharing between MSAL/broker for cache migration actions.

Tested:
- Broker cache migration w/ new shared code
- MSAL cache upgrade (online)
- MSAL cache upgrade (offline)
    * When offline, migration cannot complete successfully and `getAccounts()` returns `0` accounts
    * When you come back online and invoke `getAccounts()` migration executes and returns the migrated accounts