### PR TITLE
Changes to add enrollment id to the token request in the interrupt flow

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -48,6 +48,8 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     private BrokerRequestType requestType;
     private String negotiatedBrokerProtocolVersion;
 
+    private String enrollmentId;
+
     /**
      * Helper method to identify if the request originated from Broker itself or from client libraries.
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
@@ -39,6 +39,7 @@ public class MicrosoftTokenRequest extends TokenRequest {
     public static final String INSTANCE_AWARE = "instance_aware";
     public static final String CLIENT_APP_NAME = "x-app-name";
     public static final String CLIENT_APP_VERSION = "x-app-ver";
+    public static final String MICROSOFT_ENROLLMENT_ID = "microsoft_enrollment_id";
 
     public MicrosoftTokenRequest() {
         mClientInfoEnabled = "1";
@@ -78,6 +79,10 @@ public class MicrosoftTokenRequest extends TokenRequest {
     @Expose()
     @SerializedName(CLIENT_APP_VERSION)
     private String mClientAppVersion;
+
+    @Expose()
+    @SerializedName(MICROSOFT_ENROLLMENT_ID)
+    private String mMicrosoftEnrollmentId;
 
     private String mTokenScope;
 
@@ -166,5 +171,13 @@ public class MicrosoftTokenRequest extends TokenRequest {
 
     public void setBrokerVersion(final String brokerVersion) {
         this.mBrokerVersion = brokerVersion;
+    }
+
+    public String getMicrosoftEnrollmentId() {
+        return mMicrosoftEnrollmentId;
+    }
+
+    public void setMicrosoftEnrollmentId(String microsoftEnrollmentId) {
+        this.mMicrosoftEnrollmentId = microsoftEnrollmentId;
     }
 }


### PR DESCRIPTION
- This is to fix a bug where we are not sending enrollment id to the token endpoint in the interrupt flow.
- Broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/1324
- Work item [here](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1054430)