### PR TITLE
Improving error messaging around SSL issues, pointing to docs

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -127,6 +127,11 @@ public final class AuthenticationConstants {
          * V2 endpoint for logging the user out in browser.
          */
         public static final String LOGOUT_ENDPOINT_V2 = "https://login.microsoftonline.com/common/oauth2/v2.0/logout";
+
+        /**
+         * Go-link URL for documentation on troubleshooting common SSL, ADFS issues.
+         */
+        public static final String SSL_HELP_URL = "https://go.microsoft.com/fwlink/?linkid=2138180";
     }
 
     /**
@@ -1265,15 +1270,15 @@ public final class AuthenticationConstants {
 
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static final class BrokerContentProvider{
+    public static final class BrokerContentProvider {
         /**
-         *  URI Scheme constant to invoke content provider.
+         * URI Scheme constant to invoke content provider.
          */
         public static final String CONTENT_SCHEME = "content://";
 
         /**
          * URI Authority constant for content provider.
-         *
+         * <p>
          * This is will be pre-fixed by com.azure.authenticator or com.microsoft.windowsintune.companyportal
          * depending on which ever is the active broker.
          */
@@ -1432,14 +1437,14 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for unauthorized_client.
-         *
+         * <p>
          * Suberror code when Intune App Protection Policy is required.
          */
         public static final String PROTECTION_POLICY_REQUIRED = "protection_policy_required";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Suberror code when token is expired or invalid for all resources
          * and scopes and shouldn't be retried again as-is.
          */
@@ -1447,7 +1452,7 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Suberror code when failed to do device authentication during a token request.
          * Broker should make a request to DRS to get the current device status and act accordingly.
          */
@@ -1455,7 +1460,7 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * SubError code for cases when client not in the Microsoft first party family group
          * redeems auth code or refresh token given to a client in the family.
          */
@@ -1463,21 +1468,21 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Conditional access suberror code when a policy enforces token lifetime.
          */
         public static final String TOKEN_EXPIRED = "token_expired";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Conditional access suberror code which indicates a simple action is required by the end user, like MFA.
          */
         public static final String BASIC_ACTION = "basic_action";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Conditional access suberror code which indicates additional action is
          * required that is in the user control, but is outside of the sign in session.
          * For example, enroll in MDM or register install an app that uses Intune app protection.
@@ -1486,7 +1491,7 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Conditional access suberror code where user will be shown an informational
          * message with no immediate remediation steps.
          * For example access was blocked due to location or the device is not domain joined.
@@ -1495,14 +1500,14 @@ public final class AuthenticationConstants {
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * OpenId connect suberror code, where user consent is required.
          */
         public static final String CONSENT_REQUIRED = "consent_required";
 
         /**
          * Oauth2 suberror code for invalid_grant.
-         *
+         * <p>
          * Custom sub error that notifies the user that their password has expired.
          */
         public static final String USER_PASSWORD_EXPIRED = "user_password_expired";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -135,7 +135,7 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         super.onReceivedSslError(view, handler, error);
         handler.cancel();
 
-        final String sslHelpUrl = "https://docs.microsoft.com/en-us/troubleshoot/azure/active-directory/adal-authenticate-android-devices-fail";
+        final String sslHelpUrl = "https://go.microsoft.com/fwlink/?linkid=2138180";
         final String errMsg = String.format(
                 "Received SSL Error during request. Please see %s for more info.",
                 sslHelpUrl

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -45,6 +45,10 @@ import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NtlmC
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NtlmChallengeHandler;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR;
+
 public abstract class OAuth2WebViewClient extends WebViewClient {
     /* constants */
     private static final String TAG = OAuth2WebViewClient.class.getSimpleName();
@@ -73,7 +77,7 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     /**
      * Constructor for the OAuth2 basic web view client.
      *
-     * @param activity app Context
+     * @param activity           app Context
      * @param completionCallback Challenge completion callback
      * @param pageLoadedCallback callback to be triggered on page load. For UI purposes.
      */
@@ -116,16 +120,11 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
 
         // Create result intent when webView received an error.
         final Intent resultIntent = new Intent();
-        resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,
-                "Error Code:" + errorCode);
-        resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE,
-                description);
+        resultIntent.putExtra(RESPONSE_ERROR_CODE, "Error Code:" + errorCode);
+        resultIntent.putExtra(RESPONSE_ERROR_MESSAGE, description);
 
         // Send the result back to the calling activity
-        mCompletionCallback.onChallengeResponseReceived(
-                AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR,
-                resultIntent
-        );
+        mCompletionCallback.onChallengeResponseReceived(BROWSER_CODE_ERROR, resultIntent);
     }
 
     @Override
@@ -136,18 +135,21 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         super.onReceivedSslError(view, handler, error);
         handler.cancel();
 
+        final String sslHelpUrl = "https://docs.microsoft.com/en-us/troubleshoot/azure/active-directory/adal-authenticate-android-devices-fail";
+        final String errMsg = String.format(
+                "Received SSL Error during request. Please see %s for more info.",
+                sslHelpUrl
+        );
+
+        Logger.error(TAG + ":onReceivedSslError", errMsg, null);
+
         // WebView received the ssl error and create the result intent.
         final Intent resultIntent = new Intent();
-        resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_CODE,
-                "Code:" + ERROR_FAILED_SSL_HANDSHAKE);
-        resultIntent.putExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE,
-                error.toString());
+        resultIntent.putExtra(RESPONSE_ERROR_CODE, "Code:" + ERROR_FAILED_SSL_HANDSHAKE);
+        resultIntent.putExtra(RESPONSE_ERROR_MESSAGE, error.toString());
 
         // Send the result back to the calling activity
-        mCompletionCallback.onChallengeResponseReceived(
-                AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR,
-                resultIntent
-        );
+        mCompletionCallback.onChallengeResponseReceived(BROWSER_CODE_ERROR, resultIntent);
     }
 
     @Override
@@ -157,7 +159,7 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         mPageLoadedCallback.onPageLoaded();
 
         //Supports UI Automation... informing that the webview resource is now idle
-        if(mExpectedPage != null && url.startsWith(mExpectedPage.mExpectedPageUrlStartsWith)) {
+        if (mExpectedPage != null && url.startsWith(mExpectedPage.mExpectedPageUrlStartsWith)) {
             mExpectedPage.mCallback.onPageLoaded();
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -47,12 +47,12 @@ import com.microsoft.identity.common.internal.util.StringUtil;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_CODE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.RESPONSE_ERROR_MESSAGE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.SSL_HELP_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR;
 
 public abstract class OAuth2WebViewClient extends WebViewClient {
     /* constants */
     private static final String TAG = OAuth2WebViewClient.class.getSimpleName();
-    private static final String SSL_HELP_URL = "https://go.microsoft.com/fwlink/?linkid=2138180";
 
     private final IAuthorizationCompletionCallback mCompletionCallback;
     private final OnPageLoadedCallback mPageLoadedCallback;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -52,6 +52,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 public abstract class OAuth2WebViewClient extends WebViewClient {
     /* constants */
     private static final String TAG = OAuth2WebViewClient.class.getSimpleName();
+    private static final String SSL_HELP_URL = "https://go.microsoft.com/fwlink/?linkid=2138180";
 
     private final IAuthorizationCompletionCallback mCompletionCallback;
     private final OnPageLoadedCallback mPageLoadedCallback;
@@ -135,11 +136,7 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         super.onReceivedSslError(view, handler, error);
         handler.cancel();
 
-        final String sslHelpUrl = "https://go.microsoft.com/fwlink/?linkid=2138180";
-        final String errMsg = String.format(
-                "Received SSL Error during request. Please see %s for more info.",
-                sslHelpUrl
-        );
+        final String errMsg = "Received SSL Error during request. For more info see: " + SSL_HELP_URL;
 
         Logger.error(TAG + ":onReceivedSslError", errMsg, null);
 


### PR DESCRIPTION
See notes in related [IcM (corpnet reqd)](https://portal.microsofticm.com/imp/v3/incidents/details/198246518/home)

Gist:
- Misconfigured ADFS SSL certs frequently cause issues for customers using on-prem federation
- This PR links off to guidance docs on how to resolve common issues