### PR TITLE
Fix a UI issue while using Browser in Broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -176,12 +176,13 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                         OpenIdConnectPromptParameter.valueOf(brokerRequest.getPrompt()) :
                         OpenIdConnectPromptParameter.NONE
         );
-
+        Logger.info(TAG, "Authorization agent passed in by MSAL: " + brokerRequest.getAuthorizationAgent());
         if(brokerRequest.getAuthorizationAgent() != null
                 && brokerRequest.getAuthorizationAgent().equalsIgnoreCase(AuthorizationAgent.BROWSER.name())
                 && isCallingPackageIntune(callingActivity.getPackageName())){ // TODO : Remove this whenever we enable System Browser support in Broker for apps.
             Logger.info(TAG , "Setting Authorization Agent to Browser for Intune app");
             parameters.setAuthorizationAgent(AuthorizationAgent.BROWSER);
+            parameters.setBrokerBrowserSupportEnabled(true);
             parameters.setBrowserSafeList(getBrowserSafeListForBroker());
         }else {
             parameters.setAuthorizationAgent(AuthorizationAgent.WEBVIEW);

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -179,7 +179,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         Logger.info(TAG, "Authorization agent passed in by MSAL: " + brokerRequest.getAuthorizationAgent());
         if(brokerRequest.getAuthorizationAgent() != null
                 && brokerRequest.getAuthorizationAgent().equalsIgnoreCase(AuthorizationAgent.BROWSER.name())
-                && isCallingPackageIntune(callingActivity.getPackageName())){ // TODO : Remove this whenever we enable System Browser support in Broker for apps.
+                && isCallingPackageIntune(parameters.getCallerPackageName())){ // TODO : Remove this whenever we enable System Browser support in Broker for apps.
             Logger.info(TAG , "Setting Authorization Agent to Browser for Intune app");
             parameters.setAuthorizationAgent(AuthorizationAgent.BROWSER);
             parameters.setBrokerBrowserSupportEnabled(true);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
+import com.microsoft.identity.common.internal.request.BrokerAcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.ui.browser.BrowserAuthorizationStrategy;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.ui.webview.EmbeddedWebViewAuthorizationStrategy;
@@ -52,6 +53,7 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
                 parameters.getAuthorizationAgent(),
                 parameters.getActivity().getApplicationContext()
         );
+        boolean isBrokerRequest = (parameters instanceof BrokerAcquireTokenOperationParameters);
 
         if (validatedAuthorizationAgent == AuthorizationAgent.WEBVIEW) {
             Logger.info(TAG, "Use webView for authorization.");
@@ -68,14 +70,19 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
                     return (GenericAuthorizationStrategy) (new EmbeddedWebViewAuthorizationStrategy(parameters.getActivity()));
                 }
             }
-
             Logger.info(TAG, "Use browser for authorization.");
-            final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(parameters.getActivity());
+            final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
+                    parameters.getActivity(),
+                    isBrokerRequest
+            );
             browserAuthorizationStrategy.setBrowserSafeList(parameters.getBrowserSafeList());
             return (GenericAuthorizationStrategy) browserAuthorizationStrategy;
         } else {
             Logger.info(TAG, "Use browser for authorization.");
-            final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(parameters.getActivity());
+            final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
+                    parameters.getActivity(),
+                    isBrokerRequest
+            );
             browserAuthorizationStrategy.setBrowserSafeList(parameters.getBrowserSafeList());
             return (GenericAuthorizationStrategy) browserAuthorizationStrategy;
         }

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=1.0.9-cobo2
+versionName=1.0.9-cobo3
 versionCode=1

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=1.0.9-cobo4
+versionName=1.0.9
 versionCode=1

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=1.0.9
+versionName=1.0.9-cobo2
 versionCode=1

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=1.0.9-cobo3
+versionName=1.0.9-cobo4
 versionCode=1


### PR DESCRIPTION
-  For broker request using browser,  we need to clear all activities in the task and bring Authorization Activity to the top. If we do not add FLAG_ACTIVITY_CLEAR_TASK, Authorization Activity on finish can land on Authenticator's or Company Portal's active activity which would be confusing to the user.
- Also fixed a bug where package name was taken from activity of Broker instead of calling app.