### PR TITLE
Pass claims in non-joined acquireTokenSilent call

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -330,6 +330,10 @@ public abstract class BaseController {
         refreshTokenRequest.setRefreshToken(parameters.getRefreshToken().getSecret());
         refreshTokenRequest.setRedirectUri(parameters.getRedirectUri());
 
+        if (refreshTokenRequest instanceof MicrosoftTokenRequest) {
+            ((MicrosoftTokenRequest)refreshTokenRequest).setClaims(parameters.getClaimsRequestJson());
+        }
+
         //NOTE: this should be moved to the strategy; however requires a larger refactor
         if (parameters.getSdkType() == SdkType.ADAL) {
             ((MicrosoftTokenRequest) refreshTokenRequest).setIdTokenVersion("1");


### PR DESCRIPTION
Found this issue in the Authenticator app bug bash.

Here's the scenario.
1. Authenticator app NGC registration requires deviceid + ngcmfa claims.
2. NGC registration was successfully performed.
3. WPJ was unregistered.
4. Tried NGC registration again. Since WPJ is gone, it would fall back to the non-joined flow.
5. The non-joined flow will try to use existing RT. Since it's not passing the claim this time, Broker will return an AT that AuthApp can't use. Therefore the flow will fail.
