### PR TITLE
Throttle Telemetry with Shared pref on broker switch

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -326,7 +326,7 @@ public class StorageHelper implements IStorageHelper {
         final String activeBroker = mContext.getPackageName();
 
         if (!previousActiveBroker.equalsIgnoreCase(activeBroker)) {
-            final String message = "Failed to decrypt with keyType: " + keyType.name()
+            final String message = "Decryption failed with key: " + keyType.name()
                     + " Active broker: " + activeBroker
                     + " Exception: " + exception.toString();
 


### PR DESCRIPTION
Also cutting down noisy keyType log.
Same change as in AzureAD/azure-activedirectory-library-for-android-unity-fork/pull/268