### PR TITLE
Fix to avoid sending null slice and dc parameters

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.providers.microsoft.microsoftsts;
 
 import android.net.Uri;
+import android.text.TextUtils;
 import android.util.Pair;
 
 import com.google.gson.annotations.Expose;
@@ -156,8 +157,12 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         }
 
         if (mSlice != null) {
-            uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, mSlice.getSlice());
-            uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.DC_PARAMETER, mSlice.getDC());
+            if(!TextUtils.isEmpty(mSlice.getSlice())) {
+                uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, mSlice.getSlice());
+            }
+            if(!TextUtils.isEmpty(mSlice.getDC())) {
+                uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.DC_PARAMETER, mSlice.getDC());
+            }
         }
 
         return uriBuilder.build();


### PR DESCRIPTION
issue during a PkeyAuthChallenge

` 2019-05-01T00:55:54.8169999 INFO    MSALCommonLoggerCallback     3511   00002   MSALCommon: Tag: MicrosoftStsAuthorizationResultFactory, Message: [2019-05-01 00:55:54 - {"thread_id":"2","correlation_id":"1f8cf5c3-07a7-46c4-a0ba-5fad6f719897"}] error: invalid_requesterror subcode:null errorDescription: AADSTS500991: Unexpected AuthToken audience. Expected token audience: 'https://login.microsoftonline.com/common/DeviceAuthPKeyAuth', Actual token audience: 'https://login.microsoftonline.com/common/DeviceAuthPKeyAuth?slice=null&dc=null'.
    Trace ID: 7d6868c4-a0f5-404e-9e09-7d730f722d00
    Correlation ID: 1f8cf5c3-07a7-46c4-a0ba-5fad6f719897 `