### PR TITLE
Updating Interactive redirect that detects the Company Portal enrollment

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -939,6 +939,23 @@ public final class AuthenticationConstants {
         public static final String AZURE_AUTHENTICATOR_APP_PACKAGE_NAME = "com.azure.authenticator";
 
         /**
+         * Teams IP Phones (Sakurai devices) is supported by Intune, but does not have a back button nor browser.
+         * The only supported detection of this phone is the application install state.
+         * The Microsoft Intune app depends on the browser opening the fwlink, and in the app manifest registers to handle the URL.
+         * In the 1906 both apps will be installed on COBO devices, but the MDM CA link must open the browser to then open Microsoft Intune.
+         * On IP Phones devices (without a browser) the Company Portal must be launched.
+         * App name of Teams Phone app to detect it for the MDM Device CA redirect.
+         */
+        public static final String IPPHONE_APP_PACKAGE_NAME = "com.microsoft.skype.teams.ipphone";
+
+        /**
+         * Teams IP Phones (Sakurai devices) is supported by Intune, but does not have a back button nor browser.
+         * The only supported detection of this phone is the application install state.
+         * App signature of Teams Phone app to detect it for the MDM Device CA redirect.
+         */
+        public static final String IPPHONE_APP_SIGNATURE = "fcg80qvoM1YMKJZibjBwQcDfOno=";
+
+        /**
          * The value for pkeyauth redirect.
          */
         public static final String PKEYAUTH_REDIRECT = "urn:http-auth:PKeyAuth";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -217,6 +217,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 && packageHelper.isPackageInstalledAndEnabled(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME)
                 && AuthenticationConstants.Broker.IPPHONE_APP_SIGNATURE.equals(
                 packageHelper.getCurrentSignatureForPackage(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME))) {
+            // TODO: This flow should really check if the Microsoft Intune or the Company Portal apps are installed,
+            // which is the correct client app to launch depending on the enrollment, and launch that app, to permanently skip the browser.
+            // Also it must handle 3rd party MDMs as appropriate, which will depend on the browser flow determining the authority.
             Logger.verbose(TAG + methodName, "It is a device CA request on IPPhone. Company Portal is installed.");
             try {
                 Logger.verbose(TAG + methodName, "Sending intent to launch the CompanyPortal.");

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -213,6 +213,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodName = "#processWebsiteRequest";
         final PackageHelper packageHelper = new PackageHelper(getActivity().getApplicationContext());
         if (url.startsWith(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL)
+                && packageHelper.isPackageInstalledAndEnabled(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME)
                 && packageHelper.isPackageInstalledAndEnabled(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME)
                 && AuthenticationConstants.Broker.IPPHONE_APP_SIGNATURE.equals(
                 packageHelper.getCurrentSignatureForPackage(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME))) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -213,8 +213,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodName = "#processWebsiteRequest";
         final PackageHelper packageHelper = new PackageHelper(getActivity().getApplicationContext());
         if (url.startsWith(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL)
-                && packageHelper.isPackageInstalledAndEnabled(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME)) {
-            Logger.verbose(TAG + methodName, "It is a device CA request. Company Portal is installed.");
+                && packageHelper.isPackageInstalledAndEnabled(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME)
+                && AuthenticationConstants.Broker.IPPHONE_APP_SIGNATURE.equals(
+                packageHelper.getCurrentSignatureForPackage(AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME))) {
+            Logger.verbose(TAG + methodName, "It is a device CA request on IPPhone. Company Portal is installed.");
             try {
                 Logger.verbose(TAG + methodName, "Sending intent to launch the CompanyPortal.");
                 final Intent intent = new Intent();
@@ -255,7 +257,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final HashMap<String, String> parameters = StringExtensions.getUrlParameters(url);
         final String installLink = parameters.get(AuthenticationConstants.Broker.INSTALL_URL_KEY);
         final String userName = parameters.get(AuthenticationConstants.Broker.INSTALL_UPN_KEY);
-        if(TextUtils.isEmpty(installLink)){
+        if (TextUtils.isEmpty(installLink)) {
             Logger.verbose(TAG, "Install link is null or empty, Return to caller with BROWSER_CODE_DEVICE_REGISTER");
             resultIntent.putExtra(AuthenticationConstants.Broker.INSTALL_UPN_KEY, userName);
             getCompletionCallback().onChallengeResponseReceived(


### PR DESCRIPTION
UI to check specifically for Teams Phone app. This is due to Company
Portal and Microsoft Intune COBO apps being deployed together by default
for 1906, while there are still 4.4 IPPhone devices without a browser
but could still have MDM CA Policy.