### PR TITLE
Resolves #793 - Fix for Token Caching

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
@@ -39,6 +39,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.microsoft.identity.common.internal.controllers.BaseController.DEFAULT_SCOPES;
+
 public abstract class AbstractAccountCredentialCache implements IAccountCredentialCache {
 
     private static final String TAG = AbstractAccountCredentialCache.class.getSimpleName();
@@ -185,10 +187,10 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             if (mustMatchOnTarget) {
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, accessToken.getTarget());
+                    matches = matches && targetsIntersect(target, accessToken.getTarget(), true);
                 } else if (credential instanceof RefreshTokenRecord) {
                     final RefreshTokenRecord refreshToken = (RefreshTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, refreshToken.getTarget());
+                    matches = matches && targetsIntersect(target, refreshToken.getTarget(), true);
                 } else {
                     Logger.warn(TAG, "Query specified target-match, but no target to match.");
                 }
@@ -210,13 +212,16 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
     /**
      * Examines the intersections of the provided targets (scopes).
      *
-     * @param targetToMatch    The target value[s] our cache-query is looking for.
-     * @param credentialTarget The target against which our sought value will be compared.
+     * @param targetToMatch     The target value[s] our cache-query is looking for.
+     * @param credentialTarget  The target against which our sought value will be compared.
+     * @param omitDefaultScopes True if MSAL's default scopes should be considered in this lookup.
+     *                          False otherwise.
      * @return True, if the credentialTarget contains all of the targets (scopes) declared by
      * targetToMatch. False otherwise.
      */
     static boolean targetsIntersect(@NonNull final String targetToMatch,
-                                    @NonNull final String credentialTarget) {
+                                    @NonNull final String credentialTarget,
+                                    boolean omitDefaultScopes) {
         // The credentialTarget must contain all of the scopes in the targetToMatch
         // It may contain more, but it must contain minimally those
         // Matching is case-insensitive
@@ -235,6 +240,11 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
 
         for (final String target : credentialTargetArray) {
             credentialTargetSet.add(target.toLowerCase());
+        }
+
+        if (omitDefaultScopes) {
+            soughtTargetSet.removeAll(DEFAULT_SCOPES);
+            credentialTargetSet.removeAll(DEFAULT_SCOPES);
         }
 
         return credentialTargetSet.containsAll(soughtTargetSet);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -148,7 +148,7 @@ public class MicrosoftFamilyOAuth2TokenCache
                             && accountRecord.getEnvironment().equals(atRecord.getEnvironment())
                             && accountRecord.getHomeAccountId().equals(atRecord.getHomeAccountId())
                             && accountRecord.getRealm().equals(atRecord.getRealm())
-                            && targetsIntersect(target, atRecord.getTarget())) {
+                            && targetsIntersect(target, atRecord.getTarget(), true)) {
                         if (CredentialType.AccessToken.name().equalsIgnoreCase(atRecord.getCredentialType())
                                 && BearerAuthenticationSchemeInternal.SCHEME_BEARER.equalsIgnoreCase(authenticationScheme.getName())) {
                             atRecordToReturn = atRecord;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -82,13 +82,6 @@ public class MicrosoftStsAccountCredentialAdapter
             accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
 
             accessToken.setClientId(request.getClientId());
-            /*
-            ===============================================================
-            NOTE: When requesting tokens for resources other than MS Graph or AAD Graph the default scopes
-            openid, profile and offline_access are not returned.  They need to be written into the cache anyway
-            to avoid cache misses.
-            ===============================================================
-             */
             accessToken.setTarget(response.getScope());
             accessToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
             accessToken.setExpiresOn(String.valueOf(expiresOn));

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -78,9 +78,7 @@ public class MicrosoftStsAccountCredentialAdapter
             accessToken.setCredentialType(getCredentialType(response.getTokenType()));
             accessToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             accessToken.setRealm(getRealm(strategy, response));
-
             accessToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-
             accessToken.setClientId(request.getClientId());
             accessToken.setTarget(response.getScope());
             accessToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
@@ -128,7 +126,6 @@ public class MicrosoftStsAccountCredentialAdapter
             // Required
             refreshToken.setCredentialType(CredentialType.RefreshToken.name());
             refreshToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-
             refreshToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
             refreshToken.setClientId(request.getClientId());
             refreshToken.setSecret(response.getRefreshToken());
@@ -158,10 +155,7 @@ public class MicrosoftStsAccountCredentialAdapter
             final IdTokenRecord idToken = new IdTokenRecord();
             // Required fields
             idToken.setHomeAccountId(SchemaUtil.getHomeAccountId(clientInfo));
-
             idToken.setEnvironment(strategy.getIssuerCacheIdentifierFromTokenEndpoint());
-
-
             idToken.setRealm(getRealm(strategy, response));
             idToken.setCredentialType(
                     SchemaUtil.getCredentialTypeFromVersion(

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.cache;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -90,7 +89,7 @@ public class MicrosoftStsAccountCredentialAdapter
             to avoid cache misses.
             ===============================================================
              */
-            accessToken.setTarget(getTarget(response.getScope()));
+            accessToken.setTarget(response.getScope());
             accessToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
             accessToken.setExpiresOn(String.valueOf(expiresOn));
             accessToken.setSecret(response.getAccessToken());
@@ -121,26 +120,6 @@ public class MicrosoftStsAccountCredentialAdapter
         }
 
         return type;
-    }
-
-    /**
-     * Returns the correct target based on whether the default scopes were returned or not
-     *
-     * @param responseScope The response scope to parse.
-     * @return The target containing default scopes.
-     */
-    private String getTarget(@NonNull final String responseScope) {
-        if (responseScope.contains(AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE)) {
-            if (responseScope.contains(AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE)) {
-                return responseScope;
-            } else {
-                return responseScope + " " + AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE;
-            }
-        } else {
-            return responseScope + " " + AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE
-                    + " " + AuthenticationConstants.OAuth2Scopes.PROFILE_SCOPE
-                    + " " + AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE;
-        }
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -135,7 +135,7 @@ public class MicrosoftStsAccountCredentialAdapter
 
             // Optional
             refreshToken.setFamilyId(response.getFamilyId());
-            refreshToken.setTarget(request.getScope());
+            refreshToken.setTarget(response.getScope());
 
             // TODO are these needed? Expected?
             refreshToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -64,6 +64,7 @@ import static com.microsoft.identity.common.exception.ErrorStrings.ACCOUNT_IS_SC
 import static com.microsoft.identity.common.exception.ErrorStrings.CREDENTIAL_IS_SCHEMA_NONCOMPLIANT;
 import static com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal.SCHEME_BEARER;
 import static com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache.DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES;
+import static com.microsoft.identity.common.internal.controllers.BaseController.DEFAULT_SCOPES;
 import static com.microsoft.identity.common.internal.dto.CredentialType.ID_TOKEN_TYPES;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
@@ -154,8 +155,8 @@ public class MsalOAuth2TokenCache
     }
 
 
-     void validateNonNull(@Nullable final Object object,
-                                 @NonNull final String type) throws ClientException {
+    void validateNonNull(@Nullable final Object object,
+                         @NonNull final String type) throws ClientException {
         final String message = type + " passed in is Null";
 
         if (object == null) {
@@ -376,8 +377,8 @@ public class MsalOAuth2TokenCache
     /**
      * Helper method to remove an old refresh token if it's MRRT ot FRT.
      */
-     void removeRefreshTokenIfNeeded(@NonNull final AccountRecord accountRecord,
-                                            @NonNull final RefreshTokenRecord refreshTokenRecord) {
+    void removeRefreshTokenIfNeeded(@NonNull final AccountRecord accountRecord,
+                                    @NonNull final RefreshTokenRecord refreshTokenRecord) {
         final String methodName = ":removeRefreshTokenIfNeeded";
         final boolean isFamilyRefreshToken = !StringExtensions.isNullOrBlank(
                 refreshTokenRecord.getFamilyId()
@@ -1285,7 +1286,6 @@ public class MsalOAuth2TokenCache
     }
 
 
-
     /**
      * Validates that the supplied artifacts are schema-compliant and OK to write to the cache.
      *
@@ -1297,7 +1297,7 @@ public class MsalOAuth2TokenCache
      * @param idTokenToSave      The {@link IdTokenRecord} to save.
      * @throws ClientException If any of the supplied artifacts are non schema-compliant.
      */
-     void validateCacheArtifacts(
+    void validateCacheArtifacts(
             @NonNull final AccountRecord accountToSave,
             final AccessTokenRecord accessTokenToSave,
             @NonNull final RefreshTokenRecord refreshTokenToSave,
@@ -1353,7 +1353,7 @@ public class MsalOAuth2TokenCache
                 CredentialType.fromString(referenceToken.getCredentialType()),
                 referenceToken.getClientId(),
                 referenceToken.getRealm(),
-                null, // Wildcard - delete anything that matches...,
+                null, // Wildcard (*)
                 referenceToken.getAccessTokenType()
         );
 
@@ -1363,19 +1363,29 @@ public class MsalOAuth2TokenCache
         );
 
         for (final Credential accessToken : accessTokens) {
-            if (scopesIntersect(referenceToken, (AccessTokenRecord) accessToken)) {
-                Logger.infoPII(TAG + ":" + methodName, "Removing credential: " + accessToken);
+            if (scopesIntersect(referenceToken, (AccessTokenRecord) accessToken, true)) {
+                Logger.infoPII(
+                        TAG + ":" + methodName,
+                        "Removing credential: " + accessToken
+                );
                 mAccountCredentialCache.removeCredential(accessToken);
             }
         }
     }
 
     private boolean scopesIntersect(final AccessTokenRecord token1,
-                                    final AccessTokenRecord token2) {
+                                    final AccessTokenRecord token2,
+                                    boolean omitDefaultScopes) {
         final String methodName = "scopesIntersect";
 
         final Set<String> token1Scopes = scopesAsSet(token1);
         final Set<String> token2Scopes = scopesAsSet(token2);
+
+        if (omitDefaultScopes) {
+            // Remove the default scopes (if present), do not consider them in lookup criteria
+            token1Scopes.removeAll(DEFAULT_SCOPES);
+            token2Scopes.removeAll(DEFAULT_SCOPES);
+        }
 
         boolean result = false;
         for (final String scope : token2Scopes) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -73,6 +73,7 @@ import com.microsoft.identity.common.internal.telemetry.events.CacheEndEvent;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -81,6 +82,14 @@ import java.util.regex.Pattern;
 public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();
+
+    public static final Set<String> DEFAULT_SCOPES = new HashSet<>();
+
+    static {
+        DEFAULT_SCOPES.add(AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE);
+        DEFAULT_SCOPES.add(AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE);
+        DEFAULT_SCOPES.add(AuthenticationConstants.OAuth2Scopes.PROFILE_SCOPE);
+    }
 
     public abstract AcquireTokenResult acquireToken(final AcquireTokenOperationParameters request)
             throws Exception;
@@ -421,9 +430,7 @@ public abstract class BaseController {
 
     protected void addDefaultScopes(@NonNull final OperationParameters operationParameters) {
         final Set<String> requestScopes = operationParameters.getScopes();
-        requestScopes.add(AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE);
-        requestScopes.add(AuthenticationConstants.OAuth2Scopes.OFFLINE_ACCESS_SCOPE);
-        requestScopes.add(AuthenticationConstants.OAuth2Scopes.PROFILE_SCOPE);
+        requestScopes.addAll(DEFAULT_SCOPES);
         // sanitize empty and null scopes
         requestScopes.removeAll(Arrays.asList("", null));
         operationParameters.setScopes(requestScopes);


### PR DESCRIPTION
See #793

Related:
https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/904

This makes the following changes:
- Write tokens to cache using IdP responses (do not inject default scopes)
- Exclude default scopes from intersect criteria