### PR TITLE
Add broker redirect validation in Broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
@@ -30,7 +30,7 @@ public class ArgumentException extends BaseException {
     public final static String SCOPE_ARGUMENT_NAME = "scopes";
     public final static String IACCOUNT_ARGUMENT_NAME = "account";
 
-    private final static String ILLEGAL_ARGUMENT_ERROR_CODE = "illegal_argument_exception";
+    public final static String ILLEGAL_ARGUMENT_ERROR_CODE = "illegal_argument_exception";
 
     private String mOperationName;
     private String mArgumentName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -28,6 +28,9 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -195,6 +198,14 @@ public class BrokerValidator {
         }
 
         return selfSignedCert;
+    }
+
+
+    public static boolean isValidBrokerRedirect(@Nullable final String redirectUri,
+                                                @NonNull final Context context,
+                                                @NonNull final String packageName){
+        return !TextUtils.isEmpty(redirectUri) &&
+                redirectUri.equalsIgnoreCase(getBrokerRedirectUri(context, packageName));
     }
 
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -115,8 +115,8 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         );
 
         // set redirect uri using caller package name
-        parameters.setRedirectUri(BrokerValidator.getBrokerRedirectUri(
-                parameters.getAppContext(), parameters.getCallerPackageName())
+        parameters.setRedirectUri(
+                AuthenticationConstants.Broker.BROKER_REDIRECT_URI
         );
 
         parameters.setLoginHint(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_NAME));

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -114,9 +114,8 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY)
         );
 
-        // set redirect uri using caller package name
         parameters.setRedirectUri(
-                AuthenticationConstants.Broker.BROKER_REDIRECT_URI
+                intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_REDIRECT)
         );
 
         parameters.setLoginHint(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_NAME));
@@ -163,9 +162,8 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         );
         parameters.setCallerUId(callingAppUid);
 
-        parameters.setCallerPackageName(
-                getPackageNameFromBundle(bundle, context)
-        );
+        final String packageName = getPackageNameFromBundle(bundle, context);
+        parameters.setCallerPackageName(packageName);
 
         parameters.setCallerAppVersion(
                 bundle.getString(AuthenticationConstants.AAD.APP_VERSION)
@@ -195,6 +193,14 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY
         );
         parameters.setClientId(clientId);
+
+        String redirectUri = bundle.getString(
+                AuthenticationConstants.Broker.ACCOUNT_REDIRECT);
+        // Adal might not pass in the redirect uri, in that case calculate from broker validator
+        if(TextUtils.isEmpty(redirectUri)){
+            redirectUri = BrokerValidator.getBrokerRedirectUri(context, packageName);
+        }
+        parameters.setRedirectUri(redirectUri);
 
         parameters.setForceRefresh(Boolean.parseBoolean(
                 bundle.getString(AuthenticationConstants.Broker.BROKER_FORCE_REFRESH))

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenOperationParameters.java
@@ -22,10 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.request;
 
-import android.accounts.AccountAuthenticatorResponse;
 import android.text.TextUtils;
 
 import com.microsoft.identity.common.exception.ArgumentException;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.cache.BrokerOAuth2TokenCache;
 
 public class BrokerAcquireTokenOperationParameters extends AcquireTokenOperationParameters {
@@ -121,10 +121,12 @@ public class BrokerAcquireTokenOperationParameters extends AcquireTokenOperation
                     "mClientId", "Client Id is not set"
             );
         }
-        if (TextUtils.isEmpty(getRedirectUri())) {
+
+        if(!BrokerValidator.isValidBrokerRedirect(getRedirectUri(), getAppContext(), getCallerPackageName())){
             throw new ArgumentException(
                     ArgumentException.ACQUIRE_TOKEN_OPERATION_NAME,
-                    "mRedirectUri", "Redirect Uri is not set"
+                    "mRedirectUri", "The redirect URI doesn't match the uri" +
+                    " generated with caller package name and signature"
             );
         }
         // If the request type is BROKER_RT_REQUEST, it means the caller here would be broker itself so

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenSilentOperationParameters.java
@@ -27,6 +27,7 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.microsoft.identity.common.exception.ArgumentException;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.cache.BrokerOAuth2TokenCache;
 
 import java.util.List;
@@ -213,6 +214,14 @@ public class BrokerAcquireTokenSilentOperationParameters extends AcquireTokenSil
                     "mCallerPackageName", "Caller package name is not set"
             );
         }
+        if(!BrokerValidator.isValidBrokerRedirect(getRedirectUri(), getAppContext(), getCallerPackageName())){
+            throw new ArgumentException(
+                    ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
+                    "mRedirectUri", "The redirect URI doesn't match the uri" +
+                    " generated with caller package name and signature"
+            );
+        }
+
         if (!(getTokenCache() instanceof BrokerOAuth2TokenCache)) {
             throw new ArgumentException(
                     ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -65,7 +66,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         final BrokerRequest brokerRequest =  new BrokerRequest.Builder()
                 .authority(parameters.getAuthority().getAuthorityURL().toString())
                 .scope(TextUtils.join( " ", parameters.getScopes()))
-                .redirect(parameters.getRedirectUri())
+                .redirect(getRedirectUri(parameters))
                 .clientId(parameters.getClientId())
                 .homeAccountId(parameters.getAccount().getHomeAccountId())
                 .localAccountId(parameters.getAccount().getLocalAccountId())
@@ -218,11 +219,27 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         return parameters;
     }
 
-    private Set<String> getScopesAsSet(final String scopeString) {
+    /**
+     * Helper method to transforn scopes string to Set
+     */
+    private Set<String> getScopesAsSet(@Nullable final String scopeString) {
         if (TextUtils.isEmpty(scopeString)) {
             return new HashSet<>();
         }
         final String[] scopes = scopeString.split(" ");
         return new HashSet<>(Arrays.asList(scopes));
+    }
+
+    /**
+     * Helper method to get redirect uri from parameters, calculates from package signature if not available.
+     */
+    private String getRedirectUri(@NonNull AcquireTokenSilentOperationParameters parameters) {
+        if (TextUtils.isEmpty(parameters.getRedirectUri())) {
+            return BrokerValidator.getBrokerRedirectUri(
+                    parameters.getAppContext(),
+                    parameters.getApplicationName()
+            );
+        }
+        return parameters.getRedirectUri();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -129,10 +129,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         parameters.setClientId(brokerRequest.getClientId());
 
         // set redirect uri using caller package name
-        parameters.setRedirectUri(BrokerValidator.getBrokerRedirectUri(
-                parameters.getAppContext(),
-                parameters.getCallerPackageName())
-        );
+        parameters.setRedirectUri(brokerRequest.getRedirect());
 
         parameters.setLoginHint(brokerRequest.getUserName());
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -129,7 +129,6 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         parameters.setClientId(brokerRequest.getClientId());
 
-        // set redirect uri using caller package name
         parameters.setRedirectUri(brokerRequest.getRedirect());
 
         parameters.setLoginHint(brokerRequest.getUserName());
@@ -201,6 +200,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         parameters.setScopes(
                 getScopesAsSet(brokerRequest.getScope())
         );
+
+        parameters.setRedirectUri(brokerRequest.getRedirect());
 
         parameters.setClientId(brokerRequest.getClientId());
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -39,7 +39,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         final BrokerRequest brokerRequest =  new BrokerRequest.Builder()
                 .authority(parameters.getAuthority().getAuthorityURL().toString())
                 .scope(TextUtils.join( " ", parameters.getScopes()))
-                .redirect(parameters.getRedirectUri())
+                .redirect(getRedirectUri(parameters))
                 .clientId(parameters.getClientId())
                 .username(parameters.getLoginHint())
                 .extraQueryStringParameter(
@@ -233,7 +233,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     /**
      * Helper method to get redirect uri from parameters, calculates from package signature if not available.
      */
-    private String getRedirectUri(@NonNull AcquireTokenSilentOperationParameters parameters) {
+    private String getRedirectUri(@NonNull OperationParameters parameters) {
         if (TextUtils.isEmpty(parameters.getRedirectUri())) {
             return BrokerValidator.getBrokerRedirectUri(
                     parameters.getAppContext(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -29,6 +29,7 @@ import android.text.TextUtils;
 import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.HashMapExtensions;
+import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
@@ -205,8 +206,17 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
         } else if (ErrorStrings.USER_CANCELLED.equalsIgnoreCase(errorCode)) {
 
-            Logger.warn(TAG, "Received a User cancalled exception from Broker : " + errorCode);
+            Logger.warn(TAG, "Received a User cancelled exception from Broker : " + errorCode);
             baseException = new UserCancelException();
+
+        } else if(ArgumentException.ILLEGAL_ARGUMENT_ERROR_CODE.equalsIgnoreCase(errorCode)) {
+
+            Logger.warn(TAG, "Received a Argument exception from Broker : " + errorCode);
+            baseException = new ArgumentException(
+                    ArgumentException.ACQUIRE_TOKEN_OPERATION_NAME,
+                    errorCode,
+                    brokerResult.getErrorMessage()
+            );
 
         } else if (!TextUtils.isEmpty(brokerResult.getHttpResponseHeaders()) ||
                 !TextUtils.isEmpty(brokerResult.getHttpResponseBody())) {
@@ -229,7 +239,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         baseException.setSpeRing(brokerResult.getSpeRing());
         baseException.setRefreshTokenAge(brokerResult.getRefreshTokenAge());
 
-        return null;
+        return baseException;
 
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -208,8 +208,8 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             Logger.warn(TAG, "Received a User cancalled exception from Broker : " + errorCode);
             baseException = new UserCancelException();
 
-        } else if (TextUtils.isEmpty(brokerResult.getHttpResponseHeaders()) ||
-                TextUtils.isEmpty(brokerResult.getHttpResponseBody())) {
+        } else if (!TextUtils.isEmpty(brokerResult.getHttpResponseHeaders()) ||
+                !TextUtils.isEmpty(brokerResult.getHttpResponseBody())) {
 
             Logger.warn(TAG, "Received a Service exception from Broker : " + errorCode);
             baseException = getServiceException(brokerResult);
@@ -339,12 +339,16 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         serviceException.setSubErrorCode(brokerResult.getSubErrorCode());
         try {
             serviceException.setHttpResponseBody(
-                    HashMapExtensions.jsonStringAsMap(
-                            brokerResult.getHttpResponseBody())
+                    brokerResult.getHttpResponseBody() != null ?
+                            HashMapExtensions.jsonStringAsMap(
+                                    brokerResult.getHttpResponseBody()) :
+                            null
             );
             serviceException.setHttpResponseHeaders(
-                    HeaderSerializationUtil.fromJson(
-                            brokerResult.getHttpResponseHeaders())
+                    brokerResult.getHttpResponseHeaders() != null ?
+                            HeaderSerializationUtil.fromJson(
+                                    brokerResult.getHttpResponseHeaders()) :
+                            null
             );
 
         } catch (JSONException e) {


### PR DESCRIPTION
- For Adal , silent calls might not have redirect uri, so we still add the calculated one to parameters (hence comparison here is always true)
- Also fixed minor issues w.r.t to exception mapping found during testing.