### PR TITLE
Detect Broker Process during encryption/decryption

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -330,6 +330,11 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
             protected String getPackageName() {
                 return AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
             }
+
+            @Override
+            protected boolean isBrokerProcess() {
+                return true;
+            }
         }
 
         final Context context = getInstrumentation().getTargetContext();
@@ -362,6 +367,11 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
             @Override
             protected String getPackageName() {
                 return AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+            }
+
+            @Override
+            protected boolean isBrokerProcess() {
+                return true;
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -415,7 +415,7 @@ public class StorageHelper implements IStorageHelper {
         EncryptionType encryptionType = getEncryptionType(encryptedBlob);
 
         if (encryptionType == EncryptionType.USER_DEFINED) {
-            if (ProcessUtil.isAuthProcess(mContext)){
+            if (ProcessUtil.isBrokerProcess(mContext)){
                 if (COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
                     keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
                     keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
@@ -515,7 +515,7 @@ public class StorageHelper implements IStorageHelper {
         }
 
         // The current app runtime is the broker; load its secret key.
-        if (!sShouldEncryptWithKeyStoreKey && ProcessUtil.isAuthProcess(mContext)) {
+        if (!sShouldEncryptWithKeyStoreKey && ProcessUtil.isBrokerProcess(mContext)) {
             // Try to read keystore key - to verify how often this is invoked before the migration is done.
             // TODO: remove this whole try-catch clause once the experiment is done.
             if (mTelemetryCallback != null) {

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -422,6 +422,8 @@ public class StorageHelper implements IStorageHelper {
                 } else if (AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
                     keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
                     keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
+                } else {
+                    throw new IllegalStateException("Unexpected Broker package name.");
                 }
             } else {
                 keyTypeList.add(KeyType.ADAL_USER_DEFINED_KEY);

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.util.ProcessUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -414,14 +415,16 @@ public class StorageHelper implements IStorageHelper {
         EncryptionType encryptionType = getEncryptionType(encryptedBlob);
 
         if (encryptionType == EncryptionType.USER_DEFINED) {
-            if (AuthenticationSettings.INSTANCE.getSecretKeyData() != null) {
+            if (ProcessUtil.isAuthProcess(mContext)){
+                if (COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
+                    keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
+                    keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
+                } else if (AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
+                    keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
+                    keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
+                }
+            } else {
                 keyTypeList.add(KeyType.ADAL_USER_DEFINED_KEY);
-            } else if (COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
-                keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
-                keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
-            } else if (AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
-                keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
-                keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
             }
         } else if (encryptionType == EncryptionType.ANDROID_KEY_STORE) {
             keyTypeList.add(KeyType.KEYSTORE_ENCRYPTED_KEY);
@@ -512,9 +515,7 @@ public class StorageHelper implements IStorageHelper {
         }
 
         // The current app runtime is the broker; load its secret key.
-        if (!sShouldEncryptWithKeyStoreKey &&
-                AuthenticationSettings.INSTANCE.getBrokerSecretKeys().containsKey(getPackageName())) {
-
+        if (!sShouldEncryptWithKeyStoreKey && ProcessUtil.isAuthProcess(mContext)) {
             // Try to read keystore key - to verify how often this is invoked before the migration is done.
             // TODO: remove this whole try-catch clause once the experiment is done.
             if (mTelemetryCallback != null) {

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -216,6 +216,11 @@ public class StorageHelper implements IStorageHelper {
         return mContext.getPackageName();
     }
 
+    // Exposed to be overridden by mock tests.
+    protected boolean isBrokerProcess() {
+        return ProcessUtil.isBrokerProcess(mContext);
+    }
+
     @Override
     public String encrypt(final String clearText)
             throws GeneralSecurityException, IOException {
@@ -415,7 +420,7 @@ public class StorageHelper implements IStorageHelper {
         EncryptionType encryptionType = getEncryptionType(encryptedBlob);
 
         if (encryptionType == EncryptionType.USER_DEFINED) {
-            if (ProcessUtil.isBrokerProcess(mContext)){
+            if (isBrokerProcess()){
                 if (COMPANY_PORTAL_APP_PACKAGE_NAME.equalsIgnoreCase(packageName)) {
                     keyTypeList.add(KeyType.LEGACY_COMPANY_PORTAL_KEY);
                     keyTypeList.add(KeyType.LEGACY_AUTHENTICATOR_APP_KEY);
@@ -517,7 +522,7 @@ public class StorageHelper implements IStorageHelper {
         }
 
         // The current app runtime is the broker; load its secret key.
-        if (!sShouldEncryptWithKeyStoreKey && ProcessUtil.isBrokerProcess(mContext)) {
+        if (!sShouldEncryptWithKeyStoreKey && isBrokerProcess()) {
             // Try to read keystore key - to verify how often this is invoked before the migration is done.
             // TODO: remove this whole try-catch clause once the experiment is done.
             if (mTelemetryCallback != null) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -33,6 +33,9 @@ import java.util.List;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 
+/**
+ * Utility class for anything relating to process.
+ */
 public class ProcessUtil {
 
     private ProcessUtil(){}

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -35,6 +35,8 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 
 public class ProcessUtil {
 
+    private ProcessUtil(){}
+
     /**
      * Returns true if the calling app is the auth process.
      */
@@ -48,7 +50,10 @@ public class ProcessUtil {
                 cpAuthProcess.equalsIgnoreCase(processName);
     }
 
-    public static String getProcessName(final Context context) {
+    /**
+     * Returns the running process name.
+     */
+    public static String getProcessName(@NonNull final Context context) {
         final int pid = android.os.Process.myPid();
         final ActivityManager am = (ActivityManager) context.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
         final List<ActivityManager.RunningAppProcessInfo> runningProcesses = am.getRunningAppProcesses();

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -58,7 +58,7 @@ public class ProcessUtil {
      * Returns the running process name.
      */
     @Nullable
-    public static String getProcessName(@NonNull final Context context) {
+    private static String getProcessName(@NonNull final Context context) {
         final int pid = android.os.Process.myPid();
         final ActivityManager am = (ActivityManager) context.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
         final List<ActivityManager.RunningAppProcessInfo> runningProcesses = am.getRunningAppProcesses();

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -27,6 +27,7 @@ import android.app.ActivityManager;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.List;
 
@@ -56,6 +57,7 @@ public class ProcessUtil {
     /**
      * Returns the running process name.
      */
+    @Nullable
     public static String getProcessName(@NonNull final Context context) {
         final int pid = android.os.Process.myPid();
         final ActivityManager am = (ActivityManager) context.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -30,13 +30,22 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+
 public class ProcessUtil {
+
     /**
      * Returns true if the calling app is the auth process.
-     * */
-    public static boolean isAuthProcess(@NonNull final Context context) {
+     */
+    public static boolean isBrokerProcess(@NonNull final Context context) {
         final String processName = getProcessName(context);
-        return processName != null && processName.contains(":auth");
+
+        final String authAppAuthProcess = AZURE_AUTHENTICATOR_APP_PACKAGE_NAME + ":auth";
+        final String cpAuthProcess = COMPANY_PORTAL_APP_PACKAGE_NAME + ":auth";
+
+        return authAppAuthProcess.equalsIgnoreCase(processName) ||
+                cpAuthProcess.equalsIgnoreCase(processName);
     }
 
     public static String getProcessName(final Context context) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ProcessUtil.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.util;
+
+import android.app.ActivityManager;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import java.util.List;
+
+public class ProcessUtil {
+    /**
+     * Returns true if the calling app is the auth process.
+     * */
+    public static boolean isAuthProcess(@NonNull final Context context) {
+        final String processName = getProcessName(context);
+        return processName != null && processName.contains(":auth");
+    }
+
+    public static String getProcessName(final Context context) {
+        final int pid = android.os.Process.myPid();
+        final ActivityManager am = (ActivityManager) context.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
+        final List<ActivityManager.RunningAppProcessInfo> runningProcesses = am.getRunningAppProcesses();
+        if (runningProcesses != null) {
+            for (final ActivityManager.RunningAppProcessInfo procInfo : runningProcesses) {
+                if (procInfo.pid == pid) {
+                    return procInfo.processName;
+                }
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
**Why making this fix?**
Teams Desk phone found an issue where it was unable to sign in when they're trying to change CP account. (logs [here](https://powerlift.acompli.net/#/incidents/9dfa7f87-60bb-447e-bf88-289456700597))
The root cause is that 
1. our StorageHelper would keep using Broker's secret key after it's loaded. (technical debt that I was trying to fix in #746 , which I later had to drop).
2. In this case, CP invokes WPJ prior to its sign in
3. its local ADAL process unable to decrypt the value. 
4. RT was wiped
```
2020-07-15T11:56:28.1690000	INFO	MSALCommonLoggerCallback	 7335	00230	MSALCommon: Tag: MsalOAuth2TokenCachesetSingleSignOnState, Message:  [2020-07-15 11:56:28 - {"thread_id":"253","correlation_id":"ad65f8c8-1612-4415-b9ea-19d34e57d9ab"}] Refresh tokens removed: [0] Android 25
```
5. (I suspect) that AT is returned, but RT is not, so CP went ahead and perform WPJ without RT.
6. Teams Phone can't silently sign in as BRT does not exist.

**Proposed fix**

This fix is much simpler than #746. We use the key whenever we're in the broker auth process.
Not sure why I couldn't think of this at the time :/

(getProcessName() is a courtesy from CP team).

**How I verified**
1. Put a debugger on both :auth and non-auth process
2. Perform Join() from BrokerHost. Signs in, isBrokerProcess function returns false. (Local ADAL is used to acquire token).
3. Launch MSAL and trigger join flow. isBrokerProcess function returns true (Broker is used).