### PR TITLE
Adds shared HttpResponseCache implementation to common

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/net/cache/HttpCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/cache/HttpCache.java
@@ -1,0 +1,124 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.net.cache;
+
+import android.net.http.HttpResponseCache;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.common.internal.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Utility class for caching HTTP and HTTPS responses.
+ *
+ * @see HttpResponseCache
+ */
+public class HttpCache {
+
+    private static final String TAG = HttpCache.class.getSimpleName();
+
+    /**
+     * The default name of the HTTP/S cache on disk.
+     */
+    public static final String DEFAULT_HTTP_CACHE_NAME = "com.microsoft.identitiy.http-cache";
+
+    /**
+     * The default size of the HTTP/S cache on disk.
+     */
+    public static final long DEFAULT_HTTP_CACHE_CAPACITY_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+    /**
+     * Initializes a new {@link HttpResponseCache} based on the supplied parameters.
+     *
+     * @param cacheDirectory The parent-directory in which the cache should reside.
+     * @param cacheFileName  The directory name for the HTTP cache.
+     * @param maxSizeBytes   The maximum allowed size of the cache. Once capacity is hit,
+     *                       entries are removed according to an LRU strategy.
+     * @return True if the cache was successfully installed. False otherwise.
+     */
+    public static boolean initialize(@NonNull final File cacheDirectory,
+                                     @NonNull final String cacheFileName,
+                                     final long maxSizeBytes) {
+        final String methondName = ":initialize (3 arg)";
+        boolean success = true;
+
+        try {
+            final File httpCacheDir = new File(cacheDirectory, cacheFileName);
+            HttpResponseCache.install(httpCacheDir, maxSizeBytes);
+        } catch (IOException e) {
+            success = false;
+            Logger.error(
+                    TAG + methondName,
+                    "HTTP Response cache installation failed.",
+                    e
+            );
+        }
+
+        return success;
+    }
+
+    /**
+     * Initializes a new {@link HttpResponseCache} inside the provided directory.
+     *
+     * @param cacheDirectory The parent-directory in which the cache should reside.
+     * @return True if the cache was successfully installed. False otherwise.
+     */
+    public static boolean initialize(@NonNull final File cacheDirectory) {
+        return initialize(
+                cacheDirectory,
+                DEFAULT_HTTP_CACHE_NAME,
+                DEFAULT_HTTP_CACHE_CAPACITY_BYTES
+        );
+    }
+
+    /**
+     * Returns the currently intalled {@link HttpResponseCache} or null, if none is installed.
+     *
+     * @return The HttpResponseCache.
+     */
+    @Nullable
+    public static HttpResponseCache getInstalled() {
+        return HttpResponseCache.getInstalled();
+    }
+
+    /**
+     * Convenience function for {@link HttpResponseCache#flush()}.
+     */
+    public static void flush() {
+        final String methodName = ":flush";
+
+        final HttpResponseCache responseCache = getInstalled();
+
+        if (null != responseCache) {
+            responseCache.flush();
+        } else {
+            Logger.warn(
+                    TAG + methodName,
+                    "Unable to flush cache because none is installed."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Slated for `0.0.9-hf1` release.

Summary of changes:
- Introduces class `HttpCache` to handle bootstrapping/flushing of [`HttpResponseCache`](https://developer.android.com/reference/android/net/http/HttpResponseCache).
- Added in common to support eventual inclusion in MSAL/broker

Up next:
- ADAL integration in `1.16.2-hf1` release

Proposed usage in ADAL:
- Create cache in [`AuthenticationContext#initialize`](https://github.com/AzureAD/azure-activedirectory-library-for-android/blob/release/1.16.2-hf1/adal/src/main/java/com/microsoft/aad/adal/AuthenticationContext.java#L144-L161)
- [Flush cache](https://developer.android.com/reference/android/net/http/HttpResponseCache#flush()) after returning ATS result to caller?
    * Ideally, in the `finalize()` method of `AuthenticationContext` but the general consensus seems to be that it's a faux pas to override `finalize()`

Additional considerations:
- ADAL caches Instance Discovery Metadata in-memory already after loading. The optimization benefit in ADAL really comes through across app restarts. If the app is killed/restarted before the cache's `max-age` constraint is satisfied, then the Instance Discovery Metadata request can be serviced by the cache without a network round-trip. If restarts occur less frequently and `max-age` is frequently exceeded prior to initiating the Instance Discovery Metadata request, then I would expect no performance benefit. 