### PR TITLE
Adding the OpenIdConnectPromptParameter field UNSET

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -35,7 +35,7 @@ public enum OpenIdConnectPromptParameter {
     /**
      * No prompt parameter will be injected into the request.
      */
-    NOT_SENT,
+    UNSET,
 
     /**
      * this value is not used currently, kept as a placeholder if required for usage in the future.
@@ -62,7 +62,7 @@ public enum OpenIdConnectPromptParameter {
 
     @Override
     public String toString() {
-        if (this == NOT_SENT) {
+        if (this == UNSET) {
             return null;
         }
 
@@ -80,6 +80,6 @@ public enum OpenIdConnectPromptParameter {
 
         return promptBehavior != null && promptBehavior.equals("FORCE_PROMPT") ?
                 OpenIdConnectPromptParameter.LOGIN :
-                OpenIdConnectPromptParameter.NOT_SENT;
+                OpenIdConnectPromptParameter.UNSET;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -35,6 +35,11 @@ public enum OpenIdConnectPromptParameter {
     /**
      * No prompt parameter will be injected into the request.
      */
+    NOT_SENT,
+
+    /**
+     * this value is not used currently, kept as a placeholder if required for usage in the future.
+     */
     NONE,
 
     /**
@@ -57,7 +62,7 @@ public enum OpenIdConnectPromptParameter {
 
     @Override
     public String toString() {
-        if (this == NONE) {
+        if (this == NOT_SENT) {
             return null;
         }
 
@@ -65,9 +70,9 @@ public enum OpenIdConnectPromptParameter {
     }
 
 
-
     /**
      * Utility method to map Adal PromptBehavior with OpenIdConnectPromptParameter
+     *
      * @param promptBehavior
      * @return
      */
@@ -75,6 +80,6 @@ public enum OpenIdConnectPromptParameter {
 
         return promptBehavior != null && promptBehavior.equals("FORCE_PROMPT") ?
                 OpenIdConnectPromptParameter.LOGIN :
-                OpenIdConnectPromptParameter.NONE;
+                OpenIdConnectPromptParameter.NOT_SENT;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -247,7 +247,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .claimsRequestJson(brokerRequest.getClaims())
                 .prompt(brokerRequest.getPrompt() != null ?
                         OpenIdConnectPromptParameter.valueOf(brokerRequest.getPrompt()) :
-                        OpenIdConnectPromptParameter.NONE)
+                        OpenIdConnectPromptParameter.NOT_SENT)
                 .negotiatedBrokerProtocolVersion(negotiatedBrokerProtocolVersion)
                 .powerOptCheckEnabled(brokerRequest.isPowerOptCheckEnabled());
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -247,7 +247,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .claimsRequestJson(brokerRequest.getClaims())
                 .prompt(brokerRequest.getPrompt() != null ?
                         OpenIdConnectPromptParameter.valueOf(brokerRequest.getPrompt()) :
-                        OpenIdConnectPromptParameter.NOT_SENT)
+                        OpenIdConnectPromptParameter.UNSET)
                 .negotiatedBrokerProtocolVersion(negotiatedBrokerProtocolVersion)
                 .powerOptCheckEnabled(brokerRequest.isPowerOptCheckEnabled());
 

--- a/common/src/test/java/com/microsoft/identity/common/unit/OpenIdConnectPromptParameterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/OpenIdConnectPromptParameterTest.java
@@ -14,25 +14,25 @@ public class OpenIdConnectPromptParameterTest  {
     @Test
     public void testPromptBehaviorNull(){
        final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior(null);
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.UNSET);
     }
 
     @Test
     public void testPromptBehaviorAuto(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("Auto");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.UNSET);
     }
 
     @Test
     public void testPromptBehaviorAlways(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("Always");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.UNSET);
     }
 
     @Test
     public void testPromptBehaviorRefreshSession(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("REFRESH_SESSION");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.UNSET);
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/unit/OpenIdConnectPromptParameterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/OpenIdConnectPromptParameterTest.java
@@ -14,25 +14,25 @@ public class OpenIdConnectPromptParameterTest  {
     @Test
     public void testPromptBehaviorNull(){
        final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior(null);
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NONE);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
     }
 
     @Test
     public void testPromptBehaviorAuto(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("Auto");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NONE);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
     }
 
     @Test
     public void testPromptBehaviorAlways(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("Always");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NONE);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
     }
 
     @Test
     public void testPromptBehaviorRefreshSession(){
         final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter._fromPromptBehavior("REFRESH_SESSION");
-        assertEquals(promptParameter, OpenIdConnectPromptParameter.NONE);
+        assertEquals(promptParameter, OpenIdConnectPromptParameter.NOT_SENT);
     }
 
     @Test


### PR DESCRIPTION
Fix for the github issue https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1122

Added the field NOT_SENT and replaced the NONE, for the reasons of naming conventions