### PR TITLE
[MAM/MDM] Fix the broker installation prompt

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -244,7 +244,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
 
         if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
-            getActivity().getApplicationContext().startActivity(intent);
+            this.getActivity().startActivity(intent);
         } else {
             Logger.warn(TAG + methodName, "Unable to find an app to resolve the activity.");
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -221,7 +221,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 intent.setComponent(new ComponentName(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME,
                         AuthenticationConstants.Broker.COMPANY_PORTAL_APP_LAUNCH_ACTIVITY_NAME));
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                getActivity().getApplicationContext().startActivity(intent);
+                getActivity().startActivity(intent);
             } catch (final SecurityException ex) {
                 Logger.warn(TAG + methodName, "Failed to launch Company Portal, falling back to browser.");
                 openLinkInBrowser(url);
@@ -244,7 +244,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
 
         if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
-            this.getActivity().startActivity(intent);
+            getActivity().startActivity(intent);
         } else {
             Logger.warn(TAG + methodName, "Unable to find an app to resolve the activity.");
         }


### PR DESCRIPTION
Fix the exception thrown where calling startactivity() from outside of an activity context

The crash stacktrace
```
05-28 13:18:28.738 29207-29207/com.microsoft.identity.client.sample.local E/CallerInfo#isPackageInstalledAndEnabled:  [2019-05-28 20:18:28 - {"thread_id":"1","correlation_id":"bc0ad684-e3d9-4e90-a34c-c38ab316ac65"}] Package is not found. Package name: com.microsoft.identity.testuserapp Android 23
    android.content.pm.PackageManager$NameNotFoundException: com.microsoft.identity.testuserapp
        at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:304)
        at com.microsoft.identity.common.adal.internal.util.PackageHelper.isPackageInstalledAndEnabled(PackageHelper.java:165)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.processWebsiteRequest(AzureActiveDirectoryWebViewClient.java:216)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.handleUrl(AzureActiveDirectoryWebViewClient.java:137)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.shouldOverrideUrlLoading(AzureActiveDirectoryWebViewClient.java:97)
        at ib.a(PG:23)
        at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(PG:152)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:323)
        at android.os.Looper.loop(Looper.java:135)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
05-28 13:18:28.745 29207-29207/com.microsoft.identity.client.sample.local V/CallerInfo#isPackageInstalledAndEnabled:  [2019-05-28 20:18:28 - {"thread_id":"1","correlation_id":"bc0ad684-e3d9-4e90-a34c-c38ab316ac65"}]  Is package installed and enabled? [false] Android 23
05-28 13:18:28.752 29207-29207/com.microsoft.identity.client.sample.local V/AzureActiveDirectoryWebViewClient#openLinkInBrowser:  [2019-05-28 20:18:28 - {"thread_id":"1","correlation_id":"bc0ad684-e3d9-4e90-a34c-c38ab316ac65"}] Try to open url link in browser Android 23
05-28 13:18:28.760 29207-29207/com.microsoft.identity.client.sample.local D/AndroidRuntime: Shutting down VM
05-28 13:18:28.761 29207-29207/com.microsoft.identity.client.sample.local E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.microsoft.identity.client.sample.local, PID: 29207
    android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
        at android.app.ContextImpl.startActivity(ContextImpl.java:672)
        at android.app.ContextImpl.startActivity(ContextImpl.java:659)
        at android.content.ContextWrapper.startActivity(ContextWrapper.java:331)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.openLinkInBrowser(AzureActiveDirectoryWebViewClient.java:247)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.processWebsiteRequest(AzureActiveDirectoryWebViewClient.java:230)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.handleUrl(AzureActiveDirectoryWebViewClient.java:137)
        at com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient.shouldOverrideUrlLoading(AzureActiveDirectoryWebViewClient.java:97)
        at ib.a(PG:23)
        at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(PG:152)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:323)
        at android.os.Looper.loop(Looper.java:135)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)`
```