### PR TITLE
Fix null pointer issue when constructing Auth Request

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -292,7 +292,12 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         final Uri.Builder uriBuilder = Uri.parse(getAuthorizationEndpoint()).buildUpon();
 
         for (Map.Entry<String, Object> entry : qpMap.entrySet()) {
-            uriBuilder.appendQueryParameter(entry.getKey(), entry.getValue().toString());
+            if (entry.getKey() != null && entry.getValue() != null) {
+                uriBuilder.appendQueryParameter(
+                        entry.getKey(),
+                        entry.getValue().toString()
+                );
+            }
         }
 
         return uriBuilder.build();


### PR DESCRIPTION
Icm : https://icm.ad.msft.net/imp/v3/incidents/details/147446572/home

Power apps has a flow where user doesn't have to enter `login_hint` which seems to be issue here as the Auth Request builder could call `toString` on a null value.