### PR TITLE
ADAL adapter fix

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -165,7 +165,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .extraQueryStringParameters(extraQP)
                 .authority(authority)
                 .scopes(scopes)
-                .clientId(AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY)
+                .clientId(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY))
                 .redirectUri(redirectUri)
                 .loginHint(intent.getStringExtra(AuthenticationConstants.Broker.ACCOUNT_NAME))
                 .correlationId(correlationIdString)


### PR DESCRIPTION
We accidentally passed a hardcoded key into the clientId field, instead of the actual value from the bundle.