### PR TITLE
Place cap on the number failed request data in Last Request Telemetry at any given time

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
@@ -50,7 +50,8 @@ public class LastRequestTelemetry extends RequestTelemetry {
     }
 
     /**
-     * Get a list of Failed Request objects.
+     * Get a list of Failed Request objects. The list returned here is unmodifiable. To add new
+     * elements to this list use the {@link LastRequestTelemetry#appendFailedRequest} method.
      *
      * @return an unmodifiable list of {@link FailedRequest} objects
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
@@ -49,7 +49,12 @@ public class LastRequestTelemetry extends RequestTelemetry {
         failedRequests = new ArrayList<>();
     }
 
-    List<FailedRequest> getFailedRequests() {
+    /**
+     * Get a list of Failed Request objects.
+     *
+     * @return an unmodifiable list of {@link FailedRequest} objects
+     */
+    /* package */ List<FailedRequest> getFailedRequests() {
         return Collections.unmodifiableList(failedRequests);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/LastRequestTelemetry.java
@@ -30,9 +30,12 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class LastRequestTelemetry extends RequestTelemetry {
+
+    final static int FAILED_REQUEST_CAP = 100;
 
     @SerializedName("silent_successful_count")
     private int silentSuccessfulCount;
@@ -47,7 +50,7 @@ public class LastRequestTelemetry extends RequestTelemetry {
     }
 
     List<FailedRequest> getFailedRequests() {
-        return failedRequests;
+        return Collections.unmodifiableList(failedRequests);
     }
 
     @Override
@@ -76,10 +79,22 @@ public class LastRequestTelemetry extends RequestTelemetry {
 
 
     void appendFailedRequest(final String apiId, final String correlationId, final String error) {
-        failedRequests.add(new FailedRequest(apiId, correlationId, error));
+        appendFailedRequest(new FailedRequest(apiId, correlationId, error));
     }
 
     void appendFailedRequest(final FailedRequest failedRequest) {
+        // this should usually not be greater than - at most should be equal to the cap
+        // because the only we to add to this list is via this append method.
+        // The only time this could be greater than the cap is for some existing devices that may
+        // have caught themselves in a bad state after accumulating too much telemetry in
+        // Shared Preferences. (of course prior to the cap being put in place).
+        // So will just take the last (most recent) 100 items here to get those out of the bad state,
+        // and also to avoid having too much telemetry in the cache going forward.
+        if (failedRequests.size() >= FAILED_REQUEST_CAP) {
+            final int beginIndex = failedRequests.size() - FAILED_REQUEST_CAP + 1;
+            final int endIndex = failedRequests.size();
+            failedRequests = failedRequests.subList(beginIndex, endIndex);
+        }
         failedRequests.add(failedRequest);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
@@ -66,17 +66,17 @@ public class SharedPreferencesLastRequestTelemetryCache implements IRequestTelem
     public synchronized RequestTelemetry getRequestTelemetryFromCache() {
         final String methodName = ":getRequestTelemetryFromCache";
 
-        final String cacheValue = mSharedPreferencesFileManager.getString(LAST_TELEMETRY_OBJECT_CACHE_KEY);
-
-        if (cacheValue == null) {
-            Logger.info(TAG + methodName, "There is no last request telemetry saved in " +
-                    "the cache. Returning NULL");
-
-            return null;
-        }
-
         try {
-            LastRequestTelemetry lastRequestTelemetry = mGson.fromJson(cacheValue, LastRequestTelemetry.class);
+            final String cacheValue = mSharedPreferencesFileManager.getString(LAST_TELEMETRY_OBJECT_CACHE_KEY);
+
+            if (cacheValue == null) {
+                Logger.info(TAG + methodName, "There is no last request telemetry saved in " +
+                        "the cache. Returning NULL");
+
+                return null;
+            }
+
+            final LastRequestTelemetry lastRequestTelemetry = mGson.fromJson(cacheValue, LastRequestTelemetry.class);
 
             if (lastRequestTelemetry == null) {
                 Logger.warn(TAG + methodName,
@@ -84,9 +84,16 @@ public class SharedPreferencesLastRequestTelemetryCache implements IRequestTelem
             }
 
             return lastRequestTelemetry;
-        } catch (JsonSyntaxException e) {
+        } catch (final JsonSyntaxException e) {
             Logger.error(TAG + methodName,
                     "Last Request Telemetry deserialization failed", e);
+            return null;
+        } catch (final OutOfMemoryError e) {
+            Logger.error(TAG + methodName,
+                    "Encountered OOM while restoring last request telemetry from " +
+                            "Shared Preferences. Clearing telemetry cache to recover and returning " +
+                            "null.", e);
+            mSharedPreferencesFileManager.clear();
             return null;
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/SharedPreferencesLastRequestTelemetryCache.java
@@ -89,12 +89,8 @@ public class SharedPreferencesLastRequestTelemetryCache implements IRequestTelem
                     "Last Request Telemetry deserialization failed", e);
             return null;
         } catch (final OutOfMemoryError e) {
-            Logger.error(TAG + methodName,
-                    "Encountered OOM while restoring last request telemetry from " +
-                            "Shared Preferences. Clearing telemetry cache to recover and returning " +
-                            "null.", e);
             mSharedPreferencesFileManager.clear();
-            return null;
+            throw e;
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetryUnitTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetryUnitTest.java
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.eststelemetry;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.microsoft.identity.common.internal.eststelemetry.LastRequestTelemetry.FAILED_REQUEST_CAP;
+
+@RunWith(RobolectricTestRunner.class)
+public class EstsTelemetryUnitTest {
+
+    @Test
+    public void LastRequestTelemetryFailedRequestListIsCapped() {
+        final LastRequestTelemetry lastRequestTelemetry = new LastRequestTelemetry(
+                SchemaConstants.CURRENT_SCHEMA_VERSION
+        );
+
+        for (int i = 0; i < (FAILED_REQUEST_CAP + 20); i++) {
+            final String apiId = "fake-api-id";
+            final String correlation = UUID.randomUUID().toString();
+            final String errorCode = "fake-error-code";
+            final FailedRequest failedRequest = new FailedRequest(apiId, correlation, errorCode);
+            lastRequestTelemetry.appendFailedRequest(failedRequest);
+            final List<FailedRequest> failedRequests = lastRequestTelemetry.getFailedRequests();
+            Assert.assertTrue(failedRequests.size() <= FAILED_REQUEST_CAP);
+        }
+
+        Assert.assertEquals(FAILED_REQUEST_CAP, lastRequestTelemetry.getFailedRequests().size());
+
+    }
+
+
+}


### PR DESCRIPTION
Address: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1081276

I've put a cap of 100 -- we could go much higher but I've seen that we are generally able to send data relevant to about 50-60 failed requests in a given header (due to header length constraints). So let's say we accumulate 100 items, then we send about 60 of those in the next network request, and we send the remaining 40 in the following one. So this way in the cases where we do accumulate too much telemetry, then we are able to send the most recent and most relevant telemetry in 2 network requests.

IMO, if we keep more than 100, let's say 200, then all of that may take 4 network requests to reach the server. At that point, the telemetry is probably not that relevant because it is old, and also most likely a developer doing debugging won't look 4 requests back to get all the telemetry. Also generally speaking, most devices that run into accumulating too much telemetry without actually sending it are the devices that keep getting the same error over and over again such as a device network not available error. So there isn't usually a need to know what the remaining errors in the past may have been.

So I think a cap of 100 seems most reasonable.