### PR TITLE
Utilities for editing different tokens in the cache

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -262,12 +262,14 @@ public class AccessTokenRecord extends Credential {
         mExpiresOn = expiresOn;
     }
 
-    private boolean isExpired(final String expires) {
+    private boolean isExpired(final String expiresEpochSeconds) {
+        //TODO: Explain why this is not just
+        // return System.currentTimeMillis() < Long.valueOf(expiresEpochSeconds) * 1000;
         // Init a Calendar for the current time/date
         final Calendar calendar = Calendar.getInstance();
         final Date validity = calendar.getTime();
         // Init a Date for the accessToken's expiry
-        long epoch = Long.valueOf(expires);
+        long epoch = Long.valueOf(expiresEpochSeconds);
         final Date expiresOn = new Date(
                 TimeUnit.SECONDS.toMillis(epoch)
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -27,10 +27,6 @@ import androidx.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.internal.platform.IDevicePopManager;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
-
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.ACCESS_TOKEN_TYPE;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.AUTHORITY;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.EXTENDED_EXPIRES_ON;
@@ -129,7 +125,7 @@ public class AccessTokenRecord extends Credential {
      * epoch (1970).
      */
     @SerializedName(EXPIRES_ON)
-    private String mExpiresOn;
+    private String mExpirationEpochSeconds;
 
     /**
      * Gets the kid.
@@ -250,7 +246,7 @@ public class AccessTokenRecord extends Credential {
      * @return The expires_on to get.
      */
     public String getExpiresOn() {
-        return mExpiresOn;
+        return mExpirationEpochSeconds;
     }
 
     /**
@@ -259,25 +255,11 @@ public class AccessTokenRecord extends Credential {
      * @param expiresOn The expires_on to set.
      */
     public void setExpiresOn(final String expiresOn) {
-        mExpiresOn = expiresOn;
-    }
-
-    private boolean isExpired(final String expiresEpochSeconds) {
-        //TODO: Explain why this is not just
-        // return System.currentTimeMillis() < Long.valueOf(expiresEpochSeconds) * 1000;
-        // Init a Calendar for the current time/date
-        final Calendar calendar = Calendar.getInstance();
-        final Date validity = calendar.getTime();
-        // Init a Date for the accessToken's expiry
-        long epoch = Long.valueOf(expiresEpochSeconds);
-        final Date expiresOn = new Date(
-                TimeUnit.SECONDS.toMillis(epoch)
-        );
-        return expiresOn.before(validity);
+        mExpirationEpochSeconds = expiresOn;
     }
 
     @Override
     public boolean isExpired() {
-        return isExpired(getExpiresOn());
+        return System.currentTimeMillis() > Long.parseLong(mExpirationEpochSeconds) * 1000;
     }
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -42,27 +42,29 @@ import java.util.Map;
 public class TestUtils {
 
     public static final CacheKeyValueDelegate CACHE_KEY_VALUE_DELEGATE = new CacheKeyValueDelegate();
+    public static final Predicate<String> IS_ACCESS_TOKEN = new Predicate<String>() {
+        @Override
+        public boolean test(String s) {
+            return isAccessToken(s);
+        }
+    };
+    public static final Predicate<String> IS_REFRESH_TOKEN = new Predicate<String>() {
+        @Override
+        public boolean test(String s) {
+            return isRefreshToken(s);
+        }
+    };
 
     private interface Predicate<T> {
         boolean test(T t);
     }
 
     private static String getCacheKeyForAccessToken(Map<String, ?> cacheValues) {
-        Predicate<String> predicate = new Predicate<String>() {
-            @Override public boolean test(String s) {
-                return isAccessToken(s);
-            }
-        };
-        return getMachingKeyOrNull(cacheValues, predicate);
+        return getMachingKeyOrNull(cacheValues, IS_ACCESS_TOKEN);
     }
 
     private static String getCacheKeyForRefreshToken(Map<String, ?> cacheValues) {
-        Predicate<String> predicate = new Predicate<String>() {
-            @Override public boolean test(String s) {
-                return isRefreshToken(s);
-            }
-        };
-        return getMachingKeyOrNull(cacheValues, predicate);
+        return getMachingKeyOrNull(cacheValues, IS_REFRESH_TOKEN);
     }
 
     private static String getMachingKeyOrNull(Map<String, ?> cacheValues, Predicate<String> predicate) {
@@ -114,21 +116,11 @@ public class TestUtils {
     }
 
     public void editAccessTokenInCache(final String sharedPrefName, Function<String, String> editor) {
-        Predicate<String> predicate = new Predicate<String>() {
-            @Override public boolean test(String s) {
-                return isAccessToken(s);
-            }
-        };
-        editTokenInCache(sharedPrefName, predicate, editor);
+        editTokenInCache(sharedPrefName, IS_ACCESS_TOKEN, editor);
     }
 
     public void editRefreshTokenInCache(final String sharedPrefName, Function<String, String> editor) {
-        Predicate<String> predicate = new Predicate<String>() {
-            @Override public boolean test(String s) {
-                return isAccessToken(s);
-            }
-        };
-        editTokenInCache(sharedPrefName, predicate, editor);
+        editTokenInCache(sharedPrefName, IS_REFRESH_TOKEN, editor);
     }
 
     public static void removeAccessTokenFromCache(final String sharedPrefName) {


### PR DESCRIPTION
Expand on the TestUtil that can remove tokens to allow them
to be replaced them with any arbitrary string.