### PR TITLE
Fix multiple cloud support in msal with broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -51,6 +51,7 @@ public class BrokerRequest implements Serializable {
         final static String CLIENT_APP_VERSION = "client_app_version";
         final static String CLIENT_VERSION = "client_version";
         final static String ENVIRONMENT = "environment";
+        final static String MULTIPLE_CLOUDS_SUPPORTED = "multiple_clouds_supported";
     }
 
     /**
@@ -168,6 +169,13 @@ public class BrokerRequest implements Serializable {
     @SerializedName(SerializedNames.ENVIRONMENT)
     private String mEnvironment;
 
+    /**
+     * Boolean indicated whether app supports multiple clouds
+     */
+    @NonNull
+    @SerializedName(SerializedNames.MULTIPLE_CLOUDS_SUPPORTED)
+    private boolean mMultipleCloudsSupported;
+
 
     private BrokerRequest(BrokerRequest.Builder builder) {
         mAuthority = builder.mAuthority;
@@ -186,7 +194,7 @@ public class BrokerRequest implements Serializable {
         mApplicationVersion = builder.mApplicationVersion;
         mMsalVersion = builder.mMsalVersion;
         mEnvironment = builder.mEnvironment;
-
+        mMultipleCloudsSupported = builder.mMultipleCloudsSupported;
     }
 
 
@@ -250,8 +258,12 @@ public class BrokerRequest implements Serializable {
         return mMsalVersion;
     }
 
-    public String getEnvironment(){
+    public String getEnvironment() {
         return mEnvironment;
+    }
+
+    public boolean getMultipleCloudsSupported() {
+        return mMultipleCloudsSupported;
     }
 
     /**
@@ -290,6 +302,8 @@ public class BrokerRequest implements Serializable {
         private String mMsalVersion;
 
         private String mEnvironment;
+
+        private boolean mMultipleCloudsSupported;
 
 
         /**
@@ -418,8 +432,13 @@ public class BrokerRequest implements Serializable {
             return this;
         }
 
-        public BrokerRequest.Builder environment(@NonNull final String environment){
+        public BrokerRequest.Builder environment(@NonNull final String environment) {
             this.mEnvironment = environment;
+            return this;
+        }
+
+        public BrokerRequest.Builder multipleCloudsSupported(@NonNull final boolean multipleCloudsSupported) {
+            this.mMultipleCloudsSupported = multipleCloudsSupported;
             return this;
         }
 


### PR DESCRIPTION
When creating Broker Operation parameters, we create a new instance of the authority based on the authority url and we lose context of whether multiple clouds were supported by the developer.

To fix this I've added an additional field `mMultipleCloudsSupported` in broker request and get the value from there to set it on the authority object in broker operation parameters after the authority has been created.