### PR TITLE
Add additional suberrors which ESTS could return to map to MSAL CPP sub error constants

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1447,6 +1447,47 @@ public final class AuthenticationConstants {
          * Broker should make a request to DRS to get the current device status and act accordingly.
          */
         public static final String DEVICE_AUTHENTICATION_FAILED = "device_authentication_failed";
+
+        /**
+         * SubError code for cases when client not in the Microsoft first party family group
+         * redeems auth code or refresh token given to a client in the family
+         */
+        public static final String CLIENT_MISMATCH = "client_mismatch";
+
+        /**
+         * Conditional access suberror code when a policy enforces token lifetime.
+         */
+        public static final String TOKEN_EXPIRED = "token_expired";
+
+        /**
+         *  Conditional access suberror code.
+         *  This indicates a simple action is required by the end user, like MFA.
+         */
+        public static final String BASIC_ACTION = "basic_action";
+
+        /**
+         * Conditional access suberror code.
+         * This indicates additional action is required that is in the user control, but is outside of the sign in session.
+         * For example, enroll in MDM or register install an app that uses Intune app protection.
+         */
+        public static final String ADDITIONAL_ACTION = "additional_action";
+
+        /**
+         * Conditional access suberror code.
+         * User will be shown an informational message with no immediate remediation steps.
+         * For example access was blocked due to location or the device is not domain joined.
+         */
+        public static final String MESSAGE_ONLY = "message_only";
+
+        /**
+         * OpenId connect suberror code, when user consent is required.
+         */
+        public static final String CONSENT_REQUIRED = "consent_required";
+
+        /**
+         * Custom sub error that notifies the user that their password has expired.
+         */
+        public static final String USER_PASSWORD_EXPIRED = "user_password_expired";
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1431,60 +1431,78 @@ public final class AuthenticationConstants {
     public static final class OAuth2SubErrorCode {
 
         /**
-         * Oauth2 suberror code for Intune App Protection Policy required.
+         * Oauth2 suberror code for unauthorized_client.
+         *
+         * Suberror code when Intune App Protection Policy is required.
          */
         public static final String PROTECTION_POLICY_REQUIRED = "protection_policy_required";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         * Token is expired or invalid for all resources and scopes and shouldn't be retried again as-is.
+         *
+         * Suberror code when token is expired or invalid for all resources
+         * and scopes and shouldn't be retried again as-is.
          */
         public static final String BAD_TOKEN = "bad_token";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         * Failed to do device authentication during a token request.
+         *
+         * Suberror code when failed to do device authentication during a token request.
          * Broker should make a request to DRS to get the current device status and act accordingly.
          */
         public static final String DEVICE_AUTHENTICATION_FAILED = "device_authentication_failed";
 
         /**
+         * Oauth2 suberror code for invalid_grant.
+         *
          * SubError code for cases when client not in the Microsoft first party family group
-         * redeems auth code or refresh token given to a client in the family
+         * redeems auth code or refresh token given to a client in the family.
          */
         public static final String CLIENT_MISMATCH = "client_mismatch";
 
         /**
+         * Oauth2 suberror code for invalid_grant.
+         *
          * Conditional access suberror code when a policy enforces token lifetime.
          */
         public static final String TOKEN_EXPIRED = "token_expired";
 
         /**
-         *  Conditional access suberror code.
-         *  This indicates a simple action is required by the end user, like MFA.
+         * Oauth2 suberror code for invalid_grant.
+         *
+         * Conditional access suberror code which indicates a simple action is required by the end user, like MFA.
          */
         public static final String BASIC_ACTION = "basic_action";
 
         /**
-         * Conditional access suberror code.
-         * This indicates additional action is required that is in the user control, but is outside of the sign in session.
+         * Oauth2 suberror code for invalid_grant.
+         *
+         * Conditional access suberror code which indicates additional action is
+         * required that is in the user control, but is outside of the sign in session.
          * For example, enroll in MDM or register install an app that uses Intune app protection.
          */
         public static final String ADDITIONAL_ACTION = "additional_action";
 
         /**
-         * Conditional access suberror code.
-         * User will be shown an informational message with no immediate remediation steps.
+         * Oauth2 suberror code for invalid_grant.
+         *
+         * Conditional access suberror code where user will be shown an informational
+         * message with no immediate remediation steps.
          * For example access was blocked due to location or the device is not domain joined.
          */
         public static final String MESSAGE_ONLY = "message_only";
 
         /**
-         * OpenId connect suberror code, when user consent is required.
+         * Oauth2 suberror code for invalid_grant.
+         *
+         * OpenId connect suberror code, where user consent is required.
          */
         public static final String CONSENT_REQUIRED = "consent_required";
 
         /**
+         * Oauth2 suberror code for invalid_grant.
+         *
          * Custom sub error that notifies the user that their password has expired.
          */
         public static final String USER_PASSWORD_EXPIRED = "user_password_expired";

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -75,7 +75,7 @@ public class PopAuthenticationSchemeInternal
         super(SCHEME_POP);
     }
 
-    PopAuthenticationSchemeInternal(@NonNull final IClockSkewManager clockSkewManager,
+    public PopAuthenticationSchemeInternal(@NonNull final IClockSkewManager clockSkewManager,
                                     @Nullable final String httpMethod,
                                     @NonNull final URL url,
                                     @Nullable final String nonce) {


### PR DESCRIPTION
- Also made `PopAuthenticationSchemeInternal` constructor public to use in MSAL CPP