### PR TITLE
Browser safe list support

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
@@ -1,0 +1,221 @@
+package com.microsoft.identity.common;
+
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.ResolveInfo;
+import android.content.pm.Signature;
+import android.net.Uri;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.microsoft.identity.common.internal.ui.browser.Browser;
+import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class BrowserSelectorTest {
+    private static final String SCHEME_HTTP = "http";
+    private static final String SCHEME_HTTPS = "https";
+
+    static final Intent BROWSER_INTENT = new Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse("http://www.example.com"));
+
+    private static final TestBrowser CHROME =
+            new TestBrowserBuilder("com.android.chrome")
+                    .withBrowserDefaults()
+                    .setVersion("50")
+                    .addSignature("ChromeSignature")
+                    .build();
+
+    private static final TestBrowser FIREFOX =
+            new TestBrowserBuilder("org.mozilla.firefox")
+                    .withBrowserDefaults()
+                    .setVersion("10")
+                    .addSignature("FirefoxSignature")
+                    .build();
+
+    private static final TestBrowser FIREFOX_CUSTOM_TAB =
+            new TestBrowserBuilder("org.mozilla.firefox")
+                    .withBrowserDefaults()
+                    .setVersion("57")
+                    .addSignature("FirefoxSignature")
+                    .build();
+
+    private static final TestBrowser DOLPHIN =
+            new TestBrowserBuilder("mobi.mgeek.TunnyBrowser")
+                    .withBrowserDefaults()
+                    .setVersion("1.4.1")
+                    .addSignature("DolphinSignature")
+                    .build();
+
+    @Mock
+    Context mContext;
+    @Mock
+    PackageManager mPackageManager;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(mContext.getPackageManager()).thenReturn(mPackageManager);
+    }
+
+    @Test
+    public void testSelect_selectDefaultBrowser() throws NameNotFoundException {
+        setBrowserList(CHROME, FIREFOX);
+        when(mContext.getPackageManager().resolveActivity(BROWSER_INTENT, 0))
+                .thenReturn(CHROME.mResolveInfo);
+        List<Browser> allBrowsers = BrowserSelector.getAllBrowsers(mContext);
+        assertTrue(allBrowsers.get(0).getPackageName().equals(CHROME.mPackageName));
+        assertTrue(allBrowsers.get(1).getPackageName().equals(FIREFOX.mPackageName));
+    }
+
+    /**
+     * Browsers are expected to be in priority order, such that the default would be first.
+     */
+    private void setBrowserList(TestBrowser... browsers) throws NameNotFoundException {
+        if (browsers == null) {
+            return;
+        }
+
+        List<ResolveInfo> resolveInfos = new ArrayList<>();
+
+        for (TestBrowser browser : browsers) {
+            when(mPackageManager.getPackageInfo(
+                    eq(browser.mPackageInfo.packageName),
+                    eq(PackageManager.GET_SIGNATURES)))
+                    .thenReturn(browser.mPackageInfo);
+            resolveInfos.add(browser.mResolveInfo);
+        }
+
+        when(mPackageManager.queryIntentActivities(
+                BROWSER_INTENT,
+                PackageManager.GET_RESOLVED_FILTER))
+                .thenReturn(resolveInfos);
+    }
+
+
+    private static class TestBrowser {
+        final String mPackageName;
+        final ResolveInfo mResolveInfo;
+        final PackageInfo mPackageInfo;
+        final Set<String> mSignatureHashes;
+
+        TestBrowser(
+                String packageName,
+                PackageInfo packageInfo,
+                ResolveInfo resolveInfo,
+                Set<String> signatureHashes) {
+            mPackageName = packageName;
+            mResolveInfo = resolveInfo;
+            mPackageInfo = packageInfo;
+            mSignatureHashes = signatureHashes;
+        }
+    }
+
+    private static class TestBrowserBuilder {
+        private final String mPackageName;
+        private final List<byte[]> mSignatures = new ArrayList<>();
+        private final List<String> mActions = new ArrayList<>();
+        private final List<String> mCategories = new ArrayList<>();
+        private final List<String> mSchemes = new ArrayList<>();
+        private final List<String> mAuthorities = new ArrayList<>();
+        private String mVersion;
+
+        TestBrowserBuilder(String packageName) {
+            mPackageName = packageName;
+        }
+
+        public TestBrowserBuilder withBrowserDefaults() {
+            return addAction(Intent.ACTION_VIEW)
+                    .addCategory(Intent.CATEGORY_BROWSABLE)
+                    .addScheme(SCHEME_HTTP)
+                    .addScheme(SCHEME_HTTPS);
+        }
+
+        public TestBrowserBuilder addAction(String action) {
+            mActions.add(action);
+            return this;
+        }
+
+        public TestBrowserBuilder addCategory(String category) {
+            mCategories.add(category);
+            return this;
+        }
+
+        public TestBrowserBuilder addScheme(String scheme) {
+            mSchemes.add(scheme);
+            return this;
+        }
+
+        public TestBrowserBuilder addAuthority(String authority) {
+            mAuthorities.add(authority);
+            return this;
+        }
+
+        public TestBrowserBuilder addSignature(String signature) {
+            mSignatures.add(signature.getBytes(Charset.forName("UTF-8")));
+            return this;
+        }
+
+        public TestBrowserBuilder setVersion(String version) {
+            mVersion = version;
+            return this;
+        }
+
+        public TestBrowser build() {
+            PackageInfo pi = new PackageInfo();
+            pi.packageName = mPackageName;
+            pi.versionName = mVersion;
+            pi.signatures = new Signature[mSignatures.size()];
+
+            for (int i = 0; i < mSignatures.size(); i++) {
+                pi.signatures[i] = new Signature(mSignatures.get(i));
+            }
+
+            Set<String> signatureHashes = Browser.generateSignatureHashes(pi.signatures);
+
+            ResolveInfo ri = new ResolveInfo();
+            ri.activityInfo = new ActivityInfo();
+            ri.activityInfo.packageName = mPackageName;
+            ri.filter = new IntentFilter();
+
+            for (String action : mActions) {
+                ri.filter.addAction(action);
+            }
+
+            for (String category : mCategories) {
+                ri.filter.addCategory(category);
+            }
+
+            for (String scheme : mSchemes) {
+                ri.filter.addDataScheme(scheme);
+            }
+
+            for (String authority: mAuthorities) {
+                ri.filter.addDataAuthority(authority, null);
+            }
+
+            return new TestBrowser(mPackageName, pi, ri, signatureHashes);
+        }
+    }
+}

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
@@ -32,6 +32,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.content.pm.Signature;
 import android.net.Uri;
+import android.os.Build;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.microsoft.identity.common.exception.ClientException;
@@ -128,7 +129,7 @@ public class BrowserSelectorTest {
     }
 
     @Test
-    public void testSelect_versionNotSupportedBrowser() throws NameNotFoundException, ClientException {
+    public void testSelect_versionNotSupportedBrowser() throws NameNotFoundException {
         setBrowserList(CHROME, FIREFOX);
         when(mContext.getPackageManager().resolveActivity(BROWSER_INTENT, 0))
                 .thenReturn(CHROME.mResolveInfo);
@@ -158,7 +159,7 @@ public class BrowserSelectorTest {
             return;
         }
 
-        List<ResolveInfo> resolveInfos = new ArrayList<>();
+        final List<ResolveInfo> resolveInfos = new ArrayList<>();
 
         for (TestBrowser browser : browsers) {
             when(mPackageManager.getPackageInfo(
@@ -168,12 +169,16 @@ public class BrowserSelectorTest {
             resolveInfos.add(browser.mResolveInfo);
         }
 
+        int queryFlag = PackageManager.GET_RESOLVED_FILTER;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            queryFlag |= PackageManager.MATCH_DEFAULT_ONLY;
+        }
+
         when(mPackageManager.queryIntentActivities(
                 BROWSER_INTENT,
-                PackageManager.GET_RESOLVED_FILTER))
+                queryFlag))
                 .thenReturn(resolveInfos);
     }
-
 
     private static class TestBrowser {
         final String mPackageName;

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
@@ -1,5 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common;
-
 
 import android.content.Context;
 import android.content.Intent;
@@ -31,8 +52,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenOperationParameters.java
@@ -30,6 +30,7 @@ import android.util.Pair;
 import com.google.gson.annotations.Expose;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
+import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ public class AcquireTokenOperationParameters extends OperationParameters {
     @Expose()
     private OpenIdConnectPromptParameter mOpenIdConnectPromptParameter;
     private HashMap<String, String> mRequestHeaders;
+    private List<BrowserDescriptor> mBrowserSafeList;
 
     public AuthorizationAgent getAuthorizationAgent() {
         return mAuthorizationAgent;
@@ -103,5 +105,17 @@ public class AcquireTokenOperationParameters extends OperationParameters {
 
     public void setRequestHeaders(@Nullable final HashMap<String, String> requestHeaders) {
         this.mRequestHeaders = requestHeaders;
+    }
+
+    public void setBrowserSafeList(final List<BrowserDescriptor> browserSafeList) {
+        this.mBrowserSafeList = browserSafeList;
+    }
+
+    /**
+     * Get the list of browsers which are safe to launch for auth flow.
+     * @return list of browser descriptors
+     */
+    public List<BrowserDescriptor> getBrowserSafeList() {
+        return mBrowserSafeList;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
@@ -32,7 +31,6 @@ import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
-import com.microsoft.identity.common.internal.ui.browser.Browser;
 import com.microsoft.identity.common.internal.ui.browser.BrowserAuthorizationStrategy;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.ui.webview.EmbeddedWebViewAuthorizationStrategy;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
@@ -30,6 +30,7 @@ import android.support.annotation.NonNull;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
+import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.ui.browser.BrowserAuthorizationStrategy;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.ui.webview.EmbeddedWebViewAuthorizationStrategy;
@@ -46,20 +47,24 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
         return sInstance;
     }
 
-    public GenericAuthorizationStrategy getAuthorizationStrategy(Activity activity,
-                                                                 @NonNull AuthorizationAgent authorizationAgent,
+    public GenericAuthorizationStrategy getAuthorizationStrategy(@NonNull final AcquireTokenOperationParameters parameters,
                                                                  @NonNull Intent resultIntent) {
         //Valid if available browser installed. Will fallback to embedded webView if no browser available.
-        final AuthorizationAgent validatedAuthorizationAgent = validAuthorizationAgent(authorizationAgent, activity.getApplicationContext());
+        final AuthorizationAgent validatedAuthorizationAgent = validAuthorizationAgent(
+                parameters.getAuthorizationAgent(),
+                parameters.getActivity().getApplicationContext()
+        );
 
         if (validatedAuthorizationAgent == AuthorizationAgent.WEBVIEW) {
             Logger.info(TAG, "Use webView for authorization.");
-            return (GenericAuthorizationStrategy) (new EmbeddedWebViewAuthorizationStrategy(activity, resultIntent));
+            return (GenericAuthorizationStrategy) (new EmbeddedWebViewAuthorizationStrategy(parameters.getActivity(), resultIntent));
+        } else {
+            // Use device browser auth flow as default.
+            Logger.info(TAG, "Use browser for authorization.");
+            final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(parameters.getActivity(), resultIntent);
+            browserAuthorizationStrategy.setBrowserSafeList(parameters.getBrowserSafeList());
+            return (GenericAuthorizationStrategy) browserAuthorizationStrategy;
         }
-
-        // Use device browser auth flow as default.
-        Logger.info(TAG, "Use browser for authorization.");
-        return (GenericAuthorizationStrategy) (new BrowserAuthorizationStrategy(activity, resultIntent));
     }
 
     private AuthorizationAgent validAuthorizationAgent(final AuthorizationAgent agent, final Context context) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
+import java.util.List;
 import java.util.concurrent.Future;
 
 public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2Strategy,
@@ -50,6 +51,7 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
     private WeakReference<Activity> mReferencedActivity;
     private PendingIntent mResultIntent;
     private AuthorizationResultFuture mAuthorizationResultFuture;
+    private List<BrowserDescriptor> mBrowserSafeList;
     private boolean mDisposed;
     private GenericOAuth2Strategy mOAuth2Strategy; //NOPMD
     private GenericAuthorizationRequest mAuthorizationRequest; //NOPMD
@@ -57,6 +59,10 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
     public BrowserAuthorizationStrategy(@NonNull Activity activity, @NonNull Intent resultIntent) {
         mReferencedActivity = new WeakReference<>(activity);
         mResultIntent = PendingIntent.getActivity(activity.getApplicationContext(), 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    public void setBrowserSafeList(final List<BrowserDescriptor> browserSafeList) {
+        mBrowserSafeList = browserSafeList;
     }
 
     @Override
@@ -69,7 +75,7 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
         mOAuth2Strategy = oAuth2Strategy;
         mAuthorizationRequest = authorizationRequest;
         mAuthorizationResultFuture = new AuthorizationResultFuture();
-        final Browser browser = BrowserSelector.select(mReferencedActivity.get().getApplicationContext());
+        final Browser browser = BrowserSelector.select(mReferencedActivity.get().getApplicationContext(), mBrowserSafeList);
 
         //ClientException will be thrown if no browser found.
         Intent authIntent;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
@@ -88,49 +88,15 @@ public class BrowserDescriptor implements Serializable {
         }
 
         if (!StringUtil.isEmpty(mVersionLowerBound)
-                && compareSemanticVersion(browser.getVersion(), mVersionLowerBound) == -1) {
+                && StringUtil.compareSemanticVersion(browser.getVersion(), mVersionLowerBound) == -1) {
             return false;
         }
 
         if (!StringUtil.isEmpty(mVersionUpperBound)
-                && compareSemanticVersion(browser.getVersion(), mVersionUpperBound) == 1) {
+                && StringUtil.compareSemanticVersion(browser.getVersion(), mVersionUpperBound) == 1) {
             return false;
         }
 
         return true;
     }
-
-    /**
-     * The function to compare the two versions.
-     *
-     * @param thisVersion
-     * @param thatVersion
-     * @return int -1 if thisVersion is smaller than thatVersion,
-     *         1 if thisVersion is larger than thatVersion,
-     *         0 if thisVersion is equal to thatVersion.
-     */
-    private int compareSemanticVersion(
-            @NonNull final String thisVersion,
-            @NonNull final String thatVersion) {
-        final String[] thisParts = thisVersion.split("\\.");
-        final String[] thatParts = thatVersion.split("\\.");
-        final int length = Math.max(thisParts.length, thatParts.length);
-        for(int i = 0; i < length; i++) {
-            int thisPart = i < thisParts.length ?
-                    Integer.parseInt(thisParts[i]) : 0;
-            int thatPart = i < thatParts.length ?
-                    Integer.parseInt(thatParts[i]) : 0;
-
-            if(thisPart < thatPart) {
-                return -1;
-            }
-
-            if(thisPart > thatPart) {
-                return 1;
-            }
-        }
-
-        return 0;
-    }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.browser;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.internal.util.StringUtil;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+public class BrowserDescriptor implements Serializable {
+    @SerializedName("browser_package_name")
+    private String mPackageName;
+
+    @SerializedName("browser_signature_hashes")
+    private Set<String> mSignatureHashes;
+
+    @SerializedName("browser_use_customTab")
+    private boolean mUseCustomTab;
+
+    @SerializedName("browser_version_lower_bound")
+    private String mVersionLowerBound;
+
+    @SerializedName("browser_version_upper_bound")
+    private String mVersionUpperBound;
+
+    public BrowserDescriptor(
+            @NonNull final String packageName,
+            @NonNull final Set<String> signatureHashes,
+            final boolean useCustomTab,
+            @Nullable final String versionLowerBound,
+            @Nullable final String versionUpperBound) {
+        mPackageName = packageName;
+        mSignatureHashes = signatureHashes;
+        mUseCustomTab = useCustomTab;
+        mVersionLowerBound = versionLowerBound;
+        mVersionUpperBound = versionUpperBound;
+    }
+
+    public BrowserDescriptor(
+            @NonNull final String packageName,
+            @NonNull final String signatureHash,
+            final boolean useCustomTab,
+            @Nullable final String versionLowerBound,
+            @Nullable final String versionUpperBound) {
+        mPackageName = packageName;
+        mSignatureHashes = Collections.singleton(signatureHash);
+        mUseCustomTab = useCustomTab;
+        mVersionLowerBound = versionLowerBound;
+        mVersionUpperBound = versionUpperBound;
+    }
+
+    public boolean matches(@NonNull Browser browser) {
+        if (!mPackageName.equalsIgnoreCase(browser.getPackageName())) {
+            return false;
+        }
+
+        if (!mSignatureHashes.equals(browser.getSignatureHashes())) {
+            return false;
+        }
+
+        if (mUseCustomTab != browser.isCustomTabsServiceSupported()) {
+            return false;
+        }
+
+        if (!StringUtil.isEmpty(mVersionLowerBound)
+                && compareSemanticVersion(browser.getVersion(), mVersionLowerBound) == -1) {
+            return false;
+        }
+
+        if (!StringUtil.isEmpty(mVersionUpperBound)
+                && compareSemanticVersion(browser.getVersion(), mVersionUpperBound) == 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * The function to compare the two versions.
+     *
+     * @param thisVersion
+     * @param thatVersion
+     * @return int -1 if thisVersion is smaller than thatVersion,
+     *         1 if thisVersion is larger than thatVersion,
+     *         0 if thisVersion is equal to thatVersion.
+     */
+    private int compareSemanticVersion(
+            @NonNull final String thisVersion,
+            @NonNull final String thatVersion) {
+        final String[] thisParts = thisVersion.split("\\.");
+        final String[] thatParts = thatVersion.split("\\.");
+        final int length = Math.max(thisParts.length, thatParts.length);
+        for(int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ?
+                    Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ?
+                    Integer.parseInt(thatParts[i]) : 0;
+
+            if(thisPart < thatPart) {
+                return -1;
+            }
+
+            if(thisPart > thatPart) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -55,12 +55,12 @@ public class BrowserSelector {
      */
     public static Browser select(final Context context, final List<BrowserDescriptor> browserSafeList) throws ClientException {
         final List<Browser> allBrowsers = getAllBrowsers(context);
+        Logger.verbose(TAG, "Select the browser to launch.");
 
         for (Browser browser : allBrowsers) {
             for (BrowserDescriptor browserDescriptor : browserSafeList) {
                 if (browserDescriptor.matches(browser)) {
-                    Logger.verbose(TAG, "Select the browser to launch.");
-                    Logger.verbosePII(
+                    Logger.verbose(
                             TAG,
                             "Browser's package name: "
                                     + browser.getPackageName()

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -48,21 +48,31 @@ public class BrowserSelector {
      * Searches through all browsers for the best match.
      * Browsers are evaluated in the order returned by the package manager,
      * which should indirectly match the user's preferences.
-     * First browser in the list will be preferred no matter weather or not the custom tabs supported.
+     * First matched browser in the list will be preferred no matter weather or not the custom tabs supported.
      *
      * @param context {@link Context} to use for accessing {@link PackageManager}.
      * @return Browser selected to use.
      */
-    public static Browser select(final Context context) throws ClientException {
+    public static Browser select(final Context context, final List<BrowserDescriptor> browserSafeList) throws ClientException {
         final List<Browser> allBrowsers = getAllBrowsers(context);
-        if (!allBrowsers.isEmpty()) {
-            Logger.verbose(TAG, "Select the browser to launch.");
-            Logger.verbosePII(TAG, "Browser's package name: " + allBrowsers.get(0).getPackageName() + " version: " + allBrowsers.get(0).getVersion());
-            return allBrowsers.get(0);
-        } else {
-            Logger.error(TAG, "No available browser installed on the device.", null);
-            throw new ClientException(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND, "No available browser installed on the device.");
+
+        for (Browser browser : allBrowsers) {
+            for (BrowserDescriptor browserDescriptor : browserSafeList) {
+                if (browserDescriptor.matches(browser)) {
+                    Logger.verbose(TAG, "Select the browser to launch.");
+                    Logger.verbosePII(
+                            TAG,
+                            "Browser's package name: "
+                                    + browser.getPackageName()
+                                    + " version: "
+                                    + browser.getVersion());
+                    return browser;
+                }
+            }
         }
+
+        Logger.error(TAG, "No available browser installed on the device.", null);
+        throw new ClientException(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND, "No available browser installed on the device.");
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
@@ -118,4 +118,39 @@ public final class StringUtil {
 
         return new Pair<>(uid, utid);
     }
+
+    /**
+     * The function to compare the two versions.
+     *
+     * @param thisVersion
+     * @param thatVersion
+     * @return int -1 if thisVersion is smaller than thatVersion,
+     *         1 if thisVersion is larger than thatVersion,
+     *         0 if thisVersion is equal to thatVersion.
+     */
+    public static int compareSemanticVersion(final String thisVersion, final String thatVersion) {
+        if(thatVersion == null) {
+            return 1;
+        }
+
+        final String[] thisParts = thisVersion.split("\\.");
+        final String[] thatParts = thatVersion.split("\\.");
+        final int length = Math.max(thisParts.length, thatParts.length);
+        for(int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ?
+                    Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ?
+                    Integer.parseInt(thatParts[i]) : 0;
+
+            if(thisPart < thatPart) {
+                return -1;
+            }
+
+            if(thisPart > thatPart) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
 }


### PR DESCRIPTION
**Problem**
To avoid the broken user experience when auth through browsers.

**Proposal**
BrowserDescriptor describes the browser, including the package name, browser's signature hashes, if using the custom tab and the version range that supports the MSAL browser authorization flow.
```json
{
  "browser_package_name": "com.android.chrome",
  "browser_signature_hashes": [
 "7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg=="
      ],
  "browser_use_customTab" : true,
  "browser_version_lower_bound" : "45"
}
```

The browser safe list is a list of BrowserDescriptor objects and is defined in the msal configuration json file. Before MSAL app trying to launch a browser, it will look into the browser safe list. If there is a match, the app will launch the matching browser, otherwise, MSAL app will try the next installed browser until it finds a match. If no matched browser found, MSAL will fallback into the embedded webview flow. However, for the B2C scenario, as the browser flow is required, if no matching browser found, MSAL will throw the ClientException to the dev.

**Work Items**
- Add the BrowserDescriptor class to represent the browser attributes
- Add the BrowserSafeList property into the BrowserAuthorizationStrategy
- Add the safe list filtering inside the browser selecting logic during the authorization process
- Add unit test

**Discussion**
For the safe list object, is it better to keep it inside the BrowserAuthorizationStrategy or make it a single instance class?
