### PR TITLE
Sending BrokerRequest and BrokerResult as json to address Android's getAuthToken issue

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
@@ -94,8 +95,9 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         final Intent intent = callingActivity.getIntent();
 
-        final BrokerRequest brokerRequest = (BrokerRequest) intent.getSerializableExtra(
-                AuthenticationConstants.Broker.BROKER_REQUEST_V2);
+        final BrokerRequest brokerRequest = new Gson().fromJson(
+                intent.getStringExtra(AuthenticationConstants.Broker.BROKER_REQUEST_V2),
+                BrokerRequest.class);
 
         parameters.setActivity(callingActivity);
 
@@ -162,9 +164,9 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         Logger.verbose(TAG, "Constructing BrokerAcquireTokenSilentOperationParameters from result bundle");
 
-        final BrokerRequest brokerRequest = (BrokerRequest) bundle.getSerializable(
-                AuthenticationConstants.Broker.BROKER_REQUEST_V2
-        );
+        final BrokerRequest brokerRequest = new Gson().fromJson(
+                bundle.getString(AuthenticationConstants.Broker.BROKER_REQUEST_V2),
+                BrokerRequest.class);
 
         final BrokerAcquireTokenSilentOperationParameters parameters =
                 new BrokerAcquireTokenSilentOperationParameters();

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -95,7 +95,10 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 .build();
 
         final Bundle resultBundle = new Bundle();
-        resultBundle.putSerializable(AuthenticationConstants.Broker.BROKER_RESULT_V2, brokerResult);
+        resultBundle.putString(
+                AuthenticationConstants.Broker.BROKER_RESULT_V2,
+                new Gson().toJson(brokerResult, BrokerResult.class)
+        );
         resultBundle.putBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS, true);
 
         return resultBundle;
@@ -134,7 +137,10 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         final Bundle resultBundle = new Bundle();
-        resultBundle.putSerializable(AuthenticationConstants.Broker.BROKER_RESULT_V2, builder.build());
+        resultBundle.putString(
+                AuthenticationConstants.Broker.BROKER_RESULT_V2,
+                new Gson().toJson(builder.build(), BrokerResult.class)
+        );
         resultBundle.putBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS, false);
 
         return resultBundle;
@@ -143,8 +149,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     @Override
     public ILocalAuthenticationResult authenticationResultFromBundle(@NonNull final Bundle resultBundle) {
 
-        final BrokerResult brokerResult = (BrokerResult) resultBundle.getSerializable(
-                AuthenticationConstants.Broker.BROKER_RESULT_V2
+        final BrokerResult brokerResult = new Gson().fromJson(
+                resultBundle.getString(AuthenticationConstants.Broker.BROKER_RESULT_V2),
+                BrokerResult.class
         );
 
         if (brokerResult == null) {
@@ -175,8 +182,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     public BaseException baseExceptionFromBundle(@NonNull final Bundle resultBundle) {
         Logger.verbose(TAG, "Constructing exception from result bundle");
 
-        final BrokerResult brokerResult = (BrokerResult) resultBundle.getSerializable(
-                AuthenticationConstants.Broker.BROKER_RESULT_V2
+        final BrokerResult brokerResult = new Gson().fromJson(
+                resultBundle.getString(AuthenticationConstants.Broker.BROKER_RESULT_V2),
+                BrokerResult.class
         );
 
         if (brokerResult == null) {


### PR DESCRIPTION
- AccountManager Authenticator's `getAuthToken` method has an issue when we pass `Serializable` or `Parceleble` in the bundle. It never gets called.
 - So sending the request and result as json string.