### PR TITLE
Resolving PoP backcompat issue

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -1407,9 +1407,9 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
         assertTrue(mSharedPreferencesAccountCredentialCache.getCredentials().isEmpty());
     }
 
-    @Test(expected = RuntimeException.class) // TODO Should this *really* throw a RuntimeException
-    public void testThrowsExceptionForMalformedCredentialCacheKey() {
-        mSharedPreferencesAccountCredentialCache.getCredential("Malformed cache key");
+    @Test
+    public void testMalformedCredentialCacheKeyReturnsNull() {
+        assertNull(mSharedPreferencesAccountCredentialCache.getCredential("Malformed cache key"));
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesAccountCredentialCache.java
@@ -146,12 +146,15 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     }
 
     @Override
+    @Nullable
     public synchronized Credential getCredential(@NonNull final String cacheKey) {
         // TODO add support for more Credential types...
         Logger.verbose(TAG, "getCredential()");
         Logger.verbosePII(TAG, "Using cache key: [" + cacheKey + "]");
+
         final CredentialType type = getCredentialTypeForCredentialCacheKey(cacheKey);
-        final Class<? extends Credential> clazz;
+        Class<? extends Credential> clazz = null;
+
         if (CredentialType.AccessToken == type) {
             clazz = AccessTokenRecord.class;
         } else if (CredentialType.RefreshToken == type) {
@@ -159,14 +162,20 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         } else if (CredentialType.IdToken == type || CredentialType.V1IdToken == type) {
             clazz = IdTokenRecord.class;
         } else {
-            // TODO Log a warning, throw an Exception?
-            throw new RuntimeException("Credential type could not be resolved.");
+            Logger.warn(
+                    TAG,
+                    "Unrecognized credential type."
+            );
         }
 
-        Credential credential = mCacheValueDelegate.fromCacheValue(
-                mSharedPreferencesFileManager.getString(cacheKey),
-                clazz
-        );
+        Credential credential = null;
+
+        if (null != clazz) {
+            credential = mCacheValueDelegate.fromCacheValue(
+                    mSharedPreferencesFileManager.getString(cacheKey),
+                    clazz
+            );
+        }
 
         if (null == credential) {
             // We could not deserialize the target Credential...


### PR DESCRIPTION
This PR resolves an issue where unrecognized cache keys throw a `RuntimeException` -- now they just log a warning.