### PR TITLE
[WIP] Telemetry

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/EventValueMap.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/EventValueMap.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.telemetry;
+
+import java.util.Map;
+
+public class EventValueMap {
+    private String mEvent;
+    private Properties mProperties;
+
+    public EventValueMap(String event, Properties properties) {
+        mEvent = event;
+        mProperties = properties;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/ITelemetryReceiver.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/ITelemetryReceiver.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.telemetry;
+
+import java.util.Map;
+
+/**
+ * The interface function for apps to override if they want to get the Telemetry.
+ */
+public interface ITelemetryReceiver {
+
+    /**
+     * Invoked when telemetry data is received.
+     *
+     * @param events Map of properties for the request id.
+     */
+    void onTelemetryReceived(final Map<String, String> events);
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Properties.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Properties.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.telemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class for the event properties.
+ */
+public class Properties {
+    private Map<String, String> mProperties;
+
+    Properties(Map<String, String> properties) {
+        mProperties = properties;
+    }
+
+    public Properties put(String key, String value) {
+        if (mProperties == null) {
+            mProperties = new HashMap<>();
+            mProperties.put(key, value);
+        }
+
+        return this;
+    }
+
+    public Map<String, String> getProperties() {
+        return mProperties;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Telemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Telemetry.java
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.telemetry;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.common.internal.util.StringUtil;
+
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
+public class Telemetry {
+    static volatile Telemetry singleton = null;
+    private TelemetryDispatcher mTelemetryDispatcher;
+    private Context mContext;
+    private TelemetryConfiguration mDefaultConfiguration;
+    private ExecutorService mNetworkExecutor;
+    private final TelemetryContext mTelemetryContext;
+    private final static ExecutorService sTelemetryExecutor = Executors.newCachedThreadPool();
+
+    private Telemetry(final Context context,
+                      final TelemetryConfiguration configuration,
+                      final ExecutorService networkExecutor,
+                      final TelemetryContext telemetryContext) {
+        mContext = context;
+        mDefaultConfiguration = configuration;
+        mNetworkExecutor = networkExecutor;
+        mTelemetryContext = telemetryContext;
+    }
+
+    /**
+     * Register the receiver to flush the telemetry data.
+     * @param receiver ITelemetryReceiver
+     */
+    public synchronized void registerReceiver(final ITelemetryReceiver receiver) {
+        if (null == receiver) {
+            throw new IllegalArgumentException("Receiver instance cannot be null");
+        }
+
+        // check to make sure we're not already dispatching elsewhere
+        if (null != mTelemetryDispatcher) {
+            throw new IllegalStateException(
+                    ITelemetryReceiver.class.getSimpleName()
+                            + " instances are not swappable at this time."
+            );
+        }
+
+        // set this dispatcher
+        mTelemetryDispatcher = new TelemetryDispatcher(receiver);
+    }
+
+    public static Telemetry with(Context context) {
+        if (singleton == null) {
+            if (context == null) {
+                throw new IllegalArgumentException("Context must not be null.");
+            }
+            synchronized (Telemetry.class) {
+                if (singleton == null) {
+                    Builder builder = new Builder(context);
+
+                    try {
+                        String packageName = context.getPackageName();
+                        int flags = context.getPackageManager().getApplicationInfo(packageName, 0).flags;
+                        boolean debugging = (flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+                        if (debugging) {
+                            //TODO
+                            //builder.logLevel(LogLevel.INFO);
+                        }
+                    } catch (PackageManager.NameNotFoundException ignored) {
+                    }
+
+                    singleton = builder.build();
+                }
+            }
+        }
+        return singleton;
+    }
+
+    public void track(final @NonNull String event,
+                      final @Nullable Properties properties,
+                      final @NonNull String requestId,
+                      final @Nullable TelemetryConfiguration options) {
+
+        if (StringUtil.isEmpty(event)) {
+            throw new IllegalArgumentException("event must not be null or empty.");
+        }
+
+        sTelemetryExecutor.submit(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        final TelemetryConfiguration finalOptions;
+                        if (options == null) {
+                            finalOptions = mDefaultConfiguration;
+                        } else {
+                            finalOptions = options;
+                        }
+
+                        final Properties finalProperties;
+                        if (properties == null) {
+                            finalProperties = new Properties(new HashMap<String, String>());
+                        } else {
+                            finalProperties = properties;
+                        }
+
+                        //enqueue the properties to the event of the requestId
+//                        TrackPayload.Builder builder =
+//                                new TrackPayload.Builder().event(event).properties(finalProperties);
+//                        fillAndEnqueue(builder, finalOptions);
+                    }
+                });
+    }
+
+    public void flush(final String requestId) {
+        //TODO
+    }
+
+    /**
+     * API for creating {@link Telemetry} instances.
+     */
+    public static class Builder {
+        private Context mContext;
+        private TelemetryConfiguration mDefaultConfiguration;
+        private ExecutorService mNetworkExecutor;
+        private TelemetryContext mTelemetryContext;
+        // int flushQueueSize: should we add the limits for events to trigger flush automatically?
+        // TimeUnit timeUnit:  should we add the time interval to flush automatically?
+
+        public Builder(final Context context) {
+            if (context == null) {
+                throw new IllegalArgumentException("Context must not be null.");
+            }
+            if (!hasPermission(context, Manifest.permission.INTERNET)) {
+                throw new IllegalArgumentException("INTERNET permission is required.");
+            }
+            mContext = context.getApplicationContext();
+            if (mContext == null) {
+                throw new IllegalArgumentException("Application context must not be null.");
+            }
+        }
+
+        /**
+         * Specify the default options for all calls.
+         */
+        public Builder defaultConfiguration(final TelemetryConfiguration configuration) {
+            if (configuration == null) {
+                throw new IllegalArgumentException("defaultOptions must not be null.");
+            }
+
+            mDefaultConfiguration = configuration;
+            return this;
+        }
+
+        /**
+         * Specify the executor service for making network calls in the background.
+         */
+        public Builder networkExecutor(final ExecutorService networkExecutor) {
+            if (networkExecutor == null) {
+                throw new IllegalArgumentException("Executor service must not be null.");
+            }
+            mNetworkExecutor = networkExecutor;
+            return this;
+        }
+
+        /**
+         * Create a {@link Telemetry} client.
+         */
+        public Telemetry build() {
+            mTelemetryContext = TelemetryContext.create(mContext);
+
+            return new Telemetry(
+                    mContext,
+                    mDefaultConfiguration,
+                    mNetworkExecutor,
+                    mTelemetryContext
+            );
+        }
+    }
+
+    /**
+     * Returns true if the application has the given permission.
+     */
+    public static boolean hasPermission(Context context, String permission) {
+        return context.checkCallingOrSelfPermission(permission) == PERMISSION_GRANTED;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryConfiguration.java
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.telemetry;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+public class TelemetryConfiguration implements Serializable {
+
+    @SerializedName("enable_pii")
+    private boolean mPiiEnabled = false;
+
+    @SerializedName("notify_on_failure_only")
+    private boolean mNotifyOnFailureOnly = true;
+
+    @SerializedName("enable_debug")
+    private boolean mDebugEnabled = false;
+
+    private ITelemetryReceiver mCallback;
+
+    /**
+     * @return true to if the pii telemetry is enabled; false otherwise.
+     */
+    public boolean isPiiEnabled() {
+        return mPiiEnabled;
+    }
+
+    /**
+     * Setting piiEnabled to true, will allow sdk to return fields with user information in the telemetry events.
+     * SDK does not send telemetry data by itself to any server.
+     * If apps want to collect telemetry with user information
+     * they must setup the telemetry callback and set this flag on.
+     * <p>
+     * By default sdk will not return any user information in telemetry.
+     *
+     * @param piiEnabled true to enable the pii telemetry; false otherwise.
+     */
+    public void setPiiEnabled(boolean piiEnabled) {
+        mPiiEnabled = piiEnabled;
+    }
+
+    /**
+     * @return true if telemetry only dispatched when error occurred, false otherwise.
+     */
+    public boolean isNotifyOnFailureOnly() {
+        return mNotifyOnFailureOnly;
+    }
+
+    /**
+     * If set true, telemetry events are only dispatched when errors occurred;
+     * If set false, sdk will dispatch all events.
+     * <p>
+     * By default sdk enables the notify on failure only
+     *
+     * @param notifyOnFailureOnly true to enable telemetry when error occurred, false otherwise.
+     */
+    public void setNotifyOnFailureOnly(boolean notifyOnFailureOnly) {
+        mNotifyOnFailureOnly = notifyOnFailureOnly;
+    }
+
+    /**
+     * @return true if debugging for telemetry is enabled, false otherwise.
+     */
+    public boolean isDebugEnabled() {
+        return mDebugEnabled;
+    }
+
+    /**
+     * If set false, telemetry events are not dispatched when the app is in debugging.
+     * If set true, sdk will dispatch all events.
+     * <p>
+     * By default telemetry is disabled in debugging mode.
+     *
+     * @param debugEnabled true to enable debugging for telemetry, false otherwise.
+     */
+    public void setDebugEnabled(boolean debugEnabled) {
+        mDebugEnabled = debugEnabled;
+    }
+
+    /**
+     * @return TelemetryCallback object
+     */
+    public ITelemetryReceiver getCallback() {
+        return mCallback;
+    }
+
+    /**
+     * Invoked when telemetry data is received.
+     *
+     * @param callback TelemetryCallback
+     */
+    public void setCallback(final ITelemetryReceiver callback) {
+        mCallback = callback;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryContext.java
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.telemetry;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import com.microsoft.identity.common.BuildConfig;
+import com.microsoft.identity.common.internal.platform.Device;
+
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * TelemetryContext is a dictionary of information about the state of the device.
+ * It is attached to every outgoing telemetry calls.
+ *
+ */
+public class TelemetryContext extends ValueMap {
+    // App
+    private static final String APP_NAME_KEY = "app_name";
+    private static final String APP_VERSION_KEY = "app_version";
+    private static final String APP_PACKAGE_NAME_KEY = "app_package_name";
+    private static final String APP_BUILD_KEY = "app_build";
+    // Device
+    private static final String DEVICE_MANUFACTURER_KEY = "device_manufacturer";
+    private static final String DEVICE_MODEL_KEY = "device_model";
+    private static final String DEVICE_NAME_KEY = "device_name";
+    // Library
+    private static final String LIBRARY_NAME_KEY = "library_name";
+    private static final String LIBRARY_VERSION_KEY = "library_version";
+    // Network
+    private static final String NETWORK_CONNECTION_KEY = "network_connection";
+    private static final String NETWORK_POWER_OPTIMIZATION_KEY = "network_carrier";
+    // OS
+    private static final String OS_NAME_KEY = "os_name";
+    private static final String OS_VERSION_KEY = "os_version";
+    private static final String TIMEZONE_KEY = "timezone";
+
+    TelemetryContext(Map<String, Object> delegate) {
+        super(delegate);
+    }
+
+    /**
+     * Create a new {@link TelemetryContext} instance filled in with information from the given {@link
+     * Context}. The {@link Telemetry} client can be called from anywhere, so the returned instances
+     * is thread safe.
+     */
+    static synchronized TelemetryContext create(final Context context) {
+        TelemetryContext telemetryContext = new TelemetryContext(new ConcurrentHashMap<String, Object>());
+        telemetryContext.putApp(context);
+        telemetryContext.putDevice();
+        telemetryContext.putLibrary();
+        telemetryContext.putOs();
+        telemetryContext.put(TIMEZONE_KEY, TimeZone.getDefault().getID());
+        return telemetryContext;
+    }
+
+    void putApp(Context context) {
+        try {
+            PackageManager packageManager = context.getPackageManager();
+            PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), 0);
+            Map<String, Object> app = new ConcurrentHashMap<>();
+            put(APP_NAME_KEY, packageInfo.applicationInfo.loadLabel(packageManager));
+            put(APP_VERSION_KEY, packageInfo.versionName);
+            put(APP_PACKAGE_NAME_KEY, packageInfo.packageName);
+            put(APP_BUILD_KEY, String.valueOf(packageInfo.versionCode));
+        } catch (PackageManager.NameNotFoundException e) {
+            // ignore
+        }
+    }
+
+    void putDevice() {
+        put(DEVICE_MANUFACTURER_KEY, Build.MANUFACTURER);
+        put(DEVICE_MODEL_KEY, Build.MODEL);
+        put(DEVICE_NAME_KEY, Build.DEVICE);
+    }
+
+    void putLibrary() {
+        put(LIBRARY_NAME_KEY, "common-android");
+        put(LIBRARY_VERSION_KEY, BuildConfig.VERSION_NAME);
+    }
+
+    void putOs() {
+        put(OS_NAME_KEY, "Android");
+        put(OS_VERSION_KEY, Build.VERSION.RELEASE);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryDispatcher.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.telemetry;
+
+import android.util.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TelemetryDispatcher {
+    private final ITelemetryReceiver mEventReceiver;
+
+    /**
+     * Constructs a new EventDispatcher.
+     *
+     * @param receiver the {@link ITelemetryReceiver} to receive {@link Telemetry} data.
+     */
+    TelemetryDispatcher(final ITelemetryReceiver receiver) {
+        mEventReceiver = receiver;
+    }
+
+    /**
+     * Returns the {@link ITelemetryReceiver} to which telemetry data is dispatched.
+     *
+     * @return the event receiver.
+     */
+    ITelemetryReceiver getReceiver() {
+        return mEventReceiver;
+    }
+
+    /**
+     * Dispatches the {@link Telemetry} instances associated to receiver.
+     *
+     * @param eventsToPublish the Events to publish.
+     */
+    void dispatch(final List<Properties> eventsToPublish) {
+        if (null == mEventReceiver) {
+            return;
+        }
+
+        final Map<String, String> eventsForPublication = new HashMap<>();
+
+        for (final Properties event : eventsToPublish) {
+            eventsForPublication.putAll(event.getProperties());
+        }
+
+        mEventReceiver.onTelemetryReceived(eventsForPublication);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
@@ -27,8 +27,15 @@ import android.util.Pair;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -152,5 +159,83 @@ public final class StringUtil {
         }
 
         return 0;
+    }
+
+    /**
+     * Return a copy of the contents of the given map as a {@link JSONObject}. Instead of failing on
+     * {@code null} values like the {@link JSONObject} map constructor, it cleans them up and
+     * correctly converts them to {@link JSONObject#NULL}.
+     */
+    public static JSONObject toJsonObject(Map<String, ?> map) {
+        JSONObject jsonObject = new JSONObject();
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            Object value = wrap(entry.getValue());
+            try {
+                jsonObject.put(entry.getKey(), value);
+            } catch (JSONException ignored) {
+                // Ignore values that JSONObject doesn't accept.
+            }
+        }
+        return jsonObject;
+    }
+
+    /**
+     * Wraps the given object if necessary. {@link JSONObject#wrap(Object)} is only available on API
+     * 19+, so we've copied the implementation. Deviates from the original implementation in that it
+     * always returns {@link JSONObject#NULL} instead of {@code null} in case of a failure, and
+     * returns the {@link Object#toString} of any object that is of a custom (non-primitive or
+     * non-collection/map) type.
+     *
+     * <p>If the object is null returns {@link JSONObject#NULL}. If the object is a {@link JSONArray}
+     * or {@link JSONObject}, no wrapping is necessary. If the object is {@link JSONObject#NULL}, no
+     * wrapping is necessary. If the object is an array or {@link Collection}, returns an equivalent
+     * {@link JSONArray}. If the object is a {@link Map}, returns an equivalent {@link JSONObject}. If
+     * the object is a primitive wrapper type or {@link String}, returns the object. Otherwise returns
+     * the result of {@link Object#toString}. If wrapping fails, returns JSONObject.NULL.
+     */
+    private static Object wrap(Object o) {
+        //TODO can be removed after change the minSdk to 19.
+        if (o == null) {
+            return JSONObject.NULL;
+        }
+        if (o instanceof JSONArray || o instanceof JSONObject) {
+            return o;
+        }
+        if (o.equals(JSONObject.NULL)) {
+            return o;
+        }
+        try {
+            if (o instanceof Collection) {
+                return new JSONArray((Collection) o);
+            } else if (o.getClass().isArray()) {
+                final int length = Array.getLength(o);
+                JSONArray array = new JSONArray();
+                for (int i = 0; i < length; ++i) {
+                    array.put(wrap(Array.get(array, i)));
+                }
+                return array;
+            }
+            if (o instanceof Map) {
+                //noinspection unchecked
+                return toJsonObject((Map) o);
+            }
+            if (o instanceof Boolean
+                    || o instanceof Byte
+                    || o instanceof Character
+                    || o instanceof Double
+                    || o instanceof Float
+                    || o instanceof Integer
+                    || o instanceof Long
+                    || o instanceof Short
+                    || o instanceof String) {
+                return o;
+            }
+            // Deviate from original implementation and return the String representation of the object
+            // regardless of package.
+            return o.toString();
+        } catch (Exception ignored) {
+        }
+        // Deviate from original and return JSONObject.NULL instead of null.
+        return JSONObject.NULL;
     }
 }


### PR DESCRIPTION
**Related classes**

- [x] Add TelemetryConfiguration class
- [x] Add TelemetryContext class
- [ ] Add ITelemetryCallback interface

- [ ] Add RequestValueMap [String requestId, Map of EventValueMap]
- [ ] Add EventValueMap [String event, Map of Properties]
- [ ] Add PropertyValueMap [String propertyName, String propertyValue]

**Description of the usage**
Telemetry is a singleton class
The configuration is initialized during the app configuration initialization.
```
"telemetry" [
    {
        "enable_pii" : false,
        "notify_on_failure_only" : true,
        "enable_debug" : false
    }
]
```

- Define the specific property value map extends PropertyValueMap to specify the properties for each event. 

- RequestValueMap is created at the beginning of the ApiDispatcher when the requestId get generated

- The EventValueMap is created at the beginning of each ApiDispatcher call.
- The event data is pipelined at the end of each ApiDispatcher call  [TBD]
- The EventValueMap can be updated during the call, tracked by application context, request id and the event name. I am not planning to make the event name as enum for extensibility purpose. 

**TODO**

- [ ] Fix the PMD and Lint errors
- [ ] Add unit tests