### PR TITLE
Adding flexibility around pwd_exp return type, string, int, long

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
@@ -106,9 +106,9 @@ public abstract class MicrosoftAccount extends BaseAccount {
         mUtid = clientInfo.getUtid();
 
         long mPasswordExpiration = 0;
+        final Object expiry = claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION);
 
-        if (null != claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION)) {
-            final Object expiry = claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION);
+        if (null != expiry) {
             mPasswordExpiration = Long.valueOf(expiry.toString());
         }
 
@@ -121,8 +121,10 @@ public abstract class MicrosoftAccount extends BaseAccount {
         }
 
         mPasswordChangeUrl = null;
-        if (!StringExtensions.isNullOrBlank((String) claims.get(AzureActiveDirectoryIdToken.PASSWORD_CHANGE_URL))) {
-            mPasswordChangeUrl = Uri.parse((String) claims.get(AzureActiveDirectoryIdToken.PASSWORD_CHANGE_URL));
+        final String passwordChangeUrl = (String) claims.get(AzureActiveDirectoryIdToken.PASSWORD_CHANGE_URL);
+
+        if (!StringExtensions.isNullOrBlank(passwordChangeUrl)) {
+            mPasswordChangeUrl = Uri.parse(passwordChangeUrl);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftAccount.java
@@ -107,8 +107,9 @@ public abstract class MicrosoftAccount extends BaseAccount {
 
         long mPasswordExpiration = 0;
 
-        if (!StringExtensions.isNullOrBlank((String) claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION))) {
-            mPasswordExpiration = Long.parseLong((String) claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION));
+        if (null != claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION)) {
+            final Object expiry = claims.get(AzureActiveDirectoryIdToken.PASSWORD_EXPIRATION);
+            mPasswordExpiration = Long.valueOf(expiry.toString());
         }
 
         if (mPasswordExpiration > 0) {


### PR DESCRIPTION
Optional claim may be returned as:
- `"pwd_exp" : 1337`
- `"pwd_exp" : "1337"`

Current code will throw a `ClassCastException`, the PR tries to add some flexibility here.

Sample test here: https://repl.it/repls/ExhaustedExtrasmallNewsaggregator