### PR TITLE
Adding negotiate challenge support to WebViews

### DIFF
--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -4,7 +4,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+
     <application>
+        <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/webview_app_restrictions" />
         <activity
             android:name="com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity"
             android:configChanges="orientation|keyboardHidden|screenSize" />

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
 
     <application>
-        <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+        <!-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
         <meta-data
             android:name="android.content.APP_RESTRICTIONS"
             android:resource="@xml/webview_app_restrictions" />

--- a/common/src/main/res/values-v21/strings.xml
+++ b/common/src/main/res/values-v21/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+    <string name="AuthAndroidNegotiateAccountTypeDesc">Specifies the account type of the accounts provided by the Android authentication app that supports HTTP Negotiate authentication (e.g. Kerberos authentication). This information should be available from the supplier of the authentication app. For more details see https://goo.gl/hajyfN. If no setting is provided, HTTP Negotiate authentication is disabled on Android.</string>
+    <string name="AuthAndroidNegotiateAccountTypeTitle">Account type for HTTP Negotiate authentication</string>
+    <string name="AuthServerWhitelistDesc">Specifies which servers should be whitelisted for integrated authentication. Integrated authentication is only enabled when Chromium receives an authentication challenge from a proxy or from a server which is in this permitted list. Separate multiple server names with commas. Wildcards (*) are allowed. If you leave this policy not set Chromium will try to detect if a server is on the Intranet and only then will it respond to IWA requests. If a server is detected as Internet then IWA requests from it will be ignored by Chromium.</string>
+    <string name="AuthServerWhitelistTitle">Authentication server whitelist</string>
+    <string name="NtlmV2EnabledDesc">Controls whether NTLMv2 is enabled. All recent versions of Samba and Windows servers support NTLMv2. This should only be disabled for backwards compatibility and reduces the security of authentication. If this policy is not set, the default is true and NTLMv2 is enabled.</string>
+    <string name="NtlmV2EnabledTitle">Whether NTLMv2 authentication is enabled.</string>
+</resources>

--- a/common/src/main/res/values-v21/strings.xml
+++ b/common/src/main/res/values-v21/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+    <!-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
     <string name="AuthAndroidNegotiateAccountTypeDesc">Specifies the account type of the accounts provided by the Android authentication app that supports HTTP Negotiate authentication (e.g. Kerberos authentication). This information should be available from the supplier of the authentication app. For more details see https://goo.gl/hajyfN. If no setting is provided, HTTP Negotiate authentication is disabled on Android.</string>
     <string name="AuthAndroidNegotiateAccountTypeTitle">Account type for HTTP Negotiate authentication</string>
     <string name="AuthServerWhitelistDesc">Specifies which servers should be whitelisted for integrated authentication. Integrated authentication is only enabled when Chromium receives an authentication challenge from a proxy or from a server which is in this permitted list. Separate multiple server names with commas. Wildcards (*) are allowed. If you leave this policy not set Chromium will try to detect if a server is on the Intranet and only then will it respond to IWA requests. If a server is detected as Internet then IWA requests from it will be ignored by Chromium.</string>

--- a/common/src/main/res/xml-v21/webview_app_restrictions.xml
+++ b/common/src/main/res/xml-v21/webview_app_restrictions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <restrictions xmlns:android="http://schemas.android.com/apk/res/android">
-    <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+    <!-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
     <restriction android:description="@string/NtlmV2EnabledDesc" android:title="@string/NtlmV2EnabledTitle" android:key="com.android.browser:NtlmV2Enabled" android:restrictionType="bool" />
     <restriction android:description="@string/AuthServerWhitelistDesc" android:title="@string/AuthServerWhitelistTitle" android:key="com.android.browser:AuthServerWhitelist" android:restrictionType="string" />
     <restriction android:description="@string/AuthAndroidNegotiateAccountTypeDesc" android:title="@string/AuthAndroidNegotiateAccountTypeTitle" android:key="com.android.browser:AuthAndroidNegotiateAccountType" android:restrictionType="string" />

--- a/common/src/main/res/xml-v21/webview_app_restrictions.xml
+++ b/common/src/main/res/xml-v21/webview_app_restrictions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+    <-- used by webview to enable Negotiate Challenge handling see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md -->
+    <restriction android:description="@string/NtlmV2EnabledDesc" android:title="@string/NtlmV2EnabledTitle" android:key="com.android.browser:NtlmV2Enabled" android:restrictionType="bool" />
+    <restriction android:description="@string/AuthServerWhitelistDesc" android:title="@string/AuthServerWhitelistTitle" android:key="com.android.browser:AuthServerWhitelist" android:restrictionType="string" />
+    <restriction android:description="@string/AuthAndroidNegotiateAccountTypeDesc" android:title="@string/AuthAndroidNegotiateAccountTypeTitle" android:key="com.android.browser:AuthAndroidNegotiateAccountType" android:restrictionType="string" />
+</restrictions>


### PR DESCRIPTION
There is a hidden feature in Android WebViews that can enable them to handle Negotiate challenges (see https://chromium.googlesource.com/chromium/src/+/master/docs/webview_policies.md). 

This pull request aims at enabling exactly that. The negotiate challenge support is especially helpful for federated logins leveraging spnego authentication. This would enable intranet SSO for all MS Apps using the library (hopefull the entire Native Office Android Apps). By default the features will remain disabled (thus not changing current behaviour), only if an Administrator populates the added managed configurations, the feature is enabled. 

These configurations are also available in the native MS Edge application.