### PR TITLE
[WIP] Add 2-arg constructor to ArgumentException

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
@@ -35,6 +35,11 @@ public class ArgumentException extends BaseException {
     private String mOperationName;
     private String mArgumentName;
 
+    public ArgumentException(final String argumentName, final String message) {
+        super(ILLEGAL_ARGUMENT_ERROR_CODE, message);
+        mArgumentName = argumentName;
+    }
+
     public ArgumentException(final String operationName, final String argumentName, final String message) {
         super(ILLEGAL_ARGUMENT_ERROR_CODE, message);
         mOperationName = operationName;


### PR DESCRIPTION
In this PR, I have added a 2-arg constructor to ArgumentException. This is introduced as part of the fix for MSAL Issue #741

Link to MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/742