### PR TITLE
Add telemetry event in StorageHelper

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -295,7 +295,7 @@ public class StorageHelper implements IStorageHelper {
                 if (key == null) {
                     mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 // Best effort.
                 mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
             }
@@ -523,7 +523,7 @@ public class StorageHelper implements IStorageHelper {
                     if (key == null) {
                         mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
                     }
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     // Best effort.
                     mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
                 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -289,14 +289,16 @@ public class StorageHelper implements IStorageHelper {
 
         // Try to read keystore key - to verify how often this is invoked before the migration is done.
         // TODO: remove this whole try-catch clause once the experiment is done.
-        try {
-            final SecretKey key = loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
-            if (key == null){
-                mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
+        if (mTelemetryCallback != null) {
+            try {
+                final SecretKey key = loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
+                if (key == null) {
+                    mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
+                }
+            } catch (Exception e) {
+                // Best effort.
+                mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
             }
-        } catch (Exception e) {
-            // Best effort.
-            mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_DECRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
         }
 
         final String packageName = getPackageName();
@@ -515,16 +517,18 @@ public class StorageHelper implements IStorageHelper {
 
             // Try to read keystore key - to verify how often this is invoked before the migration is done.
             // TODO: remove this whole try-catch clause once the experiment is done.
-            try {
-                final SecretKey key = loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
-                if (key == null){
-                    mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
+            if (mTelemetryCallback != null) {
+                try {
+                    final SecretKey key = loadSecretKey(KeyType.KEYSTORE_ENCRYPTED_KEY);
+                    if (key == null) {
+                        mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_NOT_INITIALIZED");
+                    }
+                } catch (Exception e) {
+                    // Best effort.
+                    mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
                 }
-            } catch (Exception e) {
-                // Best effort.
-                mTelemetryCallback.logEvent(mContext, methodName, false, "KEY_ENCRYPTION_KEYSTORE_KEY_FAILED_TO_LOAD");
             }
-            
+
             setBlobVersion(VERSION_USER_DEFINED);
             if (AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(getPackageName())) {
                 return loadSecretKey(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);


### PR DESCRIPTION
to see how often this is invoked before https://github.com/AzureAD/ad-accounts-for-android/pull/1196 is done. (Ideally, none).