### PR TITLE
Set correlation id on operation parameters

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -83,6 +83,10 @@ public class CommandDispatcher {
             @Override
             public void run() {
                 final String correlationId = initializeDiagnosticContext(command.getParameters().getCorrelationId());
+
+                // set correlation id on parameters as it may not already be set
+                command.getParameters().setCorrelationId(correlationId);
+
                 EstsTelemetry.getInstance().emitApiId(command.getPublicApiId());
 
                 CommandResult commandResult = null;
@@ -283,6 +287,10 @@ public class CommandDispatcher {
                     final String correlationId = initializeDiagnosticContext(
                             command.getParameters().getCorrelationId()
                     );
+
+                    // set correlation id on parameters as it may not already be set
+                    command.getParameters().setCorrelationId(correlationId);
+
                     EstsTelemetry.getInstance().emitApiId(command.getPublicApiId());
 
                     if (command.getParameters() instanceof AcquireTokenOperationParameters) {


### PR DESCRIPTION
Operation Parameters has field called `mCorrelationId` as well as a getter/setter for it, however we never set it in the case of local MSAL. This isn't really an issue as we usually also don't use its getter in those cases either and instead get it from the DiagnosticContext. It may still be good to set it on the OperationParameters instead of leaving it null...hence this PR