### PR TITLE
Changed the silent request thread pool to a fixed thread pool

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -62,7 +62,7 @@ public class CommandDispatcher {
 
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
     private static final ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
-    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(5);
+    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -60,8 +60,9 @@ public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
 
+    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
     private static final ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
-    private static final ExecutorService sSilentExecutor = Executors.newCachedThreadPool();
+    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(5);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();


### PR DESCRIPTION
**Issue** : Teams is running into an issue where MSAL is not able to connect to broker, below is the stack trace 
```
android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died
    at android.os.BinderProxy.transactNative(Native Method)
    at android.os.BinderProxy.transact(BinderProxy.java:511)
    at com.microsoft.identity.client.IMicrosoftAuthService$Stub$Proxy.getAccounts(IMicrosoftAuthService.java:269)
    at com.microsoft.identity.client.internal.controllers.BrokerAuthServiceStrategy$4.perform(BrokerAuthServiceStrategy.java:224)
    at com.microsoft.identity.client.internal.controllers.BrokerAuthServiceStrategy$4.perform(BrokerAuthServiceStrategy.java:219)
    at com.microsoft.identity.client.internal.controllers.BrokerAuthServiceStrategy.performAuthServiceOperation(BrokerAuthServiceStrategy.java:119)
    at com.microsoft.identity.client.internal.controllers.BrokerAuthServiceStrategy.getBrokerAccounts(BrokerAuthServiceStrategy.java:218)
    at com.microsoft.identity.client.internal.controllers.BrokerMsalController$3.perform(BrokerMsalController.java:360)
    at com.microsoft.identity.client.internal.controllers.BrokerMsalController$3.perform(BrokerMsalController.java:356)
    at com.microsoft.identity.client.internal.controllers.BrokerMsalController.invokeBrokerOperation(BrokerMsalController.java:197)
    at com.microsoft.identity.client.internal.controllers.BrokerMsalController.getAccounts(BrokerMsalController.java:355)
    at com.microsoft.identity.common.internal.controllers.LoadAccountCommand.execute(LoadAccountCommand.java:66)
    at com.microsoft.identity.common.internal.controllers.LoadAccountCommand.execute(LoadAccountCommand.java:37)
    at com.microsoft.identity.common.internal.controllers.CommandDispatcher.executeCommand(CommandDispatcher.java:145)
    at com.microsoft.identity.common.internal.controllers.CommandDispatcher.access$200(CommandDispatcher.java:60)
    at com.microsoft.identity.common.internal.controllers.CommandDispatcher$1.run(CommandDispatcher.java:102)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:919)

04-02 19:53:55.254 18512 18668 I MSMAM - com.microsoft.intune.mam.client.ipcclient.HeartbeatThread: sending heartbeat for package: com.microsoft.skype.teams.prealpha
04-02 19:54:35.292 18512 18713 E MsalAuthenticationProvider: ProcessId: 18512, Thread: pool-9-thread-1, BrokerAccountManagerStrategy:getBrokerAccountsWithAccountManager  [2020-04-02 19:54:35 - {"thread_id":"1245","correlation_id":"bba4c0fb-d904-493d-961a-f06af37447d7"}] addAccount failed Android 29
android.accounts.AuthenticatorException: addAccount failed
    at android.accounts.AccountManager.convertErrorToException(AccountManager.java:2558)
    at android.accounts.AccountManager.access$700(AccountManager.java:162)
    at android.accounts.AccountManager$AmsTask$Response.onError(AccountManager.java:2394)
    at android.accounts.IAccountManagerResponse$Stub.onTransact(IAccountManagerResponse.java:107)
    at android.os.Binder.execTransactInternal(Binder.java:1021)
    at android.os.Binder.execTransact(Binder.java:994)
```
**Repro** : I was not able to repro this with the Teams Alpha build, but I did when I used the MSAL test app to fire around 1000 requests in parallel to broker.

The core issue here is that the Android Binder Buffer for remote IPC's is 1MB (per process) and if too many parallel requests are sent to broker at once, there is a possibility that we can exceed the buffer data prompting the OS to throw `android.os.DeadObjectException`.

**Fix** : Currently MSAL has an unlimited pool for all the silent requests (get accounts, silentauth) etc. Due to this, a large number of threads can be spawned and sent to broker. In addition broker has to accommodate all the requests from other apps using MSAL and ADAL as well. So I changed to use a Fixed Thread pool with a max of 5 threads. 

I have stress tested this change with a pool size of 10 threads by firing lot of requests and occasionally ran to this error, so reduced the pool size to 5. 

Note : This change would modify the behavior of Local Msal Authentication as well as the change is generic in Command Dispatcher. I didn't see any reason why local vs broker authentication should differ , so made the change. Let me know what you all think about it.

**Future changes to consider** : Compress the payload sent to broker , from String to a gzip, opened a work item here : https://github.com/AzureAD/ad-accounts-for-android/issues/1265

**TODO**:  Add a doc to broker describing this change for future reference.


