### PR TITLE
Removed AccountRecord validation while saving credentials

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -24,16 +24,11 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.content.Context;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
 import com.microsoft.identity.common.internal.dto.CredentialType;
-import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 import com.microsoft.identity.common.internal.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
@@ -41,6 +36,9 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal.SCHEME_BEARER;
 
@@ -93,37 +91,26 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * @param accountRecord : AccountRecord associated with the input credentials.
+     * @param accountRecord : AccountRecord associated with the input credentials, can be null.
      * @param credentials   : list of Credential which can include AccessTokenRecord, IdTokenRecord and RefreshTokenRecord.
-     *                      Note : Both IdTokenRecord and RefreshTokenRecord need to be non null. AccessTokenRecord can be optional.
      * @throws ClientException : If the supplied Account or Credential are null or schema invalid.
      */
-    public synchronized void saveCredentials(@NonNull final AccountRecord accountRecord,
+    public synchronized void saveCredentials(@Nullable final AccountRecord accountRecord,
                                              @NonNull final Credential... credentials) throws ClientException {
         if (credentials == null || credentials.length == 0) {
             throw new ClientException("Credential array passed in is null or empty");
         }
 
-        AccessTokenRecord accessTokenRecord = null;
-        IdTokenRecord idTokenRecord = null;
         RefreshTokenRecord refreshTokenRecord = null;
 
         for (final Credential credential : credentials) {
-            if (credential instanceof AccessTokenRecord) {
-                accessTokenRecord = (AccessTokenRecord) credential;
-            } else if (credential instanceof IdTokenRecord) {
-                idTokenRecord = (IdTokenRecord) credential;
-            } else if (credential instanceof RefreshTokenRecord) {
+            if (credential instanceof RefreshTokenRecord) {
                 refreshTokenRecord = (RefreshTokenRecord) credential;
             }
         }
-
-        validateNonNull(accountRecord, "AccountRecord");
-        validateNonNull(refreshTokenRecord, "RefreshTokenRecord");
-        validateNonNull(idTokenRecord, "IdTokenRecord");
-        validateCacheArtifacts(accountRecord, accessTokenRecord, refreshTokenRecord, idTokenRecord);
-
-        removeRefreshTokenIfNeeded(accountRecord, refreshTokenRecord);
+        if (accountRecord != null && refreshTokenRecord != null) {
+            removeRefreshTokenIfNeeded(accountRecord, refreshTokenRecord);
+        }
 
         saveCredentialsInternal(credentials);
     }


### PR DESCRIPTION
- Change for OneAuth
- MSALCPP expects `AccountRecord` and `Credentials` to be independant of each other, so removed hard validation of `AccountRecord` `non-null` while writing credentials.