### PR TITLE
Fixes MSAL/#915

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -23,9 +23,10 @@
 package com.microsoft.identity.common.internal.authorities;
 
 import android.net.Uri;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.exception.ClientException;
@@ -45,6 +46,7 @@ public abstract class Authority {
 
     private static final String ADFS_PATH_SEGMENT = "adfs";
     private static final String B2C_PATH_SEGMENT = "tfp";
+    public static final String B2C = "B2C";
 
     protected boolean mKnownToMicrosoft = false;
     protected boolean mKnownToDeveloper = false;
@@ -105,7 +107,7 @@ public abstract class Authority {
             final Authority configuredAuthority = getEquivalentConfiguredAuthority(authorityUrl);
             final String authorityTypeStr = configuredAuthority.mAuthorityTypeString;
 
-            if ("B2C".equalsIgnoreCase(authorityTypeStr)) {
+            if (B2C.equalsIgnoreCase(authorityTypeStr)) {
                 authority = new AzureActiveDirectoryB2CAuthority(authorityUrl);
             } else {
                 authority = createAadAuthority(authorityUri, pathSegments);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -27,6 +27,9 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.microsoft.identity.common.BaseAccount;
@@ -299,6 +302,15 @@ public class ADALOAuth2TokenCache
 
     @Override
     protected Set<String> getAllClientIds() {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
+    }
+
+    @Override
+    public AccountRecord getAccountByHomeAccountId(@Nullable final String environment,
+                                                   @NonNull final String clientId,
+                                                   @NonNull final String homeAccountId) {
         throw new UnsupportedOperationException(
                 ERR_UNSUPPORTED_OPERATION
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -1375,6 +1375,64 @@ public class BrokerOAuth2TokenCache
         return mApplicationMetadataCache.getAllClientIds();
     }
 
+    @Override
+    public AccountRecord getAccountByHomeAccountId(@Nullable final String environment,
+                                                   @NonNull final String clientId,
+                                                   @NonNull final String homeAccountId) {
+        final String methodName = "getAccountByHomeAccountId";
+
+        Logger.verbose(
+                TAG + methodName,
+                "Loading account by home account id."
+        );
+
+        if (null != environment) {
+            OAuth2TokenCache targetCache = getTokenCacheForClient(
+                    clientId,
+                    environment,
+                    mCallingProcessUid
+            );
+
+            Logger.info(
+                    TAG + methodName,
+                    "Loading from FOCI cache? ["
+                            + (targetCache == null)
+                            + "]"
+            );
+
+            if (null != targetCache) {
+                return targetCache.getAccountByHomeAccountId(
+                        environment,
+                        clientId,
+                        homeAccountId
+                );
+            } else {
+                return mFociCache.getAccountByHomeAccountId(
+                        environment,
+                        clientId,
+                        homeAccountId
+                );
+            }
+        } else {
+            AccountRecord result = null;
+
+            final List<OAuth2TokenCache> cachesToInspect = getTokenCachesForClientId(clientId);
+            final Iterator<OAuth2TokenCache> cacheIterator = cachesToInspect.iterator();
+
+            while (null == result && cacheIterator.hasNext()) {
+                result = cacheIterator
+                        .next()
+                        .getAccountByHomeAccountId(
+                                environment,
+                                clientId,
+                                homeAccountId
+                        );
+            }
+
+            return result;
+        }
+    }
+
     private MsalOAuth2TokenCache initializeProcessUidCache(@NonNull final Context context,
                                                            final int bindingProcessUid) {
         final String methodName = ":initializeProcessUidCache";

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1176,6 +1176,29 @@ public class MsalOAuth2TokenCache
         return result;
     }
 
+    @Nullable
+    @Override
+    public AccountRecord getAccountByHomeAccountId(@Nullable final String environment,
+                                                   @NonNull final String clientId,
+                                                   @NonNull final String homeAccountId) {
+        final String methodName = ":getAccountByHomeAccountId";
+
+        final List<AccountRecord> accounts = getAccounts(environment, clientId);
+
+        Logger.verbosePII(
+                TAG + methodName,
+                "homeAccountId: [" + homeAccountId + "]"
+        );
+
+        for (final AccountRecord account : accounts) {
+            if (homeAccountId.equals(account.getHomeAccountId())) {
+                return account;
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Removes Credentials of the supplied type for the supplied Account.
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -24,6 +24,9 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
@@ -273,4 +276,9 @@ public abstract class OAuth2TokenCache
     protected final Context getContext() {
         return mContext;
     }
+
+    public abstract AccountRecord getAccountByHomeAccountId(@Nullable final String environment,
+                                                            @NonNull final String clientId,
+                                                            @NonNull final String homeAccountId
+    );
 }


### PR DESCRIPTION
Issue:
https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/915

Expands:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/807

Summary:
Conditionally perform `AccountRecord` lookup from cache by `home_account_id` if `B2C == Authority.type`