### PR TITLE
Add consumer rules for common; dontwarn for lombok

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -52,6 +52,7 @@ android {
             debuggable false
             testCoverageEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-rules.pro'
         }
     }
 

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -1,0 +1,53 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in C:\Program Files\Android\android-sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+##---------------Begin: proguard configuration for MSAL  --------
+-keep class com.microsoft.** { *; }
+
+##---------------Begin: proguard configuration for Nimbus  ----------
+-keep class com.nimbusds.** { *; }
+
+##---------------Begin: proguard configuration for Lombok  ----------
+-dontwarn lombok.**
+
+##---------------Begin: proguard configuration for Gson  --------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.google.gson.examples.android.model.** { <fields>; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=2.0.10-RC1
+versionName=2.0.10-RC2
 versionCode=1


### PR DESCRIPTION
A recent change in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/919 seems to break CP builds throwing some proguard warning associated to Lombok.