### PR TITLE
Set correct authority on Access Token Record, ID Token Record

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -149,6 +149,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         when(mockStrategy.createAccount(any(MicrosoftStsTokenResponse.class))).thenReturn(mockAccount);
         when(mockStrategy.getIssuerCacheIdentifier(mockRequest)).thenReturn(MOCK_ENVIRONMENT);
         when(mockStrategy.getIssuerCacheIdentifierFromTokenEndpoint()).thenReturn(MOCK_ENVIRONMENT);
+        when(mockStrategy.getAuthorityFromTokenEndpoint()).thenReturn(MOCK_AUTHORITY);
         when(mockRequest.getAuthority()).thenReturn(new URL(MOCK_AUTHORITY));
         when(mockResponse.getIdToken()).thenReturn(MOCK_ID_TOKEN_WITH_CLAIMS);
         when(mockResponse.getClientInfo()).thenReturn(MOCK_CLIENT_INFO);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -97,12 +97,7 @@ public class MicrosoftStsAccountCredentialAdapter
             // Optional fields
             accessToken.setExtendedExpiresOn(getExtendedExpiresOn(response));
 
-            if (!StringUtil.isEmpty(response.getAuthority())) {
-                accessToken.setAuthority(response.getAuthority());
-            } else {
-                accessToken.setAuthority(request.getAuthority().toString());
-            }
-
+            accessToken.setAuthority(strategy.getAuthorityFromTokenEndpoint());
             accessToken.setAccessTokenType(response.getTokenType());
 
             return accessToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -182,13 +182,7 @@ public class MicrosoftStsAccountCredentialAdapter
             );
             idToken.setClientId(request.getClientId());
             idToken.setSecret(response.getIdToken());
-
-            // Optional fields
-            if (!StringUtil.isEmpty(response.getAuthority())) {
-                idToken.setAuthority(response.getAuthority());
-            } else { // Working around a bug - sov cloud seems to have broken response authority...
-                idToken.setAuthority(request.getAuthority().toString());
-            }
+            idToken.setAuthority(strategy.getAuthorityFromTokenEndpoint());
 
             return idToken;
         } catch (ServiceException e) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/IDToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/IDToken.java
@@ -187,11 +187,6 @@ public class IDToken {
      */
     public static final String UPDATED_AT = "updated_at";
 
-    /**
-     * The authority that issued the token
-     */
-    public static final String ISSUER = "iss";
-
 
     private Map<String, ?> mTokenClaims = null;
     private final String mRawIdToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/IDToken.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/IDToken.java
@@ -187,6 +187,11 @@ public class IDToken {
      */
     public static final String UPDATED_AT = "updated_at";
 
+    /**
+     * The authority that issued the token
+     */
+    public static final String ISSUER = "iss";
+
 
     private Map<String, ?> mTokenClaims = null;
     private final String mRawIdToken;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -158,6 +158,10 @@ public abstract class OAuth2Strategy
         mTokenEndpoint = tokenEndpoint;
     }
 
+    public final String getAuthorityFromTokenEndpoint() {
+        return mTokenEndpoint.toLowerCase().replace("oauth2/v2.0/token", "");
+    }
+
     protected final void setAuthorizationEndpoint(final String authorizationEndpoint) {
         mAuthorizationEndpoint = authorizationEndpoint;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -158,7 +158,7 @@ public abstract class OAuth2Strategy
         mTokenEndpoint = tokenEndpoint;
     }
 
-    public final String getAuthorityFromTokenEndpoint() {
+    public String getAuthorityFromTokenEndpoint() {
         return mTokenEndpoint.toLowerCase().replace("oauth2/v2.0/token", "");
     }
 


### PR DESCRIPTION
The authority set on the AccessTokenRecord is wrong. I've fixed this by setting it from the token endpoint which should always be correct as we just went there.