### PR TITLE
Fix issue #678

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -27,8 +27,11 @@ import androidx.annotation.Nullable;
 import com.google.gson.annotations.Expose;
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.internal.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
 
 public class AcquireTokenSilentOperationParameters extends OperationParameters {
+
+    private final static String TAG = AcquireTokenSilentOperationParameters.class.getSimpleName();
 
     private RefreshTokenRecord mRefreshToken;
 
@@ -46,11 +49,7 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
         super.validate();
 
         if (mAccount == null) {
-            throw new ArgumentException(
-                    ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
-                    ArgumentException.IACCOUNT_ARGUMENT_NAME,
-                    "account is null"
-            );
+            Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
         }
 
     }


### PR DESCRIPTION
Fixes #678 

To fix issue #678 , I've removed the null check for the account from the validate method for the `AcquireTokenSilentOperationParameters`. If the account is not the in the cache, then we would still throw an exception a [few lines below](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/18ab8a5e2c7eda1f7a146fc7a9f7f95f81f0d32f/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java#L232-L239) when we actually try to obtain the account from the cache by calling `getCachedAccountRecord`, and that will always throw the correct exception which would be `ClientException` with `no_account_found` error code.