### PR TITLE
Changes to cancel an existing auth request if a new auth request is invoked by the app

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -165,6 +165,12 @@ public final class AuthenticationConstants {
          * Device registration in broker apps.
          */
         public static final int BROWSER_CODE_DEVICE_REGISTER = 2007;
+
+        /**
+         * Represents that SDK signalled to cancelled the auth flow as app
+         * launched a new interactive auth request
+         */
+        public static final int BROWSER_CODE_SDK_CANCEL = 2008;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -335,10 +335,4 @@ public final class ErrorStrings {
      */
     public static final String UNSUPPORTED_BROKER_VERSION = "unsupported_broker_version";
 
-    /**
-     * User couldn't complete the authorization request within max time limit
-     *{@link com.microsoft.identity.common.internal.controllers.BaseController#AUTH_REQUEST_TIMEOUT_IN_MINUTES}
-     */
-    public static final String AUTH_REQUEST_TIMED_OUT = "User failed to complete Auth Request in maximum allotted time";
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.UserCancelException;
 import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
@@ -56,6 +57,14 @@ public class ApiDispatcher {
                 "Beginning interactive request"
         );
         synchronized (sLock) {
+
+            if(!sInteractiveExecutor.isTerminated()){
+                Logger.info(TAG, "An auth request is already in progress, sending broadcast to cancel the request ");
+                command.getParameters().getAppContext().
+                        sendBroadcast(
+                                new Intent(AuthorizationActivity.CANCEL_INTERACTIVE_REQUEST_ACTION)
+                        );
+            }
             sInteractiveExecutor.execute(new Runnable() {
                 @Override
                 public void run() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
@@ -57,14 +57,11 @@ public class ApiDispatcher {
                 "Beginning interactive request"
         );
         synchronized (sLock) {
+            // Send a broadcast to cancel if any active auth request is present.
+            command.getParameters().getAppContext().sendBroadcast(
+                            new Intent(AuthorizationActivity.CANCEL_INTERACTIVE_REQUEST_ACTION)
+            );
 
-            if(!sInteractiveExecutor.isTerminated()){
-                Logger.info(TAG, "An auth request is already in progress, sending broadcast to cancel the request ");
-                command.getParameters().getAppContext().
-                        sendBroadcast(
-                                new Intent(AuthorizationActivity.CANCEL_INTERACTIVE_REQUEST_ACTION)
-                        );
-            }
             sInteractiveExecutor.execute(new Runnable() {
                 @Override
                 public void run() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -82,8 +82,6 @@ public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();
 
-    public static final int AUTH_REQUEST_TIMEOUT_IN_MINUTES = 10;
-
     public abstract AcquireTokenResult acquireToken(final AcquireTokenOperationParameters request)
             throws ExecutionException, InterruptedException, BaseException, IOException;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -88,6 +88,13 @@ public class ExceptionAdapter {
                                 ServiceException.DEFAULT_STATUS_CODE,
                                 null
                         );
+
+                    case SDK_CANCEL:
+                        return new ClientException(
+                                authorizationErrorResponse.getError(),
+                                authorizationErrorResponse.getErrorDescription()
+                        );
+
                     case USER_CANCEL:
                         return new UserCancelException();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationErrorResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAuthorizationErrorResponse.java
@@ -41,6 +41,11 @@ public class MicrosoftAuthorizationErrorResponse extends AuthorizationErrorRespo
     public static final String USER_CANCEL = "user_cancelled";
 
     /**
+     * Error string to return if the request is cancelled by the SDK.
+     */
+    public static final String SDK_AUTH_CANCEL = "auth_cancelled_by_sdk";
+
+    /**
      * Error string to return if intent passed is null.
      */
     public static final String NULL_INTENT = "Received null intent";
@@ -54,6 +59,11 @@ public class MicrosoftAuthorizationErrorResponse extends AuthorizationErrorRespo
      * Error description string to return if the user cancelled the flow.
      */
     public static final String USER_CANCELLED_FLOW = "User pressed device back button to cancel the flow.";
+
+    /**
+     * Error description string to return if the user cancelled the flow.
+     */
+    public static final String SDK_CANCELLED_FLOW = "Sdk cancelled the auth flow as the app launched a new interactive auth request.";
 
     /**
      * Error string to return if the state parameter from authorization endpoint doesn't match with the request state.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
@@ -32,7 +32,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAutho
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResultFactory;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStatus;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
-import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.util.HashMap;
@@ -72,6 +71,15 @@ public class MicrosoftStsAuthorizationResultFactory extends AuthorizationResultF
                         AuthorizationStatus.USER_CANCEL,
                         MicrosoftAuthorizationErrorResponse.USER_CANCEL,
                         MicrosoftAuthorizationErrorResponse.USER_CANCELLED_FLOW
+                );
+                break;
+
+            case AuthenticationConstants.UIResponse.BROWSER_CODE_SDK_CANCEL:
+                Logger.verbose(TAG, null, "SDK cancelled the authorization request.");
+                result = createAuthorizationResultWithErrorResponse(
+                        AuthorizationStatus.SDK_CANCEL,
+                        MicrosoftAuthorizationErrorResponse.SDK_AUTH_CANCEL,
+                        MicrosoftAuthorizationErrorResponse.SDK_CANCELLED_FLOW
                 );
                 break;
 
@@ -118,6 +126,8 @@ public class MicrosoftStsAuthorizationResultFactory extends AuthorizationResultF
                                 AuthenticationConstants.Broker.INSTALL_UPN_KEY)
                         );
                 break;
+
+
 
             default:
                 result = createAuthorizationResultWithErrorResponse(

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
@@ -2,13 +2,13 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.support.v4.app.NotificationCompat;
 import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
@@ -26,11 +26,9 @@ import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.internal.util.StringUtil;
-import java.util.Map;
 
-import java.util.UUID;
-import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Map;
 
 import static com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResultFactory.ERROR;
 import static com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResultFactory.ERROR_DESCRIPTION;
@@ -56,10 +54,9 @@ public final class AuthorizationActivity extends Activity {
     static final String KEY_AUTH_AUTHORIZATION_AGENT = "authorizationAgent";
 
     @VisibleForTesting
-    static final String KEY_RESULT_INTENT = "resultIntent";
-
-    @VisibleForTesting
     static final String KEY_REQUEST_HEADERS = "requestHeaders";
+
+    public static final String CANCEL_INTERACTIVE_REQUEST_ACTION = "cancel_interactive_request_action";
 
     private static final String TAG = AuthorizationActivity.class.getSimpleName();
 
@@ -78,6 +75,15 @@ public final class AuthorizationActivity extends Activity {
     private HashMap<String, String> mRequestHeaders;
 
     private AuthorizationAgent mAuthorizationAgent;
+
+    private BroadcastReceiver mCancelRequestReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Logger.info(TAG, "Received Authorization flow cancel request from SDK");
+            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_SDK_CANCEL, new Intent());
+            finish();
+        }
+    };
 
     public static Intent createStartIntent(final Context context,
                                            final Intent authIntent,
@@ -168,8 +174,13 @@ public final class AuthorizationActivity extends Activity {
     protected void onCreate(final Bundle savedInstanceState) {
         final String methodName = "#onCreate";
         super.onCreate(savedInstanceState);
-
         setContentView(R.layout.common_activity_authentication);
+
+        // Register Broadcast receiver to cancel the auth request
+        // if another incoming request is lauched by the app
+        registerReceiver(mCancelRequestReceiver,
+                new IntentFilter(CANCEL_INTERACTIVE_REQUEST_ACTION));
+
         if (savedInstanceState == null) {
             Logger.verbose(TAG + methodName, "Extract state from the intent bundle.");
             extractState(getIntent().getExtras());
@@ -250,7 +261,7 @@ public final class AuthorizationActivity extends Activity {
                } else {
                    final Intent resultIntent = new Intent();
                    resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION, new ClientException(ErrorStrings.AUTHORIZATION_INTENT_IS_NULL));
-                   sendResult(AuthorizationStrategy.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION, resultIntent);
+                   sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION, resultIntent);
                    finish();
                }
            } else {
@@ -267,6 +278,7 @@ public final class AuthorizationActivity extends Activity {
     protected void onDestroy() {
         final String methodName = "#onDestroy";
         Logger.verbose(TAG + methodName, "");
+        unregisterReceiver(mCancelRequestReceiver);
         super.onDestroy();
     }
 
@@ -283,13 +295,13 @@ public final class AuthorizationActivity extends Activity {
         final String url = getIntent().getExtras().getString(AuthorizationStrategy.CUSTOM_TAB_REDIRECT);
         final Intent resultIntent = createResultIntent(url);
         if (!StringUtil.isEmpty(resultIntent.getStringExtra(AuthorizationStrategy.AUTHORIZATION_FINAL_URL))) {
-            sendResult(AuthorizationStrategy.UIResponse.AUTH_CODE_COMPLETE, resultIntent);
+            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE, resultIntent);
         } else if (!StringUtil.isEmpty(resultIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_SUBCODE))
                 && resultIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_SUBCODE).equalsIgnoreCase("cancel")) {
             //when the user click the "cancel" button in the UI, server will send the the redirect uri with "cancel" error sub-code and redirects back to the calling app
-            sendResult(AuthorizationStrategy.UIResponse.AUTH_CODE_CANCEL, resultIntent);
+            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_SDK_CANCEL, resultIntent);
         } else {
-            sendResult(AuthorizationStrategy.UIResponse.AUTH_CODE_ERROR, resultIntent);
+            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
         }
 
         finish();
@@ -299,14 +311,10 @@ public final class AuthorizationActivity extends Activity {
         Logger.info(TAG, "Authorization flow is canceled by user");
         final Intent resultIntent = new Intent();
         resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        sendResult(AuthorizationStrategy.UIResponse.AUTH_CODE_CANCEL, resultIntent);
+        sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
         finish();
     }
 
-    @Override
-    protected void onStop() {
-        super.onStop();
-    }
 
     @Override
     protected void onSaveInstanceState(final Bundle outState) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStatus.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStatus.java
@@ -37,6 +37,11 @@ public enum AuthorizationStatus {
     USER_CANCEL,
 
     /**
+     * Sdk cancelled Auth floe
+     */
+    SDK_CANCEL,
+
+    /**
      * Returned URI contains error.
      */
     FAIL,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
@@ -50,47 +50,6 @@ public abstract class AuthorizationStrategy<GenericOAuth2Strategy extends OAuth2
 
     public static final String REQUEST_CODE = "com.microsoft.identity.client.request.code";
 
-    public static final class UIResponse {
-        /**
-         * Represents that user cancelled the flow.
-         */
-        public static final int AUTH_CODE_CANCEL = 2001;
-
-        /**
-         * Represents that browser error is returned.
-         */
-        public static final int AUTH_CODE_ERROR = 2002;
-
-        /**
-         * Represents that the authorization code is returned successfully.
-         */
-        public static final int AUTH_CODE_COMPLETE = 2003;
-
-        /**
-         * Represents that broker successfully returns the response.
-         */
-        public static final int TOKEN_BROKER_RESPONSE = 2004;
-
-        /**
-         * Webview throws Authentication exception. It needs to be send to callback.
-         */
-        public static final int BROWSER_CODE_AUTHENTICATION_EXCEPTION = 2005;
-
-        /**
-         * CA flow, device doesn't have company portal or azure authenticator installed.
-         * Waiting for broker package to be installed, and resume request in broker.
-         */
-        public static final int BROKER_REQUEST_RESUME = 2006;
-
-        /**
-         * Device registration in broker apps.
-         */
-        public static final int BROWSER_CODE_DEVICE_REGISTER = 2007;
-
-        public static final String ERROR_CODE = "error_code";
-
-        public static final String ERROR_DESCRIPTION = "error_description";
-    }
 
     /**
      * Perform the authorization request.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -188,9 +188,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
             //If user clicked the "Back" button in the webview
             if (!StringUtil.isEmpty(parameters.get(ERROR_SUBCODE)) && parameters.get(ERROR_SUBCODE).equalsIgnoreCase(SUB_ERROR_UI_CANCEL)) {
-                getCompletionCallback().onChallengeResponseReceived(AuthorizationStrategy.UIResponse.AUTH_CODE_CANCEL, resultIntent);
+                getCompletionCallback().onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
             } else {
-                getCompletionCallback().onChallengeResponseReceived(AuthorizationStrategy.UIResponse.AUTH_CODE_ERROR, resultIntent);
+                getCompletionCallback().onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
             }
 
             view.stopLoading();
@@ -200,7 +200,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             resultIntent.putExtra(AuthorizationStrategy.AUTHORIZATION_FINAL_URL, url);
             //TODO log request info
             getCompletionCallback().onChallengeResponseReceived(
-                    AuthorizationStrategy.UIResponse.AUTH_CODE_COMPLETE,
+                    AuthenticationConstants.UIResponse.BROWSER_CODE_COMPLETE,
                     resultIntent);
             view.stopLoading();
             //the TokenTask should be processed at after the authorization process in the upper calling layer.
@@ -232,7 +232,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
         view.stopLoading();
         Intent resultIntent = new Intent();
-        getCompletionCallback().onChallengeResponseReceived(AuthorizationStrategy.UIResponse.AUTH_CODE_CANCEL, resultIntent);
+        getCompletionCallback().onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
         return true;
     }
 
@@ -259,7 +259,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             Logger.verbose(TAG, "Install link is null or empty, Return to caller with BROWSER_CODE_DEVICE_REGISTER");
             resultIntent.putExtra(AuthenticationConstants.Broker.INSTALL_UPN_KEY, userName);
             getCompletionCallback().onChallengeResponseReceived(
-                    AuthorizationStrategy.UIResponse.BROWSER_CODE_DEVICE_REGISTER,
+                    AuthenticationConstants.UIResponse.BROWSER_CODE_DEVICE_REGISTER,
                     resultIntent
             );
             view.stopLoading();
@@ -267,7 +267,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
 
         Logger.verbose(TAG, "Return to caller with BROKER_REQUEST_RESUME, and waiting for result.");
-        getCompletionCallback().onChallengeResponseReceived(AuthorizationStrategy.UIResponse.BROKER_REQUEST_RESUME, resultIntent);
+        getCompletionCallback().onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROKER_REQUEST_RESUME, resultIntent);
 
         // Having thread sleep for 1 second for calling activity to receive the result from
         // prepareForBrokerResumeRequest, thus the receiver for listening broker result return
@@ -324,7 +324,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE, errorCode);
         resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE, errorMessage);
         //TODO log request info
-        getCompletionCallback().onChallengeResponseReceived(AuthorizationStrategy.UIResponse.AUTH_CODE_ERROR, resultIntent);
+        getCompletionCallback().onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -111,7 +111,10 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
                 description);
 
         // Send the result back to the calling activity
-        mCompletionCallback.onChallengeResponseReceived(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);
+        mCompletionCallback.onChallengeResponseReceived(
+                AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR,
+                resultIntent
+        );
     }
 
     @Override
@@ -130,7 +133,10 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
                 error.toString());
 
         // Send the result back to the calling activity
-        mCompletionCallback.onChallengeResponseReceived(AuthorizationStrategy.UIResponse.AUTH_CODE_ERROR, resultIntent);
+        mCompletionCallback.onChallengeResponseReceived(
+                AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR,
+                resultIntent
+        );
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/PKeyAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/PKeyAuthChallengeHandler.java
@@ -33,7 +33,6 @@ import com.microsoft.identity.common.adal.internal.JWSBuilder;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.logging.Logger;
-import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -82,7 +81,10 @@ public final class PKeyAuthChallengeHandler implements IChallengeHandler<PKeyAut
             Intent resultIntent = new Intent();
             resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_AUTHENTICATION_EXCEPTION, e);
             //TODO log the request info
-            mChallengeCallback.onChallengeResponseReceived(AuthorizationStrategy.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION, resultIntent);
+            mChallengeCallback.onChallengeResponseReceived(
+                    AuthenticationConstants.UIResponse.BROWSER_CODE_AUTHENTICATION_EXCEPTION,
+                    resultIntent
+            );
         }
 
         return null;


### PR DESCRIPTION
- Removed previous timeout change in controllers as it's no longer needed.
- Introduced new error and error strings as needed.
- Removed a redundant constant class `UIResponse` in `AuthorizationStrategy` and replaced with `AuthenticationConstants.UIResponse`