### PR TITLE
Add UI Test Utilities for B2C

### DIFF
--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "androidx.test.uiautomator:uiautomator:$rootProject.ext.uiAutomatorVersion"
     implementation "androidx.test:monitor:$rootProject.ext.androidxTestMonitorVersion"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
+    implementation project(':testutils')
     compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     androidTestImplementation "androidx.test:runner:$rootProject.ext.androidxTestRunnerVersion"

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -27,6 +27,7 @@ import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 
 /**
  * A set of values that can be used to denote the behaviour we expect to observe during an oauth
@@ -35,7 +36,7 @@ import lombok.NonNull;
  * The test should fail if the actual behaviour observed deviates from what is denoted as expected
  * via these parameters.
  */
-@Builder
+@SuperBuilder
 @Getter
 public class PromptHandlerParameters {
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/AbstractB2CLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/AbstractB2CLoginComponentHandler.java
@@ -24,36 +24,45 @@ package com.microsoft.identity.client.ui.automation.interaction.b2c;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
 
-/**
- * A login component handler for B2C Local IdP
- */
-public class B2CIdLabLocalLoginComponentHandler extends AbstractB2CLoginComponentHandler {
+public abstract class AbstractB2CLoginComponentHandler implements ILoginComponentHandler {
+
+    protected abstract String getHandlerName();
 
     @Override
-    protected String getHandlerName() {
-        return B2CProvider.Local.getProviderName();
+    public void handleAccountPicker(@NonNull final String username) {
+        throw new UnsupportedOperationException(
+                "Not supported for B2C " + getHandlerName() + " Provider"
+        );
     }
 
     @Override
-    public void handleEmailField(@NonNull final String username) {
-        UiAutomatorUtils.handleInput("logonIdentifier", username);
+    public void confirmConsentPageReceived() {
+        throw new UnsupportedOperationException(
+                "Not supported for B2C " + getHandlerName() + " Provider"
+        );
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
-        UiAutomatorUtils.handleInput("password", password);
-        handleNextButton();
+    public void acceptConsent() {
+        throw new UnsupportedOperationException(
+                "Not supported for B2C " + getHandlerName() + " Provider"
+        );
     }
 
     @Override
-    public void handleBackButton() {
-        UiAutomatorUtils.pressBack();
+    public void declineConsent() {
+        throw new UnsupportedOperationException(
+                "Not supported for B2C " + getHandlerName() + " Provider"
+        );
     }
 
     @Override
-    public void handleNextButton() {
-        UiAutomatorUtils.handleButtonClick("next");
+    public void handleSpeedBump() {
+        throw new UnsupportedOperationException(
+                "Not supported for B2C " + getHandlerName() + " Provider"
+        );
     }
+
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
@@ -1,0 +1,81 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import androidx.annotation.NonNull;
+import androidx.test.uiautomator.UiObject;
+
+import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+public class B2CIdLabLocalLoginComponentHandler implements ILoginComponentHandler {
+
+    @Override
+    public void handleEmailField(@NonNull final String username) {
+        UiAutomatorUtils.handleInput("logonIdentifier", username);
+    }
+
+    @Override
+    public void handlePasswordField(@NonNull final String password) {
+        UiAutomatorUtils.handleInput("password", password);
+        handleNextButton();
+    }
+
+    @Override
+    public void handleBackButton() {
+        UiAutomatorUtils.pressBack();
+    }
+
+    @Override
+    public void handleNextButton() {
+        UiAutomatorUtils.handleButtonClick("next");
+    }
+
+    @Override
+    public void handleAccountPicker(@NonNull final String username) {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    private UiObject getConsentScreen() {
+        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
+    }
+
+    @Override
+    public void confirmConsentPageReceived() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void acceptConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    public void declineConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void handleSpeedBump() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
@@ -28,6 +28,9 @@ import androidx.test.uiautomator.UiObject;
 import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
+/**
+ * A login component handler for B2C Local IdP
+ */
 public class B2CIdLabLocalLoginComponentHandler implements ILoginComponentHandler {
 
     @Override
@@ -54,10 +57,6 @@ public class B2CIdLabLocalLoginComponentHandler implements ILoginComponentHandle
     @Override
     public void handleAccountPicker(@NonNull final String username) {
         throw new UnsupportedOperationException("Not supported for B2C Local Provider");
-    }
-
-    private UiObject getConsentScreen() {
-        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CPromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CPromptHandlerParameters.java
@@ -31,6 +31,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 public class B2CPromptHandlerParameters extends PromptHandlerParameters {
 
+    // the B2C Provider expected to be being used during the test
     private B2CProvider b2cProvider;
 
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CPromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CPromptHandlerParameters.java
@@ -1,0 +1,36 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public class B2CPromptHandlerParameters extends PromptHandlerParameters {
+
+    private B2CProvider b2cProvider;
+
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
@@ -1,0 +1,106 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+
+import lombok.Getter;
+
+@Getter
+public abstract class B2CProvider {
+
+    @NonNull
+    private String providerName;
+
+    @Nullable // should be null for LOCAL B2C provider
+    private String idpSelectionBtnResourceId;
+
+    @Nullable
+    private String domainHint;
+
+    public B2CProvider(@NonNull final String providerName,
+                       @Nullable final String idpSelectionBtnResourceId,
+                       @Nullable final String domainHint) {
+        this.providerName = providerName;
+        this.idpSelectionBtnResourceId = idpSelectionBtnResourceId;
+        this.domainHint = domainHint;
+    }
+
+    protected abstract boolean isExternalIdp();
+
+    public static class Local extends B2CProvider {
+        public Local() {
+            super(LabConstants.B2CProvider.LOCAL, null, null);
+        }
+
+        @Override
+        protected boolean isExternalIdp() {
+            return false;
+        }
+    }
+
+    public static class Google extends B2CProvider {
+        public Google() {
+            super(LabConstants.B2CProvider.GOOGLE,
+                    "GoogleExchange",
+                    "google.com"
+            );
+        }
+
+        @Override
+        protected boolean isExternalIdp() {
+            return true;
+        }
+    }
+
+    public static class Facebook extends B2CProvider {
+        public Facebook() {
+            super(LabConstants.B2CProvider.FACEBOOK,
+                    "FacebookExchange",
+                    "facebook.com"
+            );
+        }
+
+        @Override
+        protected boolean isExternalIdp() {
+            return true;
+        }
+    }
+
+    public static class Microsoft extends B2CProvider {
+        public Microsoft() {
+            super(LabConstants.B2CProvider.MICROSOFT,
+                    "MicrosoftAccountExchange",
+                    "microsoft.com"
+            );
+        }
+
+        @Override
+        protected boolean isExternalIdp() {
+            return true;
+        }
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
@@ -29,6 +29,9 @@ import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 
 import lombok.Getter;
 
+/**
+ * A class modeling a B2C Provider that is being used during a B2C UI Test
+ */
 @Getter
 public abstract class B2CProvider {
 
@@ -38,8 +41,8 @@ public abstract class B2CProvider {
     @Nullable // should be null for LOCAL B2C provider
     private String idpSelectionBtnResourceId;
 
-    @Nullable
-    private String domainHint;
+    @Nullable // should be null for LOCAL B2C provider
+    private String domainHint; // this can be used as query param to /authorize endpoint
 
     public B2CProvider(@NonNull final String providerName,
                        @Nullable final String idpSelectionBtnResourceId,
@@ -49,16 +52,18 @@ public abstract class B2CProvider {
         this.domainHint = domainHint;
     }
 
-    protected abstract boolean isExternalIdp();
+    /**
+     * Indicates if the B2C Provider is a non-local IdP
+     *
+     * @return a boolean indicating if B2C Provider is an external IdP
+     */
+    protected boolean isExternalIdp() {
+        return !(this instanceof Local);
+    }
 
     public static class Local extends B2CProvider {
         public Local() {
             super(LabConstants.B2CProvider.LOCAL, null, null);
-        }
-
-        @Override
-        protected boolean isExternalIdp() {
-            return false;
         }
     }
 
@@ -69,11 +74,6 @@ public abstract class B2CProvider {
                     "google.com"
             );
         }
-
-        @Override
-        protected boolean isExternalIdp() {
-            return true;
-        }
     }
 
     public static class Facebook extends B2CProvider {
@@ -83,11 +83,6 @@ public abstract class B2CProvider {
                     "facebook.com"
             );
         }
-
-        @Override
-        protected boolean isExternalIdp() {
-            return true;
-        }
     }
 
     public static class Microsoft extends B2CProvider {
@@ -96,11 +91,6 @@ public abstract class B2CProvider {
                     "MicrosoftAccountExchange",
                     "microsoft.com"
             );
-        }
-
-        @Override
-        protected boolean isExternalIdp() {
-            return true;
         }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CProvider.java
@@ -27,70 +27,40 @@ import androidx.annotation.Nullable;
 
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 
-import lombok.Getter;
+public enum B2CProvider {
 
-/**
- * A class modeling a B2C Provider that is being used during a B2C UI Test
- */
-@Getter
-public abstract class B2CProvider {
+    Google(LabConstants.B2CProvider.GOOGLE, "GoogleExchange", "google.com"),
+    Facebook(LabConstants.B2CProvider.FACEBOOK, "FacebookExchange", "facebook.com"),
+    MSA(LabConstants.B2CProvider.MICROSOFT, "MicrosoftAccountExchange", "live.com"),
+    Local(LabConstants.B2CProvider.LOCAL, null, null);
 
-    @NonNull
-    private String providerName;
+    private final String providerName;
 
     @Nullable // should be null for LOCAL B2C provider
-    private String idpSelectionBtnResourceId;
+    private final String idpSelectionBtnResourceId;
 
     @Nullable // should be null for LOCAL B2C provider
-    private String domainHint; // this can be used as query param to /authorize endpoint
+    private final String domainHint; // this can be used as query param to /authorize endpoint
 
-    public B2CProvider(@NonNull final String providerName,
-                       @Nullable final String idpSelectionBtnResourceId,
-                       @Nullable final String domainHint) {
+    B2CProvider(@NonNull final String providerName,
+                @Nullable final String idpSelectionBtnResourceId,
+                @Nullable final String domainHint) {
         this.providerName = providerName;
         this.idpSelectionBtnResourceId = idpSelectionBtnResourceId;
         this.domainHint = domainHint;
     }
 
-    /**
-     * Indicates if the B2C Provider is a non-local IdP
-     *
-     * @return a boolean indicating if B2C Provider is an external IdP
-     */
-    protected boolean isExternalIdp() {
-        return !(this instanceof Local);
+    public String getProviderName() {
+        return providerName;
     }
 
-    public static class Local extends B2CProvider {
-        public Local() {
-            super(LabConstants.B2CProvider.LOCAL, null, null);
-        }
+    @Nullable
+    public String getIdpSelectionBtnResourceId() {
+        return idpSelectionBtnResourceId;
     }
 
-    public static class Google extends B2CProvider {
-        public Google() {
-            super(LabConstants.B2CProvider.GOOGLE,
-                    "GoogleExchange",
-                    "google.com"
-            );
-        }
-    }
-
-    public static class Facebook extends B2CProvider {
-        public Facebook() {
-            super(LabConstants.B2CProvider.FACEBOOK,
-                    "FacebookExchange",
-                    "facebook.com"
-            );
-        }
-    }
-
-    public static class Microsoft extends B2CProvider {
-        public Microsoft() {
-            super(LabConstants.B2CProvider.MICROSOFT,
-                    "MicrosoftAccountExchange",
-                    "microsoft.com"
-            );
-        }
+    @Nullable
+    public String getDomainHint() {
+        return domainHint;
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
@@ -28,7 +28,6 @@ import androidx.annotation.NonNull;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
-import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -36,7 +35,12 @@ import org.junit.Assert;
 /**
  * A login component handler for Facebook IdP
  */
-public class FacebookLoginComponentHandler implements ILoginComponentHandler {
+public class FacebookLoginComponentHandler extends AbstractB2CLoginComponentHandler {
+
+    @Override
+    protected String getHandlerName() {
+        return B2CProvider.Facebook.getProviderName();
+    }
 
     @Override
     public void handleEmailField(@NonNull final String username) {
@@ -65,29 +69,5 @@ public class FacebookLoginComponentHandler implements ILoginComponentHandler {
         } catch (UiObjectNotFoundException e) {
             Assert.fail(e.getMessage());
         }
-    }
-
-    @Override
-    public void handleAccountPicker(@NonNull final String username) {
-        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
-    }
-
-    @Override
-    public void confirmConsentPageReceived() {
-        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
-    }
-
-    @Override
-    public void acceptConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
-    }
-
-    public void declineConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
-    }
-
-    @Override
-    public void handleSpeedBump() {
-        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
@@ -1,0 +1,98 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+
+import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+import org.junit.Assert;
+
+public class FacebookLoginComponentHandler implements ILoginComponentHandler {
+
+    @Override
+    public void handleEmailField(@NonNull final String username) {
+        UiAutomatorUtils.handleInput("m_login_email", username);
+    }
+
+    @Override
+    public void handlePasswordField(@NonNull final String password) {
+        UiAutomatorUtils.handleInput("m_login_password", password);
+        handleNextButton();
+    }
+
+    @Override
+    public void handleBackButton() {
+        UiAutomatorUtils.pressBack();
+    }
+
+    @Override
+    public void handleNextButton() {
+        final UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        final UiObject nextBtn = device.findObject(
+                new UiSelector().className(Button.class).text("Log In")
+        );
+
+        try {
+            nextBtn.click();
+        } catch (UiObjectNotFoundException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Override
+    public void handleAccountPicker(@NonNull final String username) {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    private UiObject getConsentScreen() {
+        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
+    }
+
+    @Override
+    public void confirmConsentPageReceived() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void acceptConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    public void declineConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void handleSpeedBump() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
@@ -25,11 +25,8 @@ package com.microsoft.identity.client.ui.automation.interaction.b2c;
 import android.widget.Button;
 
 import androidx.annotation.NonNull;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
-import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
@@ -59,9 +56,8 @@ public class FacebookLoginComponentHandler implements ILoginComponentHandler {
 
     @Override
     public void handleNextButton() {
-        final UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
-        final UiObject nextBtn = device.findObject(
-                new UiSelector().className(Button.class).text("Log In")
+        final UiObject nextBtn = UiAutomatorUtils.obtainUiObjectWithTextAndClassType(
+                "Log In", Button.class
         );
 
         try {
@@ -73,29 +69,25 @@ public class FacebookLoginComponentHandler implements ILoginComponentHandler {
 
     @Override
     public void handleAccountPicker(@NonNull final String username) {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
-    }
-
-    private UiObject getConsentScreen() {
-        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
+        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 
     @Override
     public void confirmConsentPageReceived() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 
     @Override
     public void acceptConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 
     public void declineConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 
     @Override
     public void handleSpeedBump() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Facebook Provider");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
@@ -36,6 +36,9 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
 
+/**
+ * A login component handler for Facebook IdP
+ */
 public class FacebookLoginComponentHandler implements ILoginComponentHandler {
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
@@ -80,29 +80,25 @@ public class GoogleLoginComponentHandler implements ILoginComponentHandler {
 
     @Override
     public void handleAccountPicker(@NonNull final String username) {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
-    }
-
-    private UiObject getConsentScreen() {
-        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
+        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 
     @Override
     public void confirmConsentPageReceived() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 
     @Override
     public void acceptConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 
     public void declineConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 
     @Override
     public void handleSpeedBump() {
-        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
@@ -34,6 +34,9 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
 
+/**
+ * A login component handler for Google IdP
+ */
 public class GoogleLoginComponentHandler implements ILoginComponentHandler {
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
@@ -1,0 +1,105 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+
+import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+import org.junit.Assert;
+
+public class GoogleLoginComponentHandler implements ILoginComponentHandler {
+
+    @Override
+    public void handleEmailField(@NonNull final String username) {
+        UiAutomatorUtils.handleInput("identifierId", username);
+        handleNextButton();
+    }
+
+    @Override
+    public void handlePasswordField(@NonNull final String password) {
+        UiAutomatorUtils.handleInput("password", password);
+        final UiObject passwordBox = UiAutomatorUtils.obtainUiObjectWithResourceId("password");
+
+        try {
+            final UiObject passwordInput = passwordBox.getChild(
+                    new UiSelector().className(EditText.class)
+            );
+
+            passwordInput.setText(password);
+        } catch (UiObjectNotFoundException e) {
+            Assert.fail(e.getMessage());
+        }
+
+        handleNextButton();
+    }
+
+    @Override
+    public void handleBackButton() {
+        UiAutomatorUtils.pressBack();
+    }
+
+    @Override
+    public void handleNextButton() {
+        final UiObject nextBtn = UiAutomatorUtils.obtainUiObjectWithText("Next");
+        try {
+            nextBtn.click();
+        } catch (UiObjectNotFoundException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Override
+    public void handleAccountPicker(@NonNull final String username) {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    private UiObject getConsentScreen() {
+        return UiAutomatorUtils.obtainUiObjectWithResourceId("consentHeader");
+    }
+
+    @Override
+    public void confirmConsentPageReceived() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void acceptConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    public void declineConsent() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+
+    @Override
+    public void handleSpeedBump() {
+        throw new UnsupportedOperationException("Not supported for B2C Local Provider");
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
@@ -29,7 +29,6 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -37,7 +36,12 @@ import org.junit.Assert;
 /**
  * A login component handler for Google IdP
  */
-public class GoogleLoginComponentHandler implements ILoginComponentHandler {
+public class GoogleLoginComponentHandler extends AbstractB2CLoginComponentHandler {
+
+    @Override
+    protected String getHandlerName() {
+        return B2CProvider.Google.getProviderName();
+    }
 
     @Override
     public void handleEmailField(@NonNull final String username) {
@@ -76,29 +80,5 @@ public class GoogleLoginComponentHandler implements ILoginComponentHandler {
         } catch (UiObjectNotFoundException e) {
             Assert.fail(e.getMessage());
         }
-    }
-
-    @Override
-    public void handleAccountPicker(@NonNull final String username) {
-        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
-    }
-
-    @Override
-    public void confirmConsentPageReceived() {
-        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
-    }
-
-    @Override
-    public void acceptConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
-    }
-
-    public void declineConsent() {
-        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
-    }
-
-    @Override
-    public void handleSpeedBump() {
-        throw new UnsupportedOperationException("Not supported for B2C Google Provider");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
@@ -51,9 +51,8 @@ public class IdLabB2cSisoPolicyPromptHandler extends AbstractPromptHandler {
             UiAutomatorUtils.handleButtonClick(b2CProvider.getIdpSelectionBtnResourceId());
         }
 
-        if (!b2CProvider.isExternalIdp() && !parameters.isLoginHintProvided()) {
-            loginComponentHandler.handleEmailField(username);
-        } else if (b2CProvider.isExternalIdp() && !parameters.isSessionExpected()) {
+        if ((!b2CProvider.isExternalIdp() && !parameters.isLoginHintProvided()) ||
+                (b2CProvider.isExternalIdp() && !parameters.isSessionExpected())) {
             loginComponentHandler.handleEmailField(username);
         }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
@@ -46,13 +46,15 @@ public class IdLabB2cSisoPolicyPromptHandler extends AbstractPromptHandler {
 
         final B2CProvider b2CProvider = b2CPromptHandlerParameters.getB2cProvider();
 
-        if (b2CProvider.isExternalIdp()) {
+        final boolean isExternalIdP = b2CProvider != B2CProvider.Local;
+
+        if (isExternalIdP) {
             assert b2CProvider.getIdpSelectionBtnResourceId() != null;
             UiAutomatorUtils.handleButtonClick(b2CProvider.getIdpSelectionBtnResourceId());
         }
 
-        if ((!b2CProvider.isExternalIdp() && !parameters.isLoginHintProvided()) ||
-                (b2CProvider.isExternalIdp() && !parameters.isSessionExpected())) {
+        if ((!isExternalIdP && !parameters.isLoginHintProvided()) ||
+                (isExternalIdP && !parameters.isSessionExpected())) {
             loginComponentHandler.handleEmailField(username);
         }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
@@ -30,12 +30,16 @@ import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHa
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 
+/**
+ * A Prompt handler for MSIDLAB B2C SISO Policy
+ */
 public class IdLabB2cSisoPolicyPromptHandler extends AbstractPromptHandler {
 
     public IdLabB2cSisoPolicyPromptHandler(@NonNull final B2CPromptHandlerParameters parameters) {
         super(getAppropriateLoginComponentHandler(parameters), parameters);
     }
 
+    @Override
     public void handlePrompt(@NonNull final String username, @NonNull final String password) {
         final B2CPromptHandlerParameters b2CPromptHandlerParameters =
                 (B2CPromptHandlerParameters) parameters;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
@@ -1,0 +1,75 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.interaction.b2c;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.ui.automation.interaction.AadLoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.interaction.AbstractPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.ILoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+
+public class IdLabB2cSisoPolicyPromptHandler extends AbstractPromptHandler {
+
+    public IdLabB2cSisoPolicyPromptHandler(@NonNull final B2CPromptHandlerParameters parameters) {
+        super(getAppropriateLoginComponentHandler(parameters), parameters);
+    }
+
+    public void handlePrompt(@NonNull final String username, @NonNull final String password) {
+        final B2CPromptHandlerParameters b2CPromptHandlerParameters =
+                (B2CPromptHandlerParameters) parameters;
+
+        final B2CProvider b2CProvider = b2CPromptHandlerParameters.getB2cProvider();
+
+        if (b2CProvider.isExternalIdp()) {
+            assert b2CProvider.getIdpSelectionBtnResourceId() != null;
+            UiAutomatorUtils.handleButtonClick(b2CProvider.getIdpSelectionBtnResourceId());
+        }
+
+        if (!b2CProvider.isExternalIdp() && !parameters.isLoginHintProvided()) {
+            loginComponentHandler.handleEmailField(username);
+        } else if (b2CProvider.isExternalIdp() && !parameters.isSessionExpected()) {
+            loginComponentHandler.handleEmailField(username);
+        }
+
+        if (!parameters.isSessionExpected()) {
+            loginComponentHandler.handlePasswordField(password);
+        }
+    }
+
+    protected static ILoginComponentHandler getAppropriateLoginComponentHandler(@NonNull final B2CPromptHandlerParameters parameters) {
+        switch (parameters.getB2cProvider().getProviderName()) {
+            case LabConstants.B2CProvider.LOCAL:
+                return new B2CIdLabLocalLoginComponentHandler();
+            case LabConstants.B2CProvider.GOOGLE:
+                return new GoogleLoginComponentHandler();
+            case LabConstants.B2CProvider.FACEBOOK:
+                return new FacebookLoginComponentHandler();
+            case LabConstants.B2CProvider.MICROSOFT:
+                return new AadLoginComponentHandler();
+            default:
+                throw new UnsupportedOperationException("Unsupported B2C Provider for this policy");
+        }
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -138,6 +138,13 @@ public class UiAutomatorUtils {
         }
     }
 
+    public static void pressBack() {
+        final UiDevice mDevice =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        mDevice.pressBack();
+    }
+
     private static boolean isKeyboardOpen() {
         for (AccessibilityWindowInfo window : InstrumentationRegistry.getInstrumentation().getUiAutomation().getWindows()) {
             if (window.getType() == AccessibilityWindowInfo.TYPE_INPUT_METHOD) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -138,6 +138,9 @@ public class UiAutomatorUtils {
         }
     }
 
+    /**
+     * Presses the device back button on the Android device
+     */
     public static void pressBack() {
         final UiDevice mDevice =
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -75,6 +75,26 @@ public class UiAutomatorUtils {
     }
 
     /**
+     * Obtain an instance of the UiObject for the given text and class name
+     *
+     * @param text      the text of the element to obtain
+     * @param className the class name of the element to obtain
+     * @return the UiObject associated to the supplied text
+     */
+    public static UiObject obtainUiObjectWithTextAndClassType(@NonNull final String text,
+                                                              @NonNull Class className) {
+        final UiDevice mDevice =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiObject uiObject = mDevice.findObject(new UiSelector()
+                .className(className)
+                .textContains(text));
+
+        uiObject.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+        return uiObject;
+    }
+
+    /**
      * Obtain a child element inside a scrollable view by specifying resource id and text
      *
      * @param scrollableResourceId the resource id of the parent scroll view


### PR DESCRIPTION
In this PR, I've added some utility classes for handling user interaction in a B2C UI Test. Everything added is primarily focused on resolving interaction with an ID LAB B2C SISO Policy. Later on we may add / modify to handle other policies.

The following things are added:

- A login component interaction handler for Local B2C Accounts
- A login component interaction handler for Google Accounts
- A login component interaction handler for Facebook Accounts
- Prompt Handler for IDLAB B2C SISO Policy
- A class modeling a B2C Provider that is being used in the test

These utilities are currently used in MSAL B2C tests here: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1074