### PR TITLE
Closes #871 - Adds support for multiple IdToken lookups in a single call when dual stacking with FoCi

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
@@ -381,4 +381,138 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         assertNull(cacheRecord3.getIdToken());
     }
 
+    @Test
+    public void testDualStackIdTokenRetrieval() throws ClientException {
+        final String randomHomeAccountId = UUID.randomUUID().toString();
+        final String randomRealm = UUID.randomUUID().toString();
+
+        final AccountCredentialTestBundle frtTestBundleV2 = new AccountCredentialTestBundle(
+                MicrosoftAccount.AUTHORITY_TYPE_V1_V2,
+                UUID.randomUUID().toString(),
+                "test.user@tenant.onmicrosoft.com",
+                randomHomeAccountId,
+                ENVIRONMENT,
+                randomRealm,
+                TARGET,
+                CACHED_AT,
+                EXPIRES_ON,
+                SECRET,
+                CLIENT_ID,
+                SECRET,
+                MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
+                "1",
+                CredentialType.IdToken
+        );
+
+        when(
+                mockCredentialAdapter.createAccount(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV2.mGeneratedAccount);
+
+        when(
+                mockCredentialAdapter.createAccessToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV2.mGeneratedAccessToken);
+
+        when(
+                mockCredentialAdapter.createRefreshToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV2.mGeneratedRefreshToken);
+
+        when(
+                mockCredentialAdapter.createIdToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV2.mGeneratedIdToken);
+
+        // Save the family token data
+        mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+
+        final AccountCredentialTestBundle frtTestBundleV1 = new AccountCredentialTestBundle(
+                MicrosoftAccount.AUTHORITY_TYPE_V1_V2,
+                UUID.randomUUID().toString(),
+                "test.user@tenant.onmicrosoft.com",
+                randomHomeAccountId,
+                ENVIRONMENT,
+                randomRealm,
+                TARGET,
+                CACHED_AT,
+                EXPIRES_ON,
+                SECRET,
+                CLIENT_ID,
+                SECRET,
+                MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS,
+                "1",
+                CredentialType.V1IdToken
+        );
+
+        when(
+                mockCredentialAdapter.createAccount(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV1.mGeneratedAccount);
+
+        when(
+                mockCredentialAdapter.createAccessToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV1.mGeneratedAccessToken);
+
+        when(
+                mockCredentialAdapter.createRefreshToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV1.mGeneratedRefreshToken);
+
+        when(
+                mockCredentialAdapter.createIdToken(
+                        mockStrategy,
+                        mockRequest,
+                        mockResponse
+                )
+        ).thenReturn(frtTestBundleV1.mGeneratedIdToken);
+
+        // Save the family token data
+        mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+
+        final ICacheRecord familyCacheRecord = mOauth2TokenCache.loadByFamilyId(
+                CLIENT_ID,
+                TARGET,
+                frtTestBundleV1.mGeneratedAccount,
+                BEARER_SCHEME
+        );
+
+        assertNotNull(familyCacheRecord);
+        assertNotNull(familyCacheRecord.getAccount());
+        assertNotNull(familyCacheRecord.getRefreshToken());
+        assertNotNull(familyCacheRecord.getIdToken());
+        assertNotNull(familyCacheRecord.getV1IdToken());
+        assertNotNull(familyCacheRecord.getAccessToken());
+    }
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MicrosoftFamilyOAuth2TokenCache.java
@@ -106,6 +106,7 @@ public class MicrosoftFamilyOAuth2TokenCache
 
         RefreshTokenRecord rtToReturn = null;
         IdTokenRecord idTokenToReturn = null;
+        IdTokenRecord v1IdTokenToReturn = null;
         AccessTokenRecord atRecordToReturn = null;
 
         final List<Credential> allCredentials = getAccountCredentialCache().getCredentials();
@@ -133,8 +134,12 @@ public class MicrosoftFamilyOAuth2TokenCache
                         && accountRecord.getEnvironment().equals(idTokenRecord.getEnvironment())
                         && accountRecord.getHomeAccountId().equals(idTokenRecord.getHomeAccountId())
                         && accountRecord.getRealm().equals(idTokenRecord.getRealm())) {
-                    idTokenToReturn = idTokenRecord;
-                    break;
+                    if (CredentialType.V1IdToken.name().equalsIgnoreCase(idTokenRecord.getCredentialType())) {
+                        v1IdTokenToReturn = idTokenRecord;
+                    } else {
+                        idTokenToReturn = idTokenRecord;
+                    }
+                    // Do not 'break' as there may still be more IdTokens to inspect
                 }
             }
         }
@@ -167,14 +172,8 @@ public class MicrosoftFamilyOAuth2TokenCache
         result.setAccount(accountRecord);
         result.setRefreshToken(rtToReturn);
         result.setAccessToken(atRecordToReturn);
-
-        if (null != idTokenToReturn) {
-            if (CredentialType.V1IdToken.name().equalsIgnoreCase(idTokenToReturn.getCredentialType())) {
-                result.setV1IdToken(idTokenToReturn);
-            } else {
-                result.setIdToken(idTokenToReturn);
-            }
-        }
+        result.setV1IdToken(v1IdTokenToReturn);
+        result.setIdToken(idTokenToReturn);
 
         return result;
     }


### PR DESCRIPTION
See issue description in #871 