### PR TITLE
Some common utilities to avoid duplication.

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/Util.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/Util.java
@@ -23,6 +23,11 @@
 
 package com.microsoft.identity.common;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.internal.logging.Logger;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -48,4 +53,30 @@ public final class Util {
         return new URL(Util.VALID_AUTHORITY);
     }
 
+    /**
+     * This is a local implementation of Objects.equals.  It is a null-safe equals execution.
+     * @param o1 the first object.
+     * @param o2 the second objectn
+     * @return true if the objects are both null or if they are both non-null and o1.equals(o2).
+     */
+    public static boolean equals(@Nullable final Object o1, @Nullable final Object o2) {
+        return (o1 == null ^ o2 == null) || (o1 != null && !o1.equals(o2));
+    }
+
+    /**
+     * A method to sleep safely without needing to explicitly handle InterruptedException.
+     * @param sleepTimeInMs the number of milliseconds to sleep.
+     * @param tag the tag for logging a message.
+     * @param message the message to log.
+     */
+    public static void sleepSafely(final int sleepTimeInMs, @NonNull final String tag, @NonNull final String message) {
+        if (sleepTimeInMs > 0) {
+            try {
+                Thread.sleep(sleepTimeInMs);
+            } catch (final InterruptedException e) {
+                Logger.info(tag, message);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Since we can't count on Objects.equals, reimplemenit it for noe.
* We do a lot of Thread.sleep() - remove some boilerplate.