### PR TITLE
[TrueMAM] Fix the IntuneAppProtectionPolicyRequiredException adapter

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -209,7 +209,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                     brokerResult.getErrorMessage()
             );
 
-        } else if (AuthenticationConstants.OAuth2ErrorCode.UNAUTHORIZED_CLIENT.equalsIgnoreCase(errorCode) ||
+        } else if (AuthenticationConstants.OAuth2ErrorCode.UNAUTHORIZED_CLIENT.equalsIgnoreCase(errorCode) &&
                 AuthenticationConstants.OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED.
                         equalsIgnoreCase(brokerResult.getSubErrorCode())) {
 


### PR DESCRIPTION
Fix for #496 

The definition for IntuneAppProtectionPolicyRequiredException is server error code UNAUTHORIZED_CLIENT **with** sub error PROTECTION_POLICY_REQUIRED