### PR TITLE
Move setting of grant type inside create token request method

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -183,7 +183,6 @@ public abstract class BaseController {
 
         TokenRequest tokenRequest = strategy.createTokenRequest(request, response);
         logExposedFieldsOfObject(TAG + methodName, tokenRequest);
-        tokenRequest.setGrantType(TokenRequest.GrantTypes.AUTHORIZATION_CODE);
 
         TokenResult tokenResult = strategy.requestToken(tokenRequest);
 
@@ -349,7 +348,6 @@ public abstract class BaseController {
         refreshTokenRequest.setClientId(parameters.getClientId());
         refreshTokenRequest.setScope(TextUtils.join(" ", parameters.getScopes()));
         refreshTokenRequest.setRefreshToken(parameters.getRefreshToken().getSecret());
-        refreshTokenRequest.setRedirectUri(parameters.getRedirectUri());
 
         if (refreshTokenRequest instanceof MicrosoftTokenRequest) {
             ((MicrosoftTokenRequest) refreshTokenRequest).setClaims(parameters.getClaimsRequestJson());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -332,6 +332,8 @@ public class MicrosoftStsOAuth2Strategy
         tokenRequest.setClientId(request.getClientId());
         tokenRequest.setScope(request.getTokenScope());
 
+        tokenRequest.setGrantType(TokenRequest.GrantTypes.AUTHORIZATION_CODE);
+
         try {
             tokenRequest.setCorrelationId(
                     UUID.fromString(


### PR DESCRIPTION
Also don't set redirect uri for silent token request (as it is not needed)

We should ideally be doing all things related to the creation of the token request inside the createTokenRequest method, however, that requires a much larger refactor as we grab most of the fields from operation parameters. We can may be address this in a future refactor.