### PR TITLE
Consider controllers while throttling

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/BaseCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/BaseCommand.java
@@ -42,7 +42,6 @@ public abstract class BaseCommand<T> implements Command<T> {
     @EqualsAndHashCode.Exclude
     private CommandCallback callback;
 
-    @EqualsAndHashCode.Exclude
     private List<BaseController> controllers;
 
     @EqualsAndHashCode.Exclude

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -93,7 +93,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2SubErrorCode.BAD_TOKEN;
 import static com.microsoft.identity.common.internal.authorities.Authority.B2C;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -87,10 +87,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import lombok.EqualsAndHashCode;
+
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2ErrorCode.INVALID_GRANT;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.OAuth2SubErrorCode.BAD_TOKEN;
 import static com.microsoft.identity.common.internal.authorities.Authority.B2C;
 
+@EqualsAndHashCode
 public abstract class BaseController {
 
     private static final String TAG = BaseController.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -76,9 +76,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * The implementation of MSAL Controller for Broker
  */
+@EqualsAndHashCode(callSuper = true)
 public class BrokerMsalController extends BaseController {
 
     private static final String TAG = BrokerMsalController.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -81,7 +81,7 @@ import lombok.EqualsAndHashCode;
 /**
  * The implementation of MSAL Controller for Broker
  */
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public class BrokerMsalController extends BaseController {
 
     private static final String TAG = BrokerMsalController.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -72,8 +72,11 @@ import java.util.concurrent.Future;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import lombok.EqualsAndHashCode;
+
 import static com.microsoft.identity.common.adal.internal.net.HttpWebRequest.throwIfNetworkNotAvailable;
 
+@EqualsAndHashCode(callSuper = true)
 public class LocalMSALController extends BaseController {
 
     private static final String TAG = LocalMSALController.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -76,7 +76,7 @@ import lombok.EqualsAndHashCode;
 
 import static com.microsoft.identity.common.adal.internal.net.HttpWebRequest.throwIfNetworkNotAvailable;
 
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public class LocalMSALController extends BaseController {
 
     private static final String TAG = LocalMSALController.class.getSimpleName();


### PR DESCRIPTION
Controllers were not being considered in the Equals comparison of commands object. In this PR, I've updated the logic to consider them so that if we get a request with the same parameters, however, different controllers then we do NOT throttle.

Consider this scenario:

- Request with parameters A comes in (uses BrokerLocalController as device is NOT joined) - Fails as device registration required for resource
- User registers device
- In less than 30 seconds since first request, Another Request with same parameters A comes in (uses BrokerJoinedAccountController as device is now joined) - Fails due to throttling as the parameters were matched.

So now with this change, we wouldn't throttle in the second request with same parameters as now we would consider the controller as well so the request thumbprint is different i.e. the equals comparison for the two commands object fails and hence we do NOT throttle in such a case.

Related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1367