### PR TITLE
Update lab classes to support migration testing

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabConstants.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabConstants.java
@@ -98,8 +98,10 @@ public class LabConstants {
         public static final String AZURE_CHINA_CLOUD = "azurechinacloud";
         public static final String AZURE_CLOUD = "azurecloud";
         public static final String AZURE_GERMANY_CLOUD = "azuregermanycloud";
+        public static final String AZURE_GERMANY_CLOUD_MIGRATED = "azuregermanycloudmigrated";
         public static final String AZURE_PPE = "azureppe";
         public static final String AZURE_US_GOVERNMENT = "azureusgovernment";
+        public static final String AZURE_US_GOVERNMENT_MIGRATED = "azureusgovernmentmigrated";
     }
 
     public static final class AppType {

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabHelper.java
@@ -45,17 +45,23 @@ public class LabHelper {
         return labInfo.getTenantId();
     }
 
-    public static String getPasswordForLab(final String labName) {
+    public static String getPasswordForLab(final String credentialVaultKeyName) {
         LabAuthenticationHelper.getInstance().setupApiClientWithAccessToken();
         LabSecretApi labUserSecretApi = new LabSecretApi();
         SecretResponse secretResponse;
 
         try {
-            secretResponse = labUserSecretApi.getLabUserSecret(labName);
+            final String secretName = getLabSecretName(credentialVaultKeyName);
+            secretResponse = labUserSecretApi.getLabUserSecret(secretName);
         } catch (com.microsoft.identity.internal.test.labapi.ApiException ex) {
             throw new RuntimeException("Error retrieving lab password", ex);
         }
 
         return secretResponse.getValue();
+    }
+
+    private static String getLabSecretName(final String credentialVaultKeyName) {
+        final String[] parts = credentialVaultKeyName.split("/");
+        return parts[parts.length - 1];
     }
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.internal.testutils.labutils;
 
-import androidx.core.util.Consumer;
-
 import com.microsoft.identity.internal.test.labapi.ApiException;
 import com.microsoft.identity.internal.test.labapi.api.AppApi;
 import com.microsoft.identity.internal.test.labapi.api.ConfigApi;
@@ -77,12 +75,13 @@ public class LabUserHelper {
         FEDERATED(LabConstants.UserType.FEDERATED),
         GUEST(LabConstants.UserType.GUEST),
         MSA(LabConstants.UserType.MSA),
-        ON_PREM(LabConstants.UserType.ON_PREM)
-        ;
+        ON_PREM(LabConstants.UserType.ON_PREM);
         String constant;
+
         UserType(String constant) {
             this.constant = constant;
         }
+
         String getValue() {
             return constant;
         }
@@ -95,9 +94,11 @@ public class LabUserHelper {
         AZURE_AD_MY_ORG(LabConstants.SignInAudience.AZURE_AD_MY_ORG),
         ;
         String constant;
+
         SignInAudience(String constant) {
             this.constant = constant;
         }
+
         String getValue() {
             return constant;
         }
@@ -110,12 +111,13 @@ public class LabUserHelper {
         AZURE_CLOUD(LabConstants.AzureEnvironment.AZURE_CLOUD),
         AZURE_GERMANY_CLOUD(LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD),
         AZURE_PPE(LabConstants.AzureEnvironment.AZURE_PPE),
-        AZURE_US_GOVERNMENT(LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT)
-        ;
+        AZURE_US_GOVERNMENT(LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT);
         String constant;
+
         AzureEnvironment(String constant) {
             this.constant = constant;
         }
+
         String getValue() {
             return constant;
         }
@@ -123,12 +125,13 @@ public class LabUserHelper {
 
     public enum IsAdminConsented {
         YES(LabConstants.IsAdminConsented.YES),
-        NO(LabConstants.IsAdminConsented.NO)
-        ;
+        NO(LabConstants.IsAdminConsented.NO);
         String constant;
+
         IsAdminConsented(String constant) {
             this.constant = constant;
         }
+
         String getValue() {
             return constant;
         }
@@ -136,12 +139,13 @@ public class LabUserHelper {
 
     public enum PublicClient {
         YES(LabConstants.PublicClient.YES),
-        NO(LabConstants.PublicClient.NO)
-        ;
+        NO(LabConstants.PublicClient.NO);
         String constant;
+
         PublicClient(String constant) {
             this.constant = constant;
         }
+
         String getValue() {
             return constant;
         }
@@ -187,7 +191,7 @@ public class LabUserHelper {
         List<LabConfig> labConfigs = new ArrayList<>();
         final List<ConfigInfo> configInfos = getConfigInfos(query);
         for (ConfigInfo configInfo : configInfos) {
-            final String password = LabHelper.getPasswordForLab(configInfo.getLabInfo().getLabName());
+            final String password = LabHelper.getPasswordForLab(configInfo.getLabInfo().getCredentialVaultKeyName());
             labConfigs.add(new LabConfig(configInfo, password));
         }
 
@@ -216,7 +220,7 @@ public class LabUserHelper {
 
         try {
             tempUser = createTempUserApi.post(userType);
-            final String password = LabHelper.getPasswordForLab(tempUser.getLabName());
+            final String password = LabHelper.getPasswordForLab(tempUser.getCredentialVaultKeyName());
             LabConfig labConfig = new LabConfig(tempUser, password);
             LabConfig.setCurrentLabConfig(labConfig);
         } catch (ApiException e) {
@@ -239,11 +243,11 @@ public class LabUserHelper {
 
     public static String getPasswordForUser(final String username) {
         final ConfigInfo configInfo = getConfigInfoFromUpn(username);
-        return LabHelper.getPasswordForLab(configInfo.getUserInfo().getLabName());
+        return LabHelper.getPasswordForLab(configInfo.getLabInfo().getCredentialVaultKeyName());
     }
 
     public static String getPasswordForUser(final LabInfo labInfo) {
-        return LabHelper.getPasswordForLab(labInfo.getLabName());
+        return LabHelper.getPasswordForLab(labInfo.getCredentialVaultKeyName());
     }
 
     public static Credential getCredentials(LabUserQuery query) {
@@ -267,9 +271,9 @@ public class LabUserHelper {
     }
 
     public static AppInfo getDefaultAppInfo() {
-            return getAppInfo(UserType.CLOUD, AzureEnvironment.AZURE_CLOUD, SignInAudience.AZURE_AD_MULTIPLE_ORGS,
-                    IsAdminConsented.YES, PublicClient.YES);
-   }
+        return getAppInfo(UserType.CLOUD, AzureEnvironment.AZURE_CLOUD, SignInAudience.AZURE_AD_MULTIPLE_ORGS,
+                IsAdminConsented.YES, PublicClient.YES);
+    }
 
     public static AppInfo getAppInfo(UserType userType, AzureEnvironment azureEnvironment, SignInAudience audience,
                                      IsAdminConsented isAdminConsented, PublicClient publicClient) {


### PR DESCRIPTION
- Add lab constants for migrated tenants
- Update lab secret helper to get password secret name from credentialVaultKeyName (lab name doesn't work for migrated tenants 😢)

Related: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1133