### PR TITLE
(API Breaking Change) Update TSL Ingestion Authority for MSA: Always Use WW/consumers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+vNext 3.0.0
+----------
+- Removed constructor param for TokenShareUtility: MSA RefreshToken ingestion always queries WW /consumers.
+
 Version 2.1.1
 ----------
 - Introduces result sharing to minimize duplicate_command errors.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/TokenShareUtility.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/TokenShareUtility.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.adal.internal.tokensharing;
 
-import android.net.Uri;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -66,7 +65,7 @@ public class TokenShareUtility implements ITokenShareInternal {
 
     private static final String TAG = TokenShareUtility.class.getSimpleName();
     private static final Map<String, String> sClaimRemapper = new HashMap<>();
-    private static final String AUDIENCE_PATH_CONSUMERS = "/consumers";
+    private static final String CONSUMERS_ENDPOINT = "https://login.microsoftonline.com/consumers";
 
     /**
      * To support caching lookups in ADAL, the following authority is used to signal
@@ -87,16 +86,13 @@ public class TokenShareUtility implements ITokenShareInternal {
 
     private final String mClientId;
     private final String mRedirectUri;
-    private final String mDefaultAuthority;
     private final MsalOAuth2TokenCache mTokenCache;
 
     public TokenShareUtility(@NonNull final String clientId,
                              @NonNull final String redirectUri,
-                             @NonNull final String defaultAuthority,
                              @NonNull final MsalOAuth2TokenCache cache) {
         mClientId = clientId;
         mRedirectUri = redirectUri;
-        mDefaultAuthority = defaultAuthority;
         mTokenCache = cache;
     }
 
@@ -250,24 +246,9 @@ public class TokenShareUtility implements ITokenShareInternal {
                 sBackgroundExecutor.submit(new Callable<Pair<MicrosoftAccount, MicrosoftRefreshToken>>() {
                     @Override
                     public Pair<MicrosoftAccount, MicrosoftRefreshToken> call() throws ClientException {
-                        // Use the /consumers endpoint relative to the current cloud
-                        final Uri defaultAuthorityUri = Uri.parse(mDefaultAuthority);
-
-                        final String tenantPath = defaultAuthorityUri.getPath();
-                        final String requestAuthority;
-
-                        if (null != tenantPath) {
-                            requestAuthority = mDefaultAuthority.replace(
-                                    tenantPath,
-                                    AUDIENCE_PATH_CONSUMERS
-                            );
-                        } else {
-                            requestAuthority = mDefaultAuthority;
-                        }
-
                         final ADALTokenCacheItem cacheItemToRenew = createTokenCacheItem(
                                 refreshToken,
-                                requestAuthority
+                                CONSUMERS_ENDPOINT
                         );
 
                         // Check that instance discovery metadata is loaded before making the request...

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=2.1.1
+versionName=3.0.0
 versionCode=1


### PR DESCRIPTION
Change requested by @shoatman for TSL + MSA in OneAuth

>Note: This change is API breaking and requires revving the common version number. This, in addition to the `changelog` is updated in this PR.