### PR TITLE
Revert getting token endpoint from well known config

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 Version 2.1.1
 ----------
 - Introduces result sharing to minimize duplicate_command errors
-- Device Code authorization endpoint is now sourced from .Well-Known config
+- No longer query well known config to obtain token endpoint - build it manually instead
 
 Version 2.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -40,10 +40,10 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
     private static final String TAG = MicrosoftStsOAuth2Configuration.class.getSimpleName();
 
     private static final String ENDPOINT_VERSION = "v2.0";
-    private static final String FALLBACK_ENDPOINT_SUFFIX = "/oAuth2/v2.0";
-    private static final String FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/authorize";
-    private static final String FALLBACK_TOKEN_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/token";
-    private static final String FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX = FALLBACK_ENDPOINT_SUFFIX + "/devicecode";
+    private static final String ENDPOINT_SUFFIX = "/oAuth2/v2.0";
+    private static final String AUTHORIZE_ENDPOINT_SUFFIX = ENDPOINT_SUFFIX + "/authorize";
+    private static final String TOKEN_ENDPOINT_SUFFIX = ENDPOINT_SUFFIX + "/token";
+    private static final String DEVICE_AUTHORIZE_ENDPOINT_SUFFIX = ENDPOINT_SUFFIX + "/devicecode";
 
     /**
      * Get the authorization endpoint to be used for making a authorization request.
@@ -52,7 +52,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return URL the authorization endpoint
      */
     public URL getAuthorizationEndpoint() {
-        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX);
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
     /**
@@ -61,7 +61,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return a URL object for the /devicecode endpoint
      */
     public URL getDeviceAuthorizationEndpoint() {
-        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX);
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), DEVICE_AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
     /**
@@ -71,7 +71,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return URL the token endpoint
      */
     public URL getTokenEndpoint() {
-        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_TOKEN_ENDPOINT_SUFFIX);
+        return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), TOKEN_ENDPOINT_SUFFIX);
     }
 
     private URL getEndpointUrlFromRootAndSuffix(@NonNull URL root, @NonNull String endpointSuffix) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -57,6 +57,7 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
 
     /**
      * Return device authorization endpoint to bo used in the authorization step of Device Code Flow.
+     *
      * @return a URL object for the /devicecode endpoint
      */
     public URL getDeviceAuthorizationEndpoint() {
@@ -71,27 +72,6 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      */
     public URL getTokenEndpoint() {
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_TOKEN_ENDPOINT_SUFFIX);
-    }
-
-    @Nullable
-    private URL getEndpointUrlFromAuthority(@NonNull final String authorityUrl) {
-        final String methodName = ":getEndpointUrlFromAuthority";
-        try {
-            return new URL(authorityUrl);
-        } catch (Exception e) {
-            Logger.error(
-                    TAG + methodName,
-                    "Unable to create URL from provided authority.",
-                    null);
-            Logger.errorPII(
-                    TAG + methodName,
-                    e.getMessage() +
-                            " Unable to create URL from provided authority." +
-                            " authority = " + authorityUrl,
-                    e);
-        }
-
-        return null;
     }
 
     private URL getEndpointUrlFromRootAndSuffix(@NonNull URL root, @NonNull String endpointSuffix) {
@@ -117,20 +97,6 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
 
         return null;
 
-    }
-
-    /**
-     * Get the Open Id Provider Configuration from the authority.
-     * This operation must NOT be called from the main thread.
-     * This method can return null if errors are encountered and the caller should check the result
-     * before using it.
-     *
-     * @return OpenIdProviderConfiguration if available or null
-     */
-    @Nullable
-    private OpenIdProviderConfiguration getOpenIdWellKnownConfigForAuthority() {
-        final URL authority = getAuthorityUrl();
-        return getOpenIdWellKnownConfig(authority.getHost(), authority.getPath());
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Configuration.java
@@ -52,10 +52,6 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return URL the authorization endpoint
      */
     public URL getAuthorizationEndpoint() {
-        final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
-        if (openIdConfig != null) {
-            return getEndpointUrlFromAuthority(openIdConfig.getAuthorizationEndpoint());
-        }
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
@@ -64,10 +60,6 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return a URL object for the /devicecode endpoint
      */
     public URL getDeviceAuthorizationEndpoint() {
-        final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
-        if (openIdConfig != null && openIdConfig.getDeviceAuthorizationEndpoint() != null) {
-            return getEndpointUrlFromAuthority(openIdConfig.getDeviceAuthorizationEndpoint());
-        }
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_DEVICE_AUTHORIZE_ENDPOINT_SUFFIX);
     }
 
@@ -78,10 +70,6 @@ public class MicrosoftStsOAuth2Configuration extends AzureActiveDirectoryOAuth2C
      * @return URL the token endpoint
      */
     public URL getTokenEndpoint() {
-        final OpenIdProviderConfiguration openIdConfig = getOpenIdWellKnownConfigForAuthority();
-        if (openIdConfig != null && openIdConfig.getTokenEndpoint() != null) {
-            return getEndpointUrlFromAuthority(openIdConfig.getTokenEndpoint());
-        }
         return getEndpointUrlFromRootAndSuffix(getAuthorityUrl(), FALLBACK_TOKEN_ENDPOINT_SUFFIX);
     }
 


### PR DESCRIPTION
This to fix the issue caused by Blackforest migrating to Public cloud as the well known config still returns the DE token endpoint for Blackforest cloud even after migration.

Also the other reason to revert this is to avoid potential simulated instance aware in the case of a tenanted authority.

The other reason to revert is because we don't know what would be expected behavior once cross cloud is implemented.