### PR TITLE
Remove fallback to iss claim if idp is not present

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -195,14 +195,6 @@ public final class SchemaUtil {
 
                         idp = (String) idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
 
-                        // For home accounts idp claim is not available, use iss claim instead.
-                        if (TextUtils.isEmpty(idp)) {
-                            Logger.info(TAG + ":" + methodName,
-                                    "idp claim was null, using iss claim"
-                            );
-                            idp = (String) idTokenClaims.get(MicrosoftIdToken.ISSUER);
-                        }
-
                     } else if (!TextUtils.isEmpty(aadVersion) &&
                             aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V2)) {
 
@@ -212,7 +204,7 @@ public final class SchemaUtil {
                     Logger.verbosePII(TAG + ":" + methodName, "idp: " + idp);
 
                     if (null == idp) {
-                        Logger.warn(TAG + ":" + methodName, "idp claim was null.");
+                        Logger.info(TAG + ":" + methodName, "idp claim was null.");
                     }
                 } else {
                     Logger.warn(TAG + ":" + methodName, "IDToken claims were null.");

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SchemaUtil.java
@@ -187,22 +187,11 @@ public final class SchemaUtil {
                 final Map<String, ?> idTokenClaims = idToken.getTokenClaims();
 
                 if (null != idTokenClaims) {
-                    final String aadVersion = (String) idTokenClaims.get(
-                            AuthenticationConstants.OAuth2.AAD_VERSION
-                    );
-                    if (!TextUtils.isEmpty(aadVersion) &&
-                            aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V1)) {
-
-                        idp = (String) idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
-
-                    } else if (!TextUtils.isEmpty(aadVersion) &&
-                            aadVersion.equalsIgnoreCase(AuthenticationConstants.OAuth2.AAD_VERSION_V2)) {
-
-                        idp = (String) idTokenClaims.get(MicrosoftIdToken.ISSUER);
-                    }
+                    // IDP claim is present only in case of guest scenerio and is empty for home tenants.
+                    // Few Apps consuming ADAL use this to differentiate between home vs guest accounts.
+                    idp = (String) idTokenClaims.get(AzureActiveDirectoryIdToken.IDENTITY_PROVIDER);
 
                     Logger.verbosePII(TAG + ":" + methodName, "idp: " + idp);
-
                     if (null == idp) {
                         Logger.info(TAG + ":" + methodName, "idp claim was null.");
                     }


### PR DESCRIPTION
Confirmed with Maxim from STS that "idp" claim is present only for guest scenerios on both V1 and V2 endpoint. 

Few Apps(Office apps reported the issue) consuming ADAL use this to differentiate between home vs guest accounts and these changes in V2 broker regressed their behavior.

Changing it back to only using "idp" claim for this method.