### PR TITLE
Fix sCommand being cleared too early

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ApiDispatcher.java
@@ -182,11 +182,12 @@ public class ApiDispatcher {
                         logInteractiveRequestParameters(methodName, (AcquireTokenOperationParameters) command.mParameters);
                     }
 
-                    sCommand = command;
                     AcquireTokenResult result = null;
                     BaseException baseException = null;
 
                     try {
+                        sCommand = command;
+                        
                         //Try executing request
                         result = command.execute();
                     } catch (Exception e) {
@@ -201,6 +202,8 @@ public class ApiDispatcher {
                         } else {
                             baseException = ExceptionAdapter.baseExceptionFromException(e);
                         }
+                    } finally {
+                        sCommand = null;
                     }
 
                     Handler handler = new Handler(Looper.getMainLooper());
@@ -367,7 +370,6 @@ public class ApiDispatcher {
         final String methodName = ":completeInteractive";
         if (sCommand != null) {
             sCommand.notify(requestCode, resultCode, data);
-            sCommand = null;
         } else {
             Logger.warn(TAG + methodName, "sCommand is null, No interactive call in progress to complete.");
         }


### PR DESCRIPTION
The previous change broke the interrupt flow, because in that particular flow, we were making 2 acquire token request internally (resolve interrupt, and update BRT).