### PR TITLE
Add clearBrokerSecretKeys()

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -140,6 +140,14 @@ public enum AuthenticationSettings {
     }
 
     /**
+     * Clear broker secret keys.
+     * Introduced as a temporary workaround to make sure Broker code clears up Broker keys in common before it's used by ADAL/MSAL.
+     * */
+    public void clearBrokerSecretKeys(){
+        mBrokerSecretKeys.clear();
+    }
+
+    /**
      * For test cases only.
      * */
     public void clearSecretKeysForTestCases(){


### PR DESCRIPTION
We will call this in OnUpgradeReceiver flow after Token migration / key migration are done, so that no keys are set in the non-auth process.