### PR TITLE
Make cache key unique between each command type

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseCommand.java
@@ -91,7 +91,7 @@ public abstract class BaseCommand<T> implements Command<T> {
         return mControllers.get(0);
     }
 
-    public abstract int getCommandCode();
+    public abstract int getCommandNameHashCode();
 
     //CHECKSTYLE:OFF
     // This method is generated. Checkstyle and/or PMD has been disabled.
@@ -116,7 +116,7 @@ public abstract class BaseCommand<T> implements Command<T> {
     @SuppressWarnings("PMD")
     @Override
     public int hashCode() {
-        return  31 * getCommandCode() + mParameters.hashCode();
+        return  31 * getCommandNameHashCode() + mParameters.hashCode();
     }
     //CHECKSTYLE:ON
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseCommand.java
@@ -91,6 +91,7 @@ public abstract class BaseCommand<T> implements Command<T> {
         return mControllers.get(0);
     }
 
+    public abstract int getCommandCode();
 
     //CHECKSTYLE:OFF
     // This method is generated. Checkstyle and/or PMD has been disabled.
@@ -115,7 +116,7 @@ public abstract class BaseCommand<T> implements Command<T> {
     @SuppressWarnings("PMD")
     @Override
     public int hashCode() {
-        return mParameters.hashCode();
+        return  31 * getCommandCode() + mParameters.hashCode();
     }
     //CHECKSTYLE:ON
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetCurrentAccountCommand.java
@@ -70,7 +70,7 @@ public class GetCurrentAccountCommand extends BaseCommand<List<ICacheRecord>> {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetCurrentAccountCommand.java
@@ -68,4 +68,9 @@ public class GetCurrentAccountCommand extends BaseCommand<List<ICacheRecord>> {
 
         return result;
     }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetDeviceModeCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetDeviceModeCommand.java
@@ -31,6 +31,8 @@ import com.microsoft.identity.common.internal.request.OperationParameters;
  * {@see com.microsoft.identity.common.internal.controllers.CommandDispatcher}.
  */
 public class GetDeviceModeCommand extends BaseCommand<Boolean> {
+    private static final String TAG = GetDeviceModeCommand.class.getSimpleName();
+
     public GetDeviceModeCommand(@NonNull final OperationParameters parameters,
                                 @NonNull final BaseController controller,
                                 @NonNull final CommandCallback callback) {
@@ -40,5 +42,10 @@ public class GetDeviceModeCommand extends BaseCommand<Boolean> {
     @Override
     public Boolean execute() throws Exception {
         return getDefaultController().getDeviceMode(getParameters());
+    }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetDeviceModeCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/GetDeviceModeCommand.java
@@ -45,7 +45,7 @@ public class GetDeviceModeCommand extends BaseCommand<Boolean> {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public class InteractiveTokenCommand extends TokenCommand {
-
     private static final String TAG = InteractiveTokenCommand.class.getSimpleName();
 
     public InteractiveTokenCommand(AcquireTokenOperationParameters parameters,
@@ -65,5 +64,10 @@ public class InteractiveTokenCommand extends TokenCommand {
     @Override
     public void notify(int requestCode, int resultCode, final Intent data) {
         getDefaultController().completeAcquireToken(requestCode, resultCode, data);
+    }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/InteractiveTokenCommand.java
@@ -67,7 +67,7 @@ public class InteractiveTokenCommand extends TokenCommand {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LoadAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LoadAccountCommand.java
@@ -70,7 +70,7 @@ public class LoadAccountCommand extends BaseCommand<List<ICacheRecord>> {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LoadAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LoadAccountCommand.java
@@ -68,4 +68,9 @@ public class LoadAccountCommand extends BaseCommand<List<ICacheRecord>> {
 
         return result;
     }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveAccountCommand.java
@@ -60,4 +60,9 @@ public class RemoveAccountCommand extends BaseCommand<Boolean> {
 
         return result;
     }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveAccountCommand.java
@@ -62,7 +62,7 @@ public class RemoveAccountCommand extends BaseCommand<Boolean> {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveCurrentAccountCommand.java
@@ -45,7 +45,7 @@ public class RemoveCurrentAccountCommand extends BaseCommand<Boolean> {
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/RemoveCurrentAccountCommand.java
@@ -31,6 +31,8 @@ import com.microsoft.identity.common.internal.request.OperationParameters;
  * {@see com.microsoft.identity.common.internal.controllers.CommandDispatcher}.
  */
 public class RemoveCurrentAccountCommand extends BaseCommand<Boolean> {
+    private static final String TAG = RemoveCurrentAccountCommand.class.getSimpleName();
+
     public RemoveCurrentAccountCommand(@NonNull final OperationParameters parameters,
                                        @NonNull final BaseController controller,
                                        @NonNull final CommandCallback callback) {
@@ -40,5 +42,10 @@ public class RemoveCurrentAccountCommand extends BaseCommand<Boolean> {
     @Override
     public Boolean execute() throws Exception {
         return getDefaultController().removeCurrentAccount(getParameters());
+    }
+
+    @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -103,7 +103,7 @@ public class TokenCommand extends BaseCommand<AcquireTokenResult> implements Tok
     }
 
     @Override
-    public int getCommandCode() {
+    public int getCommandNameHashCode() {
         return TAG.hashCode();
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -103,6 +103,11 @@ public class TokenCommand extends BaseCommand<AcquireTokenResult> implements Tok
     }
 
     @Override
+    public int getCommandCode() {
+        return TAG.hashCode();
+    }
+
+    @Override
     public void notify(int requestCode, int resultCode, Intent data) {
         throw new UnsupportedOperationException();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
@@ -297,6 +297,4 @@ public class OperationParameters {
         }
 
     }
-
-
 }


### PR DESCRIPTION
Issue:

1. run GetDeviceModeCommand.
2. run GetCurrentAccountCommand.

app crashes since the 2) hits the cache and return the value of 1). Since 1) returns boolean, it crashes when it was trying to cast to a list.