### PR TITLE
[WIP] Refactor creation of refresh token request

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -183,7 +183,6 @@ public abstract class BaseController {
 
         TokenRequest tokenRequest = strategy.createTokenRequest(request, response);
         logExposedFieldsOfObject(TAG + methodName, tokenRequest);
-        tokenRequest.setGrantType(TokenRequest.GrantTypes.AUTHORIZATION_CODE);
 
         TokenResult tokenResult = strategy.requestToken(tokenRequest);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -345,7 +345,9 @@ public abstract class BaseController {
         }
 
         final RefreshTokenRequestParameters refreshTokenRequestParameters =
-                new RefreshTokenRequestParameters(parameters);
+                new RefreshTokenRequestParameters.Builder()
+                        .fromParameters(parameters)
+                        .build();
 
         final TokenRequest refreshTokenRequest = strategy.createRefreshTokenRequest(refreshTokenRequestParameters);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenCacheItemMigrationAdapter.java
@@ -601,13 +601,13 @@ public class TokenCacheItemMigrationAdapter {
                                                               @Nullable final UUID correlationId,
                                                               @NonNull final String idTokenVersion) {
 
-        final RefreshTokenRequestParameters parameters = new RefreshTokenRequestParameters(
-                clientId,
-                scopes,
-                refreshToken,
-                idTokenVersion,
-                correlationId
-        );
+        final RefreshTokenRequestParameters parameters = new RefreshTokenRequestParameters.Builder()
+                .clientId(clientId)
+                .scopes(scopes)
+                .refreshToken(refreshToken)
+                .idTokenVersion(idTokenVersion)
+                .correlationId(correlationId)
+                .build();
 
         return strategy.createRefreshTokenRequest(parameters);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.request.RefreshTokenRequestParameters;
 
 import java.util.concurrent.Future;
 
@@ -104,7 +105,7 @@ public class ActiveDirectoryFederationServices2012R2OAuth2Strategy extends OAuth
     }
 
     @Override
-    public TokenRequest createRefreshTokenRequest() {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRequestParameters parameters) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.request.RefreshTokenRequestParameters;
 
 import java.util.concurrent.Future;
 
@@ -101,7 +102,7 @@ public class ActiveDirectoryFederationServices2016OAuth2Strategy extends OAuth2S
     }
 
     @Override
-    public TokenRequest createRefreshTokenRequest() {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRequestParameters parameters) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenErrorResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.request.RefreshTokenRequestParameters;
 
 import java.net.HttpURLConnection;
 
@@ -206,7 +207,7 @@ public class AzureActiveDirectoryOAuth2Strategy
     }
 
     @Override
-    public AzureActiveDirectoryTokenRequest createRefreshTokenRequest() {
+    public AzureActiveDirectoryTokenRequest createRefreshTokenRequest(RefreshTokenRequestParameters parameters) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.RefreshToken;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.request.RefreshTokenRequestParameters;
 
 import java.util.concurrent.Future;
 
@@ -103,7 +104,7 @@ public class AzureActiveDirectoryB2COAuth2Strategy extends OAuth2Strategy {
 
 
     @Override
-    public TokenRequest createRefreshTokenRequest() {
+    public TokenRequest createRefreshTokenRequest(RefreshTokenRequestParameters parameters) {
         return null;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -333,6 +333,8 @@ public class MicrosoftStsOAuth2Strategy
         tokenRequest.setClientId(request.getClientId());
         tokenRequest.setScope(request.getTokenScope());
 
+        tokenRequest.setGrantType(TokenRequest.GrantTypes.AUTHORIZATION_CODE);
+
         try {
             tokenRequest.setCorrelationId(
                     UUID.fromString(

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.internal.net.HttpResponse;
 import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.internal.platform.Device;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftTokenRequest;
+import com.microsoft.identity.common.internal.request.RefreshTokenRequestParameters;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -231,9 +232,10 @@ public abstract class OAuth2Strategy
     /**
      * Abstract method for creating the refresh token request.
      *
+     * @param parameters
      * @return TokenRequest.
      */
-    public abstract GenericTokenRequest createRefreshTokenRequest();
+    public abstract GenericTokenRequest createRefreshTokenRequest(RefreshTokenRequestParameters parameters);
 
     /**
      * Abstract method for validating the authorization request.  In the case of AAD this is the method

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/OperationParameters.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.request;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -207,12 +208,12 @@ public class OperationParameters {
 
     /**
      * Get the list of browsers which are safe to launch for auth flow.
+     *
      * @return list of browser descriptors
      */
     public List<BrowserDescriptor> getBrowserSafeList() {
         return mBrowserSafeList;
     }
-
 
 
     //CHECKSTYLE:OFF

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/RefreshTokenRequestParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/RefreshTokenRequestParameters.java
@@ -57,43 +57,65 @@ public class RefreshTokenRequestParameters {
         return mIdTokenVersion;
     }
 
-    private RefreshTokenRequestParameters(@NonNull final String clientId,
-                                          @NonNull final String scopes,
-                                          @NonNull final String refreshToken,
-                                          @Nullable final String claims,
-                                          @Nullable final String idTokenVersion,
-                                          @Nullable final UUID correlationId) {
-        this.mClientId = clientId;
-        this.mScopes = scopes;
-        this.mRefreshToken = refreshToken;
-        this.mClaims = claims;
-        this.mIdTokenVersion = idTokenVersion;
-        this.mCorrelationId = correlationId;
+    private RefreshTokenRequestParameters(RefreshTokenRequestParameters.Builder builder) {
+        mClientId = builder.mClientId;
+        mScopes = builder.mScopes;
+        mRefreshToken = builder.mRefreshToken;
+        mClaims = builder.mClaims;
+        mIdTokenVersion = builder.mIdTokenVersion;
+        mCorrelationId = builder.mCorrelationId;
     }
 
-    public RefreshTokenRequestParameters(@NonNull final String clientId,
-                                          @NonNull final String scopes,
-                                          @NonNull final String refreshToken,
-                                          @Nullable final String idTokenVersion,
-                                          @Nullable final UUID correlationId) {
-        this(
-                clientId,
-                scopes,
-                refreshToken,
-                null,
-                idTokenVersion,
-                correlationId
-        );
-    }
+    public static class Builder {
+        private String mClientId;
+        private String mScopes;
+        private String mRefreshToken;
+        private String mClaims;
+        private String mIdTokenVersion;
+        private UUID mCorrelationId;
 
-    public RefreshTokenRequestParameters(@NonNull final AcquireTokenSilentOperationParameters parameters) {
-        this(
-                parameters.getClientId(),
-                TextUtils.join(" ", parameters.getScopes()),
-                parameters.getRefreshToken().getSecret(),
-                parameters.getClaimsRequestJson(),
-                parameters.getSdkType() == SdkType.ADAL ? "1" : null,
-                null
-        );
+        public RefreshTokenRequestParameters.Builder clientId(@NonNull final String clientId) {
+            this.mClientId = clientId;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder scopes(@NonNull final String scopes) {
+            this.mScopes = scopes;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder refreshToken(@NonNull final String refreshToken) {
+            this.mRefreshToken = refreshToken;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder claims(@Nullable final String claims) {
+            this.mClaims = claims;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder idTokenVersion(@Nullable final String idTokenVersion) {
+            this.mIdTokenVersion = idTokenVersion;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder correlationId(@Nullable final UUID correlationId) {
+            this.mCorrelationId = correlationId;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters.Builder fromParameters(@NonNull final AcquireTokenSilentOperationParameters parameters) {
+            this.mClientId = parameters.getClientId();
+            this.mScopes = TextUtils.join(" ", parameters.getScopes());
+            this.mRefreshToken = parameters.getRefreshToken().getSecret();
+            this.mClaims = parameters.getClaimsRequestJson();
+            this.mIdTokenVersion = parameters.getSdkType() == SdkType.ADAL ? "1" : null;
+            this.mCorrelationId = null;
+            return this;
+        }
+
+        public RefreshTokenRequestParameters build() {
+            return new RefreshTokenRequestParameters(this);
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/RefreshTokenRequestParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/RefreshTokenRequestParameters.java
@@ -1,0 +1,99 @@
+package com.microsoft.identity.common.internal.request;
+
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
+public class RefreshTokenRequestParameters {
+
+    @NonNull
+    private String mClientId;
+
+    @NonNull
+    private String mScopes;
+
+    @NonNull
+    private String mRefreshToken;
+
+    @Nullable
+    private String mClaims;
+
+    @Nullable
+    private String mIdTokenVersion;
+
+    @Nullable
+    private UUID mCorrelationId;
+
+    @Nullable
+    public UUID getCorrelationId() {
+        return mCorrelationId;
+    }
+
+    @NonNull
+    public String getClientId() {
+        return mClientId;
+    }
+
+    @NonNull
+    public String getScopes() {
+        return mScopes;
+    }
+
+    @NonNull
+    public String getRefreshToken() {
+        return mRefreshToken;
+    }
+
+    @Nullable
+    public String getClaims() {
+        return mClaims;
+    }
+
+    @Nullable
+    public String getIdTokenVersion() {
+        return mIdTokenVersion;
+    }
+
+    private RefreshTokenRequestParameters(@NonNull final String clientId,
+                                          @NonNull final String scopes,
+                                          @NonNull final String refreshToken,
+                                          @Nullable final String claims,
+                                          @Nullable final String idTokenVersion,
+                                          @Nullable final UUID correlationId) {
+        this.mClientId = clientId;
+        this.mScopes = scopes;
+        this.mRefreshToken = refreshToken;
+        this.mClaims = claims;
+        this.mIdTokenVersion = idTokenVersion;
+        this.mCorrelationId = correlationId;
+    }
+
+    public RefreshTokenRequestParameters(@NonNull final String clientId,
+                                          @NonNull final String scopes,
+                                          @NonNull final String refreshToken,
+                                          @Nullable final String idTokenVersion,
+                                          @Nullable final UUID correlationId) {
+        this(
+                clientId,
+                scopes,
+                refreshToken,
+                null,
+                idTokenVersion,
+                correlationId
+        );
+    }
+
+    public RefreshTokenRequestParameters(@NonNull final AcquireTokenSilentOperationParameters parameters) {
+        this(
+                parameters.getClientId(),
+                TextUtils.join(" ", parameters.getScopes()),
+                parameters.getRefreshToken().getSecret(),
+                parameters.getClaimsRequestJson(),
+                parameters.getSdkType() == SdkType.ADAL ? "1" : null,
+                null
+        );
+    }
+}


### PR DESCRIPTION
Currently we have method called as `createRefreshTokenRequest` in the strategy, however, most of the actual creation of the token request does not happen there. We call that method, get an instance of the token request and then manually set parameters on that object instead of letting the creation method do that work.

I've refactored some code so that all the creation of the refresh token request happens in that method. To achieve this, I've introduced a new class classed as RefreshTokenRequestParameters and the createRefreshTokenRequest method will accept it as parameters and create the token request based on the information passed via those parameters.

Note: Creation the class `RefreshTokenRequestParameters` was not necessary but I felt like it lead to more cleaner code than passing numerous params (most of which are same type String) directly to createRefreshTokenRequest method.