### PR TITLE
Remove `mUseCustomTabs` from BrowserDescriptor to fix browser safe list

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
@@ -42,16 +42,16 @@ import com.microsoft.identity.common.internal.ui.browser.Browser;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
@@ -111,8 +111,8 @@ public class BrowserSelectorTest {
         when(mContext.getPackageManager().resolveActivity(BROWSER_INTENT, 0))
                 .thenReturn(CHROME.mResolveInfo);
         List<Browser> allBrowsers = BrowserSelector.getAllBrowsers(mContext);
-        assert(allBrowsers.get(0).getPackageName().equals(CHROME.mPackageName));
-        assert(allBrowsers.get(1).getPackageName().equals(FIREFOX.mPackageName));
+        assert (allBrowsers.get(0).getPackageName().equals(CHROME.mPackageName));
+        assert (allBrowsers.get(1).getPackageName().equals(FIREFOX.mPackageName));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class BrowserSelectorTest {
             BrowserSelector.select(mContext, browserSafelist);
         } catch (final ClientException exception) {
             assertNotNull(exception);
-            assert(exception.getErrorCode().equalsIgnoreCase(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND));
+            assert (exception.getErrorCode().equalsIgnoreCase(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND));
         }
     }
 
@@ -139,7 +139,6 @@ public class BrowserSelectorTest {
                 new BrowserDescriptor(
                         "com.android.chrome",
                         "ChromeSignature",
-                        true,
                         "51",
                         null)
         );
@@ -148,7 +147,7 @@ public class BrowserSelectorTest {
             BrowserSelector.select(mContext, browserSafelist);
         } catch (final ClientException exception) {
             assertNotNull(exception);
-            assert(exception.getErrorCode().equalsIgnoreCase(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND));
+            assert (exception.getErrorCode().equalsIgnoreCase(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND));
         }
     }
 
@@ -278,7 +277,7 @@ public class BrowserSelectorTest {
                 ri.filter.addDataScheme(scheme);
             }
 
-            for (String authority: mAuthorities) {
+            for (String authority : mAuthorities) {
                 ri.filter.addDataAuthority(authority, null);
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -8,6 +8,9 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ClientException;
@@ -21,8 +24,8 @@ import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
-import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 import com.microsoft.identity.common.internal.ui.browser.Browser;
+import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.util.QueryParamsAdapter;
 import com.microsoft.identity.common.internal.util.StringUtil;
@@ -33,9 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
@@ -177,14 +177,14 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                         OpenIdConnectPromptParameter.NONE
         );
         Logger.info(TAG, "Authorization agent passed in by MSAL: " + brokerRequest.getAuthorizationAgent());
-        if(brokerRequest.getAuthorizationAgent() != null
+        if (brokerRequest.getAuthorizationAgent() != null
                 && brokerRequest.getAuthorizationAgent().equalsIgnoreCase(AuthorizationAgent.BROWSER.name())
-                && isCallingPackageIntune(parameters.getCallerPackageName())){ // TODO : Remove this whenever we enable System Browser support in Broker for apps.
-            Logger.info(TAG , "Setting Authorization Agent to Browser for Intune app");
+                && isCallingPackageIntune(parameters.getCallerPackageName())) { // TODO : Remove this whenever we enable System Browser support in Broker for apps.
+            Logger.info(TAG, "Setting Authorization Agent to Browser for Intune app");
             parameters.setAuthorizationAgent(AuthorizationAgent.BROWSER);
             parameters.setBrokerBrowserSupportEnabled(true);
             parameters.setBrowserSafeList(getBrowserSafeListForBroker());
-        }else {
+        } else {
             parameters.setAuthorizationAgent(AuthorizationAgent.WEBVIEW);
         }
 
@@ -386,28 +386,20 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     /**
      * List of System Browsers which can be used from broker, currently only Chrome is supported.
      * This information here is populated from the default browser safelist in MSAL.
+     *
      * @return
      */
-    public static List<BrowserDescriptor> getBrowserSafeListForBroker(){
-        List<BrowserDescriptor>  browserDescriptors = new ArrayList<>();
+    public static List<BrowserDescriptor> getBrowserSafeListForBroker() {
+        List<BrowserDescriptor> browserDescriptors = new ArrayList<>();
         final HashSet<String> signatureHashes = new HashSet();
         signatureHashes.add("7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg==");
-        final BrowserDescriptor chromeWithCustomTabs = new BrowserDescriptor(
+        final BrowserDescriptor chrome = new BrowserDescriptor(
                 "com.android.chrome",
                 signatureHashes,
-                true,
-                "45",
-                null
-        );
-        final BrowserDescriptor chromeWithoutCustomTabs = new BrowserDescriptor(
-                "com.android.chrome",
-                signatureHashes,
-                false,
                 null,
                 null
         );
-        browserDescriptors.add(chromeWithCustomTabs);
-        browserDescriptors.add(chromeWithoutCustomTabs);
+        browserDescriptors.add(chrome);
 
         return browserDescriptors;
     }
@@ -415,9 +407,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     /**
      * Helper method to validate in Broker that the calling package in Microsoft Intune
      * to allow System Webview Support.
-     *
      */
-    private boolean isCallingPackageIntune(@NonNull final String packageName){
+    private boolean isCallingPackageIntune(@NonNull final String packageName) {
         final String methodName = ":isCallingPackageIntune";
         final String intunePackageName = "com.microsoft.intune";
         Logger.info(TAG + methodName, "Calling package name : " + packageName);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
@@ -39,9 +39,6 @@ public class BrowserDescriptor implements Serializable {
     @SerializedName("browser_signature_hashes")
     private Set<String> mSignatureHashes;
 
-    @SerializedName("browser_use_customTab")
-    private boolean mUseCustomTab;
-
     @SerializedName("browser_version_lower_bound")
     private String mVersionLowerBound;
 
@@ -51,12 +48,10 @@ public class BrowserDescriptor implements Serializable {
     public BrowserDescriptor(
             @NonNull final String packageName,
             @NonNull final Set<String> signatureHashes,
-            final boolean useCustomTab,
             @Nullable final String versionLowerBound,
             @Nullable final String versionUpperBound) {
         mPackageName = packageName;
         mSignatureHashes = signatureHashes;
-        mUseCustomTab = useCustomTab;
         mVersionLowerBound = versionLowerBound;
         mVersionUpperBound = versionUpperBound;
     }
@@ -64,12 +59,10 @@ public class BrowserDescriptor implements Serializable {
     public BrowserDescriptor(
             @NonNull final String packageName,
             @NonNull final String signatureHash,
-            final boolean useCustomTab,
             @Nullable final String versionLowerBound,
             @Nullable final String versionUpperBound) {
         mPackageName = packageName;
         mSignatureHashes = Collections.singleton(signatureHash);
-        mUseCustomTab = useCustomTab;
         mVersionLowerBound = versionLowerBound;
         mVersionUpperBound = versionUpperBound;
     }
@@ -80,10 +73,6 @@ public class BrowserDescriptor implements Serializable {
         }
 
         if (!mSignatureHashes.equals(browser.getSignatureHashes())) {
-            return false;
-        }
-
-        if (mUseCustomTab != browser.isCustomTabsServiceSupported()) {
             return false;
         }
 


### PR DESCRIPTION
This change is needed to fix [MSAL Issue 859](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/859)

Note that the field `mUseCustomTab` was irrelevant, and was only being used to determine if a particular browser version is safe to use with MSAL. Whether custom tab is supported or not is based on the `Browser` object and the field `mIsCustomTabsServiceSupported` flag on the Browser object. For details, see [Browser.java](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/e2f5c3db43763541e7651100c6b4a1f6f0c41257/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/Browser.java)