### PR TITLE
Closes #607, #604

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
@@ -145,6 +145,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
 
         final ICacheRecord familyCacheRecord = mOauth2TokenCache.loadByFamilyId(
                 null,
+                TARGET,
                 frtTestBundle.mGeneratedAccount
         );
 
@@ -156,6 +157,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
 
         final ICacheRecord familyCacheRecordWithClientId = mOauth2TokenCache.loadByFamilyId(
                 CLIENT_ID,
+                TARGET,
                 frtTestBundle.mGeneratedAccount
         );
 
@@ -168,6 +170,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         final ICacheRecord familyCacheRecordWithClientIdButNonMatchingTarget =
                 mOauth2TokenCache.loadByFamilyId(
                         CLIENT_ID,
+                        TARGET,
                         frtTestBundle.mGeneratedAccount
                 );
 
@@ -180,6 +183,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         final ICacheRecord wrongClientIdResult =
                 mOauth2TokenCache.loadByFamilyId(
                         "12345",
+                        TARGET,
                         frtTestBundle.mGeneratedAccount
                 );
 
@@ -314,6 +318,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         // Test only one FRT exists and it is the second one saved...
         final ICacheRecord cacheRecord = mOauth2TokenCache.loadByFamilyId(
                 CLIENT_ID,
+                TARGET,
                 frtTestBundle2.mGeneratedAccount
         );
 
@@ -329,6 +334,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         // Check querying for the FRT in the second app yields the same FRT
         final ICacheRecord cacheRecord2 = mOauth2TokenCache.loadByFamilyId(
                 CLIENT_ID + "2",
+                TARGET,
                 frtTestBundle2.mGeneratedAccount
         );
 
@@ -353,6 +359,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
 
         final ICacheRecord cacheRecord3 = mOauth2TokenCache.loadByFamilyId(
                 CLIENT_ID + "2",
+                TARGET,
                 randomAcct
         );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
@@ -198,8 +198,8 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
      * @return True, if the credentialTarget contains all of the targets (scopes) declared by
      * targetToMatch. False otherwise.
      */
-    private static boolean targetsIntersect(@NonNull final String targetToMatch,
-                                            @NonNull final String credentialTarget) {
+    static boolean targetsIntersect(@NonNull final String targetToMatch,
+                                    @NonNull final String credentialTarget) {
         // The credentialTarget must contain all of the scopes in the targetToMatch
         // It may contain more, but it must contain minimally those
         // Matching is case-insensitive

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -39,6 +39,8 @@ import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequ
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
+import java.util.List;
+
 import static com.microsoft.identity.common.internal.cache.AbstractAccountCredentialCache.targetsIntersect;
 
 public class MicrosoftFamilyOAuth2TokenCache
@@ -101,8 +103,10 @@ public class MicrosoftFamilyOAuth2TokenCache
         IdTokenRecord idTokenToReturn = null;
         AccessTokenRecord atRecordToReturn = null;
 
+        final List<Credential> allCredentials = getAccountCredentialCache().getCredentials();
+
         // First, filter down to only the refresh tokens...
-        for (final Credential credential : getAccountCredentialCache().getCredentials()) {
+        for (final Credential credential : allCredentials) {
             if (credential instanceof RefreshTokenRecord) {
                 final RefreshTokenRecord rtRecord = (RefreshTokenRecord) credential;
 
@@ -116,7 +120,7 @@ public class MicrosoftFamilyOAuth2TokenCache
         }
 
         // If there's a matching IdToken, pick that up too...
-        for (final Credential credential : getAccountCredentialCache().getCredentials()) {
+        for (final Credential credential : allCredentials) {
             if (credential instanceof IdTokenRecord) {
                 final IdTokenRecord idTokenRecord = (IdTokenRecord) credential;
 
@@ -131,7 +135,7 @@ public class MicrosoftFamilyOAuth2TokenCache
         }
 
         if (null != target) {
-            for (final Credential credential : getAccountCredentialCache().getCredentials()) {
+            for (final Credential credential : allCredentials) {
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord atRecord = (AccessTokenRecord) credential;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -110,7 +110,9 @@ public class MicrosoftFamilyOAuth2TokenCache
             if (credential instanceof RefreshTokenRecord) {
                 final RefreshTokenRecord rtRecord = (RefreshTokenRecord) credential;
 
-                if (refreshTokenMatchesFamilyId(accountRecord, familyId, rtRecord)) {
+                if (familyId.equals(rtRecord.getFamilyId())
+                        && accountRecord.getEnvironment().equals(rtRecord.getEnvironment())
+                        && accountRecord.getHomeAccountId().equals(rtRecord.getHomeAccountId())) {
                     rtToReturn = rtRecord;
                     break;
                 }
@@ -122,7 +124,10 @@ public class MicrosoftFamilyOAuth2TokenCache
             if (credential instanceof IdTokenRecord) {
                 final IdTokenRecord idTokenRecord = (IdTokenRecord) credential;
 
-                if (idTokenMatchesClientId(clientId, accountRecord, idTokenRecord)) {
+                if (null != clientId && clientId.equals(idTokenRecord.getClientId())
+                        && accountRecord.getEnvironment().equals(idTokenRecord.getEnvironment())
+                        && accountRecord.getHomeAccountId().equals(idTokenRecord.getHomeAccountId())
+                        && accountRecord.getRealm().equals(idTokenRecord.getRealm())) {
                     idTokenToReturn = idTokenRecord;
                     break;
                 }
@@ -134,7 +139,11 @@ public class MicrosoftFamilyOAuth2TokenCache
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord atRecord = (AccessTokenRecord) credential;
 
-                    if (accessTokenMatchesClientAndTarget(clientId, target, accountRecord, atRecord)) {
+                    if (null != clientId && clientId.equals(atRecord.getClientId())
+                            && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
+                            && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
+                            && accountRecord.getRealm().equals(atRecord.getRealm())
+                            && targetsIntersect(target, atRecord.getTarget())) {
                         atRecordToReturn = atRecord;
                         break;
                     }
@@ -156,33 +165,5 @@ public class MicrosoftFamilyOAuth2TokenCache
         }
 
         return result;
-    }
-
-    private boolean refreshTokenMatchesFamilyId(@NonNull final AccountRecord accountRecord,
-                                                @NonNull final String familyId,
-                                                @NonNull final RefreshTokenRecord rtRecord) {
-        return familyId.equals(rtRecord.getFamilyId())
-                && accountRecord.getEnvironment().equals(rtRecord.getEnvironment())
-                && accountRecord.getHomeAccountId().equals(rtRecord.getHomeAccountId());
-    }
-
-    private boolean idTokenMatchesClientId(@Nullable final String clientId,
-                                           @NonNull final AccountRecord accountRecord,
-                                           IdTokenRecord idTokenRecord) {
-        return null != clientId && clientId.equals(idTokenRecord.getClientId())
-                && accountRecord.getEnvironment().equals(idTokenRecord.getEnvironment())
-                && accountRecord.getHomeAccountId().equals(idTokenRecord.getHomeAccountId())
-                && accountRecord.getRealm().equals(idTokenRecord.getRealm());
-    }
-
-    private boolean accessTokenMatchesClientAndTarget(@Nullable final String clientId,
-                                                      @NonNull final String target,
-                                                      @NonNull final AccountRecord accountRecord,
-                                                      AccessTokenRecord atRecord) {
-        return null != clientId && clientId.equals(atRecord.getClientId())
-                && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
-                && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
-                && accountRecord.getRealm().equals(atRecord.getRealm())
-                && targetsIntersect(target, atRecord.getTarget());
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.cache;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -37,6 +38,8 @@ import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
+
+import static com.microsoft.identity.common.internal.cache.AbstractAccountCredentialCache.targetsIntersect;
 
 public class MicrosoftFamilyOAuth2TokenCache
         <GenericOAuth2Strategy extends OAuth2Strategy,
@@ -73,6 +76,7 @@ public class MicrosoftFamilyOAuth2TokenCache
      * it is returned.
      */
     public ICacheRecord loadByFamilyId(@Nullable final String clientId,
+                                       @Nullable final String target,
                                        @NonNull final AccountRecord accountRecord) {
         final String methodName = ":loadByFamilyId";
 
@@ -83,18 +87,19 @@ public class MicrosoftFamilyOAuth2TokenCache
                 "ClientId[" + clientId + ", " + familyId + "]"
         );
 
-        // The following fields must match:
+        // The following fields must match when querying for RTs:
         // - environment
         // - home_account_id
         // - credential_type == RT
         //
-        // The following fields do not matter:
+        // The following fields do not matter when querying for RTs:
         // - clientId doesn't matter (FRT)
-        // - target doesn't matter (FRT)
+        // - target doesn't matter (FRT) (but we will inspect it when looking for an AT)
         // - realm doesn't matter (MRRT)
 
         RefreshTokenRecord rtToReturn = null;
         IdTokenRecord idTokenToReturn = null;
+        AccessTokenRecord atRecordToReturn = null;
 
         // First, filter down to only the refresh tokens...
         for (final Credential credential : getAccountCredentialCache().getCredentials()) {
@@ -125,9 +130,27 @@ public class MicrosoftFamilyOAuth2TokenCache
             }
         }
 
+        if (null != target) {
+            for (final Credential credential : getAccountCredentialCache().getCredentials()) {
+                if (credential instanceof AccessTokenRecord) {
+                    final AccessTokenRecord atRecord = (AccessTokenRecord) credential;
+
+                    if (null != clientId && clientId.equals(atRecord.getClientId())
+                            && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
+                            && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
+                            && accountRecord.getRealm().equals(atRecord.getRealm())
+                            && targetsIntersect(target, atRecord.getTarget())) {
+                        atRecordToReturn = atRecord;
+                        break;
+                    }
+                }
+            }
+        }
+
         final CacheRecord result = new CacheRecord();
         result.setAccount(accountRecord);
         result.setRefreshToken(rtToReturn);
+        result.setAccessToken(atRecordToReturn);
 
         if (null != idTokenToReturn) {
             if (CredentialType.V1IdToken.name().equalsIgnoreCase(idTokenToReturn.getCredentialType())) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -110,9 +110,7 @@ public class MicrosoftFamilyOAuth2TokenCache
             if (credential instanceof RefreshTokenRecord) {
                 final RefreshTokenRecord rtRecord = (RefreshTokenRecord) credential;
 
-                if (familyId.equals(rtRecord.getFamilyId())
-                        && accountRecord.getEnvironment().equals(rtRecord.getEnvironment())
-                        && accountRecord.getHomeAccountId().equals(rtRecord.getHomeAccountId())) {
+                if (refreshTokenMatchesFamilyId(accountRecord, familyId, rtRecord)) {
                     rtToReturn = rtRecord;
                     break;
                 }
@@ -124,10 +122,7 @@ public class MicrosoftFamilyOAuth2TokenCache
             if (credential instanceof IdTokenRecord) {
                 final IdTokenRecord idTokenRecord = (IdTokenRecord) credential;
 
-                if (null != clientId && clientId.equals(idTokenRecord.getClientId())
-                        && accountRecord.getEnvironment().equals(idTokenRecord.getEnvironment())
-                        && accountRecord.getHomeAccountId().equals(idTokenRecord.getHomeAccountId())
-                        && accountRecord.getRealm().equals(idTokenRecord.getRealm())) {
+                if (idTokenMatchesClientId(clientId, accountRecord, idTokenRecord)) {
                     idTokenToReturn = idTokenRecord;
                     break;
                 }
@@ -139,11 +134,7 @@ public class MicrosoftFamilyOAuth2TokenCache
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord atRecord = (AccessTokenRecord) credential;
 
-                    if (null != clientId && clientId.equals(atRecord.getClientId())
-                            && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
-                            && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
-                            && accountRecord.getRealm().equals(atRecord.getRealm())
-                            && targetsIntersect(target, atRecord.getTarget())) {
+                    if (accessTokenMatchesClientAndTarget(clientId, target, accountRecord, atRecord)) {
                         atRecordToReturn = atRecord;
                         break;
                     }
@@ -165,5 +156,33 @@ public class MicrosoftFamilyOAuth2TokenCache
         }
 
         return result;
+    }
+
+    private boolean refreshTokenMatchesFamilyId(@NonNull final AccountRecord accountRecord,
+                                                @NonNull final String familyId,
+                                                @NonNull final RefreshTokenRecord rtRecord) {
+        return familyId.equals(rtRecord.getFamilyId())
+                && accountRecord.getEnvironment().equals(rtRecord.getEnvironment())
+                && accountRecord.getHomeAccountId().equals(rtRecord.getHomeAccountId());
+    }
+
+    private boolean idTokenMatchesClientId(@Nullable final String clientId,
+                                           @NonNull final AccountRecord accountRecord,
+                                           IdTokenRecord idTokenRecord) {
+        return null != clientId && clientId.equals(idTokenRecord.getClientId())
+                && accountRecord.getEnvironment().equals(idTokenRecord.getEnvironment())
+                && accountRecord.getHomeAccountId().equals(idTokenRecord.getHomeAccountId())
+                && accountRecord.getRealm().equals(idTokenRecord.getRealm());
+    }
+
+    private boolean accessTokenMatchesClientAndTarget(@Nullable final String clientId,
+                                                      @NonNull final String target,
+                                                      @NonNull final AccountRecord accountRecord,
+                                                      AccessTokenRecord atRecord) {
+        return null != clientId && clientId.equals(atRecord.getClientId())
+                && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
+                && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
+                && accountRecord.getRealm().equals(atRecord.getRealm())
+                && targetsIntersect(target, atRecord.getTarget());
     }
 }


### PR DESCRIPTION
Re-introduces AT lookups into family queries- API has been updated to include a `target` parameter.