### PR TITLE
Merge Release/0.0.12 back to dev

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/ITokenShareInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/ITokenShareInternal.java
@@ -33,11 +33,32 @@ public interface ITokenShareInternal {
      * @param identifier The identifier of the sought user's FRT.
      * @return The {@link com.microsoft.identity.common.internal.cache.ADALTokenCacheItem}
      * serialized to JSON.
+     * @throws Exception If the requested token cannot be found.
      */
-    String getWrappedFamilyRefreshToken(String identifier) throws Exception;
+    String getOrgIdFamilyRefreshToken(String identifier) throws Exception;
 
     /**
-     * @param tokenCacheItemJson
+     * Saves the supplied SsoStateSerializer blob into the cache.
+     *
+     * @param ssoStateSerializerBlob The blob to save.
+     * @throws Exception If an error is encountered while saving the supplied blob.
      */
-    void saveFamilyRefreshToken(String tokenCacheItemJson) throws Exception;
+    void saveOrgIdFamilyRefreshToken(String ssoStateSerializerBlob) throws Exception;
+
+    /**
+     * For the provided MSA user id, retrieve the FRT belonging to this user (if exists).
+     *
+     * @param identifier The identifier of the sought user's FRT.
+     * @return The raw FRT for the provided identifier.
+     * @throws Exception If the requested token cannot be found.
+     */
+    String getMsaFamilyRefreshToken(String identifier) throws Exception;
+
+    /**
+     * Saves the supplied FRT to the cache.
+     *
+     * @param refreshToken The FRT to save.
+     * @throws Exception If an Exception is encountered while saving the FRT.
+     */
+    void saveMsaFamilyRefreshToken(String refreshToken) throws Exception;
 }

--- a/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
@@ -34,6 +34,8 @@ public class ClientException extends BaseException {
      */
     public static final String TOKEN_SHARING_DESERIALIZATION_ERROR = "token_sharing_deserialization_error";
 
+    public static final String TOKEN_SHARING_MSA_PERSISTENCE_ERROR = "failed_to_persist_msa_credential";
+
     /**
      * There are multiple cache entries found, the sdk cannot pick the correct access token
      * or refresh token from the cache. Likely it's a bug in the sdk when caching tokens or authority

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=0.0.10
+versionName=0.0.12-RC1
 versionCode=1


### PR DESCRIPTION
The original plan was to create new releases branches for ad-accounts (release/3.1.0), common(0.0.12) and MSAL (release/1.0.0)  for the July MSAL with v2 broker release. However due to unexpected fix which needs to be targeted to master of ad-accounts (v1 broker) we couldn't merge [this PR](https://github.com/AzureAD/ad-accounts-for-android/pull/1040) and thus couldn't create a ad-accounts release branch (release/3.1.0) 

So effectively common 0.0.12 doesn't have a corresponding counterpart in ad-accounts. Hence merging back these release branches to dev and using that as a base of July release until we can cut a branch in ad-accounts.