### PR TITLE
Fix msal issue 882

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -55,6 +55,8 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
         if (mAccount == null) {
             Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
+            // if the authority is B2C, then we do not need check if matches with the account enviroment
+            // as B2C only exists in one cloud and can use custom domains
         } else if (!isAuthorityB2C() && !authorityMatchesAccountEnvironment()) {
             throw new ArgumentException(
                     ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AcquireTokenSilentOperationParameters.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.internal.request;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.exception.ArgumentException;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryB2CAuthority;
 import com.microsoft.identity.common.internal.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -54,13 +55,17 @@ public class AcquireTokenSilentOperationParameters extends OperationParameters {
 
         if (mAccount == null) {
             Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
-        } else if (!authorityMatchesAccountEnvironment()) {
+        } else if (!isAuthorityB2C() && !authorityMatchesAccountEnvironment()) {
             throw new ArgumentException(
                     ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
                     ArgumentException.AUTHORITY_ARGUMENT_NAME,
                     "Authority passed to silent parameters does not match with the cloud associated to the account."
             );
         }
+    }
+
+    private boolean isAuthorityB2C() {
+        return getAuthority() instanceof AzureActiveDirectoryB2CAuthority;
     }
 
     private boolean authorityMatchesAccountEnvironment() {


### PR DESCRIPTION
Fix [MSAL Issue 882](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/882)

If the authority is B2C, then we don't need to check if the Environment on the account that is passed matches the host or not as B2C only exists in one cloud.

cherry picked commit from pr #764 