### PR TITLE
Additional utilities for working with test accounts.

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -226,12 +226,12 @@ public class LabUserHelper {
         return tempUser.getUpn();
     }
 
-    public static TempUser loadTempUserForTest(final String userType) {
+    public static TempUser loadTempUserForTest(final UserType userType) {
         LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
 
         try {
-            return createTempUserApi.post(userType);
+            return createTempUserApi.post(userType.getValue());
         } catch (ApiException e) {
             throw new RuntimeException("Error retrieving lab user", e);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -226,12 +226,12 @@ public class LabUserHelper {
         return tempUser.getUpn();
     }
 
-    public static TempUser loadTempUserForTest(final UserType userType) {
+    public static TempUser loadTempUserForTest(final String userType) {
         LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
 
         try {
-            return createTempUserApi.post(userType.getValue());
+            return createTempUserApi.post(userType);
         } catch (ApiException e) {
             throw new RuntimeException("Error retrieving lab user", e);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -71,6 +71,82 @@ public class LabUserHelper {
         return configInfos;
     }
 
+    public enum UserType {
+        CLOUD(LabConstants.UserType.CLOUD),
+        B2C(LabConstants.UserType.B2C),
+        FEDERATED(LabConstants.UserType.FEDERATED),
+        GUEST(LabConstants.UserType.GUEST),
+        MSA(LabConstants.UserType.MSA),
+        ON_PREM(LabConstants.UserType.ON_PREM)
+        ;
+        String constant;
+        UserType(String constant) {
+            this.constant = constant;
+        }
+        String getValue() {
+            return constant;
+        }
+
+    }
+
+    public enum SignInAudience {
+        AZURE_AD_AND_PERSONAL_MICROSOFT_ACCOUNT(LabConstants.SignInAudience.AZURE_AD_AND_PERSONAL_MICROSOFT_ACCOUNT),
+        AZURE_AD_MULTIPLE_ORGS(LabConstants.SignInAudience.AZURE_AD_MULTIPLE_ORGS),
+        AZURE_AD_MY_ORG(LabConstants.SignInAudience.AZURE_AD_MY_ORG),
+        ;
+        String constant;
+        SignInAudience(String constant) {
+            this.constant = constant;
+        }
+        String getValue() {
+            return constant;
+        }
+
+    }
+
+    public enum AzureEnvironment {
+        AZURE_B2C_CLOUD(LabConstants.AzureEnvironment.AZURE_B2C_CLOUD),
+        AZURE_CHINA_CLOUD(LabConstants.AzureEnvironment.AZURE_CHINA_CLOUD),
+        AZURE_CLOUD(LabConstants.AzureEnvironment.AZURE_CLOUD),
+        AZURE_GERMANY_CLOUD(LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD),
+        AZURE_PPE(LabConstants.AzureEnvironment.AZURE_PPE),
+        AZURE_US_GOVERNMENT(LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT)
+        ;
+        String constant;
+        AzureEnvironment(String constant) {
+            this.constant = constant;
+        }
+        String getValue() {
+            return constant;
+        }
+    }
+
+    public enum IsAdminConsented {
+        YES(LabConstants.IsAdminConsented.YES),
+        NO(LabConstants.IsAdminConsented.NO)
+        ;
+        String constant;
+        IsAdminConsented(String constant) {
+            this.constant = constant;
+        }
+        String getValue() {
+            return constant;
+        }
+    }
+
+    public enum PublicClient {
+        YES(LabConstants.PublicClient.YES),
+        NO(LabConstants.PublicClient.NO)
+        ;
+        String constant;
+        PublicClient(String constant) {
+            this.constant = constant;
+        }
+        String getValue() {
+            return constant;
+        }
+    }
+
     public static ConfigInfo getConfigInfo(LabUserQuery query) {
         LabConfig labConfig;
         labConfig = sLabConfigCache.get(query);
@@ -193,10 +269,17 @@ public class LabUserHelper {
     }
 
     public static AppInfo getAppInfo() {
+            return getAppInfo(UserType.CLOUD, AzureEnvironment.AZURE_CLOUD, SignInAudience.AZURE_AD_MULTIPLE_ORGS,
+                    IsAdminConsented.YES, PublicClient.YES);
+   }
+
+    public static AppInfo getAppInfo(UserType userType, AzureEnvironment azureEnvironment, SignInAudience audience,
+                                     IsAdminConsented isAdminConsented, PublicClient publicClient) {
         LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
         AppApi api = new AppApi();
         try {
-            return api.getAppByParam("cloud", "azurecloud", "azureadmultipleorgs", "yes", "yes").get(0);
+            return api.getAppByParam(userType.getValue(), azureEnvironment.getValue(), audience.getValue(),
+                    isAdminConsented.getValue(), publicClient.getValue()).get(0);
         } catch (ApiException e) {
             throw new RuntimeException(e);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -268,7 +268,7 @@ public class LabUserHelper {
         return credential;
     }
 
-    public static AppInfo getAppInfo() {
+    public static AppInfo getDefaultAppInfo() {
             return getAppInfo(UserType.CLOUD, AzureEnvironment.AZURE_CLOUD, SignInAudience.AZURE_AD_MULTIPLE_ORGS,
                     IsAdminConsented.YES, PublicClient.YES);
    }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -226,14 +226,12 @@ public class LabUserHelper {
         return tempUser.getUpn();
     }
 
-    public static TempUser loadTempUserForTest(final String userType, Consumer<TempUser> consumer) {
+    public static TempUser loadTempUserForTest(final String userType) {
         LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
 
         try {
-            TempUser user = createTempUserApi.post(userType);
-            consumer.accept(user);
-            return user;
+            return createTempUserApi.post(userType);
         } catch (ApiException e) {
             throw new RuntimeException("Error retrieving lab user", e);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -22,10 +22,14 @@
 // THE SOFTWARE.
 package com.microsoft.identity.internal.testutils.labutils;
 
+import androidx.core.util.Consumer;
+
 import com.microsoft.identity.internal.test.labapi.ApiException;
+import com.microsoft.identity.internal.test.labapi.api.AppApi;
 import com.microsoft.identity.internal.test.labapi.api.ConfigApi;
 import com.microsoft.identity.internal.test.labapi.api.CreateTempUserApi;
 import com.microsoft.identity.internal.test.labapi.api.ResetApi;
+import com.microsoft.identity.internal.test.labapi.model.AppInfo;
 import com.microsoft.identity.internal.test.labapi.model.ConfigInfo;
 import com.microsoft.identity.internal.test.labapi.model.LabInfo;
 import com.microsoft.identity.internal.test.labapi.model.TempUser;
@@ -146,6 +150,19 @@ public class LabUserHelper {
         return tempUser.getUpn();
     }
 
+    public static TempUser loadTempUserForTest(final String userType, Consumer<TempUser> consumer) {
+        LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
+        CreateTempUserApi createTempUserApi = new CreateTempUserApi();
+
+        try {
+            TempUser user = createTempUserApi.post(userType);
+            consumer.accept(user);
+            return user;
+        } catch (ApiException e) {
+            throw new RuntimeException("Error retrieving lab user", e);
+        }
+    }
+
     public static String getPasswordForUser(final String username) {
         final ConfigInfo configInfo = getConfigInfoFromUpn(username);
         return LabHelper.getPasswordForLab(configInfo.getUserInfo().getLabName());
@@ -173,6 +190,16 @@ public class LabUserHelper {
         credential.userName = configInfo.getUserInfo().getUpn();
         credential.password = labConfig.getLabUserPassword();
         return credential;
+    }
+
+    public static AppInfo getAppInfo() {
+        LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
+        AppApi api = new AppApi();
+        try {
+            return api.getAppByParam("cloud", "azurecloud", "azureadmultipleorgs", "yes", "yes").get(0);
+        } catch (ApiException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static void resetPassword(final String upn) {


### PR DESCRIPTION
There are two of these.  

One to get the AppInfo object, and since the temp accounts are only used in the "cloud" space I wasn't sure how much flexibility they needed.

One to get the tempUser for a given user type and allow a consumer to act on it.