### PR TITLE
Removes 'Connection -> Close' HttpRequest property

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/net/HttpRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/HttpRequest.java
@@ -210,7 +210,6 @@ public final class HttpRequest {
 
     private HttpURLConnection setupConnection() throws IOException {
         final HttpURLConnection urlConnection = HttpUrlConnectionFactory.createHttpURLConnection(mRequestUrl);
-        //urlConnection.setRequestProperty("Connection", "close");
 
         // Apply request headers and update the headers with default attributes first
         final Set<Map.Entry<String, String>> headerEntries = mRequestHeaders.entrySet();


### PR DESCRIPTION
Line is currently commented out, seems to break emulators with no rhyme or reason. Removing permanently.

See https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/294