### PR TITLE
DCF: Renamed method in DeviceCodeFlowCommandCallback

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/DeviceCodeFlowCommandCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/DeviceCodeFlowCommandCallback.java
@@ -30,5 +30,5 @@ import androidx.annotation.NonNull;
  * getUserCode() method shown below
  */
 public interface DeviceCodeFlowCommandCallback<T, U> extends CommandCallback<T, U> {
-    void getUserCode(@NonNull String vUri, @NonNull String userCode, @NonNull String message);
+    void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message);
 }


### PR DESCRIPTION
Very small PR for renaming a method in the `CommandCallback` object.