### PR TITLE
Add the older throwIfNetworkNotAvailable to support dual stack ADAL and MSAL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
+Version 2.0.8
+------------
+- Fix to add the throwIfNetworkNotAvailable API back for ADAL back compat.
+
 Version 2.0.7
 ------------
+- This version is incompatible with ADAL due a breaking API change. It's is fixed in 2.0.8.
 - Added throttling
 - Added Dual Client Stack support for FoCI apps
 - Added support to compress broker payload using GZIP

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/HttpWebRequest.java
@@ -178,6 +178,20 @@ public class HttpWebRequest {
 
         return response;
     }
+    /**
+     * Check if the network is available. If the network is unavailable, {@link ClientException}
+     * will throw with error code {@link ErrorStrings#NO_NETWORK_CONNECTION_POWER_OPTIMIZATION}
+     * when connection is not available to refresh token because power optimization is enabled, or
+     * throw with error code {@link ErrorStrings#DEVICE_NETWORK_NOT_AVAILABLE} otherwise.
+     *
+     * @param context Context : application context
+     *
+     * @throws ClientException throw network exception
+     */
+    public static void throwIfNetworkNotAvailable(final Context context)
+            throws ClientException {
+        throwIfNetworkNotAvailable(context, false);
+    }
 
     /**
      * Check if the network is available. If the network is unavailable, {@link ClientException}

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
@@ -85,7 +85,7 @@ public final class Device {
         /**
          * The String representing the sdk platform version.
          */
-        public static final String PRODUCT_VERSION = "1.5.0";
+        public static final String PRODUCT_VERSION = "1.5.1";
 
         /**
          * The String representing the sdk version.

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=2.0.7
+versionName=2.0.8
 versionCode=1


### PR DESCRIPTION
If apps dual stack with ADAL and MSAL , ADAL won't be able to resolve this API with `common` of MSAL 1.5.0. So adding back the older API.

Change introduced in this PR : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/894/