### PR TITLE
Add support to set server slice & data center as build params for server teams to run our tests

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -15,6 +15,17 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
+    def sliceParameter = "" // will be blank unless specified by developer
+    def dcParameter = "" // will be blank unless specified by developer
+
+    if (project.hasProperty("slice")) {
+        sliceParameter = slice
+    }
+
+    if (project.hasProperty("dc")) {
+        dcParameter = dc
+    }
+
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
@@ -23,6 +34,8 @@ android {
         project.archivesBaseName = "common"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SLICE", "\"$sliceParameter\"")
+        buildConfigField("String", "DC", "\"$dcParameter\"")
     }
 
     buildTypes {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -29,9 +29,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.BuildConfig;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2StrategyParameters;
 
@@ -61,6 +63,17 @@ public abstract class Authority {
     @SerializedName("authority_url")
     protected String mAuthorityUrl;
 
+    @SerializedName("slice")
+    public AzureActiveDirectorySlice mSlice;
+
+    public AzureActiveDirectorySlice getSlice() {
+        return this.mSlice;
+    }
+
+    public void setSlice(AzureActiveDirectorySlice slice) {
+        mSlice = slice;
+    }
+
     public abstract Uri getAuthorityUri();
 
     public abstract URL getAuthorityURL();
@@ -75,6 +88,16 @@ public abstract class Authority {
 
     public void setDefault(Boolean isDefault) {
         mIsDefault = isDefault;
+    }
+
+    public Authority() {
+        // setting slice directly here in constructor if slice provided as command line param
+        if (!TextUtils.isEmpty(BuildConfig.SLICE) || !TextUtils.isEmpty(BuildConfig.DC)) {
+            com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice slice = new AzureActiveDirectorySlice();
+            slice.setSlice(BuildConfig.SLICE);
+            slice.setDataCenter(BuildConfig.DC);
+            mSlice = slice;
+        }
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
@@ -31,7 +31,6 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
-import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
@@ -48,14 +47,10 @@ public class AzureActiveDirectoryAuthority extends Authority {
     @SerializedName("audience")
     public AzureActiveDirectoryAudience mAudience;
 
-    @SerializedName("slice")
-    public AzureActiveDirectorySlice mSlice;
-
     @SerializedName("flight_parameters")
     public Map<String, String> mFlightParameters;
 
     public boolean mMultipleCloudsSupported = false;
-
 
     private AzureActiveDirectoryCloud mAzureActiveDirectoryCloud;
 
@@ -91,10 +86,6 @@ public class AzureActiveDirectoryAuthority extends Authority {
         mAuthorityTypeString = "AAD";
         mMultipleCloudsSupported = false;
         getAzureActiveDirectoryCloud();
-    }
-
-    public AzureActiveDirectorySlice getSlice() {
-        return this.mSlice;
     }
 
     public Map<String, String> getFlightParameters() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryB2CAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryB2CAuthority.java
@@ -68,6 +68,19 @@ public class AzureActiveDirectoryB2CAuthority extends Authority {
         MicrosoftStsOAuth2Configuration config = new MicrosoftStsOAuth2Configuration();
         config.setMultipleCloudsSupported(false);
         config.setAuthorityUrl(this.getAuthorityURL());
+
+        if (mSlice != null) {
+            Logger.info(
+                    TAG + methodName,
+                    "Setting slice parameters..."
+            );
+            com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice slice =
+                    new com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice();
+            slice.setSlice(mSlice.getSlice());
+            slice.setDataCenter(mSlice.getDC());
+            config.setSlice(slice);
+        }
+
         return config;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -40,6 +40,8 @@ import com.microsoft.identity.common.internal.net.HttpResponse;
 import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.internal.platform.Device;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftTokenRequest;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
+import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
 import com.microsoft.identity.common.internal.util.IClockSkewManager;
 
@@ -195,6 +197,28 @@ public abstract class OAuth2Strategy
 
     protected final void setTokenEndpoint(final String tokenEndpoint) {
         mTokenEndpoint = tokenEndpoint;
+
+        final Uri.Builder uriBuilder = Uri.parse(mTokenEndpoint).buildUpon();
+
+        if (mConfig != null && mConfig instanceof MicrosoftStsOAuth2Configuration) {
+
+            final MicrosoftStsOAuth2Configuration oauth2Config =
+                    (MicrosoftStsOAuth2Configuration) mConfig;
+
+            final AzureActiveDirectorySlice slice = oauth2Config.getSlice();
+
+            if (slice != null) {
+                if (!TextUtils.isEmpty(slice.getSlice())) {
+                    uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, slice.getSlice());
+                }
+
+                if (!TextUtils.isEmpty(slice.getDC())) {
+                    uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.DC_PARAMETER, slice.getDC());
+                }
+            }
+        }
+
+        mTokenEndpoint = uriBuilder.build().toString();
     }
 
     public String getAuthorityFromTokenEndpoint() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -198,8 +198,6 @@ public abstract class OAuth2Strategy
     protected final void setTokenEndpoint(final String tokenEndpoint) {
         mTokenEndpoint = tokenEndpoint;
 
-        final Uri.Builder uriBuilder = Uri.parse(mTokenEndpoint).buildUpon();
-
         if (mConfig != null && mConfig instanceof MicrosoftStsOAuth2Configuration) {
 
             final MicrosoftStsOAuth2Configuration oauth2Config =
@@ -208,6 +206,8 @@ public abstract class OAuth2Strategy
             final AzureActiveDirectorySlice slice = oauth2Config.getSlice();
 
             if (slice != null) {
+                final Uri.Builder uriBuilder = Uri.parse(mTokenEndpoint).buildUpon();
+
                 if (!TextUtils.isEmpty(slice.getSlice())) {
                     uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, slice.getSlice());
                 }
@@ -215,10 +215,10 @@ public abstract class OAuth2Strategy
                 if (!TextUtils.isEmpty(slice.getDC())) {
                     uriBuilder.appendQueryParameter(AzureActiveDirectorySlice.DC_PARAMETER, slice.getDC());
                 }
+
+                mTokenEndpoint = uriBuilder.build().toString();
             }
         }
-
-        mTokenEndpoint = uriBuilder.build().toString();
     }
 
     public String getAuthorityFromTokenEndpoint() {


### PR DESCRIPTION
The server team has requested that we provide a mechanism for them to run our tests with different slices. 

We had support for passing `slice` and `dc` parameter to the Authority object but this had to be done in MSAL config file. Different tests use different config files and it is not feasible to do this for every config file. 

In this PR, I've added support to specify `slice` and `dc` via the command line as build params and then we create Slice object from these parameters and set it on the `Authority` object. I've also added this query parameter to token endpoint as well (We used to only send to the /authorize endpoint).

Tests can be targeted towards a specific slice & dc as follows:

`./gradlew msal:testLocalDebugUnitTest -Plabtest -Pslice="testslice" -Pdc="PROD-WST-TEST1"`

In the above example:

- `-Pslice="testslice"` determines the slice to use
- `Pdc="PROD-WST-TEST1"` determines the data center to use
- `Plabtest` indicates whether to run lab based e2e tests or not. (This isn't a new change and this param was already supported)

The server team can then run these tests by passing the slice and dc parameter as build queue time parameters i.e. they can set slice and dc in the ADO UI by clicking set variables when queuing a build and they will prompted for both slice and dc parameter. An example of such a pipeline is here: https://dev.azure.com/IdentityDivision/IDDP/_build?definitionId=1110&_a=summary

