### PR TITLE
Adding "junk data" tests to the MSAL Cache

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -285,14 +285,18 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
-                ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
-                rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(IdToken.name())) {
-                ids.add(credential);
-            } else {
-                fail();
+            switch (CredentialType.fromString(credential.getCredentialType())) {
+                case AccessToken:
+                    ats.add(credential);
+                    break;
+                case RefreshToken:
+                    rts.add(credential);
+                    break;
+                case IdToken:
+                    ids.add(credential);
+                    break;
+                default:
+                    fail("Unexpected value: " + credential.getCredentialType());
             }
         }
 
@@ -365,14 +369,18 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
-                ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
-                rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(V1IdToken.name())) {
-                ids.add(credential);
-            } else {
-                fail();
+            switch (CredentialType.fromString(credential.getCredentialType())) {
+                case AccessToken:
+                    ats.add(credential);
+                    break;
+                case RefreshToken:
+                    rts.add(credential);
+                    break;
+                case V1IdToken:
+                    ids.add(credential);
+                    break;
+                default:
+                    fail("Unexpected value: " + credential.getCredentialType());
             }
         }
 
@@ -567,16 +575,21 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
-                ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
-                rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(V1IdToken.name())) {
-                ids.add(credential);
-            } else {
-                fail();
+            switch (CredentialType.fromString(credential.getCredentialType())) {
+                case AccessToken:
+                    ats.add(credential);
+                    break;
+                case RefreshToken:
+                    rts.add(credential);
+                    break;
+                case IdToken:
+                    ids.add(credential);
+                    break;
+                default:
+                    fail("Unexpected value: " + credential.getCredentialType());
             }
         }
+
         assertEquals(defaultTestBundleV1.mGeneratedIdToken, ids.get(0));
     }
 
@@ -620,14 +633,18 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
-                ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
-                rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(IdToken.name())) {
-                ids.add(credential);
-            } else {
-                fail();
+            switch (CredentialType.fromString(credential.getCredentialType())) {
+                case AccessToken:
+                    ats.add(credential);
+                    break;
+                case RefreshToken:
+                    rts.add(credential);
+                    break;
+                case IdToken:
+                    ids.add(credential);
+                    break;
+                default:
+                    fail("Unexpected value: " + credential.getCredentialType());
             }
         }
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -87,6 +87,9 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
+    private static final String JUNK_KEY = "9ac15f53-27ad-471a-ad57-033cdacb0ee9";
+    private  static final String JUNK_VALUE = "OWFjMTVmNTMtMjdhZC00NzFhLWFkNTctMDMzY2RhY2IwZWU5";
+
     private MsalOAuth2TokenCache<
             MicrosoftStsOAuth2Strategy,
             MicrosoftStsAuthorizationRequest,
@@ -123,8 +126,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     AccountCredentialTestBundle defaultTestBundleV2;
 
     IAccountCredentialCache accountCredentialCache;
-    public static final String JUNK_KEY = "9ac15f53-27ad-471a-ad57-033cdacb0ee9";
-    public static final String JUNK_VALUE = "OWFjMTVmNTMtMjdhZC00NzFhLWFkNTctMDMzY2RhY2IwZWU5";
 
     public static class AccountCredentialTestBundle {
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -402,10 +402,10 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         final ICacheRecord entry = result.get(0);
 
-        assertNotNull(entry.getAccount());
-        assertNotNull(entry.getIdToken());
-        assertNotNull(entry.getAccessToken());
-        assertNotNull(entry.getRefreshToken());
+        assertEquals(defaultTestBundleV2.mGeneratedAccount, entry.getAccount());
+        assertEquals(defaultTestBundleV2.mGeneratedIdToken, entry.getIdToken());
+        assertEquals(defaultTestBundleV2.mGeneratedAccessToken, entry.getAccessToken());
+        assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, entry.getRefreshToken());
 
         // Verify that our junk data still exists
         assertEquals(JUNK_VALUE, mSharedPreferencesFileManager.getString(JUNK_KEY));

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -77,6 +77,10 @@ import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCa
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.SECRET;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.TARGET;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.USERNAME;
+import static com.microsoft.identity.common.internal.dto.CredentialType.AccessToken;
+import static com.microsoft.identity.common.internal.dto.CredentialType.IdToken;
+import static com.microsoft.identity.common.internal.dto.CredentialType.RefreshToken;
+import static com.microsoft.identity.common.internal.dto.CredentialType.V1IdToken;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -88,7 +92,7 @@ import static org.mockito.Mockito.when;
 public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     private static final String JUNK_KEY = "9ac15f53-27ad-471a-ad57-033cdacb0ee9";
-    private  static final String JUNK_VALUE = "OWFjMTVmNTMtMjdhZC00NzFhLWFkNTctMDMzY2RhY2IwZWU5";
+    private static final String JUNK_VALUE = "OWFjMTVmNTMtMjdhZC00NzFhLWFkNTctMDMzY2RhY2IwZWU5";
 
     private MsalOAuth2TokenCache<
             MicrosoftStsOAuth2Strategy,
@@ -165,7 +169,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
             mGeneratedAccessToken.setSecret(atSecret);
             mGeneratedAccessToken.setHomeAccountId(homeAccountId);
             mGeneratedAccessToken.setEnvironment(environment);
-            mGeneratedAccessToken.setCredentialType(CredentialType.AccessToken.name());
+            mGeneratedAccessToken.setCredentialType(AccessToken.name());
             mGeneratedAccessToken.setClientId(clientId);
 
             mGeneratedRefreshToken = new RefreshTokenRecord();
@@ -173,7 +177,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
             mGeneratedRefreshToken.setTarget(target);
             mGeneratedRefreshToken.setHomeAccountId(homeAccountId);
             mGeneratedRefreshToken.setEnvironment(environment);
-            mGeneratedRefreshToken.setCredentialType(CredentialType.RefreshToken.name());
+            mGeneratedRefreshToken.setCredentialType(RefreshToken.name());
             mGeneratedRefreshToken.setClientId(clientId);
             mGeneratedRefreshToken.setFamilyId(familyId);
 
@@ -210,7 +214,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
                 null,
-                CredentialType.V1IdToken
+                V1IdToken
         );
 
         defaultTestBundleV2 = new AccountCredentialTestBundle(
@@ -228,7 +232,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
                 null,
-                CredentialType.IdToken
+                IdToken
         );
 
         // Mocks
@@ -281,11 +285,11 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(CredentialType.AccessToken.name())) {
+            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
                 ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.RefreshToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
                 rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.IdToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(IdToken.name())) {
                 ids.add(credential);
             } else {
                 fail();
@@ -320,14 +324,18 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(CredentialType.AccessToken.name())) {
-                ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.RefreshToken.name())) {
-                rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.IdToken.name())) {
-                ids.add(credential);
-            } else {
-                fail();
+            switch (CredentialType.fromString(credential.getCredentialType())) {
+                case AccessToken:
+                    ats.add(credential);
+                    break;
+                case RefreshToken:
+                    rts.add(credential);
+                    break;
+                case IdToken:
+                    ids.add(credential);
+                    break;
+                default:
+                    fail("Unexpected value: " + credential.getCredentialType());
             }
         }
 
@@ -357,11 +365,11 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(CredentialType.AccessToken.name())) {
+            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
                 ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.RefreshToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
                 rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.V1IdToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(V1IdToken.name())) {
                 ids.add(credential);
             } else {
                 fail();
@@ -438,7 +446,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         at.setSecret(SECRET);
         at.setHomeAccountId(HOME_ACCOUNT_ID);
         at.setEnvironment(ENVIRONMENT);
-        at.setCredentialType(CredentialType.AccessToken.name());
+        at.setCredentialType(AccessToken.name());
         at.setClientId(CLIENT_ID);
         at.setTarget(TARGET);
 
@@ -446,7 +454,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         id.setHomeAccountId(HOME_ACCOUNT_ID);
         id.setEnvironment(ENVIRONMENT);
         id.setRealm(REALM2);
-        id.setCredentialType(CredentialType.IdToken.name());
+        id.setCredentialType(IdToken.name());
         id.setClientId(CLIENT_ID);
         id.setSecret(MOCK_ID_TOKEN_WITH_CLAIMS);
         id.setAuthority("https://sts.windows.net/0287f963-2d72-4363-9e3a-5705c5b0f031/");
@@ -495,7 +503,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         at.setSecret(SECRET);
         at.setHomeAccountId(HOME_ACCOUNT_ID);
         at.setEnvironment(ENVIRONMENT);
-        at.setCredentialType(CredentialType.AccessToken.name());
+        at.setCredentialType(AccessToken.name());
         at.setClientId(CLIENT_ID);
         at.setTarget(TARGET);
 
@@ -503,7 +511,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         id.setHomeAccountId(HOME_ACCOUNT_ID);
         id.setEnvironment(ENVIRONMENT);
         id.setRealm(REALM2);
-        id.setCredentialType(CredentialType.IdToken.name());
+        id.setCredentialType(IdToken.name());
         id.setClientId(CLIENT_ID);
         id.setSecret(MOCK_ID_TOKEN_WITH_CLAIMS);
         id.setAuthority("https://sts.windows.net/0287f963-2d72-4363-9e3a-5705c5b0f031/");
@@ -559,11 +567,11 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(CredentialType.AccessToken.name())) {
+            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
                 ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.RefreshToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
                 rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.V1IdToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(V1IdToken.name())) {
                 ids.add(credential);
             } else {
                 fail();
@@ -584,7 +592,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         accessTokenToClear.setSecret(SECRET);
         accessTokenToClear.setHomeAccountId(HOME_ACCOUNT_ID);
         accessTokenToClear.setEnvironment(ENVIRONMENT);
-        accessTokenToClear.setCredentialType(CredentialType.AccessToken.name());
+        accessTokenToClear.setCredentialType(AccessToken.name());
         accessTokenToClear.setClientId(CLIENT_ID);
         accessTokenToClear.setTarget(TARGET);
 
@@ -612,11 +620,11 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ids = new ArrayList<>();
 
         for (final Credential credential : credentials) {
-            if (credential.getCredentialType().equalsIgnoreCase(CredentialType.AccessToken.name())) {
+            if (credential.getCredentialType().equalsIgnoreCase(AccessToken.name())) {
                 ats.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.RefreshToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(RefreshToken.name())) {
                 rts.add(credential);
-            } else if (credential.getCredentialType().equalsIgnoreCase(CredentialType.IdToken.name())) {
+            } else if (credential.getCredentialType().equalsIgnoreCase(IdToken.name())) {
                 ids.add(credential);
             } else {
                 fail();
@@ -744,7 +752,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                             SECRET,
                             MOCK_ID_TOKEN_WITH_CLAIMS,
                             null,
-                            CredentialType.IdToken
+                            IdToken
                     )
             );
         }
@@ -885,12 +893,12 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     @Test
     public void getAccounts() throws ClientException {
-        getAccounts(CredentialType.IdToken);
+        getAccounts(IdToken);
     }
 
     @Test
     public void getAccountsV1Compat() throws ClientException {
-        getAccounts(CredentialType.V1IdToken);
+        getAccounts(V1IdToken);
     }
 
     private void getAccounts(@NonNull CredentialType idTokenType) throws ClientException {
@@ -936,12 +944,12 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     @Test
     public void getAccountsWithDeletion() throws ClientException {
-        getAccountsWithDeletion(CredentialType.IdToken);
+        getAccountsWithDeletion(IdToken);
     }
 
     @Test
     public void getAccountsWithDeletionV1Compat() throws ClientException {
-        getAccountsWithDeletion(CredentialType.V1IdToken);
+        getAccountsWithDeletion(V1IdToken);
     }
 
     private void getAccountsWithDeletion(@NonNull final CredentialType idTokenType) throws ClientException {
@@ -1427,7 +1435,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Save an AccessToken into the cache
         final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setCredentialType(AccessToken.name());
         accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
@@ -1440,7 +1448,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Save a Family RefreshToken into the cache
         final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
-        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setCredentialType(RefreshToken.name());
         refreshToken.setEnvironment(ENVIRONMENT);
         refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
         refreshToken.setClientId(CLIENT_ID);
@@ -1453,7 +1461,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         id.setHomeAccountId(HOME_ACCOUNT_ID);
         id.setEnvironment(ENVIRONMENT);
         id.setRealm(REALM2);
-        id.setCredentialType(CredentialType.IdToken.name());
+        id.setCredentialType(IdToken.name());
         id.setClientId(CLIENT_ID);
         id.setSecret(MOCK_ID_TOKEN_WITH_CLAIMS);
         id.setAuthority("https://sts.windows.net/0287f963-2d72-4363-9e3a-5705c5b0f031/");
@@ -1486,7 +1494,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Save an AccessToken into the cache
         final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setCredentialType(AccessToken.name());
         accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
@@ -1499,7 +1507,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Save a Family RefreshToken into the cache
         final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
-        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setCredentialType(RefreshToken.name());
         refreshToken.setEnvironment(ENVIRONMENT);
         refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
         refreshToken.setClientId(CLIENT_ID);
@@ -1512,7 +1520,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         id.setHomeAccountId(HOME_ACCOUNT_ID);
         id.setEnvironment(ENVIRONMENT);
         id.setRealm(REALM2);
-        id.setCredentialType(CredentialType.IdToken.name());
+        id.setCredentialType(IdToken.name());
         id.setClientId(CLIENT_ID);
         id.setSecret(MOCK_ID_TOKEN_WITH_CLAIMS);
         id.setAuthority("https://sts.windows.net/0287f963-2d72-4363-9e3a-5705c5b0f031/");

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -284,21 +284,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ats = new ArrayList<>();
         final List<Credential> ids = new ArrayList<>();
 
-        for (final Credential credential : credentials) {
-            switch (CredentialType.fromString(credential.getCredentialType())) {
-                case AccessToken:
-                    ats.add(credential);
-                    break;
-                case RefreshToken:
-                    rts.add(credential);
-                    break;
-                case IdToken:
-                    ids.add(credential);
-                    break;
-                default:
-                    fail("Unexpected value: " + credential.getCredentialType());
-            }
-        }
+        sortResultToLists(credentials, rts, ats, ids);
 
         assertEquals(defaultTestBundleV2.mGeneratedAccessToken, ats.get(0));
         assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, rts.get(0));
@@ -327,21 +313,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ats = new ArrayList<>();
         final List<Credential> ids = new ArrayList<>();
 
-        for (final Credential credential : credentials) {
-            switch (CredentialType.fromString(credential.getCredentialType())) {
-                case AccessToken:
-                    ats.add(credential);
-                    break;
-                case RefreshToken:
-                    rts.add(credential);
-                    break;
-                case IdToken:
-                    ids.add(credential);
-                    break;
-                default:
-                    fail("Unexpected value: " + credential.getCredentialType());
-            }
-        }
+        sortResultToLists(credentials, rts, ats, ids);
 
         assertEquals(defaultTestBundleV2.mGeneratedAccessToken, ats.get(0));
         assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, rts.get(0));
@@ -349,6 +321,43 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Verify that our junk data still exists
         assertEquals(JUNK_VALUE, mSharedPreferencesFileManager.getString(JUNK_KEY));
+    }
+
+    @Test
+    public void saveTokensWithMalformedDataInCacheReverseOrder() throws Exception {
+        // Prepopulate valid data into the cache
+        mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+
+        // Then insert unparseable, junk data
+        mSharedPreferencesFileManager.putString(JUNK_KEY, JUNK_VALUE);
+
+        final List<AccountRecord> accounts = accountCredentialCache.getAccounts();
+        assertEquals(1, accounts.size());
+        assertEquals(defaultTestBundleV2.mGeneratedAccount, accounts.get(0));
+
+        final List<Credential> credentials = accountCredentialCache.getCredentials();
+        assertEquals(3, credentials.size());
+
+        final List<Credential> rts = new ArrayList<>();
+        final List<Credential> ats = new ArrayList<>();
+        final List<Credential> ids = new ArrayList<>();
+
+        sortResultToLists(credentials, rts, ats, ids);
+
+        validateResultListContents(rts, ats, ids);
+
+        // Verify that our junk data still exists
+        assertEquals(JUNK_VALUE, mSharedPreferencesFileManager.getString(JUNK_KEY));
+    }
+
+    private void validateResultListContents(List<Credential> rts, List<Credential> ats, List<Credential> ids) {
+        assertEquals(defaultTestBundleV2.mGeneratedAccessToken, ats.get(0));
+        assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, rts.get(0));
+        assertEquals(defaultTestBundleV2.mGeneratedIdToken, ids.get(0));
     }
 
     @Test
@@ -574,6 +583,12 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ats = new ArrayList<>();
         final List<Credential> ids = new ArrayList<>();
 
+        sortResultToLists(credentials, rts, ats, ids);
+
+        assertEquals(defaultTestBundleV1.mGeneratedIdToken, ids.get(0));
+    }
+
+    private void sortResultToLists(List<Credential> credentials, List<Credential> rts, List<Credential> ats, List<Credential> ids) {
         for (final Credential credential : credentials) {
             switch (CredentialType.fromString(credential.getCredentialType())) {
                 case AccessToken:
@@ -589,8 +604,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
                     fail("Unexpected value: " + credential.getCredentialType());
             }
         }
-
-        assertEquals(defaultTestBundleV1.mGeneratedIdToken, ids.get(0));
     }
 
     @Test
@@ -632,21 +645,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final List<Credential> ats = new ArrayList<>();
         final List<Credential> ids = new ArrayList<>();
 
-        for (final Credential credential : credentials) {
-            switch (CredentialType.fromString(credential.getCredentialType())) {
-                case AccessToken:
-                    ats.add(credential);
-                    break;
-                case RefreshToken:
-                    rts.add(credential);
-                    break;
-                case IdToken:
-                    ids.add(credential);
-                    break;
-                default:
-                    fail("Unexpected value: " + credential.getCredentialType());
-            }
-        }
+        sortResultToLists(credentials, rts, ats, ids);
 
         assertEquals(defaultTestBundleV2.mGeneratedAccessToken, ats.get(0));
         assertEquals(defaultTestBundleV2.mGeneratedRefreshToken, rts.get(0));


### PR DESCRIPTION
These are tests I wrote to verify the cache skips/preserves unexpected values; this is a setup for a future conversation around potentially storing data from OneAuth in this cache.