### PR TITLE
Fix foci issue where acquire token silent call fails with account not found

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
@@ -50,7 +50,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
     @SerializedName("flight_parameters")
     public Map<String, String> mFlightParameters;
 
-    public Boolean mMultipleCloudsSupported = false;
+    public boolean mMultipleCloudsSupported = false;
 
 
     private AzureActiveDirectoryCloud mAzureActiveDirectoryCloud;
@@ -97,11 +97,11 @@ public class AzureActiveDirectoryAuthority extends Authority {
         return this.mFlightParameters;
     }
 
-    public void setMultipleCloudsSupported(Boolean supported) {
+    public void setMultipleCloudsSupported(boolean supported) {
         mMultipleCloudsSupported = supported;
     }
 
-    public Boolean getMultipleCloudsSupported() {
+    public boolean getMultipleCloudsSupported() {
         return mMultipleCloudsSupported;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
@@ -186,7 +186,8 @@ public class TokenCacheItemMigrationAdapter {
                         + "]");
 
         if(tokenResult.getSuccess()){
-            MicrosoftStsAuthorizationRequest authorizationRequest = createAuthRequest(
+            // Save the token record in tha cache so that we have an entry in BrokerApplicationMetadata for this client id.
+            final MicrosoftStsAuthorizationRequest authorizationRequest = createAuthRequest(
                     strategy,
                     cacheRecord,
                     clientId,

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
@@ -192,15 +192,17 @@ public class TokenCacheItemMigrationAdapter {
                     clientId,
                     redirectUri,
                     scopes,
-                    correlationId);
-            ICacheRecord savedRecord = brokerOAuth2TokenCache.save(
+                    correlationId
+            );
+            Logger.verbose(TAG + methodName,
+                    "Saving records to cache with client id" + clientId
+            );
+            brokerOAuth2TokenCache.save(
                     strategy,
                     authorizationRequest,
                     (MicrosoftTokenResponse) tokenResult.getTokenResponse()
             );
-
         }
-
         return tokenResult.getSuccess();
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
@@ -26,18 +26,18 @@ import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.ADALTokenCacheItem;
+import com.microsoft.identity.common.internal.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.ITokenCacheItem;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftTokenResponse;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsRefreshToken;
@@ -58,6 +58,9 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.microsoft.identity.common.internal.authorities.AllAccounts.ALL_ACCOUNTS_TENANT_ID;
 import static com.microsoft.identity.common.internal.migration.AdalMigrationAdapter.loadCloudDiscoveryMetadata;
@@ -127,9 +130,10 @@ public class TokenCacheItemMigrationAdapter {
      * @throws ClientException
      * @throws IOException
      */
-    public static boolean tryFociTokenWithGivenClientId(final String clientId,
-                                                        final String redirectUri,
-                                                        final ICacheRecord cacheRecord)
+    public static boolean tryFociTokenWithGivenClientId(@NonNull final BrokerOAuth2TokenCache brokerOAuth2TokenCache,
+                                                        @NonNull final String clientId,
+                                                        @NonNull final String redirectUri,
+                                                        @NonNull final ICacheRecord cacheRecord)
             throws ClientException, IOException {
         final String methodName = ":tryFociTokenWithGivenClientId";
         final MicrosoftStsOAuth2Configuration config = new MicrosoftStsOAuth2Configuration();
@@ -180,6 +184,22 @@ public class TokenCacheItemMigrationAdapter {
                         + "] with correlationId ["
                         + correlationId
                         + "]");
+
+        if(tokenResult.getSuccess()){
+            MicrosoftStsAuthorizationRequest authorizationRequest = createAuthRequest(
+                    strategy,
+                    cacheRecord,
+                    clientId,
+                    redirectUri,
+                    scopes,
+                    correlationId);
+            ICacheRecord savedRecord = brokerOAuth2TokenCache.save(
+                    strategy,
+                    authorizationRequest,
+                    (MicrosoftTokenResponse) tokenResult.getTokenResponse()
+            );
+
+        }
 
         return tokenResult.getSuccess();
     }
@@ -587,6 +607,22 @@ public class TokenCacheItemMigrationAdapter {
         tokenRequest.setIdTokenVersion(idTokenVersion);
 
         return tokenRequest;
+    }
+
+    public static MicrosoftStsAuthorizationRequest createAuthRequest(@NonNull final MicrosoftStsOAuth2Strategy strategy,
+                                                                     @NonNull final ICacheRecord cacheRecord,
+                                                                     @NonNull final String clientId,
+                                                                     @NonNull final String redirectUri,
+                                                                     @NonNull final String scope,
+                                                                     @Nullable final UUID correlationId){
+        final MicrosoftStsAuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(
+                cacheRecord.getAccount()
+        );
+        return builder.setClientId(clientId)
+                .setRedirectUri(redirectUri)
+                .setCorrelationId(correlationId)
+                .setScope(scope)
+                .build();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Configuration.java
@@ -34,7 +34,7 @@ public class AzureActiveDirectoryOAuth2Configuration extends OAuth2Configuration
     private URL mAuthorityUrl;
     private Map<String, String> mFlightParameters = new HashMap<>();
     private AzureActiveDirectorySlice mSlice;
-    private Boolean mMultipleCloudsSupported;
+    private boolean mMultipleCloudsSupported;
 
     /**
      * @return True if authority host validation enabled, false otherwise.
@@ -74,11 +74,11 @@ public class AzureActiveDirectoryOAuth2Configuration extends OAuth2Configuration
         mSlice = slice;
     }
 
-    public void setMultipleCloudsSupported(Boolean supported){
+    public void setMultipleCloudsSupported(boolean supported){
         mMultipleCloudsSupported = supported;
     }
 
-    public Boolean getMultipleCloudsSupported(){
+    public boolean getMultipleCloudsSupported(){
         return mMultipleCloudsSupported;
     }
 


### PR DESCRIPTION
For FOCI scenario, `getAccounts` call for a specific client attempts to see if there are any accounts in FOCI cache and if does, it validates if the client is FOCI by sending a token request and returns the result.

However when calling `acquireTokenSilent` with this account, `getAccountByLocalAccountId` returns null, as there is no entry for this client id in `BrokerApplicationMetadata` . So the change here is to save the token record for the client once get a successful response

- Also fixed a potential null pointer due to `Boolean` instead of `boolean`