### PR TITLE
Do not send select_account if login_hint is set

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -125,8 +125,7 @@ public abstract class BaseController {
             );
 
             // We don't want to show the SELECT_ACCOUNT page if login_hint is set.
-            if (acquireTokenOperationParameters.getLoginHint() != null &&
-                    acquireTokenOperationParameters.getLoginHint().length() > 0 &&
+            if (!StringExtensions.isNullOrBlank(acquireTokenOperationParameters.getLoginHint()) &&
                     acquireTokenOperationParameters.getOpenIdConnectPromptParameter() == OpenIdConnectPromptParameter.SELECT_ACCOUNT) {
                 builder.setPrompt(null);
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -56,6 +56,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResu
 import com.microsoft.identity.common.internal.providers.oauth2.IResult;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
+import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
@@ -122,6 +123,13 @@ public abstract class BaseController {
             ).setRequestHeaders(
                     acquireTokenOperationParameters.getRequestHeaders()
             );
+
+            // We don't want to show the SELECT_ACCOUNT page if login_hint is set.
+            if (acquireTokenOperationParameters.getLoginHint() != null &&
+                    acquireTokenOperationParameters.getLoginHint().length() > 0 &&
+                    acquireTokenOperationParameters.getOpenIdConnectPromptParameter() == OpenIdConnectPromptParameter.SELECT_ACCOUNT) {
+                builder.setPrompt(null);
+            }
 
             // Set the multipleCloudAware and slice fields.
             if (acquireTokenOperationParameters.getAuthority() instanceof AzureActiveDirectoryAuthority) {


### PR DESCRIPTION
If we send both, SELECT_ACCOUNT wins and the user will always be asked to select account in the webView.

