### PR TITLE
Fix fragment state issue

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -49,9 +49,9 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 
 /**
  * This base classes
- *  - handles how AuthorizationFragments communicates with the outside world.
- *  - handles basic lifecycle operations.
- * */
+ * - handles how AuthorizationFragments communicates with the outside world.
+ * - handles basic lifecycle operations.
+ */
 public abstract class AuthorizationFragment extends Fragment {
 
     private static final String TAG = AuthorizationFragment.class.getSimpleName();
@@ -90,6 +90,12 @@ public abstract class AuthorizationFragment extends Fragment {
         LocalBroadcastManager.getInstance(getContext()).registerReceiver(mCancelRequestReceiver,
                 new IntentFilter(CANCEL_INTERACTIVE_REQUEST));
 
+        if (savedInstanceState == null && mInstanceState == null) {
+            Logger.warn(TAG, "No stored state. Unable to handle response");
+            finish();
+            return;
+        }
+
         if (savedInstanceState == null) {
             Logger.verbose(TAG + methodName, "Extract state from the intent bundle.");
             extractState(mInstanceState);
@@ -115,13 +121,7 @@ public abstract class AuthorizationFragment extends Fragment {
         }
     }
 
-    void extractState(final Bundle state) {
-        if (state == null) {
-            Logger.warn(TAG, "No stored state. Unable to handle response");
-            finish();
-            return;
-        }
-
+    void extractState(@NonNull final Bundle state) {
         setDiagnosticContextForNewThread(state.getString(DiagnosticContext.CORRELATION_ID));
     }
 
@@ -195,7 +195,7 @@ public abstract class AuthorizationFragment extends Fragment {
         final Intent resultIntent = new Intent();
         resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
-        if (isCancelledByUser){
+        if (isCancelledByUser) {
             Logger.info(TAG, "Received Authorization flow cancelled by the user");
             sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
         } else {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
@@ -94,6 +94,12 @@ public class BrowserAuthorizationFragment extends AuthorizationFragment {
 
     @Override
     void extractState(final Bundle state){
+        if (state == null) {
+            Logger.warn(TAG, "No stored state. Unable to handle response");
+            finish();
+            return;
+        }
+
         super.extractState(state);
         mAuthIntent = state.getParcelable(AUTH_INTENT);
         mBrowserFlowStarted = state.getBoolean(BROWSER_FLOW_STARTED, false);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
@@ -34,7 +34,7 @@ import static com.microsoft.identity.common.internal.providers.oauth2.Authorizat
 
 /**
  * Authorization fragment with customTabs or browsers.
- * */
+ */
 public class BrowserAuthorizationFragment extends AuthorizationFragment {
 
     private static final String TAG = BrowserAuthorizationFragment.class.getSimpleName();
@@ -93,13 +93,7 @@ public class BrowserAuthorizationFragment extends AuthorizationFragment {
     }
 
     @Override
-    void extractState(final Bundle state){
-        if (state == null) {
-            Logger.warn(TAG, "No stored state. Unable to handle response");
-            finish();
-            return;
-        }
-
+    void extractState(@NonNull final Bundle state) {
         super.extractState(state);
         mAuthIntent = state.getParcelable(AUTH_INTENT);
         mBrowserFlowStarted = state.getBoolean(BROWSER_FLOW_STARTED, false);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -29,14 +29,14 @@ import java.util.HashMap;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.AUTH_INTENT;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.POST_PAGE_LOADED_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REDIRECT_URI;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_HEADERS;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
 
 /**
  * Authorization fragment with embedded webview.
- * */
+ */
 public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private static final String TAG = WebViewAuthorizationFragment.class.getSimpleName();
@@ -86,13 +86,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     }
 
     @Override
-    void extractState(final Bundle state) {
-        if (state == null) {
-            Logger.warn(TAG, "No stored state. Unable to handle response");
-            finish();
-            return;
-        }
-
+    void extractState(@NonNull final Bundle state) {
         super.extractState(state);
         mAuthIntent = state.getParcelable(AUTH_INTENT);
         mPkeyAuthStatus = state.getBoolean(PKEYAUTH_STATUS, false);
@@ -147,7 +141,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     /**
      * NOTE: Fragment-only mode will not support this, as we don't own the activity.
-     *       This must be invoked by AuthorizationActivity.onBackPressed().
+     * This must be invoked by AuthorizationActivity.onBackPressed().
      */
     @Override
     public boolean onBackPressed() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -87,6 +87,12 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     @Override
     void extractState(final Bundle state) {
+        if (state == null) {
+            Logger.warn(TAG, "No stored state. Unable to handle response");
+            finish();
+            return;
+        }
+
         super.extractState(state);
         mAuthIntent = state.getParcelable(AUTH_INTENT);
         mPkeyAuthStatus = state.getBoolean(PKEYAUTH_STATUS, false);


### PR DESCRIPTION
If no state available we need to finish and return. This is what we used to do, but it was regressed with Fragment support.

Repro (There could be other ways to repro this too, but the fix will take care of all repros):

- Start an interactive request in MSAL
- Quickly lock the device and unlock again (before the browser even opens)

This results in a NPE when extractState is called. I wasn't able to be as quick as required in repro but slowed down code execution in debug mode by putting breakpoints and hence reproduced it. 