### PR TITLE
replacing commit() with apply() to for async access

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -139,7 +139,7 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
             editor.putString(key, encryptedValue);
         }
 
-        editor.commit();
+        editor.apply();
     }
 
     @Override
@@ -223,7 +223,7 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
     public final void clear() {
         final SharedPreferences.Editor editor = mSharedPreferences.edit();
         editor.clear();
-        editor.commit();
+        editor.apply();
     }
 
     @SuppressLint("ApplySharedPref")
@@ -236,7 +236,7 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
 
         final SharedPreferences.Editor editor = mSharedPreferences.edit();
         editor.remove(key);
-        editor.commit();
+        editor.apply();
 
         Logger.infoPII(
                 TAG,

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -124,8 +124,6 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
         mStorageHelper = storageHelper;
     }
 
-    // Suppressing because cache integrity is a greater concern than perf
-    @SuppressLint("ApplySharedPref")
     @Override
     public final void putString(
             final String key,
@@ -218,7 +216,6 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
         return !TextUtils.isEmpty(getString(key));
     }
 
-    @SuppressLint("ApplySharedPref")
     @Override
     public final void clear() {
         final SharedPreferences.Editor editor = mSharedPreferences.edit();
@@ -226,7 +223,6 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
         editor.apply();
     }
 
-    @SuppressLint("ApplySharedPref")
     @Override
     public void remove(final String key) {
         Logger.info(


### PR DESCRIPTION
Replacing commit() with apply() for async access to the persistent storage to avoid android.os.strictmode.DiskWriteViolation.
Commit() synchronously perform disk read/writes on the main UI thread which possibly leads to violation.

Link to the bug:
https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1041