### PR TITLE
Extract the cancel broadcast method from CommandDispatcher.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -300,10 +300,7 @@ public class CommandDispatcher {
 
             // only send broadcast to cancel if within broker
             if (command.getParameters() instanceof BrokerInteractiveTokenCommandParameters) {
-                // Send a broadcast to cancel if any active auth request is present.
-                localBroadcastManager.sendBroadcast(
-                        new Intent(CANCEL_INTERACTIVE_REQUEST)
-                );
+                cancelInteractiveRequest(localBroadcastManager);
             }
 
             sInteractiveExecutor.execute(new Runnable() {
@@ -353,6 +350,17 @@ public class CommandDispatcher {
                     returnCommandResult(command, commandResult, handler);
                 }
             });
+        }
+    }
+
+    /**
+     * Cancel any current interactive requests.
+     * @param broadcastManager the broadcast manager to use to cancel requests.
+     */
+    public static void cancelInteractiveRequest(LocalBroadcastManager broadcastManager) {
+        synchronized (sLock) {
+            // Send a broadcast to cancel if any active auth request is present.
+            broadcastManager.sendBroadcast(new Intent(CANCEL_INTERACTIVE_REQUEST));
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -357,7 +357,7 @@ public class CommandDispatcher {
      * Cancel any current interactive requests.
      * @param broadcastManager the broadcast manager to use to cancel requests.
      */
-    public static void cancelInteractiveRequest(LocalBroadcastManager broadcastManager) {
+    public static void cancelInteractiveRequest(@NonNull final LocalBroadcastManager broadcastManager) {
         synchronized (sLock) {
             // Send a broadcast to cancel if any active auth request is present.
             broadcastManager.sendBroadcast(new Intent(CANCEL_INTERACTIVE_REQUEST));


### PR DESCRIPTION
If we want to cancel requests from OneAuth, we'll want a method to let us do so.
We'll probably also want to synchronize on the broadcast and execution methods so that
we don't suffer from bad interleaving of requests to cancel and execute.  This is
still a living race condition, but at least it's a correct race condition.