### PR TITLE
Shared cache RT pickup, dual client stack support

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IAccountCredentialCache.java
@@ -76,7 +76,7 @@ public interface IAccountCredentialCache {
      * @param homeAccountId The homeAccountId used to match Account cache keys.
      * @param environment   The environment used to match Account cache keys.
      * @param realm         The realm used to match Account cache keys.
-     * @return A List of Accounts matching the supplied criteria.
+     * @return A mutable List of Accounts matching the supplied criteria.
      */
     List<AccountRecord> getAccountsFilteredBy(
             final String homeAccountId,
@@ -87,7 +87,7 @@ public interface IAccountCredentialCache {
     /**
      * Returns all of the Credentials saved in the cache.
      *
-     * @return The saved Credentials.
+     * @return A mutable List of saved Credentials.
      */
     List<Credential> getCredentials();
 
@@ -100,7 +100,7 @@ public interface IAccountCredentialCache {
      * @param clientId       The clientId used to match Credential cache keys.
      * @param realm          The realm used to match Credential cache keys.
      * @param target         The target used to match Credential cache keys.
-     * @return A List of Credentials matching the supplied criteria.
+     * @return A mutable List of Credentials matching the supplied criteria.
      */
     List<Credential> getCredentialsFilteredBy(
             final String homeAccountId,

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -569,12 +569,6 @@ public class MsalOAuth2TokenCache
             // Unlike the broker, where we check if an app is FoCI prior to making a network call
             // with an arbitrary FoCI RT we find in the cache, if we're in standalone mode and find
             // a FoCI RT in the cache, the current app must also be FoCI (!!!)
-            //
-            // Making the assumption that the current client id can use any FoCI RT we find in the
-            // cache is strictly contingent that app developers NOT mix 1P & 3P registrations into
-            // the same binary. If you do this, Bad Things will happen and you'll get confusing
-            // errors that the RT used doesn't match the client app registration. Also, this
-            // assumption means we don't need to implement "FoCI probing" and/or track FoCI app meta
 
             if (refreshTokens.isEmpty()) {
                 // Look for an arbitrary RT matching the current user.
@@ -599,8 +593,8 @@ public class MsalOAuth2TokenCache
                             "Inspecting fallback RTs for a FoCI match."
                     );
 
-                    // Any arbitrary RT should be OK -- if multiple clients are stacked, they're either
-                    // "all FoCI" or none are.
+                    // Any arbitrary RT should be OK -- if multiple clients are stacked,
+                    // they're either "all FoCI" or none are.
                     final Credential rt = fallbackRts.get(0);
 
                     if (rt instanceof RefreshTokenRecord) {
@@ -621,7 +615,7 @@ public class MsalOAuth2TokenCache
                     }
                 }
             }
-        } // TODO run this impl past team, if it flys, then write unit tests
+        }
 
         // Load the IdTokens
         final List<Credential> idTokens = mAccountCredentialCache.getCredentialsFilteredBy(

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -569,6 +569,12 @@ public class MsalOAuth2TokenCache
             // Unlike the broker, where we check if an app is FoCI prior to making a network call
             // with an arbitrary FoCI RT we find in the cache, if we're in standalone mode and find
             // a FoCI RT in the cache, the current app must also be FoCI (!!!)
+            //
+            // Making the assumption that the current client id can use any FoCI RT we find in the
+            // cache is strictly contingent that app developers NOT mix FoCI/non-FoCI registrations
+            // into same binary. If you do this, you'll get confusing errors that the RT used doesn't
+            // match the client app registration. This assumption means we don't need to implement
+            // "FoCI probing" and/or track FoCI app meta
             final Credential fallbackFrt = getFamilyRefreshTokenForAccount(account);
 
             if (null != fallbackFrt) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -538,7 +538,7 @@ public class MsalOAuth2TokenCache
         );
 
         // Load the RefreshTokens
-        final List<Credential> refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+        List<Credential> refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
                 account.getHomeAccountId(),
                 account.getEnvironment(),
                 CredentialType.RefreshToken,
@@ -577,6 +577,7 @@ public class MsalOAuth2TokenCache
             final Credential fallbackFrt = getFamilyRefreshTokenForAccount(account);
 
             if (null != fallbackFrt) {
+                refreshTokens = new ArrayList<>();
                 refreshTokens.add(fallbackFrt);
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -520,7 +520,6 @@ public class MsalOAuth2TokenCache
                              @Nullable final String target,
                              @NonNull final AccountRecord account,
                              @NonNull final AbstractAuthenticationScheme authScheme) {
-        final String methodName = ":load";
         Telemetry.emit(new CacheStartEvent());
 
         final boolean isMultiResourceCapable = MicrosoftAccount.AUTHORITY_TYPE_V1_V2.equals(

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -610,7 +610,7 @@ public class MsalOAuth2TokenCache
     }
 
     /**
-     * Loads any FRTs in the cache which may be used by this account.
+     * Load an FRTs from the cache which may be used by this account.
      *
      * @param account The account for which an FRT is sought.
      * @return A matching FRT credential, if exists. May be null.


### PR DESCRIPTION
### Tracking (corpnet required):
- https://identitydivision.visualstudio.com/Engineering/DevEx%20-%20Android/_queries/query/785e80fc-880c-4271-bfdf-4e15ac87f5d2/
- https://domoreexp.visualstudio.com/DefaultCollection/MSTeams/_workitems/edit/881449

### Changes in this PR:
- When looking up RTs in the local cache, if we don't find any that match our exact client id, use a FoCI RT if one is available

### What does this change enable?
- If another app has stashed tokens in our local cache, we'll pick them up even if the `client_id` doesn't match if one of those apps is FoCI enabled
- Silent auth between two FoCI apps without broker if they dual-client stack

### Don't we risk picking up the wrong RT?
We shouldn't because of few things.
- Non-broker apps are sandboxed, so apps only a share a cache if they are FoCI or if they are "dual-client" (two client ids in one binary)
- As a rule, we should say that FoCI apps can only dual-client stack with another FoCI app. Thou shalt not blend 1P & 3P registrations in a single binary
- Since 3P apps aren't FoCI, this new fallback/lookup logic will never yield a token in those cases
- This logic can be hit inside the broker, but broker sandboxes app caches in a way that this shouldn't make a difference. The broker cache sandboxing works like this:
    * All FoCI apps together
    * All non-FoCI apps get their own cache