### PR TITLE
Add null check around interactive call completion

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
@@ -356,7 +356,12 @@ public class ApiDispatcher {
     }
 
     public static void completeInteractive(int requestCode, int resultCode, final Intent data) {
-        sCommand.notify(requestCode, resultCode, data);
+        final String methodName = ":completeInteractive";
+        if(sCommand != null) {
+            sCommand.notify(requestCode, resultCode, data);
+        }else {
+            Logger.warn(TAG + methodName, "sCommand is null, No interactive call in progress to complete.");
+        }
     }
 
     public static void submitSilent(final TokenCommand command) {


### PR DESCRIPTION
Crash details:
https://rink.hockeyapp.net/manage/apps/466148/app_versions/119/crash_reasons/277385144?order=asc&sort_by=date&type=crashes#crash_data

 related issue : https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/603

Added a safety null check to avoid crash for the latest broker release , more comprehensive fix will be looked into later during MSAL release

