### PR TITLE
Remove defaulting to BadError  on ClientException

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -49,11 +49,6 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
         if (mAccount == null) {
             Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
-            throw new ArgumentException(
-                    ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
-                    ArgumentException.IACCOUNT_ARGUMENT_NAME,
-                    "account is null"
-            );
         }
 
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -249,11 +249,6 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
                     AccountManager.ERROR_CODE_NETWORK_ERROR,
                     ADALError.IO_EXCEPTION.getDescription()
             );
-        }else {
-            // Default to Error code Bad Request, just like V1 implementation.
-            setErrorToResultBundle(resultBundle,
-                    AccountManager.ERROR_CODE_BAD_REQUEST,
-                    clientException.getErrorCode());
         }
     }
 


### PR DESCRIPTION
This bug was introduced as part of this change: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/669

When `acquireToken` called on Adal , it attempts to do a silent request first with broker and it does one of the following things below
-  If broker returns `key_error_code` and `key_error_message` or any `http errors` which ADAL can comprehend, it returns an `AuthenticationException` to the user without attempting to do an interactive call.
-  If not, ADAL assumes it as `success` and checks if it broker returned an `access token` and if it doesn't , it calls interactive request.

The regression here is that since we added a default error as `Bad_Request` for client exception, ADAL converts this into `AuthenticationException` and never attempts to call interactive.

The change to add this default error was introduced as to be compatible with V1 broker, code [here](https://github.com/AzureAD/ad-accounts-for-android/blob/release/2.3.6/AADAuthenticator/src/main/java/com/microsoft/workaccount/authenticatorservice/Authenticator.java#L408) . However, since `common` returns a lot more exceptions and than `unity` we cannot do this anymore.

So reverting part of the old change to  "Default to Error code Bad Request". 

Also reverting back yesterday's change : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/695 as it was red herring