### PR TITLE
Get device authorization endpoint from well-known config

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -65,7 +65,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      */
     public URL getDeviceAuthorizationEndpoint() {
         final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
-        if (openIdConfig != null && openIdConfig.getTokenEndpoint() != null) {
+        if (openIdConfig != null && openIdConfig.getDeviceAuthorizationEndpoint() != null) {
             return getEndpointUrlFromAuthority(openIdConfig.getDeviceAuthorizationEndpoint());
         }
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -33,7 +33,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfigurationClient;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 
 public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2Configuration {
@@ -44,6 +43,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
     private static final String FALLBACK_ENDPOINT_SUFFIX = "/oAuth2/v2.0";
     private static final String FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/authorize";
     private static final String FALLBACK_TOKEN_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/token";
+    private static final String FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/devicecode";
 
     /**
      * Get the authorization endpoint to be used for making a authorization request.
@@ -57,6 +57,18 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
             return getEndpointUrlFromAuthority(openIdConfig.getAuthorizationEndpoint());
         }
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX);
+    }
+
+    /**
+     * Return device authorization endpoint to bo used in the authorization step of Device Code Flow.
+     * @return a URL object for the /devicecode endpoint
+     */
+    public URL getDeviceAuthorizationEndpoint() {
+        final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
+        if (openIdConfig != null && openIdConfig.getTokenEndpoint() != null) {
+            return getEndpointUrlFromAuthority(openIdConfig.getDeviceAuthorizationEndpoint());
+        }
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
     /**
@@ -163,13 +175,4 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
 
         return openIdConfig;
     }
-
-    /**
-     * Return device code endpoint to bo used in the authorization step of Device Code Flow.
-     * @return a URL object for the /devicecode endpoint
-     */
-    public URL getDeviceCodeEndpoint() throws MalformedURLException {
-        return new URL(this.getAuthorityUrl().toString() + "/oauth2/v2.0/devicecode");
-    }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -263,7 +263,7 @@ public abstract class OAuth2Strategy
 
         // Send request
         final HttpResponse response = HttpRequest.sendPost(
-                ((MicrosoftStsOAuth2Configuration) mConfig).getDeviceCodeEndpoint(),
+                ((MicrosoftStsOAuth2Configuration) mConfig).getDeviceAuthorizationEndpoint(),
                 headers,
                 requestBody.getBytes(ObjectMapper.ENCODING_SCHEME),
                 DEVICE_CODE_CONTENT_TYPE

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfiguration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdProviderConfiguration.java
@@ -35,6 +35,7 @@ import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProv
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.CLAIM_TYPES_SUPPORTED;
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.CLOUD_GRAPH_HOST_NAME;
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.CLOUD_INSTANCE_NAME;
+import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.DEVICE_AUTHORIZATION_ENDPOINT;
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.DISPLAY_VALUES_SUPPORTED;
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.END_SESSION_ENDPOINT;
 import static com.microsoft.identity.common.internal.providers.oauth2.OpenIdProviderConfiguration.SerializedNames.FRONTCHANNEL_LOGOUT_SUPPORTED;
@@ -84,6 +85,7 @@ public class OpenIdProviderConfiguration {
     public static final class SerializedNames {
         public static final String
                 AUTHORIZATION_ENDPOINT = "authorization_endpoint",
+                DEVICE_AUTHORIZATION_ENDPOINT = "device_authorization_endpoint",
                 TOKEN_ENDPOINT = "token_endpoint",
                 TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED = "token_endpoint_auth_methods_supported",
                 JWKS_URI = "jwks_uri",
@@ -131,6 +133,9 @@ public class OpenIdProviderConfiguration {
 
     @SerializedName(AUTHORIZATION_ENDPOINT)
     private String mAuthorizationEndpoint;
+
+    @SerializedName(DEVICE_AUTHORIZATION_ENDPOINT)
+    private String mDeviceAuthorizationEndpoint;
 
     @SerializedName(TOKEN_ENDPOINT)
     private String mTokenEndpoint;
@@ -267,6 +272,10 @@ public class OpenIdProviderConfiguration {
 
     public void setAuthorizationEndpoint(final String authorizationEndpoint) {
         mAuthorizationEndpoint = authorizationEndpoint;
+    }
+
+    public String getDeviceAuthorizationEndpoint() {
+        return mDeviceAuthorizationEndpoint;
     }
 
     public String getTokenEndpoint() {


### PR DESCRIPTION
.well-known is now returning device_authorization_endpoint, so we'll use that.

[Here's](https://login.microsoftonline.com/msidlab4.onmicrosoft.com/v2.0/.well-known/openid-configuration) an example of how the whole thing looks like.