### PR TITLE
Fix cloud url returning wrong url if authority specified in configura…

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AuthorityDeserializer.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AuthorityDeserializer.java
@@ -48,7 +48,11 @@ public class AuthorityDeserializer implements JsonDeserializer<Authority> {
                             TAG + methodName,
                             "Type: AAD"
                     );
-                    return context.deserialize(authorityObject, AzureActiveDirectoryAuthority.class);
+                    AzureActiveDirectoryAuthority aadAuthority = context.deserialize(authorityObject, AzureActiveDirectoryAuthority.class);
+                    if (aadAuthority != null && aadAuthority.mAudience != null) {
+                        aadAuthority.mAudience.setCloudUrl(aadAuthority.mAuthorityUrl);
+                    }
+                    return aadAuthority;
                 case "B2C":
                     Logger.verbose(
                             TAG + methodName,


### PR DESCRIPTION
…tion

If the authority is specified in the configuration then calling `getAuthorityUrl` on default authority should return the correct url (the one specified in the configuration), however, that is not the case as the `getAuthorityUrl` method calls the `getCloudUrl` and since the `cloud_url` is not a field in the configuration, when we deserialize the authority then we only get the authority url and don't have the cloud url and hence it returns the default cloud url which goes to worldwide cloud and that is not always correct.

We can fix this by taking the authority url specified in the configuration and setting it as the cloud url on the authority object after it has been deserialized so that the PublicClientConfiguration always has the correct cloud url.