### PR TITLE
Fix null pointer exception in BrokerMsalStrategies

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
@@ -1,0 +1,39 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.exception;
+
+/**
+ * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or Account Manager).
+ */
+public class BrokerCommunicationException extends BaseException {
+
+    /**
+     * Initiates the {@link BrokerCommunicationException} with error code, error message and throwable.
+     *
+     * @param errorMessage The error message contained in the exception.
+     */
+    public BrokerCommunicationException(final String errorMessage) {
+        super(ErrorStrings.IO_ERROR, errorMessage);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -331,9 +331,10 @@ public final class ErrorStrings {
     public static final String USER_CANCELLED = "User cancelled";
 
     /**
-     * The calling app is not supported by the broker.
+     * The broker app is too old to support the calling MSAL.
      */
-    public static final String UNSUPPORTED_BROKER_VERSION = "unsupported_broker_version";
+    public static final String UNSUPPORTED_BROKER_VERSION_ERROR_CODE = "unsupported_broker_version";
+    public static final String UNSUPPORTED_BROKER_VERSION_ERROR_MESSAGE = "Please update Intune Company Portal and/or Microsoft Authenticator to the latest version.";
 
     /**
      * Decryption failed.

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.adal.internal.util.HashMapExtensions;
 import com.microsoft.identity.common.adal.internal.util.JsonExtensions;
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException;
@@ -177,7 +178,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         );
 
         if (brokerResult == null) {
-            Logger.error(TAG, "Broker Result not returned from Broker, ", null);
+            Logger.error(TAG, "Broker Result not returned from Broker", null);
             return new BaseException(ErrorStrings.UNKNOWN_ERROR, "Broker Result not returned from Broker");
         }
 
@@ -306,11 +307,14 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
     }
 
-    public boolean getHelloFromResultBundle(final Bundle bundle) throws ClientException {
-        final String methodName = ":getHelloFromResultBundle";
+    public void verifyHelloFromResultBundle(final Bundle bundle) throws ClientException {
+        final String methodName = ":verifyHelloFromResultBundle";
+
+        // This means that the Broker doesn't support hello().
         if (bundle == null) {
             Logger.warn(TAG + methodName, "The hello result bundle is null.");
-            return false;
+            throw new ClientException(ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE,
+                    ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_MESSAGE);
         }
 
         if (!StringUtil.isEmpty(bundle.getString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY))) {
@@ -319,7 +323,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                     "Able to establish the connect, " +
                             "the broker protocol version in common is ["
                             + negotiatedBrokerProtocolVersion + "]");
-            return true;
+            return;
         }
 
         if (!StringUtil.isEmpty(bundle.getString(AuthenticationConstants.OAuth2.ERROR))
@@ -336,7 +340,10 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             throw new ClientException(brokerResult.getErrorCode(), brokerResult.getErrorMessage());
         }
 
-        return false;
+        // This means that the Broker doesn't support hello().
+        Logger.warn(TAG + methodName, "The result bundle is not in a recognizable format.");
+        throw new ClientException(ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE,
+                ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_MESSAGE);
     }
 
     public AcquireTokenResult getAcquireTokenResultFromResultBundle(@NonNull final Bundle resultBundle) throws BaseException {


### PR DESCRIPTION
Related PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/create?base=AzureAD%3Adev&head=AzureAD%3Arapong%2FfixMsalStrategies

Root cause:
- verifyHelloFromResultBundle returned boolean.
- In BrokerMsalController, since it returned boolean, exception is never thrown for that strategy.
- if hello failed twice - for BindService and AccountManager, then we'll end up with result = null.

Fix:
1. verifyHelloFromResultBundle() now throw an exception, if it gets an unexpected result bundle (i.e. Broker doesn't support hello in the calling strategy, which could be BindService or AccountManager).
 
2. Also introduce BrokerCommunicationException, which is thrown when
 - We ran into bind service errors in BrokerAuthServiceStrategy
 - We ran into AccountManager error in BrokerAccountManagerStrategy

3. In BrokerMsalController
 - When we loop through strategies, if BrokerCommunicationException is thrown, we continue, otherwise we throw an exception right away.
 - After the loop is done, if result = null, it means we got BrokerCommunicationException for EVERY strategies we iterated through. In this case, we throw BrokerCommunicationException. 