### PR TITLE
Trim extra spaces in loginHint

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
@@ -80,7 +80,7 @@ public class AcquireTokenOperationParameters extends OperationParameters {
     }
 
     public void setLoginHint(String loginHint) {
-        this.mLoginHint = loginHint;
+        this.mLoginHint = loginHint.trim();
     }
 
     public String getLoginHint() {


### PR DESCRIPTION
Run into an issue where the account can't be found because loginHint has an extra white space. 

Putting a change here so that it covers both ADAL/MSAL flows. 
