### PR TITLE
Fix issue #709, #718

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -148,6 +148,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         MockitoAnnotations.initMocks(this);
         when(mockStrategy.createAccount(any(MicrosoftStsTokenResponse.class))).thenReturn(mockAccount);
         when(mockStrategy.getIssuerCacheIdentifier(mockRequest)).thenReturn(MOCK_ENVIRONMENT);
+        when(mockStrategy.getIssuerCacheIdentifierFromTokenEndpoint()).thenReturn(MOCK_ENVIRONMENT);
         when(mockRequest.getAuthority()).thenReturn(new URL(MOCK_AUTHORITY));
         when(mockResponse.getIdToken()).thenReturn(MOCK_ID_TOKEN_WITH_CLAIMS);
         when(mockResponse.getClientInfo()).thenReturn(MOCK_CLIENT_INFO);

--- a/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ArgumentException.java
@@ -28,6 +28,7 @@ public class ArgumentException extends BaseException {
     public final static String ACQUIRE_TOKEN_SILENT_OPERATION_NAME = "acquireTokenSilent";
 
     public final static String SCOPE_ARGUMENT_NAME = "scopes";
+    public final static String AUTHORITY_ARGUMENT_NAME = "authority";
     public final static String IACCOUNT_ARGUMENT_NAME = "account";
 
     public final static String ILLEGAL_ARGUMENT_ERROR_CODE = "illegal_argument_exception";

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -84,7 +84,7 @@ public class MicrosoftStsAccountCredentialAdapter
             if (!StringUtil.isEmpty(response.getAuthority())) {
                 accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
             } else {
-                accessToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+                accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
             }
 
             accessToken.setClientId(request.getClientId());
@@ -153,7 +153,7 @@ public class MicrosoftStsAccountCredentialAdapter
             if (null != response.getAuthority()) {
                 refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
             } else {
-                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
             }
 
             refreshToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
@@ -193,7 +193,7 @@ public class MicrosoftStsAccountCredentialAdapter
                         )
                 );
             } else {
-                idToken.setEnvironment(strategy.getIssuerCacheIdentifier(request));
+                idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
             }
 
             idToken.setRealm(getRealm(strategy, response));

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -42,8 +42,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.M
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 public class MicrosoftStsAccountCredentialAdapter
@@ -81,11 +79,7 @@ public class MicrosoftStsAccountCredentialAdapter
             accessToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             accessToken.setRealm(getRealm(strategy, response));
 
-            if (!StringUtil.isEmpty(response.getAuthority())) {
-                accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
-            } else {
-                accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-            }
+            accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
 
             accessToken.setClientId(request.getClientId());
             /*
@@ -112,7 +106,7 @@ public class MicrosoftStsAccountCredentialAdapter
             accessToken.setAccessTokenType(response.getTokenType());
 
             return accessToken;
-        } catch (ServiceException | MalformedURLException e) {
+        } catch (ServiceException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }
@@ -150,11 +144,7 @@ public class MicrosoftStsAccountCredentialAdapter
             final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
             // Required
             refreshToken.setCredentialType(CredentialType.RefreshToken.name());
-            if (null != response.getAuthority()) {
-                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromAuthority(new URL(response.getAuthority())));
-            } else {
-                refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-            }
+            refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
 
             refreshToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             refreshToken.setClientId(request.getClientId());
@@ -168,7 +158,7 @@ public class MicrosoftStsAccountCredentialAdapter
             refreshToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
 
             return refreshToken;
-        } catch (ServiceException | MalformedURLException e) {
+        } catch (ServiceException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }
@@ -186,15 +176,8 @@ public class MicrosoftStsAccountCredentialAdapter
             // Required fields
             idToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
 
-            if (null != response.getAuthority()) {
-                idToken.setEnvironment(
-                        strategy.getIssuerCacheIdentifierFromAuthority(
-                                new URL(response.getAuthority())
-                        )
-                );
-            } else {
-                idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-            }
+            idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
+
 
             idToken.setRealm(getRealm(strategy, response));
             idToken.setCredentialType(
@@ -213,7 +196,7 @@ public class MicrosoftStsAccountCredentialAdapter
             }
 
             return idToken;
-        } catch (ServiceException | MalformedURLException e) {
+        } catch (ServiceException e) {
             // TODO handle this properly
             throw new RuntimeException(e);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -111,6 +111,14 @@ public class AzureActiveDirectory
     }
 
     /**
+     * @param preferredCacheHostName String
+     * @return AzureActiveDirectoryCloud
+     */
+    public static AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(final String preferredCacheHostName) {
+        return sAadClouds.get(preferredCacheHostName.toLowerCase(Locale.US));
+    }
+
+    /**
      * @param host  String
      * @param cloud AzureActiveDirectoryCloud
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -114,7 +114,7 @@ public class AzureActiveDirectory
      * @param preferredCacheHostName String
      * @return AzureActiveDirectoryCloud
      */
-    public static AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(final String preferredCacheHostName) {
+    public static AzureActiveDirectoryCloud getAzureActiveDirectoryCloudFromHostName(final String preferredCacheHostName) {
         return sAadClouds.get(preferredCacheHostName.toLowerCase(Locale.US));
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -53,9 +53,9 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
     public URL getAuthorizationEndpoint() {
         final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
         if (openIdConfig != null) {
-            return getEndpoint(openIdConfig.getAuthorizationEndpoint());
+            return getEndpointUrlFromAuthority(openIdConfig.getAuthorizationEndpoint());
         }
-        return getEndpoint(getAuthorityUrl(), FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX);
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
     /**
@@ -67,41 +67,51 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
     public URL getTokenEndpoint() {
         final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
         if (openIdConfig != null && openIdConfig.getTokenEndpoint() != null) {
-            return getEndpoint(openIdConfig.getTokenEndpoint());
+            return getEndpointUrlFromAuthority(openIdConfig.getTokenEndpoint());
         }
-        return getEndpoint(getAuthorityUrl(), FALLBACK_TOKEN_ENDPOINT_SUFFIX);
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_TOKEN_ENDPOINT_SUFFIX);
     }
 
     @Nullable
-    private URL getEndpoint(@NonNull final String endpoint) {
-        final String methodName = ":getEndpoint";
+    private URL getEndpointUrlFromAuthority(@NonNull final String authorityUrl) {
+        final String methodName = ":getEndpointUrlFromAuthority";
         try {
-            return new URL(endpoint);
+            return new URL(authorityUrl);
         } catch (Exception e) {
             Logger.error(
                     TAG + methodName,
-                    "Unable to create URL from provided endpoint.",
+                    "Unable to create URL from provided authority.",
                     null);
             Logger.errorPII(
                     TAG + methodName,
                     e.getMessage() +
-                            " Unable to create URL from provided endpoint." +
-                            " endpoint = " + endpoint,
+                            " Unable to create URL from provided authority." +
+                            " authority = " + authorityUrl,
                     e);
         }
 
         return null;
     }
 
-    private URL getEndpoint(URL root, String endpoint) {
+    private URL getEndpointUrlFromRootAndSuffix(@NonNull URL root, @NonNull String endpointSuffix) {
+        final String methodName = ":getEndpointUrlFromRootAndSuffix";
         try {
             Uri authorityUri = Uri.parse(root.toString());
             Uri endpointUri = authorityUri.buildUpon()
-                    .appendPath(endpoint)
+                    .appendPath(endpointSuffix)
                     .build();
             return new URL(endpointUri.toString());
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.error(
+                    TAG + methodName,
+                    "Unable to create URL from provided root and suffix.",
+                    null);
+            Logger.errorPII(
+                    TAG + methodName,
+                    e.getMessage() +
+                            " Unable to create URL from provided root and suffix." +
+                            " root = " + root.toString() + " suffix = " + endpointSuffix,
+                    e);
         }
 
         return null;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -93,8 +93,6 @@ public class MicrosoftStsOAuth2Strategy
 
     private static final String TAG = MicrosoftStsOAuth2Strategy.class.getSimpleName();
 
-    private static final String ENDPOINT_VERSION = "v2.0";
-
     /**
      * Constructor of MicrosoftStsOAuth2Strategy.
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -155,6 +155,27 @@ public class MicrosoftStsOAuth2Strategy
         return authority.getHost();
     }
 
+    public String getIssuerCacheIdentifierFromTokenEndpoint() {
+        final String methodName = ":getIssuerCacheIdentifierFromTokenEndpoint";
+        URL authority = null;
+        String cacheIdentifier = null;
+
+        try {
+            authority = new URL(mTokenEndpoint);
+        } catch (MalformedURLException e) {
+            Logger.verbose(
+                    TAG + methodName,
+                    "Getting issuer cache identifier from token endpoint failed due to malformed URL (mTokenEndpoint)..."
+            );
+        }
+
+        if (authority != null) {
+            cacheIdentifier = getIssuerCacheIdentifierFromAuthority(authority);
+        }
+
+        return cacheIdentifier;
+    }
+
     @Override
     public MicrosoftStsAccessToken getAccessTokenFromResponse(
             @NonNull final MicrosoftStsTokenResponse response) {
@@ -212,23 +233,7 @@ public class MicrosoftStsOAuth2Strategy
 
         MicrosoftStsAccount account = new MicrosoftStsAccount(idToken, clientInfo);
 
-        // The Account created by the strategy sets the environment to get the 'iss' from the IdToken
-        // For caching purposes, this may not be the correct value due to the preferred cache identifier
-        // in the InstanceDiscoveryMetadata
-        URL authority = null;
-
-        try {
-            authority = new URL(mTokenEndpoint);
-        } catch (MalformedURLException e) {
-            Logger.verbose(
-                    TAG + methodName,
-                    "Creating account from TokenResponse failed due to malformed URL (mTokenEndpoint)..."
-            );
-        }
-
-        if (authority != null) {
-            account.setEnvironment(getIssuerCacheIdentifierFromAuthority(authority));
-        }
+        account.setEnvironment(getIssuerCacheIdentifierFromTokenEndpoint());
 
         return account;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -92,6 +92,8 @@ public class MicrosoftStsOAuth2Strategy
 
     private static final String TAG = MicrosoftStsOAuth2Strategy.class.getSimpleName();
 
+    private static final String ENDPOINT_VERSION = "v2.0";
+
     /**
      * Constructor of MicrosoftStsOAuth2Strategy.
      *
@@ -318,7 +320,7 @@ public class MicrosoftStsOAuth2Strategy
                 "Creating TokenRequest..."
         );
 
-        OpenIdProviderConfigurationClient configurationClient = new OpenIdProviderConfigurationClient(request, response, "v2.0");
+        OpenIdProviderConfigurationClient configurationClient = new OpenIdProviderConfigurationClient(request, response, ENDPOINT_VERSION);
 
         OpenIdProviderConfiguration openIdConfig = null;
         String tokenEndpoint;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -166,9 +166,10 @@ public class MicrosoftStsOAuth2Strategy
         try {
             authority = new URL(mTokenEndpoint);
         } catch (MalformedURLException e) {
-            Logger.verbose(
+            Logger.error(
                     TAG + methodName,
-                    "Getting issuer cache identifier from token endpoint failed due to malformed URL (mTokenEndpoint)..."
+                    "Getting issuer cache identifier from token endpoint failed due to malformed URL (mTokenEndpoint)...",
+                    e
             );
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -499,7 +499,7 @@ public class MicrosoftStsOAuth2Strategy
 
     private String buildCloudSpecificTokenEndpoint(
             @NonNull final MicrosoftStsAuthorizationResponse response) {
-        if (!StringUtil.isEmpty(response.getCloudGraphHostName())) {
+        if (!StringUtil.isEmpty(response.getCloudInstanceHostName())) {
             final String updatedTokenEndpoint =
                     Uri.parse(mTokenEndpoint)
                             .buildUpon()
@@ -517,6 +517,10 @@ public class MicrosoftStsOAuth2Strategy
                                                  MicrosoftAuthorizationResponse response) {
         final String methodName = ":getCloudSpecificTokenEndpoint";
         String tokenEndpoint;
+
+        if (StringUtil.isEmpty(response.getCloudInstanceHostName())) {
+            return mTokenEndpoint;
+        }
 
         final OpenIdProviderConfiguration openIdConfig = mConfig.getOpenIdWellKnownConfig(
                 response.getCloudInstanceHostName(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -322,6 +322,7 @@ public class MicrosoftStsOAuth2Strategy
         );
 
         if (mConfig.getMultipleCloudsSupported() || request.getMultipleCloudAware()) {
+            Logger.verbose(TAG, "get cloud specific authority based on authorization response.");
             setTokenEndpoint(getCloudSpecificTokenEndpoint(request, response));
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -117,7 +117,7 @@ public class OpenIdProviderConfigurationClient {
         final String methodName = ":loadOpenIdProviderConfiguration";
 
         try {
-            //Update the token response authority with cloud instance host name.
+            //Create config uri from issuer, path and version
             final String configUriString = new Uri.Builder().scheme("https")
                     .authority(mIssuer)
                     .appendPath(mPath)

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -77,7 +77,11 @@ public class OpenIdProviderConfigurationClient {
         mVersion = NA;
     }
 
-    public OpenIdProviderConfigurationClient(@NonNull final MicrosoftAuthorizationRequest request, @NonNull final MicrosoftAuthorizationResponse response, @Nullable final String version) {
+    public OpenIdProviderConfigurationClient(@NonNull final MicrosoftAuthorizationRequest request, @NonNull final MicrosoftAuthorizationResponse response) {
+        this(request, response, NA);
+    }
+
+    public OpenIdProviderConfigurationClient(@NonNull final MicrosoftAuthorizationRequest request, @NonNull final MicrosoftAuthorizationResponse response, @NonNull final String version) {
         mIssuer = response.getCloudInstanceHostName();
         mPath = request.getAuthority().getPath();
         mVersion = version;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -28,8 +28,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
-import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;
-import com.microsoft.identity.common.adal.internal.net.WebRequestHandler;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -68,7 +66,6 @@ public class OpenIdProviderConfigurationClient {
     private final String mPath;
     private final String mVersion;
     private final Gson mGson = new Gson();
-    private final IWebRequestHandler mWebRequestHandler = new WebRequestHandler();
 
     public OpenIdProviderConfigurationClient(@NonNull final String issuer) {
         mIssuer = sanitize(issuer);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -26,7 +26,6 @@ import android.net.Uri;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.net.IWebRequestHandler;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -69,19 +69,16 @@ public class OpenIdProviderConfigurationClient {
         mIssuer = Uri.parse(sanitize(issuer)).toString();
     }
 
-    public OpenIdProviderConfigurationClient(@NonNull final MicrosoftAuthorizationRequest request, @NonNull final MicrosoftAuthorizationResponse response) {
-        this(request, response, NA);
+    public OpenIdProviderConfigurationClient(@NonNull final String authority, @NonNull final String path) {
+        this(authority, path, NA);
     }
 
-    public OpenIdProviderConfigurationClient(@NonNull final MicrosoftAuthorizationRequest request, @NonNull final MicrosoftAuthorizationResponse response, @NonNull final String version) {
-        final String authority = response.getCloudInstanceHostName();
-        final String path = request.getAuthority().getPath();
-
+    public OpenIdProviderConfigurationClient(@NonNull final String authority, @NonNull final String path, @NonNull final String endpointVersion) {
         mIssuer = new Uri.Builder()
                 .scheme("https")
                 .authority(authority)
                 .appendPath(path)
-                .appendPath(version)
+                .appendPath(endpointVersion)
                 .build().toString();
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -33,8 +33,6 @@ import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackW
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.net.HttpRequest;
 import com.microsoft.identity.common.internal.net.HttpResponse;
-import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAuthorizationRequest;
-import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAuthorizationResponse;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -56,8 +54,6 @@ public class OpenIdProviderConfigurationClient {
     private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
     private static final Map<URL, OpenIdProviderConfiguration> sConfigCache = new HashMap<>();
 
-    private static final String NA = "";
-
     public interface OpenIdProviderConfigurationCallback
             extends TaskCompletedCallbackWithError<OpenIdProviderConfiguration, Exception> {
     }
@@ -69,11 +65,13 @@ public class OpenIdProviderConfigurationClient {
         mIssuer = Uri.parse(sanitize(issuer)).toString();
     }
 
-    public OpenIdProviderConfigurationClient(@NonNull final String authority, @NonNull final String path) {
-        this(authority, path, NA);
+    public OpenIdProviderConfigurationClient(@NonNull final String authority,
+                                             @NonNull final String path) {
+        this(authority, path, "");
     }
 
-    public OpenIdProviderConfigurationClient(@NonNull final String authority, @NonNull final String path, @NonNull final String endpointVersion) {
+    public OpenIdProviderConfigurationClient(@NonNull final String authority,
+                                             @NonNull final String path, @NonNull final String endpointVersion) {
         mIssuer = new Uri.Builder()
                 .scheme("https")
                 .authority(authority)

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -36,6 +36,8 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
     private final static String TAG = AcquireTokenSilentOperationParameters.class.getSimpleName();
 
+    private static final Object sLock = new Object();
+
     private RefreshTokenRecord mRefreshToken;
 
 
@@ -80,7 +82,6 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
     }
 
     private static void performCloudDiscovery() throws IOException {
-        final Object sLock = new Object();
         final String methodName = ":performCloudDiscovery";
         Logger.verbose(
                 TAG + methodName,

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -70,7 +70,7 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
             if (!AzureActiveDirectory.isInitialized()) {
                 performCloudDiscovery();
             }
-            final AzureActiveDirectoryCloud cloud = AzureActiveDirectory.getAzureActiveDirectoryCloud(mAccount.getEnvironment());
+            final AzureActiveDirectoryCloud cloud = AzureActiveDirectory.getAzureActiveDirectoryCloudFromHostName(mAccount.getEnvironment());
             return cloud != null && cloud.getPreferredNetworkHostName().equals(getAuthority().getAuthorityURL().getAuthority());
         } catch (IOException e) {
             Logger.error(

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -22,11 +22,13 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.request;
 
+import androidx.annotation.Nullable;
+
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.internal.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
-
-import androidx.annotation.Nullable;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 
 public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
@@ -49,8 +51,19 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
         if (mAccount == null) {
             Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
+        } else if (!authorityMatchesAccountEnvironment()) {
+            throw new ArgumentException(
+                    ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
+                    ArgumentException.AUTHORITY_ARGUMENT_NAME,
+                    "Authority passed to silent parameters does not match with the cloud associated to the account."
+            );
         }
+    }
 
+    private boolean authorityMatchesAccountEnvironment() {
+        final AzureActiveDirectoryCloud cloud = AzureActiveDirectory.getAzureActiveDirectoryCloud(mAccount.getEnvironment());
+        return cloud.getPreferredNetworkHostName().equals(getAuthority().getAuthorityURL().getAuthority());
     }
 
 }
+


### PR DESCRIPTION
Fixes #709 
Fixes #718 

In this PR, I've added the following fix for issue #709 :
Instead of setting the environment from the authorization request, we would now set it from the token endpoint as that will be the correct one.

Also set the token endpoint by querying openid provider config metadata

To fix issue #718, we will know throw an exception if the cloud associated to the account passed by the user and the authority passed by the user as part of silent parameters do not match. We achieve this by doing a reverse lookup from the `mEnvironment` field on the account object and get the cloud associated to that preferredCacheHostName. From the cloud, then we get the `preferredNetworkHostName` and we see if it matches with the authority passed by the user. If not, we throw an exception.