### PR TITLE
Support null 'm' & 'p' claims in SHRs

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -76,7 +76,7 @@ public class PopAuthenticationSchemeInternal
     }
 
     PopAuthenticationSchemeInternal(@NonNull final IClockSkewManager clockSkewManager,
-                                    @NonNull final String httpMethod,
+                                    @Nullable final String httpMethod,
                                     @NonNull final URL url,
                                     @Nullable final String nonce) {
         super(SCHEME_POP);
@@ -107,6 +107,7 @@ public class PopAuthenticationSchemeInternal
     }
 
     @Override
+    @Nullable
     public String getHttpMethod() {
         return mHttpMethod;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -442,7 +442,7 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
-    public String mintSignedAccessToken(@NonNull final String httpMethod,
+    public String mintSignedAccessToken(@Nullable final String httpMethod,
                                         final long timestamp,
                                         @NonNull final URL requestUrl,
                                         @NonNull final String accessToken,
@@ -454,10 +454,16 @@ class DevicePopManager implements IDevicePopManager {
             final JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
             claimsBuilder.claim(SignedHttpRequestJwtClaims.ACCESS_TOKEN, accessToken);
             claimsBuilder.claim(SignedHttpRequestJwtClaims.TIMESTAMP, timestamp);
-            claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_METHOD, httpMethod);
             claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_HOST, requestUrl.getHost());
-            claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_PATH, requestUrl.getPath());
             claimsBuilder.claim(SignedHttpRequestJwtClaims.CNF, getDevicePopJwkMinifiedJson());
+
+            if (!TextUtils.isEmpty(requestUrl.getPath())) {
+                claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_PATH, requestUrl.getPath());
+            }
+
+            if (!TextUtils.isEmpty(httpMethod)) {
+                claimsBuilder.claim(SignedHttpRequestJwtClaims.HTTP_METHOD, httpMethod);
+            }
 
             if (!TextUtils.isEmpty(nonce)) {
                 claimsBuilder.claim(SignedHttpRequestJwtClaims.NONCE, nonce);

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -93,11 +93,11 @@ public interface IDevicePopManager {
     /**
      * Api to create the signed PoP access token.
      *
-     * @param httpMethod  The HTTP method that will be used with this outbound request.
+     * @param httpMethod  (Optional) The HTTP method that will be used with this outbound request.
      * @param timestamp   Seconds since January 1st, 1970 (UTC).
      * @param requestUrl  The recipient URL of the outbound request.
      * @param accessToken The access_token from which to derive the signed JWT.
-     * @param nonce       Arbitrary value used for replay protection by middleware.
+     * @param nonce       (Optional) Arbitrary value used for replay protection by middleware.
      * @return The signed PoP access token.
      */
     String mintSignedAccessToken(String httpMethod,


### PR DESCRIPTION
Impetus:
https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1025

- Blocked: this is currently upsupported by RP middleware
    * Middleware tracking issue is [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1393)