### PR TITLE
Remove connection close from HttpWebRequest

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 0.0.10-hf2
+------------
+- Removed connection close from HttpWebRequest to fix emulator EOF issue.
+
 Version 0.0.10-hf1
 ------------
 Nimbus version update to 8.2

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
@@ -109,8 +109,6 @@ public class HttpWebRequest {
         HttpURLConnection.setFollowRedirects(true);
         final HttpURLConnection connection = HttpUrlConnectionFactory.createHttpUrlConnection(mUrl);
         connection.setConnectTimeout(CONNECT_TIME_OUT);
-        connection.setRequestProperty("Connection", "close");
-
 
         // Apply the request headers
         final Set<Map.Entry<String, String>> headerEntries = mRequestHeaders.entrySet();

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=0.0.10-hf1
+versionName=0.0.10-hf2
 versionCode=1


### PR DESCRIPTION
- There is another place where we are setting `connection close` which is resulting the EOF issue with emulators