### PR TITLE
remove caching temporarily

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -62,7 +62,6 @@ public class CommandDispatcher {
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();
-    private static final Set sExecutingCommands = Collections.synchronizedSet(new HashSet<BaseCommand>());
 
     /**
      * submitSilent - Run a command using the silent thread pool
@@ -75,17 +74,6 @@ public class CommandDispatcher {
                 TAG + methodName,
                 "Beginning execution of silent command."
         );
-
-        if(sExecutingCommands.contains(command)){
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-                @Override
-                public void run() {
-                    command.getCallback().onError(new ClientException(ClientException.DUPLICATE_COMMAND, "The same command was already received and is being processed."));
-                }
-            });
-        }else{
-            sExecutingCommands.add(command);
-        }
 
         sSilentExecutor.execute(new Runnable() {
             @Override
@@ -118,8 +106,6 @@ public class CommandDispatcher {
 
                 //Return the result via the callback
                 returnCommandResult(command, commandResult, handler);
-
-                sExecutingCommands.remove(command);
 
                 Telemetry.getInstance().flush(correlationId);
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/TokenCommand.java
@@ -104,7 +104,7 @@ public class TokenCommand extends BaseCommand<AcquireTokenResult> implements Tok
 
     @Override
     public boolean isEligibleForCaching(){
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Removed caching for now.  Going to follow up with changes to make OperationParameters immutable in addition to a discussion on how to improve maintainability of generated hashCode and Equals methods for value objects.