### PR TITLE
Move BrokerActivity manifest entry to common

### DIFF
--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
         <activity
             android:name="com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout" />
+
+        <!-- Activity to invoke an interactive request to the intent passed by ad-accounts(Broker) -->
+        <activity
+            android:name="com.microsoft.identity.common.internal.broker.BrokerActivity" />
     </application>
 
 </manifest>


### PR DESCRIPTION
- Missed to stage this change file, should have been part of this PR : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/986