### PR TITLE
Adds new tests for MsalCppOAuth2TokenCache

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common;
+
+import android.content.Context;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.microsoft.identity.common.adal.internal.AndroidSecretKeyEnabledHelper;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
+import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.cache.MsalCppOAuth2TokenCache;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
+import static com.microsoft.identity.common.MsalOAuth2TokenCacheTest.AccountCredentialTestBundle;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CACHED_AT;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CLIENT_ID;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.ENVIRONMENT;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.EXPIRES_ON;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.HOME_ACCOUNT_ID;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.LOCAL_ACCOUNT_ID;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.REALM;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.SECRET;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.TARGET;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.USERNAME;
+
+@RunWith(AndroidJUnit4.class)
+public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
+
+    private MsalCppOAuth2TokenCache mCppCache;
+
+    // Test Accounts/Credentials
+    private AccountCredentialTestBundle mTestBundle;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // Context and related init
+        final Context context = InstrumentationRegistry.getTargetContext();
+        mCppCache = MsalCppOAuth2TokenCache.create(context);
+
+        // Credentials for testing
+        mTestBundle = new AccountCredentialTestBundle(
+                MicrosoftAccount.AUTHORITY_TYPE_V1_V2,
+                LOCAL_ACCOUNT_ID,
+                USERNAME,
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                REALM,
+                TARGET,
+                CACHED_AT,
+                EXPIRES_ON,
+                SECRET,
+                CLIENT_ID,
+                SECRET,
+                MOCK_ID_TOKEN_WITH_CLAIMS,
+                null,
+                CredentialType.V1IdToken
+        );
+    }
+
+    @After
+    public void tearDown() {
+        mCppCache.clearCache();
+    }
+
+    @Test
+    public void saveAndGetAccountTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+
+        // Save the the cache
+        mCppCache.saveAccountRecord(generatedAccount);
+
+        // Restore it
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        Assert.assertNotNull(restoredAccount);
+        Assert.assertEquals(generatedAccount, restoredAccount);
+    }
+
+    @Test
+    public void getAccountNullTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+        Assert.assertNull(restoredAccount);
+    }
+
+    @Test
+    public void getAllAccountsTest() {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+        mCppCache.saveAccountRecord(generatedAccount);
+
+        final List<AccountRecord> accounts = mCppCache.getAllAccounts();
+        final AccountRecord restoredAccount = accounts.get(0);
+        Assert.assertEquals(generatedAccount, restoredAccount);
+
+        // TODO this API makes no statement about the immutability of the List returned
+        // TODO results should not be mutable
+    }
+
+    @Test
+    public void getAllAccountsEmptyTest() {
+        final List<AccountRecord> accounts = mCppCache.getAllAccounts();
+        Assert.assertTrue(accounts.isEmpty());
+    }
+
+    @Ignore // Ignore this test until API behavior is decided
+    @Test
+    public void removeAccountTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+        mCppCache.saveAccountRecord(generatedAccount);
+        final AccountDeletionRecord deletionRecord = mCppCache.removeAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+        Assert.assertEquals(generatedAccount, deletionRecord.get(0));
+
+        // TODO There's confusing behavior here...
+        // In MSAL we have defined an account as "existing" if we have an RT for it
+        // This API doesn't make this constraint obvious. Should we delete any matching account?
+        // In a double-client stack situation, this could delete an account from another app (TFL/TFW)
+    }
+
+    @Test
+    public void removeNonexistentAccountTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+        final AccountDeletionRecord deletionRecord = mCppCache.removeAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+        Assert.assertTrue(deletionRecord.isEmpty());
+    }
+
+    @Test
+    public void saveAccountRecordIncompleteTest() {
+
+    }
+
+    @Test
+    public void saveCredentialsWithAccountTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+
+        mCppCache.saveAccountRecord(generatedAccount);
+
+        mCppCache.saveCredentials(
+                generatedAccount,
+                mTestBundle.mGeneratedAccessToken,
+                mTestBundle.mGeneratedIdToken,
+                mTestBundle.mGeneratedRefreshToken
+        );
+
+        // Restore it
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        Assert.assertNotNull(restoredAccount);
+        Assert.assertEquals(generatedAccount, restoredAccount);
+
+        final ICacheRecord cacheRecord = mCppCache.load(
+                mTestBundle.mGeneratedIdToken.getClientId(),
+                mTestBundle.mGeneratedAccessToken.getTarget(),
+                generatedAccount,
+                new BearerAuthenticationSchemeInternal()
+        );
+
+        Assert.assertEquals(
+                mTestBundle.mGeneratedAccessToken,
+                cacheRecord.getAccessToken()
+        );
+    }
+
+    @Test
+    public void saveCredentialsWithoutAccountTest() throws ClientException {
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+
+        mCppCache.saveCredentials(
+                null,
+                mTestBundle.mGeneratedAccessToken,
+                mTestBundle.mGeneratedIdToken,
+                mTestBundle.mGeneratedRefreshToken
+        );
+
+        // Restore it
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        // Account doesn't exist
+        Assert.assertNull(restoredAccount);
+
+        // Inspect the contents of the cache
+        final List<Credential> credentials = mCppCache.getCredentials();
+        Assert.assertTrue(credentials.contains(mTestBundle.mGeneratedAccessToken));
+        Assert.assertTrue(credentials.contains(mTestBundle.mGeneratedIdToken));
+        Assert.assertTrue(credentials.contains(mTestBundle.mGeneratedRefreshToken));
+    }
+}

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
 import static com.microsoft.identity.common.MsalOAuth2TokenCacheTest.AccountCredentialTestBundle;
@@ -152,15 +153,31 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     @Ignore // Ignore this test until API behavior is decided
     @Test
     public void removeAccountTest() throws ClientException {
+        // Get the generated account
         final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+
+        // Save it to the cache
         mCppCache.saveAccountRecord(generatedAccount);
+
+        // Call remove
         final AccountDeletionRecord deletionRecord = mCppCache.removeAccount(
                 generatedAccount.getHomeAccountId(),
                 generatedAccount.getEnvironment(),
                 generatedAccount.getRealm()
         );
+
+        // Check the receipt
         Assert.assertEquals(generatedAccount, deletionRecord.get(0));
 
+        // Try to restore it
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        // Make sure it doesn't exist....
+        Assert.assertNull(restoredAccount);
         // TODO There's confusing behavior here...
         // In MSAL we have defined an account as "existing" if we have an RT for it
         // This API doesn't make this constraint obvious. Should we delete any matching account?

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -139,9 +139,12 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<AccountRecord> accounts = mCppCache.getAllAccounts();
         final AccountRecord restoredAccount = accounts.get(0);
         Assert.assertEquals(generatedAccount, restoredAccount);
+    }
 
-        // TODO this API makes no statement about the immutability of the List returned
-        // TODO results should not be mutable
+    @Test(expected = UnsupportedOperationException.class)
+    public void getAllAccountsResultImmutableTest() {
+        final List<AccountRecord> accounts = mCppCache.getAllAccounts();
+        accounts.add(mTestBundle.mGeneratedAccount);
     }
 
     @Test

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -137,6 +137,7 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<AccountRecord> accounts = mCppCache.getAllAccounts();
         final AccountRecord restoredAccount = accounts.get(0);
         Assert.assertEquals(generatedAccount, restoredAccount);
+        Assert.assertEquals(1, accounts.size());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -179,13 +179,35 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Make sure it doesn't exist....
         Assert.assertNull(restoredAccount);
+    }
 
-        // TODO 6/15/20
-        // I have added a new api to "force remove" an AccountRecord even if no RT exists to match it
-        // Open questions:
-        // Is the current behavior of removeAccount() where the AccountRecord is deleted only if
-        // there is a matching RT acceptable?
-        // A 'backup' API is provided to delete the AccountRecord
+    @Test
+    public void removeAccountNoRTTest() throws ClientException {
+        // Get the generated account
+        final AccountRecord generatedAccount = mTestBundle.mGeneratedAccount;
+
+        // Save it to the cache
+        mCppCache.saveAccountRecord(generatedAccount);
+
+        // Call remove
+        final AccountDeletionRecord deletionRecord = mCppCache.removeAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        // Check the receipt
+        Assert.assertEquals(generatedAccount, deletionRecord.get(0));
+
+        // Try to restore it
+        final AccountRecord restoredAccount = mCppCache.getAccount(
+                generatedAccount.getHomeAccountId(),
+                generatedAccount.getEnvironment(),
+                generatedAccount.getRealm()
+        );
+
+        // Make sure it doesn't exist....
+        Assert.assertNull(restoredAccount);
     }
 
     @Test
@@ -195,6 +217,8 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Save it to the cache
         mCppCache.saveAccountRecord(generatedAccount);
+
+        // Do not save any credentials for this account...
 
         final AccountDeletionRecord deletionRecord = mCppCache.forceRemoveAccount(
                 generatedAccount.getHomeAccountId(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
@@ -293,6 +294,17 @@ public class ADALOAuth2TokenCache
                                                final String clientId,
                                                final String homeAccountId,
                                                final String realm) {
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
+    }
+
+    @Override
+    public AccountDeletionRecord removeAccount(final String environment,
+                                               final String clientId,
+                                               final String homeAccountId,
+                                               final String realm,
+                                               final CredentialType... typesToRemove) {
         throw new UnsupportedOperationException(
                 ERR_UNSUPPORTED_OPERATION
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -1192,6 +1192,18 @@ public class BrokerOAuth2TokenCache
     }
 
     @Override
+    public AccountDeletionRecord removeAccount(String environment,
+                                               String clientId,
+                                               String homeAccountId,
+                                               String realm,
+                                               CredentialType... typesToRemove) {
+        // This API not needed for now...
+        throw new UnsupportedOperationException(
+                ERR_UNSUPPORTED_OPERATION
+        );
+    }
+
+    @Override
     public void clearAll() {
         throw new UnsupportedOperationException(
                 ERR_UNSUPPORTED_OPERATION

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -127,7 +127,6 @@ public class MsalCppOAuth2TokenCache
      */
     public synchronized void saveAccountRecord(@NonNull final AccountRecord accountRecord) {
         getAccountCredentialCache().saveAccount(accountRecord);
-
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -189,7 +189,9 @@ public class MsalCppOAuth2TokenCache
      * @return {@link List<AccountRecord>}
      */
     public List<AccountRecord> getAllAccounts() {
-        return getAccountCredentialCache().getAccounts();
+        return Collections.unmodifiableList(
+                getAccountCredentialCache().getAccounts()
+        );
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -154,7 +154,7 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * API to force remove an AccountRecord matching the supplied criteria.
+     * Force remove an AccountRecord matching the supplied criteria.
      *
      * @param homeAccountId HomeAccountId of the Account.
      * @param environment   The Environment of the Account.
@@ -162,6 +162,7 @@ public class MsalCppOAuth2TokenCache
      * @return An {@link AccountDeletionRecord} containing a receipt of the removed Accounts.
      * @throws ClientException
      */
+    @VisibleForTesting // private by default for production code
     public synchronized AccountDeletionRecord forceRemoveAccount(@NonNull final String homeAccountId,
                                                                  @Nullable final String environment,
                                                                  @NonNull final String realm) throws ClientException {
@@ -243,9 +244,10 @@ public class MsalCppOAuth2TokenCache
                     CredentialType.IdToken,
                     CredentialType.V1IdToken
             );
+        } else {
+            // Remove was called, but no RTs exist for the account. Force remove it.
+            return forceRemoveAccount(homeAccountId, environment, realm);
         }
-
-        return new AccountDeletionRecord(null);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -184,7 +184,7 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * Method to get all the Accounts in the cache.
+     * Gets an immutable {@link List} of {@link AccountRecord} objects.
      *
      * @return {@link List<AccountRecord>}
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -125,7 +125,7 @@ public class MsalCppOAuth2TokenCache
      *
      * @param accountRecord : accountRecord to be saved.
      */
-    public synchronized void saveAccountRecord(@NonNull AccountRecord accountRecord) {
+    public synchronized void saveAccountRecord(@NonNull final AccountRecord accountRecord) {
         getAccountCredentialCache().saveAccount(accountRecord);
 
     }
@@ -202,9 +202,9 @@ public class MsalCppOAuth2TokenCache
      * @throws ClientException : throws ClientException if input validation fails
      */
     @Nullable
-    public AccountRecord getAccount(@NonNull String homeAccountId,
-                                    @NonNull String environment,
-                                    @NonNull String realm) throws ClientException {
+    public AccountRecord getAccount(@NonNull final String homeAccountId,
+                                    @NonNull final String environment,
+                                    @NonNull final String realm) throws ClientException {
         final String methodName = ":getAccount";
 
         validateNonNull(homeAccountId, "homeAccountId");
@@ -223,8 +223,8 @@ public class MsalCppOAuth2TokenCache
             );
             return null;
         }
-        return accountRecords.get(0);
 
+        return accountRecords.get(0);
     }
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -24,6 +24,10 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -35,10 +39,8 @@ import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequ
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 
+import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal.SCHEME_BEARER;
 
@@ -132,8 +134,22 @@ public class MsalCppOAuth2TokenCache
      * API to clear all cache.
      * Note: This method is intended to be only used for testing purposes.
      */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public synchronized void clearCache() {
         getAccountCredentialCache().clearAll();
+    }
+
+    /**
+     * API to inspect cache contents.
+     * Note: This method is intended to be only used for testing purposes.
+     *
+     * @return A immutable List of Credentials contained in this cache.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public synchronized List<Credential> getCredentials() {
+        return Collections.unmodifiableList(
+                getAccountCredentialCache().getCredentials()
+        );
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1268,7 +1268,7 @@ public class MsalOAuth2TokenCache
                 "IsRealmAgnostic? " + isRealmAgnostic
         );
 
-        if (null != typesToRemove) {
+        if (null != typesToRemove && typesToRemove.length > 0) {
             for (final CredentialType type : typesToRemove) {
                 // A count of the deleted creds...
                 int deletedCredentialsOfTypeCount = removeCredentialsOfTypeForAccount(
@@ -1287,6 +1287,11 @@ public class MsalOAuth2TokenCache
                                 + type
                 );
             }
+        } else {
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                    TAG + methodName,
+                    "removeAccount called, but no CredentialTypes to remove specified"
+            );
         }
 
         final List<AccountRecord> deletedAccounts = new ArrayList<>();

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1025,6 +1025,20 @@ public class MsalOAuth2TokenCache
                 )
         );
 
+        // And any refresh tokens...
+        // TODO Why are the IdTokens being used here? I can't remember... is that a bug?
+        appCredentials.addAll(
+                mAccountCredentialCache.getCredentialsFilteredBy(
+                        null,
+                        environment,
+                        CredentialType.RefreshToken,
+                        clientId,
+                        null,
+                        null,
+                        null
+                )
+        );
+
         // For each Account with an associated RT, add it to the result List...
         for (final AccountRecord account : accountsForEnvironment) {
             if (accountHasCredential(account, appCredentials)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1026,7 +1026,6 @@ public class MsalOAuth2TokenCache
         );
 
         // And any refresh tokens...
-        // TODO Why are the IdTokens being used here? I can't remember... is that a bug?
         appCredentials.addAll(
                 mAccountCredentialCache.getCredentialsFilteredBy(
                         null,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2TokenCache.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 
 import java.util.List;
@@ -257,6 +258,23 @@ public abstract class OAuth2TokenCache
                                                         final String clientId,
                                                         final String homeAccountId,
                                                         final String realm
+    );
+
+    /**
+     * Removes the Account (and its associated Credentials) matching the supplied criteria.
+     *
+     * @param environment   The environment to which the targeted Account is associated.
+     * @param clientId      The clientId of this current app.
+     * @param homeAccountId The homeAccountId of the Account targeted for deletion.
+     * @param realm         The tenant id of the targeted Account (if applicable).
+     * @param typesToRemove The CredentialTypes to be deleted for this Account.
+     * @return The {@link AccountDeletionRecord} containing the removed AccountRecords.
+     */
+    public abstract AccountDeletionRecord removeAccount(final String environment,
+                                                        final String clientId,
+                                                        final String homeAccountId,
+                                                        final String realm,
+                                                        final CredentialType... typesToRemove
     );
 
     /**


### PR DESCRIPTION
Adds new test, API surface to caching components for CPP scenarios

## Summary of changes
- Adds `MsalCppOAuth2TokenCacheTest`
- Adds new `removeAccount` overload to `OAuth2TokenCache`
    * API accepts a varargs array of `CredentialType` to delete upon removal of the `AccountRecord`
- Makes behavior of `MsalCppOAuth2TokenCache#remove` match the `Credential` deletion behavior specified [here](https://github.com/AzureAD/microsoft-authentication-library-for-cpp/blob/develop/source/zgenerated/java/com/microsoft/identity/internal/StorageManager.java#L68-L77).
    - Deletes: access tokens, id tokens, account
    - Preserves: the refresh token

## Points to clarify before merge
- Android MSAL has previously defined the presence of an Account (for `getAccounts()`'s purposes) as: an `AccountRecord` with a matching `RefreshTokenRecord` for a given `client_id`
    * The CPP APIs are more free form: `getAllAccounts()` returns whatever `AccountRecords` are in the cache, irrespective of whether we have an RT for this client or not
    * `removeAccount()` has different behavior: you can only delete an `AccountRecord` for which we have an RT.... **should this be the case?**
        - This _could_ indiscriminately delete the account and its associated AT, ID tokens
        - It's possible, in the current implementation for an `AccountRecord` to get "stuck" -- if you save an `AccountRecord` but don't supply an RT for it, then it's as if we don't have it. `getAccount()` will still return it though....

>Brian's thoughts....
> I am thinking that `removeAccount()` should also call `forceRemove()` to _forcibly_ expel the `AccountRecord` from the cache, if it exists. This is probably the closest behavior to what CPP expects.... 

## Summary of offline decision
For now, the implementation will assume a single stack. Force delete any account that was requested for removal even if no RTs exist for it; under normal single-stack conditions this is fine.