### PR TITLE
Send cancel command result if base exception is user cancel exception

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -153,8 +153,12 @@ public class CommandDispatcher {
         }
 
         if (baseException != null) {
-            //Post On Error
-            commandResult = new CommandResult(CommandResult.ResultStatus.ERROR, baseException);
+            if (baseException instanceof UserCancelException) {
+                commandResult = new CommandResult(CommandResult.ResultStatus.CANCEL, null);
+            } else {
+                //Post On Error
+                commandResult = new CommandResult(CommandResult.ResultStatus.ERROR, baseException);
+            }
         } else {
             if (result != null && result instanceof AcquireTokenResult) {
                 //Handler handler, final BaseCommand command, BaseException baseException, AcquireTokenResult result


### PR DESCRIPTION
When broker sends broker result to MSAL, then in case of error MSAL adapts it into some type of exception and then the MSAL Broker controller will throw that exception. In case of a User Cancel, that will be the UserCancel exception. In this case, the Command Result returned by MSAL  should be the CANCEL result. Currently, in broker scenarios, we were just returning it an error result even though it should have been a CANCEL result. This PR fixes that scenario.