### PR TITLE
Fix msal crash on cancel interactive broadcast

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
+import com.microsoft.identity.common.internal.request.BrokerAcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.ILocalAuthenticationResult;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;
@@ -268,10 +269,13 @@ public class CommandDispatcher {
         synchronized (sLock) {
             final LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(command.getParameters().getAppContext());
 
-            // Send a broadcast to cancel if any active auth request is present.
-            localBroadcastManager.sendBroadcast(
-                    new Intent(CANCEL_INTERACTIVE_REQUEST)
-            );
+            // only send broadcast to cancel if within broker
+            if (command.getParameters() instanceof BrokerAcquireTokenOperationParameters) {
+                // Send a broadcast to cancel if any active auth request is present.
+                localBroadcastManager.sendBroadcast(
+                        new Intent(CANCEL_INTERACTIVE_REQUEST)
+                );
+            }
 
             sInteractiveExecutor.execute(new Runnable() {
                 @Override


### PR DESCRIPTION
Fix [MSAL Issue 940](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/940)
Fix [MSAL Issue 935](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/935)
Fix [MSAL Issue 920](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/920)
Fix [MSAL Issue 924](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/924)

MSAL crashes intermittently due to the CANCEL_INTERACTIVE_BROADCAST. This usually happens and is easy to reproduce when the developer starts another interactive call from the onError callback of the first one. This can result in a loop where each new request cancel the previous one. This is because cancelling the request by the SDK also results in an error and hits the onError again (_May be this should also hit `onCancel` instead of onError?_) and starts a chain reaction where the SDK keeps starting a new interactive request and keeps cancelling it.  After some time MSAL runs into a some weird threading state where it calls the `completeAuthorization` method on a null authorization strategy object. See [this file](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/d806fa789f29c77e9d1e190f4149c91af8923c53/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java#L217). I'm not too sure why and how it happens as it is not possible to reproduce it while debugging and seems to be a timing/threading issue to me.

I also discussed with @shoatman and he suggested that this entire broadcast wasn't even meant for MSAL but rather only for the Broker to avoid multiple apps making interactive calls against the broker at the same time which would result in the current one being blocked until the previous one finishes. I think this makes sense and hence I've removed the broadcast from the local MSAL case and made it specific to just the broker.