### PR TITLE
Add tenant id as param to Mock Token Creator

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -234,6 +234,9 @@ public class BrokerResult implements Serializable {
     @SerializedName(SerializedNames.SUCCESS)
     private boolean mSuccess;
 
+    /**
+     * boolean to indicate if the result was returned from cache
+     */
     @SerializedName(SerializedNames.SERVICED_FROM_CACHE)
     private boolean mServicedFromCache;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/LocalAuthenticationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/LocalAuthenticationResult.java
@@ -60,7 +60,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult {
     public LocalAuthenticationResult(@NonNull final ICacheRecord lastAuthorized,
                                      @NonNull final List<ICacheRecord> completeResultFromCache,
                                      @NonNull final SdkType sdkType,
-                                     @Nullable final boolean isServicedFromCache) {
+                                     final boolean isServicedFromCache) {
         this(lastAuthorized, sdkType);
         mCompleteResultFromCache = completeResultFromCache;
         mServicedFromCache = isServicedFromCache;

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
@@ -48,7 +48,7 @@ public class MockTokenCreator {
     private static final String TENANT_ID_CLAIM = "tid";
     private static final String VERSION_CLAIM = "ver";
 
-    // default values
+    // mock token constants values
     private static final String AUDIENCE = "audience-for-testing";
     private static final String TENANT_ID = TestConstants.Authorities.AAD_MOCK_HTTP_RESPONSE_AUTHORITY_TENANT;
     private static final String OBJECT_ID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
@@ -59,6 +59,8 @@ public class MockTokenCreator {
     private static final String UID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
     private static final String UTID = TENANT_ID;
     private static final String ENCODING_UTF8 = "UTF-8";
+    private static final String ISSUER_PREFIX = "https://test.authority/";
+    private static final String ISSUER_SUFFIX = "/v2.0";
 
     private static String createMockToken(final String issuer,
                                           final String subject,
@@ -141,7 +143,7 @@ public class MockTokenCreator {
     }
 
     public static String createMockIdTokenWithExpAndTenantId(long exp, final String tenantId) {
-        final String issuer = "https://test.authority/" + tenantId + "/v2.0";
+        final String issuer = ISSUER_PREFIX + tenantId + ISSUER_SUFFIX;
         return createMockIdToken(
                 issuer,
                 SUBJECT,

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
@@ -48,11 +48,11 @@ public class MockTokenCreator {
     private static final String TENANT_ID_CLAIM = "tid";
     private static final String VERSION_CLAIM = "ver";
 
+    // default values
     private static final String AUDIENCE = "audience-for-testing";
     private static final String TENANT_ID = TestConstants.Authorities.AAD_MOCK_HTTP_RESPONSE_AUTHORITY_TENANT;
     private static final String OBJECT_ID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
     private static final String PREFERRED_USERNAME = "test@test.onmicrosoft.com";
-    private static final String ISSUER = "https://test.authority/" + TENANT_ID + "/v2.0";
     private static final String SUBJECT = "TestSubject";
     private static final String VERSION = "2.0";
     private static final String NAME = "test";
@@ -132,17 +132,18 @@ public class MockTokenCreator {
 
     public static String createMockIdToken() {
         long exp = getExpirationTimeAfterSpecifiedTime(3600);
-        return createMockIdTokenWithExpAndIssuer(exp, TENANT_ID);
+        return createMockIdTokenWithExpAndTenantId(exp, TENANT_ID);
     }
 
-    public static String createMockIdTokenWithIssuer(final String tenantId) {
+    public static String createMockIdTokenWithTenantId(final String tenantId) {
         long exp = getExpirationTimeAfterSpecifiedTime(3600);
-        return createMockIdTokenWithExpAndIssuer(exp, tenantId);
+        return createMockIdTokenWithExpAndTenantId(exp, tenantId);
     }
 
-    public static String createMockIdTokenWithExpAndIssuer(long exp, final String tenantId) {
+    public static String createMockIdTokenWithExpAndTenantId(long exp, final String tenantId) {
+        final String issuer = "https://test.authority/" + tenantId + "/v2.0";
         return createMockIdToken(
-                ISSUER,
+                issuer,
                 SUBJECT,
                 AUDIENCE,
                 NAME,

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
@@ -52,7 +52,7 @@ public class MockTokenCreator {
     private static final String TENANT_ID = TestConstants.Authorities.AAD_MOCK_HTTP_RESPONSE_AUTHORITY_TENANT;
     private static final String OBJECT_ID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
     private static final String PREFERRED_USERNAME = "test@test.onmicrosoft.com";
-    private static final String ISSUER =  "https://test.authority/" + TENANT_ID + "/v2.0";
+    private static final String ISSUER = "https://test.authority/" + TENANT_ID + "/v2.0";
     private static final String SUBJECT = "TestSubject";
     private static final String VERSION = "2.0";
     private static final String NAME = "test";
@@ -132,10 +132,15 @@ public class MockTokenCreator {
 
     public static String createMockIdToken() {
         long exp = getExpirationTimeAfterSpecifiedTime(3600);
-        return createMockIdTokenWithExp(exp);
+        return createMockIdTokenWithExpAndIssuer(exp, TENANT_ID);
     }
 
-    public static String createMockIdTokenWithExp(long exp) {
+    public static String createMockIdTokenWithIssuer(final String tenantId) {
+        long exp = getExpirationTimeAfterSpecifiedTime(3600);
+        return createMockIdTokenWithExpAndIssuer(exp, tenantId);
+    }
+
+    public static String createMockIdTokenWithExpAndIssuer(long exp, final String tenantId) {
         return createMockIdToken(
                 ISSUER,
                 SUBJECT,
@@ -143,7 +148,7 @@ public class MockTokenCreator {
                 NAME,
                 PREFERRED_USERNAME,
                 OBJECT_ID,
-                TENANT_ID,
+                tenantId,
                 VERSION,
                 new Date(),
                 new Date(),

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenResponse.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenResponse.java
@@ -33,7 +33,7 @@ public class MockTokenResponse {
     public static MicrosoftStsTokenResponse getMockSuccessTokenResponse() {
         String mockAccessToken = "aaaa.BBBB.123";
         String mockRefreshToken = "abcDeFGhijkl";
-        String mockIdToken = MockTokenCreator.createMockIdTokenWithIssuer(TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT);
+        String mockIdToken = MockTokenCreator.createMockIdTokenWithTenantId(TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT);
         String mockClientInfo = MockTokenCreator.createMockRawClientInfo();
 
         MicrosoftStsTokenResponse tokenResponse = new MicrosoftStsTokenResponse();

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenResponse.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenResponse.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.internal.testutils.mocks;
 
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse;
+import com.microsoft.identity.internal.testutils.TestConstants;
 
 public class MockTokenResponse {
 
@@ -32,7 +33,7 @@ public class MockTokenResponse {
     public static MicrosoftStsTokenResponse getMockSuccessTokenResponse() {
         String mockAccessToken = "aaaa.BBBB.123";
         String mockRefreshToken = "abcDeFGhijkl";
-        String mockIdToken = MockTokenCreator.createMockIdToken();
+        String mockIdToken = MockTokenCreator.createMockIdTokenWithIssuer(TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT);
         String mockClientInfo = MockTokenCreator.createMockRawClientInfo();
 
         MicrosoftStsTokenResponse tokenResponse = new MicrosoftStsTokenResponse();


### PR DESCRIPTION
There were some tests executing silent requests and running into cache misses after some changes to the test shadow code recently in a telemetry PR. This was due to authority (tenant id) not matching with the credentials in cache. In this PR, I have made tenant id an optional param to Mock Token Creator so it can be used in a more variety of tests.

Those cache misses were detected by the change being made in this PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1048