### PR TITLE
An approach to triggering fewer duplicate command errors

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -105,7 +105,7 @@ public class CommandDispatcher {
                 // our value was inserted.
                 resultFuture.whenComplete(getCommandResultConsumer(command, handler));
             } else {
-                // Our value was not inserted, grab the one that was and hand a new listener off it
+                // Our value was not inserted, grab the one that was and hang a new listener off it
                 putValue.whenComplete(getCommandResultConsumer(command, handler));
                 return;
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -109,8 +109,6 @@ public class CommandDispatcher {
                 putValue.whenComplete(getCommandResultConsumer(command, handler));
                 return;
             }
-
-            sExecutingCommandMap.put(command, resultFuture);
         }
 
         sSilentExecutor.execute(new Runnable() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -77,7 +77,6 @@ public class CommandDispatcher {
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();
-    //private static final Set<BaseCommand> sExecutingCommands = Collections.synchronizedSet(new HashSet<BaseCommand>());
     private static final ConcurrentMap<BaseCommand, ResultFuture<CommandResult>> sExecutingCommandMap = new ConcurrentHashMap<>();
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -99,7 +99,17 @@ public class CommandDispatcher {
             return;
         } else {
             final ResultFuture<CommandResult> resultFuture = new ResultFuture<>();
-            resultFuture.whenComplete(getCommandResultConsumer(command, handler));
+            final ResultFuture<CommandResult> putValue = sExecutingCommandMap.putIfAbsent(command, resultFuture);
+
+            if (null == putValue) {
+                // our value was inserted.
+                resultFuture.whenComplete(getCommandResultConsumer(command, handler));
+            } else {
+                // Our value was not inserted, grab the one that was and hand a new listener off it
+                putValue.whenComplete(getCommandResultConsumer(command, handler));
+                return;
+            }
+
             sExecutingCommandMap.put(command, resultFuture);
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.internal.util.BiConsumer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -57,21 +58,21 @@ public class ResultFuture<T> implements Future<T> {
     }
 
     @Override
-    public T get() throws InterruptedException {
+    public T get() throws InterruptedException, ExecutionException {
         mCountDownLatch.await();
 
         if (null != mException) {
-            throw new RuntimeException(mException);
+            throw new ExecutionException(mException);
         }
 
         return mResult;
     }
 
     @Override
-    public T get(final long l, @NonNull final TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+    public T get(final long l, @NonNull final TimeUnit timeUnit) throws InterruptedException, TimeoutException, ExecutionException {
         if (mCountDownLatch.await(l, timeUnit)) {
             if (null != mException) {
-                throw new RuntimeException(mException);
+                throw new ExecutionException(mException);
             }
 
             return mResult;

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -84,6 +84,11 @@ public class ResultFuture<T> implements Future<T> {
         }
     }
 
+    /**
+     * Sets the Exception on this ResultFuture.
+     *
+     * @param exception The Exception to set.
+     */
     public synchronized void setException(@NonNull final Exception exception) {
         mException = exception;
         mCountDownLatch.countDown();
@@ -93,6 +98,11 @@ public class ResultFuture<T> implements Future<T> {
         }
     }
 
+    /**
+     * Sets the Result on this ResultFuture.
+     *
+     * @param result The Result to set.
+     */
     public synchronized void setResult(@Nullable final T result) {
         mResult = result;
         mCountDownLatch.countDown();
@@ -102,6 +112,12 @@ public class ResultFuture<T> implements Future<T> {
         }
     }
 
+    /**
+     * Sets the whenComplete {@link BiConsumer} callback. Invoked upon completion
+     * (either success/error).
+     *
+     * @param consumerToAdd The BiConsumer to invoke.
+     */
     public synchronized void whenComplete(@NonNull final BiConsumer<T, Throwable> consumerToAdd) {
         if (isDone()) {
             consumerToAdd.accept(mResult, mException);

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.result;
 
+import androidx.annotation.NonNull;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +56,7 @@ public class ResultFuture<T> implements Future<T> {
     }
 
     @Override
-    public T get(long l, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+    public T get(final long l, @NonNull final TimeUnit timeUnit) throws InterruptedException, TimeoutException {
         if (mCountDownLatch.await(l, timeUnit)) {
             return mResult;
         } else {
@@ -63,7 +65,7 @@ public class ResultFuture<T> implements Future<T> {
 
     }
 
-    public void setResult(T result) {
+    public void setResult(final T result) {
         mResult = result;
         mCountDownLatch.countDown();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.internal.result;
 
 import java.util.concurrent.CountDownLatch;

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -105,9 +105,9 @@ public class ResultFuture<T> implements Future<T> {
     public synchronized void whenComplete(@NonNull final BiConsumer<T, Throwable> consumerToAdd) {
         if (isDone()) {
             consumerToAdd.accept(mResult, mException);
+            return;
         }
 
-        // TODO Should we still add the consumer even if the ResultFuture isDone() == true?
         mConsumers.add(consumerToAdd);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -110,6 +110,8 @@ public class ResultFuture<T> implements Future<T> {
         for (final BiConsumer<T, Throwable> consumer : mConsumers) {
             consumer.accept(result, mException);
         }
+
+        mConsumers.clear();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/ResultFuture.java
@@ -102,7 +102,7 @@ public class ResultFuture<T> implements Future<T> {
         }
     }
 
-    public synchronized void addListener(@NonNull final BiConsumer<T, Throwable> consumerToAdd) {
+    public synchronized void whenComplete(@NonNull final BiConsumer<T, Throwable> consumerToAdd) {
         if (isDone()) {
             consumerToAdd.accept(mResult, mException);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/BiConsumer.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/BiConsumer.java
@@ -1,0 +1,40 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.util;
+
+/**
+ * Represents an operation accepting two arguments and returning no result.
+ *
+ * @param <T> The first input argument type.
+ * @param <U> The second input argument type.
+ */
+public interface BiConsumer<T, U> {
+
+    /**
+     * Performs an operation on the supplied arguments.
+     *
+     * @param t The first input argument.
+     * @param u The second input argument.
+     */
+    void accept(T t, U u);
+}


### PR DESCRIPTION
Redux of #1010 with suggestions from @AdamBJohnsonx 

Related:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/905

Add observers to Commands, once those commands finish notify the observers.