### PR TITLE
Allow nonce to be null, not provided by client

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.authscheme;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.exception.ClientException;
@@ -70,7 +71,7 @@ public class PopAuthenticationSchemeInternal
 
     PopAuthenticationSchemeInternal(@NonNull final String httpMethod,
                                     @NonNull final URL url,
-                                    @NonNull final String nonce) {
+                                    @Nullable final String nonce) {
         super(SCHEME_POP);
         mHttpMethod = httpMethod;
         mUrl = url;
@@ -100,6 +101,7 @@ public class PopAuthenticationSchemeInternal
     }
 
     @Override
+    @Nullable
     public String getNonce() {
         return mNonce;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -30,6 +30,7 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyProperties;
 import android.security.keystore.StrongBoxUnavailableException;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
@@ -457,7 +458,10 @@ class DevicePopManager implements IDevicePopManager {
             claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_HOST, requestUrl.getHost());
             claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_PATH, requestUrl.getPath());
             claimsBuilder.claim(SignedHttpRequestJwtClaims.CNF, getDevicePopJwkMinifiedJson());
-            claimsBuilder.claim(SignedHttpRequestJwtClaims.NONCE, nonce);
+
+            if (!TextUtils.isEmpty(nonce)) {
+                claimsBuilder.claim(SignedHttpRequestJwtClaims.NONCE, nonce);
+            }
 
             final JWTClaimsSet claimsSet = claimsBuilder.build();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -96,6 +96,7 @@ public interface IDevicePopManager {
      * @param httpMethod  The HTTP method that will be used with this outbound request.
      * @param requestUrl  The recipient URL of the outbound request.
      * @param accessToken The access_token from which to derive the signed JWT.
+     * @param nonce       Arbitrary value used for replay protection by middleware.
      * @return The signed PoP access token.
      */
     String mintSignedAccessToken(String httpMethod,


### PR DESCRIPTION
Related:
https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/909