### PR TITLE
Let implementers choose their own proguard config for common, nimbus

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ Version 2.1.1
 - No longer query well known config to obtain token endpoint - build it manually instead
 - Improved null-safety in String comparisons.
 - Improved thread safety when querying cloud metadata.
-- Less broad Proguard configuration now restricted to common lib packages + displayMask.
+- Proguard configuration no longer keeps classes in common or nimbus, per request from Office.
 - Improved logging for SSL errors to assist in troubleshooting.
 
 Version 2.1.0

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -17,11 +17,10 @@
 #}
 
 ##---------------Begin: proguard configuration for Common  --------
--keep class com.microsoft.identity.common.** { *; }
--keep class com.microsoft.device.display.** { *; }
+# Intentionally blank, left to consumers of common to implement.
 
 ##---------------Begin: proguard configuration for Nimbus  ----------
--keep class com.nimbusds.** { *; }
+# Intentionally blank, left to consumers of common to implement.
 
 ##---------------Begin: proguard configuration for Lombok  ----------
 -dontwarn lombok.**


### PR DESCRIPTION
Removes rules from Proguard that previously kept all classes in `common` and classes in `nimbus`