### PR TITLE
Fix ests telemetry memory leak and improve telemetry caching logic

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
@@ -301,6 +301,9 @@ public class EstsTelemetry {
         }
     }
 
+    // if we don't have api id then we won't save telemetry to cache
+    // this can happen for commands like the GetDeviceModeCommand
+    // that are generated via a method for which we don't want telemetry
     private boolean eligibleToCache(RequestTelemetry lastTelemetry) {
         return !TextUtils.isEmpty(lastTelemetry.getSchemaVersion()) &&
                 !TextUtils.isEmpty(lastTelemetry.getCommonTelemetry().get(Schema.Key.API_ID));

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.eststelemetry;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -286,19 +287,23 @@ public class EstsTelemetry {
         currentTelemetry.clearTelemetry();
         mTelemetryMap.remove(correlationId);
 
-
-        if (mLastRequestTelemetryCache != null) {
-            // remove old last request telemetry data from cache
-            mLastRequestTelemetryCache.clearAll();
-            // save new last request telemetry data to cache
-            mLastRequestTelemetryCache.saveRequestTelemetryToCache(lastTelemetry);
-        } else {
-            Logger.verbose(
+        if (mLastRequestTelemetryCache == null) {
+            Logger.warn(
                     TAG + methodName,
                     "Last Request Telemetry Cache object was null. " +
                             "Unable to save request telemetry to cache."
             );
+        } else if (eligibleToCache(lastTelemetry)) {
+            // remove old last request telemetry data from cache
+            mLastRequestTelemetryCache.clearAll();
+            // save new last request telemetry data to cache
+            mLastRequestTelemetryCache.saveRequestTelemetryToCache(lastTelemetry);
         }
+    }
+
+    private boolean eligibleToCache(RequestTelemetry lastTelemetry) {
+        return !TextUtils.isEmpty(lastTelemetry.getSchemaVersion()) &&
+                !TextUtils.isEmpty(lastTelemetry.getCommonTelemetry().get(Schema.Key.API_ID));
     }
 
     String getCurrentTelemetryHeaderString() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
@@ -218,7 +218,7 @@ public class EstsTelemetry {
      * Removes the telemetry associated to the correlation id from the telemetry map,
      * and saves it to the cache (SharedPreferences) as the last request telemetry.
      */
-    public void flush() {
+    void flush() {
         String correlationId = DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID);
         flush(correlationId);
     }
@@ -233,18 +233,6 @@ public class EstsTelemetry {
     public void flush(final String correlationId) {
         final String errorCode = null; // there was no error
         flush(correlationId, errorCode);
-    }
-
-    /**
-     * Flush the telemetry data for the current request to the {@link android.content.SharedPreferences} using the {@link SharedPreferencesLastRequestTelemetryCache}.
-     * Removes the telemetry associated to the correlation id from the telemetry map,
-     * and saves it to the cache (SharedPreferences) as the last request telemetry.
-     *
-     * @param baseException exception that may have occurred during the request
-     */
-    public void flush(final BaseException baseException) {
-        String correlationId = DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID);
-        flush(correlationId, baseException);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.eststelemetry;
 
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -98,7 +100,9 @@ public class SharedPreferencesLastRequestTelemetryCache implements IRequestTelem
         for (Map.Entry<String, String> entry : data.entrySet()) {
             final String cacheKey = entry.getKey();
             final String cacheValue = entry.getValue();
-            mSharedPreferencesFileManager.putString(cacheKey, cacheValue);
+            if (!TextUtils.isEmpty(cacheKey) && !TextUtils.isEmpty(cacheValue)) {
+                mSharedPreferencesFileManager.putString(cacheKey, cacheValue);
+            }
         }
     }
 


### PR DESCRIPTION
We have a memory leak in the ests telemetry hashmap where telemetry objects for all silent calls are not being removed from the hashmap. This is happening by calling a flush method that does not accept a correlation id and that results in using the correlation id from the Diagnostic Context which does not match with anything in the map and hence the object is not removed.

This bug got introduced when we refactored Command Dispatcher to implement the command cache. 

To fix this, I've removed flush overloads that do not accept a correlation id, and refactored the `returnCommandResult` method to pass the correct correlation id to the flush method.

I've also improved telemetry caching logic in this PR, by adding a check to not cache telemetry associated to requests where we don't set the public api id so that those are not cached and are not sent to ests as the last request.