### PR TITLE
Fix the CustomTabsService binding exception on Huawei device

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -79,7 +79,7 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
                     "CustomTabsService is supported."
             );
             //create customTabsIntent
-            mCustomTabManager = new CustomTabsManager(mReferencedActivity.get());
+            mCustomTabManager = new CustomTabsManager(mReferencedActivity.get().getApplicationContext());
             mCustomTabManager.bind(browser.getPackageName());
             authIntent = mCustomTabManager.getCustomTabsIntent().intent;
         } else {


### PR DESCRIPTION
Issue:
In Huawei device, when the msal trying to bind the CustomTabsService, msal is not able to switch the thread and invoke the binding. As the result, the CustomTabsClient is not initialized which introduce the NullPointerException.

```java
2019-03-22 14:37:39.090 8373-8536/com.microsoft.identity.client.sample.local E/ApiDispatcher:beginInteractive:  [2019-03-22 21:37:39 - {"thread_id":"485","correlation_id":"77892acc-d2b0-4498-9adc-3a2a3b0931c6"}] Interactive request failed with Exception Android 26
    java.lang.NullPointerException: Attempt to invoke virtual method 'android.support.customtabs.CustomTabsSession android.support.customtabs.CustomTabsClient.newSession(android.support.customtabs.CustomTabsCallback)' on a null object reference
        at com.microsoft.identity.common.internal.ui.browser.CustomTabsManager.bind(CustomTabsManager.java:102)
        at com.microsoft.identity.common.internal.ui.browser.BrowserAuthorizationStrategy.requestAuthorization(BrowserAuthorizationStrategy.java:83)
        at com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy.requestAuthorization(OAuth2Strategy.java:93)
        at com.microsoft.identity.client.internal.controllers.LocalMSALController.performAuthorizationRequest(LocalMSALController.java:139)
        at com.microsoft.identity.client.internal.controllers.LocalMSALController.acquireToken(LocalMSALController.java:93)
        at com.microsoft.identity.common.internal.controllers.InteractiveTokenCommand.execute(InteractiveTokenCommand.java:59)
        at com.microsoft.identity.common.internal.controllers.ApiDispatcher$1.run(ApiDispatcher.java:74)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:784)
```


- Add the function `createSession()` to create the custom tabs session.
- Change the property `WeakReference<Activity> mActivityRef` to `WeakReference<Context> mContextRef` to avoid the duplicate calling of `getApplicationContext`

- Did the E2E testing on the repro device - Huawei Mate 9 pro w/ api 8.0.0. 
- Also, sanity tested on Nexus 6p with api 8.1.0 and api 6.0.