### PR TITLE
Moved Broker strategy and controller classes to common to re purpose them for MSAL CPP broker integration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version v.Next
+----------
+- Moved broker controller and strategy classes to common for MSALCPP brokered auth.
+
 Version 2.0.15
 -----------
 - Introduces additional tests for cache resiliency

--- a/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
@@ -1,0 +1,39 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.exception;
+
+/**
+ * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or AccountManager).
+ */
+public class BrokerCommunicationException extends BaseException {
+    /**
+     * Initiates the {@link BrokerCommunicationException} with error message and throwable.
+     *
+     * @param errorMessage The error message contained in the exception.
+     * @param throwable    The {@link Throwable} contains the cause for the exception.
+     */
+    public BrokerCommunicationException(final String errorMessage, final Throwable throwable) {
+        super(ErrorStrings.IO_ERROR, errorMessage, throwable);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAccountManagerStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAccountManagerStrategy.java
@@ -1,0 +1,385 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
+
+import java.io.IOException;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
+    private static final String TAG = BrokerAccountManagerStrategy.class.getSimpleName();
+
+    public interface OperationInfo<T extends CommandParameters, U> {
+        /**
+         * Performs this AccountManager operation in this method with the given IMicrosoftAuthService.
+         */
+        Bundle getRequestBundle(T parameters);
+
+        /**
+         * Name of the task (for logging purposes).
+         */
+        String getMethodName();
+
+        /**
+         * Extracts result from the given bundle.
+         */
+        U getResultFromBundle(Bundle bundle) throws BaseException;
+    }
+
+    @SuppressLint("MissingPermission")
+    public <T extends CommandParameters, U> U invokeBrokerAccountManagerOperation(final T parameters,
+                                                                                  final OperationInfo<T, U> operationInfo) throws BaseException {
+        final String methodName = operationInfo.getMethodName();
+
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+                        .putStrategy(TelemetryEventStrings.Value.ACCOUNT_MANAGER)
+        );
+
+        final U result;
+        try {
+            final AccountManager accountManager = AccountManager.get(parameters.getAndroidApplicationContext());
+            final AccountManagerFuture<Bundle> resultBundle =
+                    accountManager.addAccount(
+                            AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                            AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                            null,
+                            operationInfo.getRequestBundle(parameters),
+                            null,
+                            null,
+                            getPreferredHandler());
+
+            Logger.verbose(TAG + methodName, "Received result from broker");
+            result = operationInfo.getResultFromBundle(resultBundle.getResult());
+        } catch (final AuthenticatorException | IOException | OperationCanceledException e) {
+            Logger.error(TAG + methodName, e.getMessage(), e);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.IO_ERROR)
+                            .putErrorDescription(e.getMessage()));
+
+            throw new BrokerCommunicationException("Failed to connect to AccountManager", e);
+        } catch (final BaseException e) {
+            Logger.error(TAG + methodName, e.getMessage(), e);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(e.getErrorCode())
+                            .putErrorDescription(e.getMessage()));
+
+            throw e;
+        }
+
+        Telemetry.emit(
+                new BrokerEndEvent()
+                        .putAction(methodName)
+                        .isSuccessful(true)
+        );
+
+        return result;
+    }
+
+    @WorkerThread
+    @SuppressLint("MissingPermission")
+    public String hello(@NonNull final CommandParameters parameters)
+            throws BaseException {
+        return invokeBrokerAccountManagerOperation(parameters, new OperationInfo<CommandParameters, String>() {
+            @Override
+            public Bundle getRequestBundle(CommandParameters parameters) {
+                final Bundle requestBundle = mRequestAdapter.getRequestBundleForHello(parameters);
+                requestBundle.putString(AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                        AuthenticationConstants.BrokerAccountManagerOperation.HELLO);
+                return requestBundle;
+            }
+
+            @Override
+            public String getMethodName() {
+                return ":helloWithAccountManager";
+            }
+
+            @Override
+            public String getResultFromBundle(Bundle bundle) throws BaseException {
+                return mResultAdapter.verifyHelloFromResultBundle(bundle);
+            }
+        });
+    }
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    @WorkerThread
+    public Intent getBrokerAuthorizationIntent(@NonNull final InteractiveTokenCommandParameters parameters,
+                                               @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        final String methodName = ":getBrokerAuthorizationIntent";
+        Logger.verbose(TAG + methodName, "Get the broker authorization intent from AccountManager.");
+
+        return invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<InteractiveTokenCommandParameters, Intent>() {
+                    @Override
+                    public Bundle getRequestBundle(InteractiveTokenCommandParameters parameters) {
+                        final Bundle requestBundle = new Bundle();
+                        requestBundle.putString(AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.GET_INTENT_FOR_INTERACTIVE_REQUEST);
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @Override
+                    public Intent getResultFromBundle(Bundle bundle) {
+                        final Intent interactiveRequestIntent = bundle.getParcelable(AccountManager.KEY_INTENT);
+                        return completeInteractiveRequestIntent(
+                                interactiveRequestIntent,
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+
+                    }
+                });
+    }
+
+    @WorkerThread
+    public AcquireTokenResult acquireTokenSilent(@NonNull final SilentTokenCommandParameters parameters,
+                                                 @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        return invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<SilentTokenCommandParameters, AcquireTokenResult>() {
+                    @Override
+                    public Bundle getRequestBundle(SilentTokenCommandParameters parameters) {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForAcquireTokenSilent(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.ACQUIRE_TOKEN_SILENT
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":acquireTokenSilentWithAccountManager";
+                    }
+
+                    @Override
+                    public AcquireTokenResult getResultFromBundle(Bundle bundle) throws BaseException {
+                        return mResultAdapter.getAcquireTokenResultFromResultBundle(bundle);
+                    }
+                });
+    }
+
+    @WorkerThread
+    public List<ICacheRecord> getBrokerAccounts(@NonNull final CommandParameters parameters,
+                                                @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        return invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<CommandParameters, List<ICacheRecord>>() {
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.GET_ACCOUNTS
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getBrokerAccountsWithAccountManager";
+                    }
+
+                    @Override
+                    public List<ICacheRecord> getResultFromBundle(Bundle bundle) throws BaseException {
+                        return mResultAdapter.getAccountsFromResultBundle(bundle);
+                    }
+                });
+    }
+
+    @WorkerThread
+    public void removeBrokerAccount(@NonNull final RemoveAccountCommandParameters parameters,
+                                    @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<RemoveAccountCommandParameters, Void>() {
+                    @Override
+                    public Bundle getRequestBundle(RemoveAccountCommandParameters parameters) {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForRemoveAccount(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.REMOVE_ACCOUNT
+
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":removeBrokerAccountWithAccountManager";
+                    }
+
+                    @Override
+                    public Void getResultFromBundle(Bundle bundle) throws BaseException {
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(bundle);
+                        return null;
+                    }
+                });
+    }
+
+    @Override
+    public boolean getDeviceMode(@NonNull final CommandParameters parameters,
+                                 @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        return invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<CommandParameters, Boolean>() {
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        final Bundle requestBundle = new Bundle();
+                        requestBundle.putString(AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.GET_DEVICE_MODE);
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getDeviceModeWithAccountManager";
+                    }
+
+                    @Override
+                    public Boolean getResultFromBundle(Bundle bundle) throws BaseException {
+                        return mResultAdapter.getDeviceModeFromResultBundle(bundle);
+                    }
+                });
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final CommandParameters parameters,
+                                                              @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        return invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<CommandParameters, List<ICacheRecord>>() {
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.GET_CURRENT_ACCOUNT
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getCurrentAccountInSharedDeviceWithAccountManager";
+                    }
+
+                    @Override
+                    public List<ICacheRecord> getResultFromBundle(Bundle bundle) throws BaseException {
+                        return mResultAdapter.getAccountsFromResultBundle(bundle);
+                    }
+                });
+    }
+
+    @Override
+    public void signOutFromSharedDevice(@NonNull final RemoveAccountCommandParameters parameters,
+                                        @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        invokeBrokerAccountManagerOperation(parameters,
+                new OperationInfo<RemoveAccountCommandParameters, Void>() {
+                    @Override
+                    public Bundle getRequestBundle(RemoveAccountCommandParameters parameters) {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForRemoveAccountFromSharedDevice(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        requestBundle.putString(
+                                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                                AuthenticationConstants.BrokerAccountManagerOperation.REMOVE_ACCOUNT_FROM_SHARED_DEVICE
+                        );
+                        return requestBundle;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":signOutFromSharedDeviceWithAccountManager";
+                    }
+
+                    @Override
+                    public Void getResultFromBundle(Bundle bundle) throws BaseException {
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(bundle);
+                        return null;
+                    }
+                });
+    }
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -1,0 +1,120 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.logging.Logger;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.RETURN_INTERACTIVE_REQUEST_RESULT;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.RESULT_CODE;
+
+public final class BrokerActivity extends Activity {
+
+    public static final String BROKER_INTENT = "broker_intent";
+    static final String BROKER_INTENT_STARTED = "broker_intent_started";
+    static final int BROKER_INTENT_REQUEST_CODE = 1001;
+
+    private static final String TAG = BrokerActivity.class.getSimpleName();
+
+    private Intent mBrokerInteractiveRequestIntent;
+    private Boolean mBrokerIntentStarted = false;
+
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState == null) {
+            mBrokerInteractiveRequestIntent = getIntent().getExtras().getParcelable(BROKER_INTENT);
+        } else {
+            mBrokerInteractiveRequestIntent = savedInstanceState.getParcelable(BROKER_INTENT);
+            mBrokerIntentStarted = savedInstanceState.getBoolean(BROKER_INTENT_STARTED);
+        }
+
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        if (!mBrokerIntentStarted) {
+            mBrokerIntentStarted = true;
+            startActivityForResult(mBrokerInteractiveRequestIntent, BROKER_INTENT_REQUEST_CODE);
+        }
+
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+    }
+
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelable(BROKER_INTENT, mBrokerInteractiveRequestIntent);
+        outState.putBoolean(BROKER_INTENT_STARTED, mBrokerIntentStarted);
+    }
+
+    /**
+     * Receive result from broker intent
+     *
+     * @param requestCode
+     * @param resultCode
+     * @param data
+     */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+
+        final String methodName = ":onActivityResult";
+        Logger.info(TAG + methodName,
+                "Result received from Broker "
+                        + "Request code: " + requestCode
+                        + " Result code: " + requestCode
+        );
+
+        if (resultCode == AuthenticationConstants.UIResponse.TOKEN_BROKER_RESPONSE ||
+                resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL
+                || resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR) {
+
+            Logger.verbose(TAG + methodName, "Completing interactive request ");
+
+            data.setAction(RETURN_INTERACTIVE_REQUEST_RESULT);
+            data.putExtra(REQUEST_CODE, AuthenticationConstants.UIRequest.BROWSER_FLOW);
+            data.putExtra(RESULT_CODE, resultCode);
+
+            LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(data);
+        }
+        finish();
+    }
+
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAuthServiceStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAuthServiceStrategy.java
@@ -1,0 +1,340 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.RemoteException;
+
+import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
+    private static final String TAG = BrokerAuthServiceStrategy.class.getSimpleName();
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    @WorkerThread
+    public Intent getBrokerAuthorizationIntent(@NonNull final InteractiveTokenCommandParameters parameters,
+                                               @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        final String methodName = ":getBrokerAuthorizationIntent";
+        Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
+        Intent interactiveRequestIntent;
+        interactiveRequestIntent = getBrokerAuthorizationIntentFromAuthService(parameters);
+        return completeInteractiveRequestIntent(
+                interactiveRequestIntent,
+                parameters,
+                negotiatedBrokerProtocolVersion
+        );
+    }
+
+    /**
+     * A broker task to be performed. Use in conjunction with performBrokerTask()
+     */
+    public interface AuthServiceOperation<T> {
+
+        /**
+         * Performs a task in this method with the given IMicrosoftAuthService.
+         * If the operation doesn't return expected value, the implementer MUST thrown an exception.
+         * Otherwise, this operation is considered succeeded.
+         * <p>
+         * {@link IMicrosoftAuthService}
+         */
+        T perform(IMicrosoftAuthService service) throws BaseException, RemoteException;
+
+        /**
+         * Name of the task (for logging purposes).
+         */
+        String getOperationName();
+    }
+
+    /**
+     * Perform an operation with Broker's MicrosoftAuthService on a background thread.
+     *
+     * @param appContext           app context.
+     * @param authServiceOperation the task to be performed.
+     */
+    private <T> T performAuthServiceOperation(@NonNull final Context appContext,
+                                              @NonNull final AuthServiceOperation<T> authServiceOperation)
+            throws BaseException {
+
+        final String methodName = authServiceOperation.getOperationName();
+
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+                        .putStrategy(TelemetryEventStrings.Value.BOUND_SERVICE)
+        );
+
+        final T result;
+        final IMicrosoftAuthService service;
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(appContext);
+        try {
+            //Do we want a time out here?
+            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+            service = authServiceFuture.get();
+            result = authServiceOperation.perform(service);
+        } catch (final RemoteException | InterruptedException | ExecutionException e) {
+            final String errorDescription;
+            if (e instanceof RemoteException) {
+                errorDescription = "RemoteException occurred while attempting to invoke remote service";
+            } else {
+                errorDescription = "Exception occurred while awaiting (get) return of MicrosoftAuthService";
+            }
+
+            Logger.error(TAG + methodName, errorDescription, e);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.IO_ERROR)
+                            .putErrorDescription(e.getMessage()));
+
+            throw new BrokerCommunicationException(errorDescription, e);
+        } catch (final BaseException e) {
+            Logger.error(TAG + methodName, e.getMessage(), e);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(e.getErrorCode())
+                            .putErrorDescription(e.getMessage()));
+            throw e;
+        } finally {
+            client.disconnect();
+        }
+
+        Telemetry.emit(
+                new BrokerEndEvent()
+                        .putAction(methodName)
+                        .isSuccessful(true)
+        );
+
+        return result;
+    }
+
+    @WorkerThread
+    public String hello(@NonNull final CommandParameters parameters) throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<String>() {
+                    @Override
+                    public String perform(IMicrosoftAuthService service) throws RemoteException, ClientException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForHello(parameters);
+                        String negotiatedProtocolVersion = mResultAdapter.verifyHelloFromResultBundle(
+                                service.hello(requestBundle)
+                        );
+                        return negotiatedProtocolVersion;
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":helloWithMicrosoftAuthService";
+                    }
+                });
+    }
+
+    private Intent getBrokerAuthorizationIntentFromAuthService(@NonNull final InteractiveTokenCommandParameters parameters)
+            throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<Intent>() {
+                    @Override
+                    public Intent perform(IMicrosoftAuthService service) throws RemoteException {
+                        return service.getIntentForInteractiveRequest();
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":getBrokerAuthorizationIntentFromAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public AcquireTokenResult acquireTokenSilent(@NonNull final SilentTokenCommandParameters parameters,
+                                                 @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<AcquireTokenResult>() {
+                    @Override
+                    public AcquireTokenResult perform(IMicrosoftAuthService service) throws RemoteException, BaseException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForAcquireTokenSilent(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        return mResultAdapter.getAcquireTokenResultFromResultBundle(
+                                service.acquireTokenSilently(requestBundle)
+                        );
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":acquireTokenSilentWithAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public List<ICacheRecord> getBrokerAccounts(@NonNull final CommandParameters parameters,
+                                                @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<List<ICacheRecord>>() {
+                    @Override
+                    public List<ICacheRecord> perform(IMicrosoftAuthService service) throws RemoteException, BaseException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        return mResultAdapter.getAccountsFromResultBundle(
+                                service.getAccounts(requestBundle)
+                        );
+
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":getBrokerAccountsWithAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public void removeBrokerAccount(@NonNull final RemoveAccountCommandParameters parameters,
+                                    @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<Void>() {
+                    @Override
+                    public Void perform(IMicrosoftAuthService service) throws RemoteException, BaseException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForRemoveAccount(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(
+                                service.removeAccount(requestBundle)
+                        );
+
+                        return null;
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":removeBrokerAccountWithAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public boolean getDeviceMode(@NonNull CommandParameters parameters,
+                                 @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<Boolean>() {
+                    @Override
+                    public Boolean perform(IMicrosoftAuthService service) throws BaseException, RemoteException {
+                        return mResultAdapter.getDeviceModeFromResultBundle(
+                                service.getDeviceMode()
+                        );
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":getDeviceModeWithAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final CommandParameters parameters,
+                                                              @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        return performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<List<ICacheRecord>>() {
+                    @Override
+                    public List<ICacheRecord> perform(IMicrosoftAuthService service) throws RemoteException, BaseException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        return mResultAdapter.getAccountsFromResultBundle(
+                                service.getCurrentAccount(requestBundle)
+                        );
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":getCurrentAccountInSharedDeviceWithAuthService";
+                    }
+                });
+    }
+
+    @WorkerThread
+    public void signOutFromSharedDevice(@NonNull final RemoveAccountCommandParameters parameters,
+                                        @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        performAuthServiceOperation(parameters.getAndroidApplicationContext(),
+                new AuthServiceOperation<Void>() {
+                    @Override
+                    public Void perform(IMicrosoftAuthService service) throws RemoteException, BaseException {
+                        final Bundle requestBundle = mRequestAdapter.getRequestBundleForRemoveAccountFromSharedDevice(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(
+                                service.removeAccountFromSharedDevice(requestBundle)
+                        );
+
+                        return null;
+                    }
+
+                    @Override
+                    public String getOperationName() {
+                        return ":signOutFromSharedDeviceWithAuthService";
+                    }
+                });
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerBaseStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerBaseStrategy.java
@@ -1,0 +1,89 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class BrokerBaseStrategy {
+    protected final MsalBrokerRequestAdapter mRequestAdapter = new MsalBrokerRequestAdapter();
+
+    protected final MsalBrokerResultAdapter mResultAdapter = new MsalBrokerResultAdapter();
+
+    public abstract String hello(@NonNull final CommandParameters parameters) throws BaseException;
+
+    public abstract Intent getBrokerAuthorizationIntent(@NonNull InteractiveTokenCommandParameters parameters,
+                                                        @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract AcquireTokenResult acquireTokenSilent(@NonNull SilentTokenCommandParameters parameters,
+                                                          @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract List<ICacheRecord> getBrokerAccounts(@NonNull final CommandParameters parameters,
+                                                         @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract void removeBrokerAccount(@NonNull final RemoveAccountCommandParameters parameters,
+                                             @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract boolean getDeviceMode(@NonNull final CommandParameters parameters,
+                                          @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final CommandParameters parameters,
+                                                                       @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    public abstract void signOutFromSharedDevice(@NonNull final RemoveAccountCommandParameters parameters,
+                                                 @Nullable String negotiatedBrokerProtocolVersion) throws BaseException;
+
+    Handler getPreferredHandler() {
+        if (null != Looper.myLooper() && Looper.getMainLooper() != Looper.myLooper()) {
+            return new Handler(Looper.myLooper());
+        } else {
+            return new Handler(Looper.getMainLooper());
+        }
+    }
+
+    protected Intent completeInteractiveRequestIntent(@NonNull final Intent interactiveRequestIntent,
+                                                      @NonNull final InteractiveTokenCommandParameters parameters,
+                                                      @Nullable final String negotiatedProtocolVersion) {
+
+        interactiveRequestIntent.putExtras(
+                mRequestAdapter.getRequestBundleForAcquireTokenInteractive(parameters, negotiatedProtocolVersion)
+        );
+        return interactiveRequestIntent;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerContentProviderStrategy.java
@@ -1,0 +1,450 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Base64;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
+import com.microsoft.identity.common.internal.util.ParcelableUtil;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.ACQUIRE_TOKEN_INTERACTIVE_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.ACQUIRE_TOKEN_SILENT_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.AUTHORITY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.CONTENT_SCHEME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.GET_ACCOUNTS_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.GET_CURRENT_ACCOUNT_SHARED_DEVICE_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.GET_DEVICE_MODE_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.HELLO_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.REMOVE_ACCOUNTS_PATH;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.SIGN_OUT_FROM_SHARED_DEVICE_PATH;
+
+/**
+ * Class to invoke active broker's BrokerContentProvider to perform Broker operations from MSAL.
+ * Implements {@link BrokerBaseStrategy}
+ * Defines an interface ContentProviderOperation to perform this operation.
+ */
+public class BrokerContentProviderStrategy extends BrokerBaseStrategy {
+
+    private static final String TAG = BrokerContentProviderStrategy.class.getName();
+
+    public interface ContentProviderOperation<T extends CommandParameters, U> {
+
+        /**
+         * Constructs and returns a data string for the request to the broker from the CommandParameters.
+         */
+        @Nullable
+        Bundle getRequestBundle(T parameters);
+
+        /**
+         * Name of task for logging and telemetry purposes
+         */
+        @NonNull
+        String getMethodName();
+
+        /**
+         * Uri path for specific broker operation
+         */
+        @NonNull
+        String getUriPath();
+
+        /**
+         * Constructs and returns the result from the request bundle returned by the broker.
+         */
+        @NonNull
+        U getResultFromBundle(Bundle resultBundle) throws BaseException;
+    }
+
+    private <T extends CommandParameters, U> U performContentProviderOperation(
+            @NonNull final T parameters,
+            @NonNull final ContentProviderOperation<T, U> contentProviderOperation) throws BaseException {
+
+        final String methodName = contentProviderOperation.getMethodName();
+
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+                        .putStrategy(TelemetryEventStrings.Value.CONTENT_PROVIDER)
+        );
+        final Uri uri = getContentProviderURI(
+                parameters.getAndroidApplicationContext(),
+                contentProviderOperation.getUriPath()
+        );
+        Logger.info(TAG + methodName, "Request to BrokerContentProvider for uri path " +
+                contentProviderOperation.getUriPath()
+        );
+
+        String marshalledRequestString = null;
+
+        final Bundle requestBundle = contentProviderOperation.getRequestBundle(parameters);
+        if (requestBundle != null) {
+            byte[] marshalledBytes = ParcelableUtil.marshall(requestBundle);
+            marshalledRequestString = Base64.encodeToString(marshalledBytes, 0);
+        }
+
+        final Cursor cursor = parameters.getAndroidApplicationContext().getContentResolver().query(
+                uri,
+                null,
+                marshalledRequestString,
+                null,
+                null
+        );
+
+        if (cursor != null) {
+            final U result = contentProviderOperation.getResultFromBundle(cursor.getExtras());
+            cursor.close();
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(true)
+            );
+            Logger.info(TAG + methodName, "Received successful result from broker");
+            return result;
+        } else {
+            final String message = "Failed to get result from Broker Content Provider, cursor is null";
+            Logger.error(TAG + methodName, message, null);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorDescription(message)
+            );
+            throw new BrokerCommunicationException(message, null);
+        }
+    }
+
+    @Override
+    public String hello(@NonNull CommandParameters parameters) throws BaseException {
+        final String methodName = "helloWithContentProvider";
+
+        return performContentProviderOperation(parameters, new ContentProviderOperation<CommandParameters, String>() {
+            @Override
+            public Bundle getRequestBundle(CommandParameters parameters) {
+                return mRequestAdapter.getRequestBundleForHello(parameters);
+            }
+
+            @Override
+            public String getMethodName() {
+                return methodName;
+            }
+
+            @Override
+            public String getUriPath() {
+                return HELLO_PATH;
+            }
+
+            @Override
+            public String getResultFromBundle(Bundle resultBundle) throws BaseException {
+                return mResultAdapter.verifyHelloFromResultBundle(resultBundle);
+            }
+        });
+    }
+
+    @Override
+    public Intent getBrokerAuthorizationIntent(@NonNull final InteractiveTokenCommandParameters parameters,
+                                               @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        final String methodName = "getBrokerAuthorizationIntentForContentProvider";
+
+        return performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<InteractiveTokenCommandParameters, Intent>() {
+
+                    @Override
+                    public Bundle getRequestBundle(InteractiveTokenCommandParameters parameters) {
+                        return null; // broker returns us an intent based on calling uid , no request string needed
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @Override
+                    public String getUriPath() {
+                        return ACQUIRE_TOKEN_INTERACTIVE_PATH;
+                    }
+
+                    @Override
+                    public Intent getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        return mRequestAdapter.getRequestIntentForAcquireTokenInteractive(
+                                resultBundle,
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+                });
+    }
+
+    @Override
+    public AcquireTokenResult acquireTokenSilent(@NonNull final SilentTokenCommandParameters parameters,
+                                                 @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        final String methodName = "acquireTokenSilentWithContentProvider";
+
+        return performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<SilentTokenCommandParameters, AcquireTokenResult>() {
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(SilentTokenCommandParameters parameters) {
+                        return mRequestAdapter.getRequestBundleForAcquireTokenSilent(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return ACQUIRE_TOKEN_SILENT_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public AcquireTokenResult getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        return mResultAdapter.getAcquireTokenResultFromResultBundle(resultBundle);
+                    }
+                });
+    }
+
+    @Override
+    public List<ICacheRecord> getBrokerAccounts(@NonNull final CommandParameters parameters,
+                                                @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        final String methodName = "getBrokerAccountsWithContentProvider";
+        return performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<CommandParameters, List<ICacheRecord>>() {
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        return mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return GET_ACCOUNTS_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public List<ICacheRecord> getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        return mResultAdapter.getAccountsFromResultBundle(resultBundle);
+                    }
+                });
+    }
+
+    @Override
+    public void removeBrokerAccount(@NonNull final RemoveAccountCommandParameters parameters,
+                                    @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+
+        final String methodName = "removeBrokerAccountWithContentProvider";
+
+        performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<RemoveAccountCommandParameters, Void>() {
+
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(RemoveAccountCommandParameters parameters) {
+                        return mRequestAdapter.getRequestBundleForRemoveAccount(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return REMOVE_ACCOUNTS_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public Void getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(resultBundle);
+                        return null;
+                    }
+                });
+    }
+
+    @Override
+    public boolean getDeviceMode(@NonNull final CommandParameters parameters,
+                                 @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        final String methodName = "getDeviceModeWithContentProvider";
+        return performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<CommandParameters, Boolean>() {
+
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        return null; // broker returns a boolean to indicate the device mode, no request string needed.
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return GET_DEVICE_MODE_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public Boolean getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        return mResultAdapter.getDeviceModeFromResultBundle(resultBundle);
+                    }
+                });
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final CommandParameters parameters,
+                                                              @Nullable final String negotiatedBrokerProtocolVersion)
+            throws BaseException {
+        final String method = "getCurrentAccountInSharedDeviceWithContentProvider";
+        return performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<CommandParameters, List<ICacheRecord>>() {
+
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(CommandParameters parameters) {
+                        return mRequestAdapter.getRequestBundleForGetAccounts(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return method;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return GET_CURRENT_ACCOUNT_SHARED_DEVICE_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public List<ICacheRecord> getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        return mResultAdapter.getAccountsFromResultBundle(resultBundle);
+                    }
+                });
+    }
+
+    @Override
+    public void signOutFromSharedDevice(@NonNull final RemoveAccountCommandParameters parameters,
+                                        @Nullable final String negotiatedBrokerProtocolVersion) throws BaseException {
+        final String methodName = "signOutFromSharedDeviceWithContentProvider";
+        performContentProviderOperation(
+                parameters,
+                new ContentProviderOperation<RemoveAccountCommandParameters, Void>() {
+
+                    @Nullable
+                    @Override
+                    public Bundle getRequestBundle(RemoveAccountCommandParameters parameters) {
+                        return mRequestAdapter.getRequestBundleForRemoveAccountFromSharedDevice(
+                                parameters,
+                                negotiatedBrokerProtocolVersion
+                        );
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @NonNull
+                    @Override
+                    public String getUriPath() {
+                        return SIGN_OUT_FROM_SHARED_DEVICE_PATH;
+                    }
+
+                    @NonNull
+                    @Override
+                    public Void getResultFromBundle(Bundle resultBundle) throws BaseException {
+                        mResultAdapter.verifyRemoveAccountResultFromBundle(resultBundle);
+                        return null;
+                    }
+                });
+    }
+
+    private Uri getContentProviderURI(@NonNull final Context context, @NonNull final String path) {
+        final BrokerValidator brokerValidator = new BrokerValidator(context);
+        final String activeBrokerPackage = brokerValidator.getCurrentActiveBrokerPackageName();
+        final String authority = activeBrokerPackage + "." + AUTHORITY;
+        return Uri.parse(CONTENT_SCHEME + authority + path);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -1,0 +1,645 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.controllers;
+
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ProviderInfo;
+import android.os.Bundle;
+import android.os.RemoteException;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.exception.ServiceException;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
+import com.microsoft.identity.common.internal.broker.BrokerAccountManagerStrategy;
+import com.microsoft.identity.common.internal.broker.BrokerActivity;
+import com.microsoft.identity.common.internal.broker.BrokerAuthServiceStrategy;
+import com.microsoft.identity.common.internal.broker.BrokerBaseStrategy;
+import com.microsoft.identity.common.internal.broker.BrokerContentProviderStrategy;
+import com.microsoft.identity.common.internal.broker.BrokerResult;
+import com.microsoft.identity.common.internal.broker.BrokerResultFuture;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
+import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.DeviceCodeFlowCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
+import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAccount;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResult;
+import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
+import com.microsoft.identity.common.internal.util.AccountManagerUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
+
+/**
+ * The implementation of MSAL Controller for Broker
+ */
+public class BrokerMsalController extends BaseController {
+
+    private static final String TAG = BrokerMsalController.class.getSimpleName();
+
+    private BrokerResultFuture mBrokerResultFuture;
+    private Context mApplicationContext;
+
+    public BrokerMsalController(final Context applicationContext) {
+        mApplicationContext = applicationContext;
+    }
+
+    @Override
+    public AcquireTokenResult acquireToken(InteractiveTokenCommandParameters parameters) throws Exception {
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putProperties(parameters)
+                        .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+
+        //Create BrokerResultFuture to block on response from the broker... response will be return as an activity result
+        //BrokerActivity will receive the result and ask the API dispatcher to complete the request
+        //In completeAcquireToken below we will set the result on the future and unblock the flow.
+        mBrokerResultFuture = new BrokerResultFuture();
+
+        //Get the broker interactive parameters intent
+        final Intent interactiveRequestIntent = getBrokerAuthorizationIntent(parameters);
+
+        //Pass this intent to the BrokerActivity which will be used to start this activity
+        final Intent brokerActivityIntent = new Intent(parameters.getAndroidApplicationContext(), BrokerActivity.class);
+        brokerActivityIntent.putExtra(BrokerActivity.BROKER_INTENT, interactiveRequestIntent);
+
+        mBrokerResultFuture = new BrokerResultFuture();
+
+        //Start the BrokerActivity
+        // TODO add fragment support to AccountChooserActivity.
+        parameters.getActivity().startActivity(brokerActivityIntent);
+
+        //Wait to be notified of the result being returned... we could add a timeout here if we want to
+        final Bundle resultBundle = mBrokerResultFuture.get();
+
+        // For MSA Accounts Broker doesn't save the accounts, instead it just passes the result along,
+        // MSAL needs to save this account locally for future token calls.
+        // parameters.getOAuth2TokenCache() will be non-null only in case of MSAL native
+        // If the request is from MSALCPP , OAuth2TokenCache will be null.
+        if (parameters.getOAuth2TokenCache() != null) {
+            saveMsaAccountToCache(resultBundle, (MsalOAuth2TokenCache) parameters.getOAuth2TokenCache());
+        }
+
+        final AcquireTokenResult result;
+        try {
+            result = new MsalBrokerResultAdapter().getAcquireTokenResultFromResultBundle(resultBundle);
+        } catch (BaseException e) {
+            Telemetry.emit(
+                    new ApiEndEvent()
+                            .putException(e)
+                            .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_INTERACTIVE)
+            );
+            throw e;
+        }
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putResult(result)
+                        .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+
+        return result;
+    }
+
+    /**
+     * Info of a broker operation to be performed with available strategies.
+     */
+    private interface BrokerOperationInfo<T extends CommandParameters, U> {
+        /**
+         * Performs this broker operation in this method with the given IMicrosoftAuthService.
+         */
+        @Nullable
+        U perform(BrokerBaseStrategy strategy, T parameters, String negotiatedBrokerProtocolVersion) throws Exception;
+
+        /**
+         * Name of the task (for logging purposes).
+         */
+        String getMethodName();
+
+        /**
+         * ID of the telemetry API event associated to this strategy task.
+         * If this value returns null, no telemetry event will be emitted.
+         */
+        @Nullable
+        String getTelemetryApiId();
+
+        /**
+         * A method that will be invoked before the success event is emitted.
+         * If the calling operation wants to put any value in the success event, put it here.
+         */
+        void putValueInSuccessEvent(ApiEndEvent event, U result);
+    }
+
+    /**
+     * A generic method that would initialize and iterate through available strategies.
+     * It will return a result immediately if any of the strategy succeeds, or throw an exception if all of the strategies fails.
+     */
+    private <T extends CommandParameters, U> U invokeBrokerOperation(@NonNull final T parameters,
+                                                                     @NonNull final BrokerOperationInfo<T, U> strategyTask)
+            throws Exception {
+
+        if (strategyTask.getTelemetryApiId() != null) {
+            Telemetry.emit(
+                    new ApiStartEvent()
+                            .putProperties(parameters)
+                            .putApiId(strategyTask.getTelemetryApiId())
+            );
+        }
+
+        final List<BrokerBaseStrategy> strategies = getStrategies();
+
+        U result = null;
+        Exception lastCaughtException = null;
+        for (int ii = 0; ii < strategies.size(); ii++) {
+            final BrokerBaseStrategy strategy = strategies.get(ii);
+            try {
+                com.microsoft.identity.common.internal.logging.Logger.info(
+                        TAG + strategyTask.getMethodName(),
+                        "Executing with broker strategy: "
+                                + strategy.getClass().getSimpleName()
+                );
+
+                final String negotiatedBrokerProtocolVersion = strategy.hello(parameters);
+                result = strategyTask.perform(strategy, parameters, negotiatedBrokerProtocolVersion);
+                if (result != null) {
+                    break;
+                }
+            } catch (final BrokerCommunicationException communicationException) {
+                // These are known MSAL-Broker communication exception. Continue.
+                lastCaughtException = communicationException;
+            } catch (final BaseException exception) {
+                // MSAL is aware of these exceptions. throw.
+                if (strategyTask.getTelemetryApiId() != null) {
+                    Telemetry.emit(
+                            new ApiEndEvent()
+                                    .putException(exception)
+                                    .putApiId(strategyTask.getTelemetryApiId())
+                    );
+                }
+                throw exception;
+            } catch (final Exception exception) {
+                // We know for a fact that in some OEM, bind service might throw a runtime exception.
+                // Given that the type of exception here could be unpredictable,
+                // it is better to catch 'every' exception so that we could try the next strategy - which could work.
+                lastCaughtException = exception;
+            }
+        }
+
+        // This means that we've tried every strategies...
+        if (result == null) {
+            final ClientException exception = new ClientException(
+                    ErrorStrings.BROKER_BIND_SERVICE_FAILED,
+                    "Unable to connect to the broker",
+                    lastCaughtException);
+
+            if (strategyTask.getTelemetryApiId() != null) {
+                Telemetry.emit(
+                        new ApiEndEvent()
+                                .putException(exception)
+                                .putApiId(strategyTask.getTelemetryApiId())
+                );
+            }
+
+            throw exception;
+        }
+
+        if (strategyTask.getTelemetryApiId() != null) {
+            final ApiEndEvent successEvent = new ApiEndEvent()
+                    .putApiId(strategyTask.getTelemetryApiId())
+                    .isApiCallSuccessful(Boolean.TRUE);
+            strategyTask.putValueInSuccessEvent(successEvent, result);
+            Telemetry.emit(successEvent);
+        }
+
+        return result;
+    }
+
+
+    // The order matters.
+    private List<BrokerBaseStrategy> getStrategies() {
+        final List<BrokerBaseStrategy> strategies = new ArrayList<>();
+        final StringBuilder sb = new StringBuilder(100);
+        sb.append("Broker Strategies added : ");
+
+        if (isBrokerContentProviderAvailable()) {
+            sb.append("ContentProviderStrategy, ");
+            strategies.add(new BrokerContentProviderStrategy());
+        }
+
+        if (isMicrosoftAuthServiceSupported()) {
+            sb.append("AuthServiceStrategy, ");
+            strategies.add(new BrokerAuthServiceStrategy());
+        }
+
+        if (AccountManagerUtil.canUseAccountManagerOperation(mApplicationContext)) {
+            sb.append("AccountManagerStrategy.");
+            strategies.add(new BrokerAccountManagerStrategy());
+        }
+
+        Logger.info(TAG, sb.toString());
+
+        return strategies;
+    }
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    private Intent getBrokerAuthorizationIntent(@NonNull final InteractiveTokenCommandParameters parameters) throws Exception {
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<InteractiveTokenCommandParameters, Intent>() {
+                    @Nullable
+                    @Override
+                    public Intent perform(@NonNull BrokerBaseStrategy strategy,
+                                          @NonNull InteractiveTokenCommandParameters parameters,
+                                          @Nullable String negotiatedBrokerProtocolVersion)
+                            throws BaseException, InterruptedException, ExecutionException, RemoteException {
+                        return strategy.getBrokerAuthorizationIntent(parameters, negotiatedBrokerProtocolVersion);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getBrokerAuthorizationIntent";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return null;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Intent result) {
+                    }
+                });
+    }
+
+    /**
+     * Get the response from the Broker captured by BrokerActivity.
+     * BrokerActivity will pass along the response to the broker controller
+     * The Broker controller will map th response into the broker result
+     * And signal the future with the broker result to unblock the request.
+     *
+     * @param requestCode
+     * @param resultCode
+     * @param data
+     */
+    @Override
+    public void completeAcquireToken(int requestCode, int resultCode, Intent data) {
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putApiId(TelemetryEventStrings.Api.BROKER_COMPLETE_ACQUIRE_TOKEN_INTERACTIVE)
+                        .put(TelemetryEventStrings.Key.RESULT_CODE, String.valueOf(resultCode))
+                        .put(TelemetryEventStrings.Key.REQUEST_CODE, String.valueOf(requestCode))
+        );
+
+        mBrokerResultFuture.setResultBundle(data.getExtras());
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putApiId(TelemetryEventStrings.Api.BROKER_COMPLETE_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+    }
+
+    @Override
+    public AcquireTokenResult acquireTokenSilent(SilentTokenCommandParameters parameters) throws Exception {
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<SilentTokenCommandParameters, AcquireTokenResult>() {
+                    @Nullable
+                    @Override
+                    public AcquireTokenResult perform(@NonNull BrokerBaseStrategy strategy,
+                                                      @NonNull SilentTokenCommandParameters parameters,
+                                                      @Nullable String negotiatedBrokerProtocolVersion) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+                        return strategy.acquireTokenSilent(parameters, negotiatedBrokerProtocolVersion);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":acquireTokenSilent";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, AcquireTokenResult result) {
+                        event.putResult(result);
+                    }
+                });
+    }
+
+    /**
+     * Returns list of accounts that has previously been used to acquire token with broker through the calling app.
+     * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT.
+     * <p>
+     * This method might be called on an UI thread, since we connect to broker,
+     * this needs to be called on background thread.
+     */
+    @Override
+    public List<ICacheRecord> getAccounts(@NonNull final CommandParameters parameters) throws Exception {
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<CommandParameters, List<ICacheRecord>>() {
+                    @Nullable
+                    @Override
+                    public List<ICacheRecord> perform(@NonNull BrokerBaseStrategy strategy,
+                                                      @NonNull CommandParameters parameters,
+                                                      @Nullable String negotiatedBrokerProtocolVersion) throws RemoteException, InterruptedException, ExecutionException, AuthenticatorException, IOException, OperationCanceledException, BaseException {
+                        return strategy.getBrokerAccounts(parameters, negotiatedBrokerProtocolVersion);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getBrokerAccounts";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, List<ICacheRecord> result) {
+                        event.put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(result.size()));
+                    }
+                });
+    }
+
+    @Override
+    @WorkerThread
+    public boolean removeAccount(@NonNull final RemoveAccountCommandParameters parameters) throws Exception {
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<RemoveAccountCommandParameters, Boolean>() {
+                    @Nullable
+                    @Override
+                    public Boolean perform(@NonNull BrokerBaseStrategy strategy,
+                                           @NonNull RemoveAccountCommandParameters parameters,
+                                           @Nullable String negotiatedBrokerProtocolVersion) throws InterruptedException, ExecutionException, BaseException, RemoteException {
+                        strategy.removeBrokerAccount(parameters, negotiatedBrokerProtocolVersion);
+                        return true;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":removeAccount";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Boolean result) {
+                    }
+                });
+    }
+
+    @Override
+    @WorkerThread
+    public boolean getDeviceMode(@NonNull final CommandParameters parameters) throws Exception {
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<CommandParameters, Boolean>() {
+                    @Nullable
+                    @Override
+                    public Boolean perform(@NonNull BrokerBaseStrategy strategy,
+                                           @NonNull CommandParameters parameters,
+                                           @Nullable String negotiatedBrokerProtocolVersion) throws Exception {
+                        return strategy.getDeviceMode(parameters, negotiatedBrokerProtocolVersion);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getDeviceMode";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Boolean result) {
+                        event.put(TelemetryEventStrings.Key.IS_DEVICE_SHARED, Boolean.toString(result));
+                    }
+                });
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccount(CommandParameters parameters) throws Exception {
+        final String methodName = ":getCurrentAccount";
+
+        if (!parameters.isSharedDevice()) {
+            Logger.verbose(TAG + methodName, "Not a shared device, invoke getAccounts() instead of getCurrentAccount()");
+            return getAccounts(parameters);
+        }
+
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<CommandParameters, List<ICacheRecord>>() {
+                    @Nullable
+                    @Override
+                    public List<ICacheRecord> perform(@NonNull BrokerBaseStrategy strategy,
+                                                      @NonNull CommandParameters parameters,
+                                                      @Nullable String negotiatedBrokerProtocolVersion) throws Exception {
+                        return strategy.getCurrentAccountInSharedDevice(parameters, negotiatedBrokerProtocolVersion);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.BROKER_GET_CURRENT_ACCOUNT;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, List<ICacheRecord> result) {
+                        event.put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(result.size()));
+                    }
+                });
+    }
+
+    @Override
+    public boolean removeCurrentAccount(RemoveAccountCommandParameters parameters) throws Exception {
+        final String methodName = ":removeCurrentAccount";
+
+        if (!parameters.isSharedDevice()) {
+            Logger.verbose(TAG + methodName, "Not a shared device, invoke removeAccount() instead of removeCurrentAccount()");
+            return removeAccount(parameters);
+        }
+
+        /**
+         * Given an account, perform a global sign-out from this shared device (End my shift capability).
+         * This will invoke Broker and
+         * 1. Remove account from token cache.
+         * 2. Remove account from AccountManager.
+         * 3. Clear WebView cookies.
+         *
+         * If everything succeeds on the broker side, it will then
+         * 4. Sign out from default browser.
+         */
+        return invokeBrokerOperation(parameters,
+                new BrokerOperationInfo<RemoveAccountCommandParameters, Boolean>() {
+                    @Nullable
+                    @Override
+                    public Boolean perform(@NonNull BrokerBaseStrategy strategy,
+                                           @NonNull RemoveAccountCommandParameters parameters,
+                                           @Nullable String negotiatedBrokerProtocolVersion)
+                            throws InterruptedException, ExecutionException, BaseException, RemoteException {
+                        strategy.signOutFromSharedDevice(parameters, negotiatedBrokerProtocolVersion);
+                        return true;
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiId() {
+                        return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT_FROM_SHARED_DEVICE;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Boolean result) {
+                    }
+                });
+    }
+
+    @Override
+    public AuthorizationResult deviceCodeFlowAuthRequest(DeviceCodeFlowCommandParameters parameters) throws ClientException {
+        throw new ClientException("deviceCodeFlowAuthRequest() not supported in BrokerMsalController");
+    }
+
+    @Override
+    public AcquireTokenResult acquireDeviceCodeFlowToken(AuthorizationResult authorizationResult, DeviceCodeFlowCommandParameters commandParameters) throws ClientException {
+        throw new ClientException("acquireDeviceCodeFlowToken() not supported in BrokerMsalController");
+    }
+
+    /**
+     * Checks if the account returns is a MSA Account and sets single on state in cache
+     *
+     * @param resultBundle
+     * @param msalOAuth2TokenCache
+     */
+    private void saveMsaAccountToCache(@NonNull final Bundle resultBundle,
+                                       @NonNull final MsalOAuth2TokenCache msalOAuth2TokenCache) throws ClientException {
+        final String methodName = ":saveMsaAccountToCache";
+
+        final BrokerResult brokerResult = new MsalBrokerResultAdapter().brokerResultFromBundle(resultBundle);
+
+        if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)
+                && brokerResult != null &&
+                AzureActiveDirectoryAudience.MSA_MEGA_TENANT_ID.equalsIgnoreCase(brokerResult.getTenantId())) {
+            Logger.info(TAG + methodName, "Result returned for MSA Account, saving to cache");
+
+            try {
+                final ClientInfo clientInfo = new ClientInfo(brokerResult.getClientInfo());
+                final MicrosoftStsAccount microsoftStsAccount = new MicrosoftStsAccount(
+                        new IDToken(brokerResult.getIdToken()),
+                        clientInfo
+                );
+                microsoftStsAccount.setEnvironment(brokerResult.getEnvironment());
+
+                final MicrosoftRefreshToken microsoftRefreshToken = new MicrosoftRefreshToken(
+                        brokerResult.getRefreshToken(),
+                        clientInfo,
+                        brokerResult.getScope(),
+                        brokerResult.getClientId(),
+                        brokerResult.getEnvironment(),
+                        brokerResult.getFamilyId()
+                );
+
+                msalOAuth2TokenCache.setSingleSignOnState(microsoftStsAccount, microsoftRefreshToken);
+            } catch (ServiceException e) {
+                Logger.errorPII(TAG + methodName, "Exception while creating Idtoken or ClientInfo," +
+                        " cannot save MSA account tokens", e
+                );
+                throw new ClientException(ErrorStrings.INVALID_JWT, e.getMessage(), e);
+            }
+        }
+
+    }
+
+    private boolean isMicrosoftAuthServiceSupported() {
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(mApplicationContext);
+        final Intent microsoftAuthServiceIntent = client.getIntentForAuthService(mApplicationContext);
+        return null != microsoftAuthServiceIntent;
+    }
+
+    private boolean isBrokerContentProviderAvailable() {
+        final String activeBrokerPackageName = new BrokerValidator(mApplicationContext)
+                .getCurrentActiveBrokerPackageName();
+        final String brokerContentProviderAuthority = activeBrokerPackageName + "." +
+                AuthenticationConstants.BrokerContentProvider.AUTHORITY;
+
+        final List<ProviderInfo> providers = mApplicationContext.getPackageManager()
+                .queryContentProviders(null, 0, 0);
+
+        for (final ProviderInfo providerInfo : providers) {
+            if (providerInfo.authority != null && providerInfo.authority.equals(brokerContentProviderAuthority)) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -1,0 +1,472 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.controllers;
+
+import android.content.Context;
+import android.content.Intent;
+import android.text.TextUtils;
+
+import com.microsoft.identity.common.exception.ArgumentException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.exception.ServiceException;
+import com.microsoft.identity.common.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.DeviceCodeFlowCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResult;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStatus;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2StrategyParameters;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
+import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.internal.request.SdkType;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
+import com.microsoft.identity.common.internal.ui.AuthorizationStrategyFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+
+import static com.microsoft.identity.common.adal.internal.net.HttpWebRequest.throwIfNetworkNotAvailable;
+
+public class LocalMSALController extends BaseController {
+
+    private static final String TAG = LocalMSALController.class.getSimpleName();
+
+    private AuthorizationStrategy mAuthorizationStrategy = null;
+    private AuthorizationRequest mAuthorizationRequest = null;
+
+    @Override
+    public AcquireTokenResult acquireToken(
+            @NonNull final InteractiveTokenCommandParameters parameters)
+            throws ExecutionException, InterruptedException, ClientException, IOException, ArgumentException {
+        final String methodName = ":acquireToken";
+
+        Logger.verbose(
+                TAG + methodName,
+                "Acquiring token..."
+        );
+
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putProperties(parameters)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+
+        final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
+
+        //00) Validate MSAL Parameters
+        parameters.validate();
+
+        // Add default scopes
+        final Set<String> mergedScopes = addDefaultScopes(parameters);
+
+        final InteractiveTokenCommandParameters parametersWithScopes = parameters
+                .toBuilder()
+                .scopes(mergedScopes)
+                .build();
+
+        logParameters(TAG, parametersWithScopes);
+
+        //0) Get known authority result
+        throwIfNetworkNotAvailable(
+                parametersWithScopes.getAndroidApplicationContext(),
+                parametersWithScopes.isPowerOptCheckEnabled()
+        );
+
+        Authority.KnownAuthorityResult authorityResult = Authority.getKnownAuthorityResult(parametersWithScopes.getAuthority());
+
+        //0.1 If not known throw resulting exception
+        if (!authorityResult.getKnown()) {
+            Telemetry.emit(
+                    new ApiEndEvent()
+                            .putException(authorityResult.getClientException())
+                            .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_INTERACTIVE)
+            );
+
+            throw authorityResult.getClientException();
+        }
+
+        // Build up params for Strategy construction
+        final OAuth2StrategyParameters strategyParameters = new OAuth2StrategyParameters();
+        strategyParameters.setContext(parametersWithScopes.getAndroidApplicationContext());
+
+        //1) Get oAuth2Strategy for Authority Type
+        final OAuth2Strategy oAuth2Strategy = parametersWithScopes
+                .getAuthority()
+                .createOAuth2Strategy(strategyParameters);
+
+
+        //2) Request authorization interactively
+        final AuthorizationResult result = performAuthorizationRequest(
+                oAuth2Strategy,
+                parametersWithScopes.getAndroidApplicationContext(),
+                parametersWithScopes
+        );
+        acquireTokenResult.setAuthorizationResult(result);
+
+        logResult(TAG, result);
+
+        if (result.getAuthorizationStatus().equals(AuthorizationStatus.SUCCESS)) {
+            //3) Exchange authorization code for token
+            final TokenResult tokenResult = performTokenRequest(
+                    oAuth2Strategy,
+                    mAuthorizationRequest,
+                    result.getAuthorizationResponse(),
+                    parametersWithScopes
+            );
+
+            acquireTokenResult.setTokenResult(tokenResult);
+
+            if (tokenResult != null && tokenResult.getSuccess()) {
+                //4) Save tokens in token cache
+                final List<ICacheRecord> records = saveTokens(
+                        oAuth2Strategy,
+                        mAuthorizationRequest,
+                        tokenResult.getTokenResponse(),
+                        parametersWithScopes.getOAuth2TokenCache()
+                );
+
+                // The first element in the returned list is the item we *just* saved, the rest of
+                // the elements are necessary to construct the full IAccount + TenantProfile
+                final ICacheRecord newestRecord = records.get(0);
+
+                acquireTokenResult.setLocalAuthenticationResult(
+                        new LocalAuthenticationResult(
+                                finalizeCacheRecordForResult(
+                                        newestRecord,
+                                        parametersWithScopes.getAuthenticationScheme()
+                                ),
+                                records,
+                                SdkType.MSAL,
+                                false
+                        )
+                );
+            }
+        }
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putResult(acquireTokenResult)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+
+        return acquireTokenResult;
+    }
+
+    private AuthorizationResult performAuthorizationRequest(@NonNull final OAuth2Strategy strategy,
+                                                            @NonNull final Context context,
+                                                            @NonNull final InteractiveTokenCommandParameters parameters)
+            throws ExecutionException, InterruptedException, ClientException {
+
+        throwIfNetworkNotAvailable(context, parameters.isPowerOptCheckEnabled());
+
+        mAuthorizationStrategy = AuthorizationStrategyFactory.getInstance()
+                .getAuthorizationStrategy(
+                        parameters
+                );
+        mAuthorizationRequest = getAuthorizationRequest(strategy, parameters);
+
+        final Future<AuthorizationResult> future = strategy.requestAuthorization(
+                mAuthorizationRequest,
+                mAuthorizationStrategy
+        );
+
+        final AuthorizationResult result = future.get();
+
+        return result;
+    }
+
+    @Override
+    public void completeAcquireToken(final int requestCode,
+                                     final int resultCode,
+                                     final Intent data) {
+        final String methodName = ":completeAcquireToken";
+        Logger.verbose(
+                TAG + methodName,
+                "Completing acquire token..."
+        );
+
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_COMPLETE_ACQUIRE_TOKEN_INTERACTIVE)
+                        .put(TelemetryEventStrings.Key.RESULT_CODE, String.valueOf(resultCode))
+                        .put(TelemetryEventStrings.Key.REQUEST_CODE, String.valueOf(requestCode))
+        );
+
+        mAuthorizationStrategy.completeAuthorization(requestCode, resultCode, data);
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_COMPLETE_ACQUIRE_TOKEN_INTERACTIVE)
+        );
+    }
+
+    @Override
+    public AcquireTokenResult acquireTokenSilent(
+            @NonNull final SilentTokenCommandParameters parameters)
+            throws IOException, ClientException, ArgumentException, ServiceException {
+        final String methodName = ":acquireTokenSilent";
+        Logger.verbose(
+                TAG + methodName,
+                "Acquiring token silently..."
+        );
+
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putProperties(parameters)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_SILENT)
+        );
+
+        final AcquireTokenResult acquireTokenSilentResult = new AcquireTokenResult();
+
+        //Validate MSAL Parameters
+        parameters.validate();
+
+        // Add default scopes
+        final Set<String> mergedScopes = addDefaultScopes(parameters);
+
+        final SilentTokenCommandParameters parametersWithScopes = parameters
+                .toBuilder()
+                .scopes(mergedScopes)
+                .build();
+
+        final OAuth2TokenCache tokenCache = parametersWithScopes.getOAuth2TokenCache();
+
+        final AccountRecord targetAccount = getCachedAccountRecord(parametersWithScopes);
+
+        // Build up params for Strategy construction
+        final AbstractAuthenticationScheme authScheme = parametersWithScopes.getAuthenticationScheme();
+        final OAuth2StrategyParameters strategyParameters = new OAuth2StrategyParameters();
+        strategyParameters.setContext(parametersWithScopes.getAndroidApplicationContext());
+
+        final OAuth2Strategy strategy = parametersWithScopes.getAuthority().createOAuth2Strategy(strategyParameters);
+
+        final List<ICacheRecord> cacheRecords = tokenCache.loadWithAggregatedAccountData(
+                parametersWithScopes.getClientId(),
+                TextUtils.join(" ", parametersWithScopes.getScopes()),
+                targetAccount,
+                authScheme
+        );
+
+        // The first element is the 'fully-loaded' CacheRecord which may contain the AccountRecord,
+        // AccessTokenRecord, RefreshTokenRecord, and IdTokenRecord... (if all of those artifacts exist)
+        // subsequent CacheRecords represent other profiles (projections) of this principal in
+        // other tenants. Those tokens will be 'sparse', meaning that their AT/RT will not be loaded
+        final ICacheRecord fullCacheRecord = cacheRecords.get(0);
+
+        if (accessTokenIsNull(fullCacheRecord)
+                || refreshTokenIsNull(fullCacheRecord)
+                || parametersWithScopes.isForceRefresh()
+                || !isRequestAuthorityRealmSameAsATRealm(parametersWithScopes.getAuthority(), fullCacheRecord.getAccessToken())
+                || !strategy.validateCachedResult(authScheme, fullCacheRecord)) {
+            if (!refreshTokenIsNull(fullCacheRecord)) {
+                // No AT found, but the RT checks out, so we'll use it
+                Logger.verbose(
+                        TAG + methodName,
+                        "No access token found, but RT is available."
+                );
+
+                renewAccessToken(
+                        parametersWithScopes,
+                        acquireTokenSilentResult,
+                        tokenCache,
+                        strategy,
+                        fullCacheRecord
+                );
+            } else {
+                //TODO need the refactor, should just throw the ui required exception, rather than
+                // wrap the exception later in the exception wrapper.
+                final ClientException exception = new ClientException(
+                        ErrorStrings.NO_TOKENS_FOUND,
+                        "No refresh token was found. "
+                );
+
+                Telemetry.emit(
+                        new ApiEndEvent()
+                                .putException(exception)
+                                .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_SILENT)
+                );
+
+                throw exception;
+            }
+        } else if (fullCacheRecord.getAccessToken().isExpired()) {
+            Logger.warn(
+                    TAG + methodName,
+                    "Access token is expired. Removing from cache..."
+            );
+            // Remove the expired token
+            tokenCache.removeCredential(fullCacheRecord.getAccessToken());
+
+            Logger.verbose(
+                    TAG + methodName,
+                    "Renewing access token..."
+            );
+            // Request a new AT
+            renewAccessToken(
+                    parametersWithScopes,
+                    acquireTokenSilentResult,
+                    tokenCache,
+                    strategy,
+                    fullCacheRecord
+            );
+        } else {
+            Logger.verbose(
+                    TAG + methodName,
+                    "Returning silent result"
+            );
+            // the result checks out, return that....
+            acquireTokenSilentResult.setLocalAuthenticationResult(
+                    new LocalAuthenticationResult(
+                            finalizeCacheRecordForResult(
+                                    fullCacheRecord,
+                                    parametersWithScopes.getAuthenticationScheme()
+                            ),
+                            cacheRecords,
+                            SdkType.MSAL,
+                            true
+                    )
+            );
+        }
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putResult(acquireTokenSilentResult)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_ACQUIRE_TOKEN_SILENT)
+        );
+
+        return acquireTokenSilentResult;
+    }
+
+    @Override
+    @WorkerThread
+    public List<ICacheRecord> getAccounts(@NonNull final CommandParameters parameters) {
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putProperties(parameters)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_GET_ACCOUNTS)
+        );
+
+        final List<ICacheRecord> accountsInCache =
+                parameters
+                        .getOAuth2TokenCache()
+                        .getAccountsWithAggregatedAccountData(
+                                null, // * wildcard
+                                parameters.getClientId()
+                        );
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_GET_ACCOUNTS)
+                        .put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(accountsInCache.size()))
+                        .put(TelemetryEventStrings.Key.IS_SUCCESSFUL, TelemetryEventStrings.Value.TRUE)
+        );
+
+        return accountsInCache;
+    }
+
+    @Override
+    @WorkerThread
+    public boolean removeAccount(
+            @NonNull final RemoveAccountCommandParameters parameters) {
+        Telemetry.emit(
+                new ApiStartEvent()
+                        .putProperties(parameters)
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_REMOVE_ACCOUNT)
+        );
+
+        String realm = null;
+
+        if (parameters.getAccount() != null) {
+            realm = parameters.getAccount().getRealm();
+        }
+
+        final boolean localRemoveAccountSuccess = !parameters
+                .getOAuth2TokenCache()
+                .removeAccount(
+                        parameters.getAccount() == null ? null : parameters.getAccount().getEnvironment(),
+                        parameters.getClientId(),
+                        parameters.getAccount() == null ? null : parameters.getAccount().getHomeAccountId(),
+                        realm
+                ).isEmpty();
+
+        Telemetry.emit(
+                new ApiEndEvent()
+                        .put(TelemetryEventStrings.Key.IS_SUCCESSFUL, String.valueOf(localRemoveAccountSuccess))
+                        .putApiId(TelemetryEventStrings.Api.LOCAL_REMOVE_ACCOUNT)
+        );
+
+        return localRemoveAccountSuccess;
+    }
+
+    @Override
+    public boolean getDeviceMode(CommandParameters parameters) throws Exception {
+        final String methodName = ":getDeviceMode";
+
+        final String errorMessage = "LocalMSALController is not eligible to use the broker. Do not check sharedDevice mode and return false immediately.";
+        com.microsoft.identity.common.internal.logging.Logger.warn(TAG + methodName, errorMessage);
+
+        return false;
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccount(CommandParameters parameters) throws Exception {
+        return getAccounts(parameters);
+    }
+
+    @Override
+    public boolean removeCurrentAccount(RemoveAccountCommandParameters parameters) throws Exception {
+        return removeAccount(parameters);
+    }
+
+    @Override
+    public AuthorizationResult deviceCodeFlowAuthRequest(final DeviceCodeFlowCommandParameters parameters) throws Exception {
+        // TODO: Placeholder to avoid inheritance error. Will be implemented after Command/Controller level PR in Common
+        return null;
+    }
+
+    @Override
+    public AcquireTokenResult acquireDeviceCodeFlowToken(final AuthorizationResult authorizationResult, DeviceCodeFlowCommandParameters commandParameters) throws Exception {
+        // TODO: Placeholder to avoid inheritance error. Will be implemented after Command/Controller level PR in Common
+        return null;
+    }
+}


### PR DESCRIPTION
To support broker authentication for MSAL CPP , we require few classes to be moved from `MSAL` to `common`. Moved the following classes.

| Class Name                    	| Moved from Package                                 	| Moved to Package                                   	|
|-------------------------------	|----------------------------------------------------	|----------------------------------------------------	|
| BrokerCommunicationException  	| com.microsoft.identity.client.exception            	| com.microsoft.identity.common.exception            	|
| BrokerBaseStrategy            	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.broker      	|
| BrokerContentProviderStrategy 	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.broker      	|
| BrokerAuthServiceStrategy     	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.broker      	|
| BrokerAccountManagerStrategy  	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.broker      	|
| BrokerActivity                	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.broker      	|
| BrokerMsalController          	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.controllers 	|
| LocalMSALController           	| com.microsoft.identity.client.internal.controllers 	| com.microsoft.identity.common.internal.controllers 	|

MSAL PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1115

The PR is a primarily moving classes , in addition I had to change minor things to use `Constants` from `common` instead of MSAL, here is the list of those changes 

- Changed to `ClientException` from `MsalClientException` here, this should work as is as MSAL layer will convert is the appropriate exception as needed [here](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java#L230)

- Refactored the constant to use `ErrorStrings.NO_TOKENS_FOUND` [here](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java#L324)

- Updated the access modifiers of methods of `BrokerBaseStrategy`   to public from package-protected.