### PR TITLE
Migrate Key only + Inject telemetry

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1238,4 +1238,18 @@ public final class AuthenticationConstants {
          */
         public static final String APPLICATION_JSON = "application/json";
     }
+
+    public static final class TelemetryEvents {
+        public static final String DECRYPTION_ERROR = "decryption_error_v2";
+
+        public static final String KEYCHAIN_WRITE = "keychain_write_v2";
+
+        public static final String KEYCHAIN_READ = "keychain_read_v2";
+
+        public static final String KEY_RETRIEVAL = "key_retrieval_v2";
+
+        public static final String KEY_DISTRIBUTION = "key_distribution_v2";
+
+        public static final String KEY_CREATED = "key_created_v2";
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/IWpjTelemetryCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/IWpjTelemetryCallback.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.adal.internal.cache;
+
+import android.content.Context;
+
+/**
+ * Temporary interface.
+ * For injecting telemetry into common (until common's telemetry is properly wired up).
+ * */
+public interface IWpjTelemetryCallback {
+    void logEvent(Context context, final String operation, final Boolean isFailed, final String reason);
+    void logSessionStart(Context context, final String operation);
+    void logSessionEnd(Context context, final String operation, final Boolean isFailed, final String reason);
+}

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -35,7 +35,6 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ErrorStrings;
-import com.microsoft.identity.common.internal.broker.InactiveBrokerClient;
 import com.microsoft.identity.common.internal.logging.Logger;
 
 import java.io.ByteArrayOutputStream;
@@ -49,9 +48,7 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.DigestException;
 import java.security.GeneralSecurityException;
-import java.security.InvalidParameterException;
 import java.security.Key;
-import java.security.KeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
@@ -59,9 +56,7 @@ import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.UnrecoverableEntryException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
@@ -82,9 +77,13 @@ import javax.security.auth.x500.X500Principal;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 
-
 public class StorageHelper implements IStorageHelper {
     private static final String TAG = "StorageHelper";
+
+    /**
+     * A flag to turn on/off keystore encryption on Broker apps.
+     */
+    public static final boolean SHOULD_ENCRYPT_BROKER_VALUES_WITH_KEYSTORE_ENCRYPTED_KEY = false;
 
     /**
      * HMac key hashing algorithm.
@@ -174,6 +173,7 @@ public class StorageHelper implements IStorageHelper {
 
     private final Context mContext;
     private final SecureRandom mRandom;
+    private IWpjTelemetryCallback mTelemetryCallback;
 
     /**
      * Public and private keys that are generated in AndroidKeyStore.
@@ -188,12 +188,22 @@ public class StorageHelper implements IStorageHelper {
      * Constructor for {@link StorageHelper}.
      *
      * @param context The {@link Context} to create {@link StorageHelper}.
+     */
+    public StorageHelper(@NonNull final Context context) {
+        this(context, null);
+    }
+
+    /**
+     * Constructor for {@link StorageHelper}.
+     *
+     * @param context The {@link Context} to create {@link StorageHelper}.
      *                TODO: Remove this suppression: https://android-developers.blogspot.com/2013/08/some-securerandom-thoughts.html
      */
     @SuppressLint("TrulyRandom")
-    public StorageHelper(@NonNull final Context context) {
+    public StorageHelper(@NonNull final Context context, @Nullable final IWpjTelemetryCallback telemetryCallback) {
         mContext = context.getApplicationContext();
         mRandom = new SecureRandom();
+        mTelemetryCallback = telemetryCallback;
     }
 
     // Exposed to be overridden by mock tests.
@@ -276,10 +286,6 @@ public class StorageHelper implements IStorageHelper {
         final String packageName = getPackageName();
         final List<KeyType> keysForDecryptionType = getKeysForDecryptionType(encryptedBlob, packageName);
 
-        // At the point of writing, Telemetry isn't wired into common yet.
-        // The best effort is to return a proper exception, and have its caller (Presumably in ad-accounts), emit an exception event).
-        Exception lastKnownException = null;
-
         final byte[] bytes = getByteArrayFromEncryptedBlob(encryptedBlob);
         for (final KeyType keyType : keysForDecryptionType) {
             try {
@@ -292,14 +298,10 @@ public class StorageHelper implements IStorageHelper {
                 Logger.verbose(TAG + methodName, "Finished decryption.");
                 return result;
             } catch (GeneralSecurityException | IOException e) {
-                Logger.error(
-                        TAG + methodName,
-                        "Failed to decrypt with KeyType: "
-                                + keyType.toString(),
-                        e
-                );
-
-                lastKnownException = e;
+                logEvent(methodName,
+                        AuthenticationConstants.TelemetryEvents.DECRYPTION_ERROR,
+                        true,
+                        "failed to decrypt with keyType:" + keyType.name() + " exception: " + e.toString());
             }
         }
 
@@ -307,13 +309,13 @@ public class StorageHelper implements IStorageHelper {
                 TAG + methodName,
                 "Tried all decryption keys and decryption still fails. Throw an exception.");
 
-        throw new GeneralSecurityException(ErrorStrings.DECRYPTION_FAILED, lastKnownException);
+        throw new GeneralSecurityException(ErrorStrings.DECRYPTION_FAILED);
     }
 
     /**
      * Determine type of encryption performed on the given data blob.
-     * NOTE :If it cannot verify the keyVersion, it will assume that this data is not encrypted.
-     * */
+     * NOTE: If it cannot verify the keyVersion, it will assume that this data is not encrypted.
+     */
     public EncryptionType getEncryptionType(@NonNull final String data) throws UnsupportedEncodingException {
         final String methodName = ":getEncryptionType";
 
@@ -389,8 +391,6 @@ public class StorageHelper implements IStorageHelper {
     private String decryptWithSecretKey(@NonNull final byte[] bytes,
                                         @NonNull final SecretKey secretKey)
             throws GeneralSecurityException, IOException {
-        final String methodName = ":decryptWithSecretKey";
-
         final SecretKey hmacKey = getHMacKey(secretKey);
 
         // byte input array: encryptedData-iv-macDigest
@@ -434,8 +434,6 @@ public class StorageHelper implements IStorageHelper {
                 AuthenticationConstants.ENCODING_UTF8
         );
 
-        Logger.verbose(TAG + methodName, "Finished decryption");
-
         return decrypted;
     }
 
@@ -462,12 +460,35 @@ public class StorageHelper implements IStorageHelper {
     @Override
     public synchronized SecretKey loadSecretKeyForEncryption() throws IOException,
             GeneralSecurityException {
+        final String methodName = ":loadSecretKeyForEncryption";
+
         // Loading key only once for performance. If API is upgraded, it will
         // restart the device anyway. It will load the correct key for new API.
         if (mEncryptionKey != null && mEncryptionHMACKey != null) {
             return mEncryptionKey;
         }
 
+        // The current app runtime is the broker; load its secret key.
+        if (!SHOULD_ENCRYPT_BROKER_VALUES_WITH_KEYSTORE_ENCRYPTED_KEY &&
+                AuthenticationSettings.INSTANCE.getBrokerSecretKeys().containsKey(getPackageName())) {
+
+            // Try to read keystore key - so that we get telemetry data on its reliability.
+            // If anything happens, do not crash the app.
+            try {
+                loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
+            } catch (Exception e){
+                // Best effort.
+            }
+
+            setBlobVersion(VERSION_USER_DEFINED);
+            if (AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(getPackageName())) {
+                return loadSecretKey(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
+            } else {
+                return loadSecretKey(KeyType.LEGACY_COMPANY_PORTAL_KEY);
+            }
+        }
+
+        // Try to get user defined key (ADAL/MSAL).
         if (AuthenticationSettings.INSTANCE.getSecretKeyData() != null) {
             setBlobVersion(VERSION_USER_DEFINED);
             return loadSecretKey(KeyType.ADAL_USER_DEFINED_KEY);
@@ -475,9 +496,17 @@ public class StorageHelper implements IStorageHelper {
 
         // Try loading existing keystore-encrypted key. If it doesn't exist, create a new one.
         setBlobVersion(VERSION_ANDROID_KEY_STORE);
-        SecretKey key = loadOrCreateKey();
+        try {
+            SecretKey key = loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
+            if (key != null) {
+                return key;
+            }
+        } catch (final IOException | GeneralSecurityException e) {
+            // If we fail to load key, proceed and generate a new one.
+        }
 
-        return key;
+        Logger.verbose(TAG + methodName, "Keystore-encrypted key does not exist, try to generate new keys.");
+        return generateKeyStoreEncryptedKey();
     }
 
     /**
@@ -497,22 +526,20 @@ public class StorageHelper implements IStorageHelper {
     public SecretKey loadSecretKey(@NonNull final KeyType keyType) throws IOException, GeneralSecurityException {
         final String methodName = ":loadSecretKey";
 
+        Logger.verbose(TAG + methodName, "Loading key with Type:" + keyType.name());
+
         switch (keyType) {
             case LEGACY_AUTHENTICATOR_APP_KEY:
-                Logger.verbose(TAG + methodName, "Loading legacy authApp key.");
                 return getSecretKey(AuthenticationSettings.INSTANCE.getBrokerSecretKeys().get(AZURE_AUTHENTICATOR_APP_PACKAGE_NAME));
 
             case LEGACY_COMPANY_PORTAL_KEY:
-                Logger.verbose(TAG + methodName, "Loading legacy companyPortal key.");
                 return getSecretKey(AuthenticationSettings.INSTANCE.getBrokerSecretKeys().get(COMPANY_PORTAL_APP_PACKAGE_NAME));
 
             case ADAL_USER_DEFINED_KEY:
-                Logger.verbose(TAG + methodName, "Loading ADAL userDefined key.");
                 return getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
 
             case KEYSTORE_ENCRYPTED_KEY:
-                Logger.verbose(TAG + methodName, "Loading KeyStore encrypted key.");
-                return loadKey();
+                return loadKeyStoreEncryptedKey();
         }
 
         Logger.verbose(TAG + methodName, "Unknown KeyType. This code should never be reached.");
@@ -520,124 +547,87 @@ public class StorageHelper implements IStorageHelper {
     }
 
     /**
-     * If needed, get the key from inactive broker (if there is one).
-     * If it fails to get a new key. It will create a new one.
-     *
-     * IMPORTANT: This function can only be invoked by Broker apps, and must NOT be called from main thread.
+     * Encrypt the given unencrypted symmetric key with Keystore key and save to storage.
      */
-    public void migrateEncryptionKeyIfNeeded() throws GeneralSecurityException, IOException {
-        final String methodName = ":migrateEncryptionKeyIfNeeded";
-
-        if (!(COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(getPackageName()) ||
-                AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(getPackageName()))) {
-            final String errorMessage = "Caller is not a broker. Migration is not needed";
-            Logger.error(TAG + methodName, errorMessage, null);
-            throw new IllegalStateException(errorMessage);
-        }
-
-        mEncryptionKey = loadKey();
-        if (mEncryptionKey != null){
-            Logger.verbose(TAG + methodName, "Key already exists.");
-            return;
-        }
-
-        mEncryptionKey = getKeyFromInactiveBroker();
-        if (mEncryptionKey != null){
-            Logger.verbose(TAG + methodName, "Key is successfully retrieved from inactive broker. Saving key...");
-            saveSecretKey(mEncryptionKey);
-            return;
-        }
-
-        Logger.verbose(TAG + methodName, "Key migration failed. Create a new key.");
-        mEncryptionKey = createKey();
-        return;
-    }
-
-    @Nullable
-    protected SecretKey getKeyFromInactiveBroker() {
-        final String methodName = ":getKeyFromInactiveBroker";
-        final String serializedKey = InactiveBrokerClient.getSerializedSymmetricKeyFromInactiveBroker(mContext, getPackageName());
-
-        if (serializedKey == null || serializedKey.length() == 0) {
-            Logger.verbose(TAG + methodName, "The returned bundle doesn't contain any key.");
-            return null;
-        }
-
-        return deserializeSecretKey(serializedKey);
-    }
-
-    private void saveSecretKey(@NonNull SecretKey key) throws GeneralSecurityException, IOException {
+    public void saveKeyStoreEncryptedKey(@NonNull SecretKey unencryptedKey) throws GeneralSecurityException, IOException {
         final String methodName = ":saveSecretKey";
 
-        Logger.verbose(TAG + methodName, "Saving secret key to storage.");
-
-        if (mKeyPair == null) {
-            mKeyPair = generateKeyPairFromAndroidKeyStore();
-        }
-
-        final byte[] keyWrapped = wrap(key);
-        writeKeyData(keyWrapped);
-    }
-
-    /**
-     * For API <18 or user provide the key, will return the user supplied key.
-     * Supported API >= 18 PrivateKey is stored in AndroidKeyStore. Loads key
-     * from the file if it exists. If not exist, it will generate one.
-     *
-     * @return The {@link SecretKey} used to encrypt data.
-     * @throws GeneralSecurityException
-     * @throws IOException
-     */
-    protected synchronized SecretKey loadOrCreateKey()
-            throws GeneralSecurityException, IOException {
-        final String methodName = ":loadOrCreateKey";
         try {
-            mCachedKeyStoreEncryptedKey = loadKey();
-        } catch (final IOException | GeneralSecurityException exception) {
-            Logger.verbose(TAG + methodName, "Key does not exist in AndroidKeyStore, try to generate new keys.");
-        }
+            logFlowStart(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_WRITE);
 
-        if (mCachedKeyStoreEncryptedKey == null) {
-            createKey();
-        }
+            if (mKeyPair == null) {
+                mKeyPair = generateKeyPairFromAndroidKeyStore();
+            }
 
-        return mCachedKeyStoreEncryptedKey;
+            final byte[] keyWrapped = wrap(unencryptedKey);
+            writeKeyData(keyWrapped);
+
+            logFlowSuccess(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_WRITE, "");
+        } catch (final GeneralSecurityException | IOException e) {
+            logFlowError(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_WRITE, e.toString(), e);
+            throw e;
+        }
     }
 
     /**
-     * Generate a new key and save to storage.
+     * Generate a new keystore-encrypted key and save to storage.
      */
-    private synchronized SecretKey createKey() throws GeneralSecurityException, IOException {
+    public synchronized SecretKey generateKeyStoreEncryptedKey() throws GeneralSecurityException, IOException {
+        final String methodName = ":generateKeyStoreEncryptedKey";
         mCachedKeyStoreEncryptedKey = generateSecretKey();
-        saveSecretKey(mCachedKeyStoreEncryptedKey);
+        saveKeyStoreEncryptedKey(mCachedKeyStoreEncryptedKey);
+
+        logEvent(methodName,
+                AuthenticationConstants.TelemetryEvents.KEY_CREATED,
+                false,
+                "New key is generated.");
 
         return mCachedKeyStoreEncryptedKey;
     }
 
     /**
-     * Load the saved key. Will only do read operation.
+     * Load the saved keystore-encrypted key. Will only do read operation.
      *
      * @return SecretKey. Null if there isn't any.
      * @throws GeneralSecurityException
      * @throws IOException
      */
     @Nullable
-    private synchronized SecretKey loadKey()
+    private synchronized SecretKey loadKeyStoreEncryptedKey()
             throws GeneralSecurityException, IOException {
-
+        final String methodName = ":loadKeyStoreEncryptedKey";
         if (mCachedKeyStoreEncryptedKey != null) {
             return mCachedKeyStoreEncryptedKey;
         }
 
-        // androidKeyStore can store app specific self signed cert.
-        // Asymmetric cryptography is used to protect the session key
-        // used for Encryption and HMac
-        mKeyPair = readKeyPair();
-        if (mKeyPair == null) {
-            return null;
+        try {
+            logFlowStart(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_READ);
+
+            // androidKeyStore can store app specific self signed cert.
+            // Asymmetric cryptography is used to protect the session key
+            // used for Encryption and HMac
+            mKeyPair = readKeyPair();
+            if (mKeyPair == null) {
+                logFlowSuccess(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_READ, "KeyStore is empty.");
+                return null;
+            }
+
+            mCachedKeyStoreEncryptedKey = getUnwrappedSecretKey();
+            logFlowSuccess(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_READ, "KeyStore encrypted key is loaded.");
+
+        } catch (final GeneralSecurityException | IOException e) {
+            logFlowError(methodName, AuthenticationConstants.TelemetryEvents.KEYCHAIN_READ, e.toString(), e);
+
+            // Reset KeyPair info so that new request will generate correct KeyPairs.
+            // All tokens with previous SecretKey are not possible to decrypt.
+            Logger.error(TAG + methodName, ErrorStrings.ANDROIDKEYSTORE_FAILED, e);
+            mKeyPair = null;
+            mCachedKeyStoreEncryptedKey = null;
+            deleteKeyFile();
+            resetKeyPairFromAndroidKeyStore();
+            throw e;
         }
 
-        mCachedKeyStoreEncryptedKey = getUnwrappedSecretKey();
         return mCachedKeyStoreEncryptedKey;
     }
 
@@ -659,6 +649,7 @@ public class StorageHelper implements IStorageHelper {
         final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA",
                 ANDROID_KEY_STORE);
         generator.initialize(getKeyPairGeneratorSpec(mContext, start.getTime(), end.getTime()));
+
         try {
             return generator.generateKeyPair();
         } catch (final IllegalStateException exception) {
@@ -671,6 +662,7 @@ public class StorageHelper implements IStorageHelper {
             // The thrown exception in this case is:
             // java.lang.IllegalStateException: could not generate key in keystore
             // To avoid app crashing, re-throw as checked exception
+
             throw new KeyStoreException(exception);
         }
     }
@@ -681,7 +673,8 @@ public class StorageHelper implements IStorageHelper {
      * @return KeyPair. Null if there isn't any.
      */
     @Nullable
-    private synchronized KeyPair readKeyPair() throws KeyStoreException {
+    private synchronized KeyPair readKeyPair()
+            throws GeneralSecurityException, IOException {
         final String methodName = ":readKeyPair";
         Logger.verbose(TAG + methodName, "Reading Key entry");
 
@@ -697,15 +690,15 @@ public class StorageHelper implements IStorageHelper {
                 return null;
             }
 
-            return new KeyPair(cert.getPublicKey(), (PrivateKey)privateKey);
-
-        } catch (final RuntimeException | NoSuchAlgorithmException | CertificateException | UnrecoverableEntryException | IOException e) {
+            return new KeyPair(cert.getPublicKey(), (PrivateKey) privateKey);
+        } catch (final RuntimeException e) {
             // There is an issue in android keystore that resets keystore
             // Issue 61989:  AndroidKeyStore deleted after changing screen lock type
             // https://code.google.com/p/android/issues/detail?id=61989
             // in this case getEntry throws
             // java.lang.RuntimeException: error:0D07207B:asn1 encoding routines:ASN1_get_object:header too long
             // handle it as regular KeyStoreException
+
             throw new KeyStoreException(e);
         }
     }
@@ -723,7 +716,7 @@ public class StorageHelper implements IStorageHelper {
                 .build();
     }
 
-    protected static SecretKey getSecretKey(final byte[] rawBytes) {
+    private static SecretKey getSecretKey(final byte[] rawBytes) {
         if (rawBytes == null) {
             throw new IllegalArgumentException("rawBytes");
         }
@@ -791,26 +784,14 @@ public class StorageHelper implements IStorageHelper {
         Logger.verbose(TAG + methodName, "Reading SecretKey");
 
         final SecretKey unwrappedSecretKey;
-        try {
-            final byte[] wrappedSecretKey = readKeyData();
-            if (wrappedSecretKey == null){
-                Logger.verbose(TAG + methodName, "Key data is null");
-                return null;
-            }
-
-            unwrappedSecretKey = unwrap(wrappedSecretKey);
-            Logger.verbose(TAG + methodName, "Finished reading SecretKey");
-        } catch (final GeneralSecurityException | IOException ex) {
-            // Reset KeyPair info so that new request will generate correct KeyPairs.
-            // All tokens with previous SecretKey are not possible to decrypt.
-            Logger.error(TAG + methodName, ErrorStrings.ANDROIDKEYSTORE_FAILED, ex);
-            mKeyPair = null;
-            deleteKeyFile();
-            resetKeyPairFromAndroidKeyStore();
-            Logger.verbose(TAG + methodName, "Removed previous key pair info.");
-            throw ex;
+        final byte[] wrappedSecretKey = readKeyData();
+        if (wrappedSecretKey == null) {
+            Logger.verbose(TAG + methodName, "Key data is null");
+            return null;
         }
 
+        unwrappedSecretKey = unwrap(wrappedSecretKey);
+        Logger.verbose(TAG + methodName, "Finished reading SecretKey");
         return unwrappedSecretKey;
     }
 
@@ -907,11 +888,53 @@ public class StorageHelper implements IStorageHelper {
         }
     }
 
-    public String serializeSecretKey(@NonNull final SecretKey key){
+    public String serializeSecretKey(@NonNull final SecretKey key) {
         return Base64.encodeToString(key.getEncoded(), Base64.DEFAULT);
     }
 
-    public SecretKey deserializeSecretKey(@NonNull final String serializedKey){
+    public SecretKey deserializeSecretKey(@NonNull final String serializedKey) {
         return getSecretKey(Base64.decode(serializedKey, Base64.DEFAULT));
     }
+
+    /**
+     * Since Common isn't wired to telemetry yet at the point of implementation (July 18, 2019)
+     * We use these functions to pass telemetry events to the calling ad-accounts.
+     */
+    private void logEvent(@NonNull final String methodName,
+                          @NonNull final String operationName,
+                          @NonNull final boolean isFailed,
+                          @NonNull final String reason) {
+        Logger.verbose(TAG + methodName, operationName + ": " + reason);
+        if (mTelemetryCallback != null) {
+            mTelemetryCallback.logEvent(mContext, operationName, isFailed, reason);
+        }
+    }
+
+    private void logFlowStart(@NonNull final String methodName,
+                              @NonNull final String operationName) {
+        Logger.verbose(TAG + methodName, operationName + " started.");
+        if (mTelemetryCallback != null) {
+            mTelemetryCallback.logSessionStart(mContext, operationName);
+        }
+    }
+
+    private void logFlowSuccess(@NonNull final String methodName,
+                                @NonNull final String operationName,
+                                @NonNull final String reason) {
+        Logger.verbose(TAG + methodName, operationName + " successfully finished: " + reason);
+        if (mTelemetryCallback != null) {
+            mTelemetryCallback.logSessionEnd(mContext, operationName, false, reason);
+        }
+    }
+
+    private void logFlowError(@NonNull final String methodName,
+                              @NonNull final String operationName,
+                              @NonNull final String reason,
+                              @Nullable Exception e) {
+        Logger.error(TAG + methodName, operationName + " failed: " + reason, e);
+        if (mTelemetryCallback != null) {
+            mTelemetryCallback.logSessionEnd(mContext, operationName, true, reason);
+        }
+    }
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
@@ -1,0 +1,55 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.broker;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.microsoft.identity.common.exception.ClientException;
+
+/**
+ * Represents packageName and SignatureHash of a broker app.
+ * */
+public class BrokerData{
+    public final String packageName;
+    public final String signatureHash;
+
+    private BrokerData(String packageName, String hash) {
+        this.packageName = packageName;
+        this.signatureHash = hash;
+    }
+
+    /**
+     * Given a broker package name, verify its signature and returns a BrokerData object.
+     *
+     * @throws ClientException an exception containing mismatch signature hashes as its error message.
+     * */
+    public static BrokerData getBrokerDataForBrokerApp(@NonNull final Context context,
+                                                       @NonNull String brokerPackageName) throws ClientException {
+
+        // Verify the signature to make sure that we're not binding to malicious apps.
+        final BrokerValidator validator = new BrokerValidator(context);
+        return new BrokerData(brokerPackageName, validator.verifySignatureAndThrow(brokerPackageName));
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
@@ -41,7 +41,7 @@ public class BrokerData{
     }
 
     /**
-     * Given a broker package name, verify its signature and returns a BrokerData object.
+     * Given a broker package name, verify its signature and return a BrokerData object.
      *
      * @throws ClientException an exception containing mismatch signature hashes as its error message.
      * */

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -78,13 +78,12 @@ public class BrokerValidator {
      * Verifies that the installed broker package's signing certificate hash matches the known
      * release certificate hash.
      *
-     * If signature hash verification fails, this will throw a Client exception, with its error message being a list of hashes.
+     * If signature hash verification fails, this will throw a Client exception containing the cause of error, which could contain a list of mismatch hashes.
      *
      * @param brokerPackageName The broker package to inspect.
-     * @return True if the certificate hash is known. False otherwise.
+     * @return SignatureHash of brokerPackageName, if the verification succeeds..
      */
-    public boolean verifySignatureAndThrowIfHashVerificationFailed(final String brokerPackageName) throws ClientException {
-        final String methodName = ":verifySignatureAndThrowIfHashVerificationFailed";
+    public String verifySignatureAndThrow(final String brokerPackageName) throws ClientException {
         try {
             // Read all the certificates associated with the package name. In higher version of
             // android sdk, package manager will only returned the cert that is used to sign the
@@ -94,7 +93,7 @@ public class BrokerValidator {
             final List<X509Certificate> certs = readCertDataForBrokerApp(brokerPackageName);
 
             // Verify the cert list contains the cert we trust.
-            verifySignatureHash(certs);
+            final String signatureHash = verifySignatureHash(certs);
 
             // Perform the certificate chain validation. If there is only one cert returned,
             // no need to perform certificate chain validation.
@@ -102,22 +101,14 @@ public class BrokerValidator {
                 verifyCertificateChain(certs);
             }
 
-            return true;
+            return signatureHash;
         } catch (NameNotFoundException e) {
-            Logger.error(TAG + methodName, "Broker related package does not exist", e);
+            throw new ClientException(ErrorStrings.APP_PACKAGE_NAME_NOT_FOUND, e.getMessage(), e);
         } catch (NoSuchAlgorithmException e) {
-            Logger.error(TAG + methodName, "Digest SHA algorithm does not exists", e);
+            throw new ClientException(ErrorStrings.NO_SUCH_ALGORITHM, e.getMessage(), e);
         } catch (final IOException | GeneralSecurityException e) {
-            Logger.error(TAG + methodName, ErrorStrings.BROKER_VERIFICATION_FAILED, e);
-        } catch (final ClientException e){
-            Logger.error(TAG + methodName, ErrorStrings.BROKER_VERIFICATION_FAILED, e);
-
-            if (e.getErrorCode().equalsIgnoreCase(ErrorStrings.BROKER_APP_VERIFICATION_FAILED)){
-                throw e;
-            }
+            throw new ClientException(ErrorStrings.BROKER_VERIFICATION_FAILED, e.getMessage(), e);
         }
-
-        return false;
     }
 
     /**
@@ -128,16 +119,17 @@ public class BrokerValidator {
      * @return True if the certificate hash is known. False otherwise.
      */
     public boolean verifySignature(final String brokerPackageName) {
+        final String methodName = ":verifySignature";
         try {
-            return verifySignatureAndThrowIfHashVerificationFailed(brokerPackageName);
-        } catch (final ClientException e) {
-            // Do not throw.
+            return verifySignatureAndThrow(brokerPackageName) != null;
+        } catch (final ClientException e){
+            Logger.error(TAG + methodName, e.getErrorCode() + ": " + e.getMessage(), e);
         }
 
         return false;
     }
 
-    private void verifySignatureHash(final List<X509Certificate> certs) throws NoSuchAlgorithmException,
+    private String verifySignatureHash(final List<X509Certificate> certs) throws NoSuchAlgorithmException,
             CertificateEncodingException, ClientException {
 
         final StringBuilder hashListStringBuilder = new StringBuilder();
@@ -154,11 +146,11 @@ public class BrokerValidator {
 
             if (mCompanyPortalSignature.equals(signatureHash)
                     || AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_SIGNATURE.equals(signatureHash)) {
-                return;
+                return signatureHash;
             }
         }
 
-        throw new ClientException(ErrorStrings.BROKER_APP_VERIFICATION_FAILED, hashListStringBuilder.toString());
+        throw new ClientException(ErrorStrings.BROKER_APP_VERIFICATION_FAILED, "SignatureHashes: " + hashListStringBuilder.toString());
     }
 
     @SuppressLint("PackageManagerGetSignatures")

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/InactiveBrokerClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/InactiveBrokerClient.java
@@ -2,22 +2,12 @@ package com.microsoft.identity.common.internal.broker;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
-import android.os.Looper;
-import android.os.RemoteException;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
-import com.microsoft.aad.adal.IBrokerAccountService;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.logging.Logger;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Use for communicating with inactive broker only.
@@ -29,87 +19,21 @@ public class InactiveBrokerClient {
     private static final String BROKER_ACCOUNT_SERVICE_INTENT_FILTER = "com.microsoft.workaccount.BrokerAccount";
     private static final String BROKER_ACCOUNT_SERVICE_CLASS_NAME = "com.microsoft.aad.adal.BrokerAccountService";
 
-    // Time out for the encryption key retrieval bind service.
-    private static final int KEY_BIND_TIMEOUT_IN_SECONDS = 5;
-
     private Context mContext;
-    private String mActiveBrokerPackageName;
+    private String mInactiveBrokerPackageName;
     private BrokerAccountServiceConnection mBrokerAccountServiceConnection;
-    private Intent mBrokerAccountServiceIntent;
     private Boolean mBound = false;
-
-    /**
-     * IMPORTANT:
-     *      1.) This operation might perform an IPC call, which requires the main thread to be free.
-     *      (onServiceConnected will only be resumed on the main thread).
-     *
-     *      2.) The caller has to be certain that there are no other operation blocking the main thread.
-     *      Otherwise, deadlock will occur.
-     *
-     *      2.) BrokerAccountServiceFuture.get() blocks the calling thread, waiting for the IPC connection to be established.
-     *      Therefore, THIS OPERATION MUST NOT BE CALLED FROM THE MAIN THREAD.
-     * */
-    public static String getSerializedSymmetricKeyFromInactiveBroker(@NonNull Context context,
-                                                                     @NonNull final String activeBrokerPackageName) {
-        final String methodName = ":getSerializedSymmetricKeyFromInactiveBroker";
-
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            final String errorMessage =  methodName + " can't be called from main thread.";
-            Logger.error(TAG + methodName, errorMessage, null);
-            throw new IllegalStateException(errorMessage);
-        }
-
-        final InactiveBrokerClient client = new InactiveBrokerClient(context, activeBrokerPackageName);
-        try {
-            final BrokerAccountServiceFuture brokerAccountServiceFuture = client.connect();
-            final IBrokerAccountService service = brokerAccountServiceFuture.get(KEY_BIND_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
-
-            final Bundle requestBundle = new Bundle();
-            requestBundle.putString(AuthenticationConstants.Broker.CALLER_INFO_PACKAGE, context.getPackageName());
-
-            final Bundle resultBundle = service.getInactiveBrokerKey(requestBundle);
-
-            // This means that the inactive broker doesn't support getInactiveBrokerKey().
-            if (resultBundle == null){
-                Logger.verbose(TAG + methodName, "resultBundle is null");
-                return null;
-            }
-            else if (resultBundle.getString(AuthenticationConstants.OAuth2.ERROR) != null) {
-                // NOTE: BrokerAccountService's createErrorBundle is still using OAuth2.ERROR. so i'm keeping the pattern here.
-                Logger.error(
-                        TAG + methodName,
-                        "Receiving error result from inactive broker: "
-                                + resultBundle.getString(AuthenticationConstants.OAuth2.ERROR_DESCRIPTION),
-                        null);
-                return null;
-            }
-
-            return resultBundle.getString(AuthenticationConstants.Broker.BROKER_KEYSTORE_SYMMETRIC_KEY);
-
-        } catch (final BaseException | InterruptedException | ExecutionException | RemoteException | TimeoutException e) {
-            Logger.error(
-                    TAG + methodName,
-                    "Exception is thrown when trying to get key from inactive broker:"
-                            + e.getMessage(),
-                    e);
-        } finally {
-            client.disconnect();
-        }
-
-        return null;
-    }
 
     /**
      * Constructor for the BrokerAccountServiceClient
      *
      * @param context
-     * @param activeBrokerPackageName package name of the calling active broker.
+     * @param inactiveBrokerData
      */
-    private InactiveBrokerClient(@NonNull final Context context,
-                                 @NonNull final String activeBrokerPackageName) {
+    public InactiveBrokerClient(@NonNull final Context context,
+                                @NonNull final BrokerData inactiveBrokerData) {
         mContext = context;
-        mActiveBrokerPackageName = activeBrokerPackageName;
-        mBrokerAccountServiceIntent = getIntentForBrokerAccountService(mContext);
+        mInactiveBrokerPackageName = inactiveBrokerData.packageName;
     }
 
     /**
@@ -118,16 +42,11 @@ public class InactiveBrokerClient {
      * @return BrokerAccountServiceFuture
      */
     @NonNull
-    private BrokerAccountServiceFuture connect() throws ClientException {
-
-        if (mBrokerAccountServiceIntent == null) {
-            throw new ClientException("mBrokerAccountServiceIntent is null. BrokerAccountService.");
-        }
-
+    public BrokerAccountServiceFuture connect() throws ClientException {
         final BrokerAccountServiceFuture future = new BrokerAccountServiceFuture();
         mBrokerAccountServiceConnection = new BrokerAccountServiceConnection(future);
 
-        mBound = mContext.bindService(mBrokerAccountServiceIntent, mBrokerAccountServiceConnection, Context.BIND_AUTO_CREATE);
+        mBound = mContext.bindService(getIntentForBrokerAccountService(), mBrokerAccountServiceConnection, Context.BIND_AUTO_CREATE);
         Logger.verbose(TAG + "connect", "The status for BrokerAccountService bindService call is: " + Boolean.valueOf(mBound));
 
         if (!mBound) {
@@ -140,7 +59,7 @@ public class InactiveBrokerClient {
     /**
      * Disconnects (unbinds) from the bound BrokerAccountService
      */
-    private void disconnect() {
+    public void disconnect() {
         if (mBound) {
             mContext.unbindService(mBrokerAccountServiceConnection);
             mBound = false;
@@ -151,54 +70,15 @@ public class InactiveBrokerClient {
      * Gets the intent that points to the bound service on the device... if available
      * You shouldn't get this far if it's not available
      *
-     * @param context
      * @return Intent
      */
     @Nullable
-    private Intent getIntentForBrokerAccountService(final Context context) {
-        final String inactiveBrokerPackageName = getInactiveBrokerPackageName(context);
-
-        if (TextUtils.isEmpty(inactiveBrokerPackageName)) {
-            return null;
-        }
-
+    private Intent getIntentForBrokerAccountService() {
         final Intent authServiceToBind = new Intent(BROKER_ACCOUNT_SERVICE_INTENT_FILTER);
-        authServiceToBind.setPackage(inactiveBrokerPackageName);
-        authServiceToBind.setClassName(inactiveBrokerPackageName, BROKER_ACCOUNT_SERVICE_CLASS_NAME);
+        authServiceToBind.setPackage(mInactiveBrokerPackageName);
+        authServiceToBind.setClassName(mInactiveBrokerPackageName, BROKER_ACCOUNT_SERVICE_CLASS_NAME);
 
         return authServiceToBind;
     }
-
-    /**
-     * Returns the inactive installed authenticator.
-     * - If CP is the broker, this will return authenticator.
-     * - If authenticator is the broker, this will return CP.
-     *
-     * @param context
-     * @return package name of the installed inactive broker app, if there's any.
-     */
-    @Nullable
-    private String getInactiveBrokerPackageName(@NonNull final Context context) {
-        final String methodName = ":getInactiveBrokerPackageName";
-
-        final String inactiveBrokerPackageName;
-        if (AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(mActiveBrokerPackageName)) {
-            inactiveBrokerPackageName = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
-        } else if (AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(mActiveBrokerPackageName)) {
-            inactiveBrokerPackageName = AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
-        } else {
-            Logger.error(TAG + methodName, "Unknown active broker package name:" + mActiveBrokerPackageName, null);
-            return null;
-        }
-
-        // Verify the signature to make sure that we're not binding to malicious apps.
-        final BrokerValidator validator = new BrokerValidator(context);
-        if (validator.verifySignature(inactiveBrokerPackageName)) {
-            Logger.verbose(TAG + methodName, "inactive broker package found:" + inactiveBrokerPackageName);
-            return inactiveBrokerPackageName;
-        }
-
-        Logger.verbose(TAG + methodName, "Inactive broker package not found.");
-        return null;
-    }
 }
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/InactiveBrokerClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/InactiveBrokerClient.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.logging.Logger;
 

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=0.0.11-RC13
+versionName=0.0.11-RC14
 versionCode=1


### PR DESCRIPTION
- Inject telemetry.
- Revert the code to migrate key only.
- Move some of the function to ad-accounts.