### PR TITLE
Set default bearer auth scheme in broker with adal

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
+import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -81,6 +82,8 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 new BrokerAcquireTokenOperationParameters();
 
         final Intent intent = callingActivity.getIntent();
+
+        parameters.setAuthenticationScheme(new BearerAuthenticationSchemeInternal());
 
         parameters.setActivity(callingActivity);
 
@@ -201,6 +204,8 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
         );
         final BrokerAcquireTokenSilentOperationParameters parameters =
                 new BrokerAcquireTokenSilentOperationParameters();
+
+        parameters.setAuthenticationScheme(new BearerAuthenticationSchemeInternal());
 
         parameters.setAppContext(context);
 


### PR DESCRIPTION
ADAL with Broker is not working after PoP merge and returning `authentication_scheme` is undefined error. 

This is happening because there is no default authentication scheme provided to the Broker in the case of ADAL. Hence when the broker (common) calls validate method on the `BrokerAcquireTokenOperationParameters` we throw an ArgumentException as the auth scheme is not present on operation parameters.

I've fixed this by providing a default Bearer Authentication Scheme in via the AdalBrokerRequestAdapter