### PR TITLE
Add getAccountMode() and getCurrentAccount() to MSAuthService

### DIFF
--- a/common/src/main/aidl/com/microsoft/identity/client/IMicrosoftAuthService.aidl
+++ b/common/src/main/aidl/com/microsoft/identity/client/IMicrosoftAuthService.aidl
@@ -32,7 +32,11 @@ interface IMicrosoftAuthService {
 
     Bundle hello(in Bundle bundle);
 
+    Bundle getAccountMode();
+
     Bundle getAccounts(in Bundle bundle);
+
+    Bundle getCurrentAccount();
 
     Bundle acquireTokenSilently(in Bundle requestBundle);
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1022,20 +1022,20 @@ public final class AuthenticationConstants {
          * String to return the broker account mode.
          * This is used to determine what PublicClientApplication MSAL will return to its caller.
          */
-        public static final String BROKER_ACCOUNT_MODE = "broker.account.mode";
+        public static final String BROKER_ACCOUNT_MODE = "broker_account_mode";
 
         /**
          * Represents MSAL's single account mode.
          * In this mode, there will be only one signed-in account in this device (meaning that other accounts will not be able to acquire token.)
          * See SingleAccountPublicClientApplication for more details.
          */
-        public static final String BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT = "broker.account.mode.single.account";
+        public static final String BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT = "broker_account_mode_single_account";
 
         /**
          * Represents MSAL's multiple account mode.
          * See MultipleAccountPublicClientApplication for more details.
          */
-        public static final String BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT = "broker.account.mode.multiple.account";
+        public static final String BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT = "broker_account_mode_multiple_account";
 
         /**
          * String to return a true if the request succeeded, false otherwise.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1019,6 +1019,25 @@ public final class AuthenticationConstants {
         public static final String BROKER_RESULT_V2 = "broker.result.v2";
 
         /**
+         * String to return the broker account mode.
+         * This is used to determine what PublicClientApplication MSAL will return to its caller.
+         */
+        public static final String BROKER_ACCOUNT_MODE = "broker.account.mode";
+
+        /**
+         * Represents MSAL's single account mode.
+         * In this mode, there will be only one signed-in account in this device (meaning that other accounts will not be able to acquire token.)
+         * See SingleAccountPublicClientApplication for more details.
+         */
+        public static final String BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT = "broker.account.mode.single.account";
+
+        /**
+         * Represents MSAL's multiple account mode.
+         * See MultipleAccountPublicClientApplication for more details.
+         */
+        public static final String BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT = "broker.account.mode.multiple.account";
+
+        /**
          * String to return a true if the request succeeded, false otherwise.
          */
         public static final String BROKER_REQUEST_V2_SUCCESS = "broker.request.v2.success";
@@ -1073,6 +1092,11 @@ public final class AuthenticationConstants {
          * String to return account list from broker.
          */
         public static final String BROKER_ACCOUNTS = "broker_accounts";
+
+        /**
+         * String to return current account from broker (only available in shared device mode)
+         */
+        public static final String BROKER_CURRENT_ACCOUNT = "broker_current_account";
 
         /**
          * Bundle identifiers for x-ms-clitelem info.

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -436,7 +436,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
      * @param bundle Bundle
      * @return Account mode.
      */
-    public static String getAccountModeFromBundle(@NonNull final Bundle bundle) {
+    public static String accountModeFromBundle(@NonNull final Bundle bundle) {
         final String accountMode = bundle.getString(BROKER_ACCOUNT_MODE);
 
         if (accountMode == null) {
@@ -467,7 +467,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
      * @param bundle Bundle
      * @return AccountRecord of the current account. This could be null.
      */
-    public static AccountRecord getCurrentAccountFromBundle(@NonNull final Bundle bundle) {
+    public static AccountRecord currentAccountFromBundle(@NonNull final Bundle bundle) {
         final String accountJson = bundle.getString(BROKER_CURRENT_ACCOUNT);
 
         if (accountJson == null) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -49,6 +49,7 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAccount;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
+
 import com.microsoft.identity.common.internal.util.HeaderSerializationUtil;
 
 import org.json.JSONException;
@@ -59,7 +60,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_ACCOUNTS;
-
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_CURRENT_ACCOUNT;
 
 public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
@@ -416,5 +418,63 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         return result;
+    }
+
+    /**
+     * Get a bundle from an Account Mode string.
+     * @param accountMode an Account Mode string.
+     * @return Bundle
+     */
+    public Bundle bundleFromAccountMode(@NonNull final String accountMode) {
+        final Bundle resultBundle = new Bundle();
+        resultBundle.putString(BROKER_ACCOUNT_MODE, accountMode);
+        return resultBundle;
+    }
+
+    /**
+     * Get Account mode from bundle.
+     * @param bundle Bundle
+     * @return Account mode.
+     */
+    public static String getAccountModeFromBundle(@NonNull final Bundle bundle) {
+        final String accountMode = bundle.getString(BROKER_ACCOUNT_MODE);
+
+        if (accountMode == null) {
+            // Return default mode.
+            Logger.verbose(TAG, "Unexpected value: account mode is not set.");
+            return AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT;
+        }
+
+        return accountMode;
+    }
+
+    /**
+     * Get a bundle from current account's AccountRecord.
+     * @param record current account's AccountRecord.
+     * @return Bundle
+     */
+    public static Bundle bundleFromCurrentAccount(@NonNull final AccountRecord record) {
+        final Bundle resultBundle = new Bundle();
+
+        final String recordInGson = new Gson().toJson(record, AccountRecord.class);
+        resultBundle.putString(BROKER_CURRENT_ACCOUNT, recordInGson);
+
+        return resultBundle;
+    }
+
+    /**
+     * Get current account's AccountRecord from bundle.
+     * @param bundle Bundle
+     * @return AccountRecord of the current account. This could be null.
+     */
+    public static AccountRecord getCurrentAccountFromBundle(@NonNull final Bundle bundle) {
+        final String accountJson = bundle.getString(BROKER_CURRENT_ACCOUNT);
+
+        if (accountJson == null) {
+            //The bundle does not contain the BROKER_CURRENT_ACCOUNT value.
+            return null;
+        }
+
+        return new Gson().fromJson(accountJson, AccountRecord.class);
     }
 }


### PR DESCRIPTION
Introducing 2 more functions to MicrosoftAuthService.
- getAccountMode()
- getCurrentAccount()

Please see [the spec](https://identitydivision.visualstudio.com/IDDP/_git/general-docs/pullrequest/744?_a=files&path=%2FSharedDevice%2FSharedDeviceAndroid.md) for reference.