### PR TITLE
Get Correlation id from Operation parameters if available

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenOperationParameters.java
@@ -55,8 +55,6 @@ public class BrokerAcquireTokenOperationParameters extends AcquireTokenOperation
 
     private String mCallerAppVersion;
 
-    private String mCorrelationId;
-
     /** Specifying that this acquireToken operation was hit by an interrupt, which needs to be interactively resolved.*/
     private boolean mShouldResolveInterrupt;
 
@@ -84,14 +82,6 @@ public class BrokerAcquireTokenOperationParameters extends AcquireTokenOperation
 
     public void setCallerAppVersion(final String callerAppVersion) {
         this.mCallerAppVersion = callerAppVersion;
-    }
-
-    public String getCorrelationId() {
-        return mCorrelationId;
-    }
-
-    public void setCorrelationId(final String correlationId) {
-        this.mCorrelationId = correlationId;
     }
 
     public RequestType getRequestType() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/BrokerAcquireTokenSilentOperationParameters.java
@@ -50,8 +50,6 @@ public class BrokerAcquireTokenSilentOperationParameters extends AcquireTokenSil
 
     private String mLoginHint;
 
-    private String mCorrelationId;
-
     private List<Pair<String, String>> mExtraQueryStringParameters;
 
     // Device state might not be propagated to MSODS yet, so we might want to wait before re-acquiring PRT.
@@ -111,15 +109,6 @@ public class BrokerAcquireTokenSilentOperationParameters extends AcquireTokenSil
 
     public void setLoginHint(final String loginHint) {
         this.mLoginHint = loginHint;
-    }
-
-
-    public String getCorrelationId() {
-        return mCorrelationId;
-    }
-
-    public void setCorrelationId(final String correlationId) {
-        this.mCorrelationId = correlationId;
     }
 
     public List<Pair<String, String>> getExtraQueryStringParameters() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
@@ -65,6 +65,8 @@ public class OperationParameters {
     private String mRequiredBrokerProtocolVersion; //Move the required broker protocol var into parent class, as the interactive call also needs Bound Service.
     @Expose()
     private boolean mForceRefresh;
+    @Expose
+    private String mCorrelationId;
 
     public String getRequiredBrokerProtocolVersion() {
         return mRequiredBrokerProtocolVersion;
@@ -176,6 +178,14 @@ public class OperationParameters {
 
     public boolean getForceRefresh() {
         return mForceRefresh;
+    }
+
+    public String getCorrelationId() {
+        return mCorrelationId;
+    }
+
+    public void setCorrelationId(final String correlationId) {
+        this.mCorrelationId = correlationId;
     }
 
 


### PR DESCRIPTION
- For Broker we need to use the correlation id passed by application, so setting here to the DiagonisticContext, as we had a bug where for non-joined flow a new correlation could have been passed instead of the one passed in by the app.
- Moved correlation id to base `OperationParameters` class.