### PR TITLE
Adding null safety check to avoid crash on EmbeddedWebViewStrategy if broadcast is sent multiple times

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -88,13 +88,18 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
     public void completeAuthorization(int requestCode, int resultCode, Intent data) {
         if (requestCode == BROWSER_FLOW) {
             if (mOAuth2Strategy != null && mAuthorizationResultFuture != null) {
-                final AuthorizationResult result = mOAuth2Strategy.getAuthorizationResultFactory().createAuthorizationResult(
-                        resultCode, data, mAuthorizationRequest
-                );
+                final AuthorizationResult result = mOAuth2Strategy
+                        .getAuthorizationResultFactory()
+                        .createAuthorizationResult(
+                                resultCode,
+                                data,
+                                mAuthorizationRequest
+                        );
                 mAuthorizationResultFuture.setResult(result);
             } else {
                 Logger.warn(TAG, "SDK Cancel triggering before request is sent out. " +
-                        "Potentially due to an activity stale state where onDestroy might not be called or a broadcast is sent out twice "
+                        "Potentially due to an activity stale state where onDestroy " +
+                        "might not be called or a broadcast is sent out multiple times "
                 );
             }
         } else {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.common.internal.ui.webview;
 
 import android.app.Activity;
-import android.app.PendingIntent;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.NonNull;
@@ -88,8 +87,16 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
     @Override
     public void completeAuthorization(int requestCode, int resultCode, Intent data) {
         if (requestCode == BROWSER_FLOW) {
-            final AuthorizationResult result = mOAuth2Strategy.getAuthorizationResultFactory().createAuthorizationResult(resultCode, data, mAuthorizationRequest);
-            mAuthorizationResultFuture.setResult(result);
+            if (mOAuth2Strategy != null && mAuthorizationResultFuture != null) {
+                final AuthorizationResult result = mOAuth2Strategy.getAuthorizationResultFactory().createAuthorizationResult(
+                        resultCode, data, mAuthorizationRequest
+                );
+                mAuthorizationResultFuture.setResult(result);
+            } else {
+                Logger.warn(TAG, "SDK Cancel triggering before request is sent out. " +
+                        "Potentially due to an activity stale state where onDestroy might not be called or a broadcast is sent out twice "
+                );
+            }
         } else {
             Logger.warnPII(TAG, "Unknown request code " + requestCode);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -98,8 +98,9 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
                 mAuthorizationResultFuture.setResult(result);
             } else {
                 Logger.warn(TAG, "SDK Cancel triggering before request is sent out. " +
-                        "Potentially due to an activity stale state where onDestroy " +
-                        "might not be called or a broadcast is sent out multiple times "
+                        "Potentially due to an stale activity state, " +
+                        "oAuth2Strategy null ? [" + (mOAuth2Strategy == null) + "]" +
+                        "mAuthorizationResultFuture ? [" + (mAuthorizationResultFuture == null) + "]"
                 );
             }
         } else {


### PR DESCRIPTION
- This could potentially happen if the `Activity` is in a stale state in call stack  where `onDestroy` is not called and `broadcastrececiver` is not unregistered.

crash details : https://rink.hockeyapp.net/manage/apps/231071/app_versions/170/crash_reasons/280769560