### PR TITLE
Fix a bug w.r.t given name to Adal's Authentication result

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -71,7 +71,7 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
         );
         resultBundle.putString(
                 AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME,
-                accountRecord.getName()
+                accountRecord.getFirstName()
         );
         resultBundle.putString(
                 AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME,


### PR DESCRIPTION
V2's `AccountRecord` has fields exposed for `name` , `given_name` ,`family_name` . Adal with V1 broker only exposed `given_name` and `family_name` as part of `AuthenticationResult`. We were incorrectly passing the value from `name` claim as a instead of `given_name` claim to ADAL in V2 broker.