### PR TITLE
Added null check for optional parameter Prompt

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -167,7 +167,9 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         parameters.setClaimsRequest(brokerRequest.getClaims());
 
         parameters.setOpenIdConnectPromptParameter(
-                OpenIdConnectPromptParameter.valueOf(brokerRequest.getPrompt())
+                brokerRequest.getPrompt() != null ?
+                        OpenIdConnectPromptParameter.valueOf(brokerRequest.getPrompt()) :
+                        OpenIdConnectPromptParameter.NONE
         );
 
         parameters.setAuthorizationAgent(AuthorizationAgent.WEBVIEW);


### PR DESCRIPTION
- It's an optional parameter from MSAL to broker, default is None, so added a null check. Xamarin team ran into a null pointer if they didn't pass in.