### PR TITLE
Always compute the redirectUri when ADAL calls broker - ignore the parameterized value

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -28,10 +28,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Pair;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.authorities.Authority;
@@ -105,7 +106,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         // V1 endpoint always add an organizational account if the tenant id is common.
         // We need to explicitly add tenant id as organizations if we want similar behavior from V2 endpoint
 
-        if(authority.getAudience().getTenantId().equalsIgnoreCase(AzureActiveDirectoryAudience.ALL)){
+        if (authority.getAudience().getTenantId().equalsIgnoreCase(AzureActiveDirectoryAudience.ALL)) {
             authority.getAudience().setTenantId(AzureActiveDirectoryAudience.ORGANIZATIONS);
         }
         parameters.setAuthority(authority);
@@ -210,7 +211,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         String redirectUri = bundle.getString(
                 AuthenticationConstants.Broker.ACCOUNT_REDIRECT);
         // Adal might not pass in the redirect uri, in that case calculate from broker validator
-        if(TextUtils.isEmpty(redirectUri)){
+        if (TextUtils.isEmpty(redirectUri)) {
             redirectUri = BrokerValidator.getBrokerRedirectUri(context, packageName);
         }
         parameters.setRedirectUri(redirectUri);
@@ -270,7 +271,6 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
     /**
      * TODO : Refactor to remove this code and move the logic to better place
-     *
      */
     public static AzureActiveDirectoryAuthority getRequestAuthorityWithExtraQP(final String authority,
                                                                                final List<Pair<String, String>> extraQP) {
@@ -301,7 +301,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
                     requestAuthority.mMultipleCloudsSupported =
                             null != parameter.second &&
-                            parameter.second.equalsIgnoreCase(Boolean.TRUE.toString());
+                                    parameter.second.equalsIgnoreCase(Boolean.TRUE.toString());
 
                     extraQP.remove(parameter);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -130,7 +130,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         // callers to pass non-URL-encoded signature hashes into the library despite the documentation
         // prescribing otherwise. The ADAL.NET implementation unfortunately RELIES on this behavior,
         // forcing customers to use non-encoded values in order to pass validation check inside of
-        // ADAL.NET. In order to not regress this experience, the redirect URI must not be computed
+        // ADAL.NET. In order to not regress this experience, the redirect URI must now be computed
         // meaning that the ACCOUNT_REDIRECT parameter is basically ignored.
         parameters.setRedirectUri(
                 BrokerValidator.getBrokerRedirectUri(


### PR DESCRIPTION
This is a change to match the former [Unity implementation](https://github.com/AzureAD/azure-activedirectory-library-for-android-unity-fork/blob/master/adal-unity-fork/src/main/java/com/microsoft/aad/adal/unity/BrokerClient.java#L670) where the broker redirect_uri was _always_ computed when broker makes requests on behalf of an ADAL client.

Things to note:
- The `redirect_uri` parameter `ACCOUNT_REDIRECT` is now _ignored_ except when performing validation
- This value is computed for both the silent and the interactive calls

Alternative approaches that could have been taken:
- Encode the URL _only_ when embedded in PRT requests
    * I chose not to do this because this would mean the same the URL with various encodings is passed around at different parts of the code. This felt confusing and not the right way to address the bug