### PR TITLE
 Fix True MAM silent call scenerio

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -28,7 +28,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.ADALError;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ArgumentException;
@@ -257,10 +256,16 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
 
         Logger.verbose(TAG , "Setting properties from ServiceException.");
 
+        // Silent call in ADAL expects these calls which differs from intercative adal call,
+        // so adding values to these constants as well
+        resultBundle.putString(AuthenticationConstants.OAuth2.ERROR, serviceException.getErrorCode());
+        resultBundle.putString(AuthenticationConstants.OAuth2.ERROR_DESCRIPTION, serviceException.getMessage());
+        resultBundle.putString(AuthenticationConstants.OAuth2.SUBERROR, serviceException.getOAuthSubErrorCode());
+
         if (null != serviceException.getHttpResponseBody()) {
-            resultBundle.putString(
+            resultBundle.putSerializable(
                     AuthenticationConstants.OAuth2.HTTP_RESPONSE_BODY,
-                    new Gson().toJson(serviceException.getHttpResponseBody())
+                    serviceException.getHttpResponseBody()
             );
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -270,11 +270,9 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         if (null != serviceException.getHttpResponseHeaders()) {
-            resultBundle.putString(
+            resultBundle.putSerializable(
                     AuthenticationConstants.OAuth2.HTTP_RESPONSE_HEADER,
-                    HeaderSerializationUtil.toJson(
-                            serviceException.getHttpResponseHeaders()
-                    )
+                    serviceException.getHttpResponseHeaders()
             );
         }
         resultBundle.putInt(

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=0.0.11-RC15
+versionName=0.0.11-RC16
 versionCode=1


### PR DESCRIPTION
Issue : https://github.com/AzureAD/ad-accounts-for-android/issues/1080
- Adal is unfortunately reading different constant values for interactive and silent request for the Intune MAM CA error.
- Sending both values as expected by silent call.