### PR TITLE
Closes ad-accounts/#926 (Adds V1IdToken caching support)

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -162,7 +162,8 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 CLIENT_ID,
                 SECRET,
                 MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                "1"
+                "1",
+                CredentialType.IdToken
         );
 
         mDefaultAppUidTestBundle = new MsalOAuth2TokenCacheTest.AccountCredentialTestBundle(
@@ -179,7 +180,8 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 CLIENT_ID,
                 SECRET,
                 MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                null
+                null,
+                CredentialType.IdToken
         );
 
         mOtherCacheTestBundles = new ArrayList<>();
@@ -200,7 +202,8 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                             UUID.randomUUID().toString(),
                             SECRET,
                             MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                            null
+                            null,
+                            CredentialType.IdToken
                     )
             );
         }

--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.MicrosoftFamilyOAuth2TokenCache;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -99,7 +100,8 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 CLIENT_ID,
                 SECRET,
                 MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                "1"
+                "1",
+                CredentialType.IdToken
         );
 
         when(
@@ -209,7 +211,8 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 CLIENT_ID,
                 SECRET,
                 MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                "1"
+                "1",
+                CredentialType.IdToken
         );
 
         when(
@@ -265,7 +268,8 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 CLIENT_ID + "2",
                 SECRET,
                 MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
-                "1"
+                "1",
+                CredentialType.IdToken
         );
 
         when(

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -224,37 +224,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         );
 
         // Mocks
-        when(
-                mockCredentialAdapter.createAccount(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV2.mGeneratedAccount);
-
-        when(
-                mockCredentialAdapter.createAccessToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV2.mGeneratedAccessToken);
-
-        when(
-                mockCredentialAdapter.createRefreshToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV2.mGeneratedRefreshToken);
-
-        when(
-                mockCredentialAdapter.createIdToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV2.mGeneratedIdToken);
+        configureMocksForTestBundle(defaultTestBundleV2);
 
         // Context and related init
         final Context context = InstrumentationRegistry.getTargetContext();
@@ -323,43 +293,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     public void saveTokensV1Compat() throws ClientException {
         // This test asserts that if an IdToken is returned in the v1 format (broker cases),
         // it is saved property.
-        when(
-                mockCredentialAdapter.createAccount(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV1.mGeneratedAccount);
-
-        when(
-                mockCredentialAdapter.createAccessToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV1.mGeneratedAccessToken);
-
-        when(
-                mockCredentialAdapter.createRefreshToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV1.mGeneratedRefreshToken);
-
-        when(
-                mockCredentialAdapter.createIdToken(
-                        mockStrategy,
-                        mockRequest,
-                        mockResponse
-                )
-        ).thenReturn(defaultTestBundleV1.mGeneratedIdToken);
-
-        mOauth2TokenCache.save(
-                mockStrategy,
-                mockRequest,
-                mockResponse
-        );
+        loadTestBundleIntoCache(defaultTestBundleV1);
 
         final List<AccountRecord> accounts = accountCredentialCache.getAccounts();
         assertEquals(1, accounts.size());
@@ -511,6 +445,17 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 mockResponse
         );
 
+        assertAccountLoaded();
+    }
+
+    @Test
+    public void getAccountV1Compat() throws ClientException {
+        loadTestBundleIntoCache(defaultTestBundleV1);
+
+        assertAccountLoaded();
+    }
+
+    private void assertAccountLoaded() {
         final AccountRecord account = mOauth2TokenCache.getAccount(
                 ENVIRONMENT,
                 CLIENT_ID,
@@ -555,43 +500,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         }
 
         for (int i = 0; i < iterations; i++) {
-            when(
-                    mockCredentialAdapter.createAccount(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccount);
-
-            when(
-                    mockCredentialAdapter.createAccessToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccessToken);
-
-            when(
-                    mockCredentialAdapter.createRefreshToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedRefreshToken);
-
-            when(
-                    mockCredentialAdapter.createIdToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedIdToken);
-
-            mOauth2TokenCache.save(
-                    mockStrategy,
-                    mockRequest,
-                    mockResponse
-            );
+            loadTestBundleIntoCache(testBundles.get(i));
         }
 
         final List<AccountRecord> accounts = mOauth2TokenCache.getAccounts(
@@ -673,43 +582,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         }
 
         for (int i = 0; i < iterations; i++) {
-            when(
-                    mockCredentialAdapter.createAccount(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccount);
-
-            when(
-                    mockCredentialAdapter.createAccessToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccessToken);
-
-            when(
-                    mockCredentialAdapter.createRefreshToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedRefreshToken);
-
-            when(
-                    mockCredentialAdapter.createIdToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedIdToken);
-
-            mOauth2TokenCache.save(
-                    mockStrategy,
-                    mockRequest,
-                    mockResponse
-            );
+            loadTestBundleIntoCache(testBundles.get(i));
         }
 
         final List<AccountRecord> accounts = mOauth2TokenCache.getAccounts(
@@ -762,43 +635,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         }
 
         for (int i = 0; i < iterations; i++) {
-            when(
-                    mockCredentialAdapter.createAccount(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccount);
-
-            when(
-                    mockCredentialAdapter.createAccessToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedAccessToken);
-
-            when(
-                    mockCredentialAdapter.createRefreshToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedRefreshToken);
-
-            when(
-                    mockCredentialAdapter.createIdToken(
-                            mockStrategy,
-                            mockRequest,
-                            mockResponse
-                    )
-            ).thenReturn(testBundles.get(i).mGeneratedIdToken);
-
-            mOauth2TokenCache.save(
-                    mockStrategy,
-                    mockRequest,
-                    mockResponse
-            );
+            loadTestBundleIntoCache(testBundles.get(i));
         }
 
         final List<AccountRecord> accounts = mOauth2TokenCache.getAccounts(
@@ -845,6 +682,66 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 ).size(),
                 1
         );
+    }
+
+    @Test
+    public void removeAccountV1Compat() throws ClientException {
+        loadTestBundleIntoCache(defaultTestBundleV1);
+
+        assertEquals(
+                mOauth2TokenCache.removeAccount(
+                        ENVIRONMENT,
+                        CLIENT_ID,
+                        HOME_ACCOUNT_ID,
+                        REALM
+                ).size(),
+                1
+        );
+    }
+
+    private ICacheRecord loadTestBundleIntoCache(
+            @NonNull final AccountCredentialTestBundle testBundle) throws ClientException {
+        configureMocksForTestBundle(testBundle);
+
+        return mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+    }
+
+    private void configureMocksForTestBundle(@NonNull final AccountCredentialTestBundle testBundle) {
+        when(
+                mockCredentialAdapter.createAccount(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(testBundle.mGeneratedAccount);
+
+        when(
+                mockCredentialAdapter.createAccessToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(testBundle.mGeneratedAccessToken);
+
+        when(
+                mockCredentialAdapter.createRefreshToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(testBundle.mGeneratedRefreshToken);
+
+        when(
+                mockCredentialAdapter.createIdToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(testBundle.mGeneratedIdToken);
     }
 
     @Test
@@ -898,6 +795,24 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 CLIENT_ID,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount
+        );
+
+        assertEquals(result, secondaryLoad);
+    }
+
+    @Test
+    public void loadTokensV1Compat() throws ClientException {
+        final ICacheRecord result = loadTestBundleIntoCache(defaultTestBundleV1);
+
+        assertEquals(defaultTestBundleV1.mGeneratedAccount, result.getAccount());
+        assertEquals(defaultTestBundleV1.mGeneratedAccessToken, result.getAccessToken());
+        assertEquals(defaultTestBundleV1.mGeneratedRefreshToken, result.getRefreshToken());
+        assertEquals(defaultTestBundleV1.mGeneratedIdToken, result.getV1IdToken());
+
+        final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
+                CLIENT_ID,
+                TARGET,
+                defaultTestBundleV1.mGeneratedAccount
         );
 
         assertEquals(result, secondaryLoad);
@@ -970,6 +885,26 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         assertEquals(defaultTestBundleV2.mGeneratedAccessToken, secondaryLoad.getAccessToken());
         assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, secondaryLoad.getRefreshToken());
         assertNull(secondaryLoad.getIdToken());
+        assertNull(secondaryLoad.getV1IdToken());
+    }
+
+    @Test
+    public void removeV1IdToken() throws ClientException {
+        final ICacheRecord result = loadTestBundleIntoCache(defaultTestBundleV1);
+
+        mOauth2TokenCache.removeCredential(result.getV1IdToken());
+
+        final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
+                CLIENT_ID,
+                TARGET,
+                defaultTestBundleV2.mGeneratedAccount
+        );
+
+        assertEquals(defaultTestBundleV1.mGeneratedAccount, secondaryLoad.getAccount());
+        assertEquals(defaultTestBundleV1.mGeneratedAccessToken, secondaryLoad.getAccessToken());
+        assertEquals(defaultTestBundleV1.mGeneratedRefreshToken, secondaryLoad.getRefreshToken());
+        assertNull(secondaryLoad.getIdToken());
+        assertNull(secondaryLoad.getV1IdToken());
     }
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
@@ -56,10 +56,11 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
                 credentialClass = RefreshTokenRecord.class;
                 break;
             case IdToken:
+            case V1IdToken:
                 credentialClass = IdTokenRecord.class;
                 break;
             default:
-                Logger.warn(TAG, "Could not match CredentialType to class."
+                Logger.warn(TAG, "Could not match CredentialType to class. "
                         + "Did you forget to update this method with a new type?");
                 if (null != cacheKey) {
                     Logger.warnPII(TAG, "Sought key was: [" + cacheKey + "]");

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -222,8 +222,8 @@ public class BrokerOAuth2TokenCache
         }
 
         updateApplicationMetadataCache(
-                result.getIdToken().getClientId(),
-                result.getIdToken().getEnvironment(),
+                result.getAccessToken().getClientId(),
+                result.getAccessToken().getEnvironment(),
                 familyId,
                 mCallingProcessUid
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -286,8 +286,8 @@ public class BrokerOAuth2TokenCache
         );
 
         updateApplicationMetadataCache(
-                result.getIdToken().getClientId(),
-                result.getIdToken().getEnvironment(),
+                result.getRefreshToken().getClientId(),
+                result.getRefreshToken().getEnvironment(),
                 result.getRefreshToken().getFamilyId(),
                 mCallingProcessUid
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/CacheRecord.java
@@ -33,6 +33,7 @@ public class CacheRecord implements ICacheRecord {
     private AccessTokenRecord mAccessToken;
     private RefreshTokenRecord mRefreshToken;
     private IdTokenRecord mIdToken;
+    private IdTokenRecord mV1IdToken;
 
     public void setAccount(final AccountRecord account) {
         mAccount = account;
@@ -68,6 +69,15 @@ public class CacheRecord implements ICacheRecord {
     @Override
     public IdTokenRecord getIdToken() {
         return mIdToken;
+    }
+
+    public void setV1IdToken(final IdTokenRecord idToken) {
+        mV1IdToken = idToken;
+    }
+
+    @Override
+    public IdTokenRecord getV1IdToken() {
+        return mV1IdToken;
     }
 
     //CHECKSTYLE:OFF

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ICacheRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ICacheRecord.java
@@ -60,4 +60,10 @@ public interface ICacheRecord {
      */
     IdTokenRecord getIdToken();
 
+    /**
+     * Gets the {@link IdTokenRecord} in v1 format.
+     * @return
+     */
+    IdTokenRecord getV1IdToken();
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.support.annotation.NonNull;
 
-import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -154,13 +153,23 @@ public class MicrosoftStsAccountCredentialAdapter
             final IdTokenRecord idToken = new IdTokenRecord();
             // Required fields
             idToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
+
             if (null != response.getAuthority()) {
-                idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
+                idToken.setEnvironment(
+                        strategy.getIssuerCacheIdentifierFromAuthority(
+                                new URL(response.getAuthority())
+                        )
+                );
             } else {
                 idToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
             }
+
             idToken.setRealm(getRealm(strategy, response));
-            idToken.setCredentialType(CredentialType.IdToken.name());
+            idToken.setCredentialType(
+                    SchemaUtil.getCredentialTypeFromVersion(
+                            response.getIdToken()
+                    )
+            );
             idToken.setClientId(request.getClientId());
             idToken.setSecret(response.getIdToken());
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -533,7 +533,7 @@ public class MsalOAuth2TokenCache
                 "Found " + accountsForEnvironment.size() + " accounts for this environment"
         );
 
-        // Grab the Credentials for this app...
+        // Grab the Credentials for this app...start with the v2 IdTokens....
         final List<Credential> appCredentials =
                 mAccountCredentialCache.getCredentialsFilteredBy(
                         null, // homeAccountId
@@ -543,6 +543,18 @@ public class MsalOAuth2TokenCache
                         null, // realm
                         null // target
                 );
+
+        // And also grab any V1IdTokens....
+        appCredentials.addAll(
+                mAccountCredentialCache.getCredentialsFilteredBy(
+                        null, // homeAccountId
+                        environment,
+                        CredentialType.V1IdToken,
+                        clientId,
+                        null, // realm
+                        null // target
+                )
+        );
 
         // For each Account with an associated RT, add it to the result List...
         for (final AccountRecord account : accountsForEnvironment) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -706,6 +706,14 @@ public class MsalOAuth2TokenCache
                 isRealmAgnostic
         );
 
+        final int v1IdsRemoved = removeCredentialsOfTypeForAccount(
+                environment,
+                clientId,
+                CredentialType.V1IdToken,
+                targetAccount,
+                isRealmAgnostic
+        );
+
         final List<AccountRecord> deletedAccounts = new ArrayList<>();
 
         if (isRealmAgnostic) {
@@ -731,7 +739,8 @@ public class MsalOAuth2TokenCache
         final String[][] logInfo = new String[][]{
                 {"Access tokens", String.valueOf(atsRemoved)},
                 {"Refresh tokens", String.valueOf(rtsRemoved)},
-                {"Id tokens", String.valueOf(idsRemoved)},
+                {"Id tokens (v1)", String.valueOf(v1IdsRemoved)},
+                {"Id tokens (v2)", String.valueOf(idsRemoved)},
                 {"Accounts", String.valueOf(deletedAccounts.size())}
         };
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.AAD_VERSION_V1;
 import static com.microsoft.identity.common.exception.ErrorStrings.ACCOUNT_IS_SCHEMA_NONCOMPLIANT;
 import static com.microsoft.identity.common.exception.ErrorStrings.CREDENTIAL_IS_SCHEMA_NONCOMPLIANT;
 
@@ -235,7 +236,12 @@ public class MsalOAuth2TokenCache
         result.setAccount(accountToSave);
         result.setAccessToken(accessTokenToSave);
         result.setRefreshToken(refreshTokenToSave);
-        result.setIdToken(idTokenToSave);
+
+        if (idTokenToSave.getCredentialType().equalsIgnoreCase(AAD_VERSION_V1)) {
+            result.setV1IdToken(idTokenToSave);
+        } else {
+            result.setIdToken(idTokenToSave);
+        }
 
         return result;
     }
@@ -370,11 +376,22 @@ public class MsalOAuth2TokenCache
                 null // wildcard (*)
         );
 
+        // Load the v1 IdTokens
+        final List<Credential> v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                account.getHomeAccountId(),
+                account.getEnvironment(),
+                CredentialType.V1IdToken,
+                clientId,
+                account.getRealm(),
+                null // wildcard (*)
+        );
+
         final CacheRecord result = new CacheRecord();
         result.setAccount(account);
         result.setAccessToken(accessTokens.isEmpty() ? null : (AccessTokenRecord) accessTokens.get(0));
         result.setRefreshToken(refreshTokens.isEmpty() ? null : (RefreshTokenRecord) refreshTokens.get(0));
         result.setIdToken(idTokens.isEmpty() ? null : (IdTokenRecord) idTokens.get(0));
+        result.setV1IdToken(v1IdTokens.isEmpty() ? null : (IdTokenRecord) v1IdTokens.get(0));
 
         return result;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -49,7 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2.AAD_VERSION_V1;
 import static com.microsoft.identity.common.exception.ErrorStrings.ACCOUNT_IS_SCHEMA_NONCOMPLIANT;
 import static com.microsoft.identity.common.exception.ErrorStrings.CREDENTIAL_IS_SCHEMA_NONCOMPLIANT;
 
@@ -237,7 +236,7 @@ public class MsalOAuth2TokenCache
         result.setAccessToken(accessTokenToSave);
         result.setRefreshToken(refreshTokenToSave);
 
-        if (idTokenToSave.getCredentialType().equalsIgnoreCase(AAD_VERSION_V1)) {
+        if (CredentialType.V1IdToken.name().equalsIgnoreCase(idTokenToSave.getCredentialType())) {
             result.setV1IdToken(idTokenToSave);
         } else {
             result.setIdToken(idTokenToSave);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.cache;
 
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -144,13 +145,13 @@ public final class SchemaUtil {
         return alternativeAccountId;
     }
 
-    static String getCredentialTypeFromVersion(String idTokenString) {
+    public static String getCredentialTypeFromVersion(@Nullable final String idTokenString) {
         final String methodName = "getCredentialTypeFromVersion";
 
         // Default is v2
         String idTokenVersion = CredentialType.IdToken.name();
 
-        if (null != idTokenString) {
+        if (!TextUtils.isEmpty(idTokenString)) {
             IDToken idToken;
             try {
                 idToken = new IDToken(idTokenString);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -27,6 +27,7 @@ import android.text.TextUtils;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ServiceException;
+import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftIdToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
@@ -41,6 +42,7 @@ import java.util.Map;
 public final class SchemaUtil {
 
     private static final String TAG = SchemaUtil.class.getSimpleName();
+    private static final String EXCEPTION_CONSTRUCTING_IDTOKEN = "Exception constructing IDToken. ";
 
     private SchemaUtil() {
         // Utility class.
@@ -142,6 +144,33 @@ public final class SchemaUtil {
         return alternativeAccountId;
     }
 
+    static String getCredentialTypeFromVersion(String idTokenString) {
+        final String methodName = "getCredentialTypeFromVersion";
+
+        // Default is v2
+        String idTokenVersion = CredentialType.IdToken.name();
+
+        if (null != idTokenString) {
+            IDToken idToken;
+            try {
+                idToken = new IDToken(idTokenString);
+                final Map<String, String> idTokenClaims = idToken.getTokenClaims();
+                final String aadVersion = idTokenClaims.get(
+                        AuthenticationConstants.OAuth2.AAD_VERSION
+                );
+
+                if (!TextUtils.isEmpty(aadVersion)
+                        && aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V1)) {
+                    idTokenVersion = CredentialType.V1IdToken.name();
+                }
+            } catch (ServiceException e) {
+                Logger.warn(TAG + ":" + methodName, EXCEPTION_CONSTRUCTING_IDTOKEN + e.getMessage());
+            }
+        }
+
+        return idTokenVersion;
+    }
+
     public static String getIdentityProvider(final String idTokenString) {
         final String methodName = "getIdentityProvider";
 
@@ -163,7 +192,7 @@ public final class SchemaUtil {
                         idp = idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
 
                         // For home accounts idp claim is not available, use iss claim instead.
-                        if(TextUtils.isEmpty(idp)){
+                        if (TextUtils.isEmpty(idp)) {
                             Logger.info(TAG + ":" + methodName,
                                     "idp claim was null, using iss claim"
                             );
@@ -185,7 +214,7 @@ public final class SchemaUtil {
                     Logger.warn(TAG + ":" + methodName, "IDToken claims were null.");
                 }
             } catch (ServiceException e) {
-                Logger.warn(TAG + ":" + methodName, "Exception constructing IDToken. " + e.getMessage());
+                Logger.warn(TAG + ":" + methodName, EXCEPTION_CONSTRUCTING_IDTOKEN + e.getMessage());
             }
         } else {
             Logger.warn(TAG + ":" + methodName, "IDToken was null.");

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesAccountCredentialCache.java
@@ -156,7 +156,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             clazz = AccessTokenRecord.class;
         } else if (CredentialType.RefreshToken == type) {
             clazz = RefreshTokenRecord.class;
-        } else if (CredentialType.IdToken == type) {
+        } else if (CredentialType.IdToken == type || CredentialType.V1IdToken == type) {
             clazz = IdTokenRecord.class;
         } else {
             // TODO Log a warning, throw an Exception?
@@ -424,6 +424,9 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                     break;
                 } else if (credentialTypeStr.equalsIgnoreCase(CredentialType.IdToken.name())) {
                     type = CredentialType.IdToken;
+                    break;
+                } else if (credentialTypeStr.equalsIgnoreCase(CredentialType.V1IdToken.name())) {
+                    type = CredentialType.V1IdToken;
                     break;
                 } else {
                     // TODO Log a warning and skip this value?

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/CredentialType.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/CredentialType.java
@@ -45,6 +45,11 @@ public enum CredentialType {
     IdToken,
 
     /**
+     * V1IdToken.
+     */
+    V1IdToken,
+
+    /**
      * Password.
      */
     Password,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -23,8 +23,6 @@
 
 package com.microsoft.identity.common.internal.providers.oauth2;
 
-import android.support.annotation.NonNull;
-
 /**
  * The UI options that developer can pass during interactive token acquisition requests.
  */
@@ -64,12 +62,12 @@ public enum OpenIdConnectPromptParameter {
 
     /**
      * Utility method to map Adal PromptBehavior with OpenIdConnectPromptParameter
-     * @param promptbehavior
+     * @param promptBehavior
      * @return
      */
-    public static OpenIdConnectPromptParameter _fromPromptBehavior(@NonNull final String promptbehavior){
+    public static OpenIdConnectPromptParameter _fromPromptBehavior(final String promptBehavior){
 
-        switch (promptbehavior) {
+        switch (promptBehavior) {
             case "Auto":
             case "REFRESH_SESSION":
             case "Always":

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -47,6 +47,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                                 : null
                 ).prompt(parameters.getOpenIdConnectPromptParameter().name())
                 .claims(parameters.getClaimsRequestJson())
+                .forceRefresh(!TextUtils.isEmpty(parameters.getClaimsRequestJson()))
                 .correlationId(DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID))
                 .applicationName(parameters.getApplicationName())
                 .applicationVersion(parameters.getApplicationVersion())
@@ -70,7 +71,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .localAccountId(parameters.getAccount().getLocalAccountId())
                 .username(parameters.getAccount().getUsername())
                 .claims(parameters.getClaimsRequestJson())
-                .forceRefresh(parameters.getForceRefresh())
+                .forceRefresh(parameters.getForceRefresh() || !TextUtils.isEmpty(parameters.getClaimsRequestJson()))
                 .correlationId(DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID))
                 .applicationName(parameters.getApplicationName())
                 .applicationVersion(parameters.getApplicationVersion())
@@ -108,7 +109,6 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         parameters.setCallerPackageName(brokerRequest.getApplicationName());
 
         parameters.setCallerAppVersion(brokerRequest.getApplicationVersion());
-
 
         List<Pair<String, String>> extraQP = new ArrayList<>();
 


### PR DESCRIPTION
See:
- https://github.com/AzureAD/ad-accounts-for-android/issues/926

To do:
- Add tests