### PR TITLE
Add support for exporting public key data, signing arbitrary string data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 vNext 3.0.0
 ----------
 - Removed constructor param for TokenShareUtility: MSA RefreshToken ingestion always queries WW /consumers.
+- Added support for exporting public keys in the following formats:
+    * X.509 SubjectPublicKeyInfo
+    * JWK (RFC-7517)
+- Added support for signing and verifying arbitrary String data with select RSA algorithms.
 
 Version 2.1.1
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -1,0 +1,111 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.platform;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.exception.ClientException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Arrays;
+
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.MD5_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.NONE_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_256_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_256_WITH_RSA_PSS;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_384_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_384_WITH_RSA_PSS;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_512_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_512_WITH_RSA_PSS;
+
+@RunWith(Parameterized.class)
+public class DevicePoPManagerSigningTests {
+
+    private static final String DATA_TO_SIGN = "The quick brown fox jumped over the lazy dog.";
+
+    private final IDevicePopManager devicePopManager;
+    private final String signingAlg;
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testParams() {
+        return Arrays.asList(
+                new Object[]{
+                        MD5_WITH_RSA
+                },
+                new Object[]{
+                        NONE_WITH_RSA
+                },
+                new Object[]{
+                        SHA_256_WITH_RSA
+                },
+                new Object[]{
+                        SHA_256_WITH_RSA_PSS
+                },
+                new Object[]{
+                        SHA_384_WITH_RSA
+                },
+                new Object[]{
+                        SHA_384_WITH_RSA_PSS
+                },
+                new Object[]{
+                        SHA_512_WITH_RSA
+                },
+                new Object[]{
+                        SHA_512_WITH_RSA_PSS
+                }
+        );
+    }
+
+    @SuppressWarnings("unused")
+    public DevicePoPManagerSigningTests(final String signingAlg)
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        devicePopManager = new DevicePopManager();
+        this.signingAlg = signingAlg;
+    }
+
+    @Before
+    public void setUp() throws ClientException {
+        devicePopManager.generateAsymmetricKey(ApplicationProvider.getApplicationContext());
+    }
+
+    @After
+    public void tearDown() {
+        devicePopManager.clearAsymmetricKey();
+    }
+
+    @Test
+    public void testSigning() throws ClientException {
+        final String sampleSignature = devicePopManager.sign(signingAlg, DATA_TO_SIGN);
+        Assert.assertTrue(devicePopManager.verify(signingAlg, DATA_TO_SIGN, sampleSignature));
+    }
+}

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
+import android.os.Build;
+
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.exception.ClientException;
@@ -37,7 +39,8 @@ import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.MD5_WITH_RSA;
 import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.NONE_WITH_RSA;
@@ -57,33 +60,23 @@ public class DevicePoPManagerSigningTests {
     private final String signingAlg;
 
     @Parameterized.Parameters
-    public static Iterable<Object[]> testParams() {
-        return Arrays.asList(
-                new Object[]{
-                        MD5_WITH_RSA
-                },
-                new Object[]{
-                        NONE_WITH_RSA
-                },
-                new Object[]{
-                        SHA_256_WITH_RSA
-                },
-                new Object[]{
-                        SHA_256_WITH_RSA_PSS
-                },
-                new Object[]{
-                        SHA_384_WITH_RSA
-                },
-                new Object[]{
-                        SHA_384_WITH_RSA_PSS
-                },
-                new Object[]{
-                        SHA_512_WITH_RSA
-                },
-                new Object[]{
-                        SHA_512_WITH_RSA_PSS
-                }
-        );
+    public static Iterable<String> testParams() {
+        final List<String> signingAlgs = new ArrayList<String>() {{
+            add(MD5_WITH_RSA);
+            add(NONE_WITH_RSA);
+            add(SHA_256_WITH_RSA);
+            add(SHA_384_WITH_RSA);
+            add(SHA_512_WITH_RSA);
+        }};
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // Only execute these tests at appropriate API levels...
+            signingAlgs.add(SHA_256_WITH_RSA_PSS);
+            signingAlgs.add(SHA_384_WITH_RSA_PSS);
+            signingAlgs.add(SHA_512_WITH_RSA_PSS);
+        }
+
+        return signingAlgs;
     }
 
     @SuppressWarnings("unused")
@@ -106,6 +99,10 @@ public class DevicePoPManagerSigningTests {
     @Test
     public void testSigning() throws ClientException {
         final String sampleSignature = devicePopManager.sign(signingAlg, DATA_TO_SIGN);
-        Assert.assertTrue(devicePopManager.verify(signingAlg, DATA_TO_SIGN, sampleSignature));
+        final boolean verified = devicePopManager.verify(signingAlg, DATA_TO_SIGN, sampleSignature);
+
+        if (!verified) {
+            Assert.fail("Failed signing/verification on: " + signingAlg);
+        }
     }
 }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -42,14 +42,14 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.MD5_WITH_RSA;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.NONE_WITH_RSA;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_256_WITH_RSA;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_256_WITH_RSA_PSS;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_384_WITH_RSA;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_384_WITH_RSA_PSS;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_512_WITH_RSA;
-import static com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms.SHA_512_WITH_RSA_PSS;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.MD5_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.NONE_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_256_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_256_WITH_RSA_PSS;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_384_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_384_WITH_RSA_PSS;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_512_WITH_RSA;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.SigningAlgorithm.SHA_512_WITH_RSA_PSS;
 
 @RunWith(Parameterized.class)
 public class DevicePoPManagerSigningTests {
@@ -57,17 +57,18 @@ public class DevicePoPManagerSigningTests {
     private static final String DATA_TO_SIGN = "The quick brown fox jumped over the lazy dog.";
 
     private final IDevicePopManager devicePopManager;
-    private final String signingAlg;
+    private final IDevicePopManager.SigningAlgorithm signingAlg;
 
     @Parameterized.Parameters
-    public static Iterable<String> testParams() {
-        final List<String> signingAlgs = new ArrayList<String>() {{
-            add(MD5_WITH_RSA);
-            add(NONE_WITH_RSA);
-            add(SHA_256_WITH_RSA);
-            add(SHA_384_WITH_RSA);
-            add(SHA_512_WITH_RSA);
-        }};
+    public static Iterable<IDevicePopManager.SigningAlgorithm> testParams() {
+        final List<IDevicePopManager.SigningAlgorithm> signingAlgs =
+                new ArrayList<IDevicePopManager.SigningAlgorithm>() {{
+                    add(MD5_WITH_RSA);
+                    add(NONE_WITH_RSA);
+                    add(SHA_256_WITH_RSA);
+                    add(SHA_384_WITH_RSA);
+                    add(SHA_512_WITH_RSA);
+                }};
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             // Only execute these tests at appropriate API levels...
@@ -80,7 +81,7 @@ public class DevicePoPManagerSigningTests {
     }
 
     @SuppressWarnings("unused")
-    public DevicePoPManagerSigningTests(final String signingAlg)
+    public DevicePoPManagerSigningTests(final IDevicePopManager.SigningAlgorithm signingAlg)
             throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
         devicePopManager = new DevicePopManager();
         this.signingAlg = signingAlg;

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -330,4 +330,16 @@ public class DevicePoPManagerTests {
         final PublicKey pubKeyRestored = keyFactory.generatePublic(new X509EncodedKeySpec(bytes));
         Assert.assertEquals("X.509", pubKeyRestored.getFormat());
     }
+
+    @Test
+    public void testVerifySigning() throws ClientException {
+        // Generate a key
+        mDevicePopManager.generateAsymmetricKey(mContext);
+
+        // Sign a string
+        final String sampleStr = "Contoso";
+        final String sampleSignature = mDevicePopManager.sign(sampleStr);
+
+        Assert.assertTrue(mDevicePopManager.verify(sampleStr, sampleSignature));
+    }
 }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -354,8 +354,16 @@ public class DevicePoPManagerTests {
         // 'kty' - Key Type - Identifies the cryptographic alg used with this key (ex: RSA, EC)
         // 'e' - Public Exponent - The exponent used on signed/encoded data to decode the orig value
         // 'n' - Modulus - The product of two prime numbers used to generate the key pair
-        Assert.assertNotNull(jwkObj.get("kty"));
-        Assert.assertNotNull(jwkObj.get("e"));
-        Assert.assertNotNull(jwkObj.get("n"));
+        final JsonElement kty = jwkObj.get("kty");
+        Assert.assertNotNull(kty);
+        Assert.assertFalse(kty.getAsString().isEmpty());
+
+        final JsonElement e = jwkObj.get("e");
+        Assert.assertNotNull(e);
+        Assert.assertFalse(e.getAsString().isEmpty());
+
+        final JsonElement n = jwkObj.get("n");
+        Assert.assertNotNull(n);
+        Assert.assertFalse(n.getAsString().isEmpty());
     }
 }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -325,7 +325,7 @@ public class DevicePoPManagerTests {
         final String publicKey = mDevicePopManager.getPublicKey(X_509_SubjectPublicKeyInfo_ASN_1);
 
         // Rehydrate the certificate
-        final byte[] bytes = Base64.decode(publicKey, 2);
+        final byte[] bytes = Base64.decode(publicKey, Base64.DEFAULT);
         final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         final PublicKey pubKeyRestored = keyFactory.generatePublic(new X509EncodedKeySpec(bytes));
         Assert.assertEquals("X.509", pubKeyRestored.getFormat());

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -358,16 +358,4 @@ public class DevicePoPManagerTests {
         Assert.assertNotNull(jwkObj.get("e"));
         Assert.assertNotNull(jwkObj.get("n"));
     }
-
-    @Test
-    public void testVerifySigning() throws ClientException {
-        // Generate a key
-        mDevicePopManager.generateAsymmetricKey(mContext);
-
-        // Sign a string
-        final String sampleStr = "Contoso";
-        final String sampleSignature = mDevicePopManager.sign(sampleStr);
-
-        Assert.assertTrue(mDevicePopManager.verify(sampleStr, sampleSignature));
-    }
 }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -304,7 +304,7 @@ public class DevicePoPManagerTests {
     }
 
     @Test
-    public void testAsymmetricKeyNullWhenUninitialized() throws ClientException {
+    public void testAsymmetricKeyCreationDateNullWhenUninitialized() throws ClientException {
         final Date createdDate = mDevicePopManager.getAsymmetricKeyCreationDate();
         Assert.assertNull(createdDate);
     }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.platform;
 
 import android.content.Context;
+import android.util.Base64;
 
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -41,10 +42,17 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.KeyFactory;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
+import java.util.Date;
+
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
 
 @RunWith(AndroidJUnit4.class)
 public class DevicePoPManagerTests {
@@ -288,5 +296,38 @@ public class DevicePoPManagerTests {
         Assert.assertEquals(accessToken, jwtClaimsSet.getClaim("at"));
         Assert.assertEquals(nonce, jwtClaimsSet.getClaim("nonce"));
         Assert.assertNotNull(jwtClaimsSet.getClaim("cnf"));
+    }
+
+    @Test
+    public void testAsymmetricKeyNullWhenUninitialized() throws ClientException {
+        final Date createdDate = mDevicePopManager.getAsymmetricKeyCreationDate();
+        Assert.assertNull(createdDate);
+    }
+
+    @Test
+    public void testAsymmetricKeyHasCreationDate() throws ClientException {
+        final Date createdDate = mDevicePopManager.getAsymmetricKeyCreationDate();
+        Assert.assertNull(createdDate);
+
+        // Generate it
+        mDevicePopManager.generateAsymmetricKey(mContext);
+
+        // Assert the Date exists
+        Assert.assertNotNull(mDevicePopManager.getAsymmetricKeyCreationDate());
+    }
+
+    @Test
+    public void testAsymmetricKeyHasPublicKey() throws ClientException, NoSuchAlgorithmException, InvalidKeySpecException {
+        // Generate keys
+        mDevicePopManager.generateAsymmetricKey(mContext);
+
+        // Get the public key
+        final String publicKey = mDevicePopManager.getPublicKey(X_509_SubjectPublicKeyInfo_ASN_1);
+
+        // Rehydrate the certificate
+        final byte[] bytes = Base64.decode(publicKey, 2);
+        final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        final PublicKey pubKeyRestored = keyFactory.generatePublic(new X509EncodedKeySpec(bytes));
+        Assert.assertEquals("X.509", pubKeyRestored.getFormat());
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
@@ -182,6 +182,11 @@ public class ClientException extends BaseException {
     public static final String THUMBPRINT_COMPUTATION_FAILURE = "failed_to_compute_thumbprint_with_sha256";
 
     /**
+     * Emitted when the requested export format of our public key is unknown or unsupported.
+     */
+    public static final String UNKNOWN_EXPORT_FORMAT = "unknown_public_key_export_format";
+
+    /**
      * Emitted when the Android subsystem emits errors thrown while constructing new JSON objects.
      */
     public static final String JSON_CONSTRUCTION_FAILED = "json_construction_failed";

--- a/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ClientException.java
@@ -176,6 +176,16 @@ public class ClientException extends BaseException {
     public static final String INVALID_PROTECTION_PARAMS = "protection_params_invalid";
 
     /**
+     * Invalid key: cannot be used due to invalid encoding, wrong length, uninitialized, etc.
+     */
+    public static final String INVALID_KEY = "invalid_key";
+
+    /**
+     * Private key material cannot be loaded for use.
+     */
+    public static final String INVALID_KEY_MISSING = INVALID_KEY + "_private_key_missing";
+
+    /**
      * Emitted when the target certificate's thumbprint cannot be computed due to lack of support for
      * SHA-256.
      */
@@ -197,9 +207,14 @@ public class ClientException extends BaseException {
     public static final String INTERRUPTED_OPERATION = "operation_interrupted";
 
     /**
+     * Generic signing failure.
+     */
+    public static final String SIGNING_FAILURE = "failed_to_sign";
+
+    /**
      * Emitted when an error is encountered during signing.
      */
-    public static final String JWT_SIGNING_FAILURE = "failed_to_sign_jwt";
+    public static final String JWT_SIGNING_FAILURE = SIGNING_FAILURE + "_jwt";
 
     /**
      * Emitted if the STS returns an unexpected/incorrect token_type.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -125,7 +125,7 @@ class DevicePopManager implements IDevicePopManager {
     /**
      * Log message when private key material cannot be found.
      */
-    public static final String PRIVATE_KEY_NOT_FOUND = "Not an instance of a PrivateKeyEntry";
+    private static final String PRIVATE_KEY_NOT_FOUND = "Not an instance of a PrivateKeyEntry";
 
     /**
      * The keystore backing this implementation.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -523,6 +523,7 @@ class DevicePopManager implements IDevicePopManager {
     public @NonNull
     String sign(@NonNull final String alg,
                 @NonNull final String input) throws ClientException {
+        final String methodName = ":sign";
         final Exception exception;
         final String errCode;
 
@@ -532,7 +533,7 @@ class DevicePopManager implements IDevicePopManager {
 
             if (!(keyEntry instanceof KeyStore.PrivateKeyEntry)) {
                 Logger.warn(
-                        TAG + ":sign",
+                        TAG + methodName,
                         PRIVATE_KEY_NOT_FOUND
                 );
                 throw new ClientException(INVALID_KEY_MISSING);
@@ -582,6 +583,7 @@ class DevicePopManager implements IDevicePopManager {
     public boolean verify(@NonNull final String alg,
                           @NonNull final String plainText,
                           @NonNull final String signatureStr) {
+        final String methodName = ":verify";
         final String errCode;
         final Exception exception;
 
@@ -591,7 +593,7 @@ class DevicePopManager implements IDevicePopManager {
 
             if (!(keyEntry instanceof KeyStore.PrivateKeyEntry)) {
                 Logger.warn(
-                        TAG + ":verify",
+                        TAG + methodName,
                         PRIVATE_KEY_NOT_FOUND
                 );
                 return false;
@@ -634,6 +636,8 @@ class DevicePopManager implements IDevicePopManager {
     @Override
     public @NonNull
     String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
+        final String methodName = ":getPublicKey";
+
         switch (format) {
             case X_509_SubjectPublicKeyInfo_ASN_1:
                 return getX509SubjectPublicKeyInfo();
@@ -647,7 +651,7 @@ class DevicePopManager implements IDevicePopManager {
                 );
 
                 Logger.error(
-                        TAG + ":getPublicKey",
+                        TAG + methodName,
                         errMsg,
                         clientException
                 );

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -631,7 +631,7 @@ class DevicePopManager implements IDevicePopManager {
 
         try {
             final net.minidev.json.JSONObject jwkJson = getDevicePopJwkMinifiedJson();
-            return jwkJson.getAsString(SignedHttpRequestJwtClaims.JWK); // TODO create a constant
+            return jwkJson.getAsString(SignedHttpRequestJwtClaims.JWK);
         } catch (final UnrecoverableEntryException e) {
             exception = e;
             errCode = INVALID_PROTECTION_PARAMS;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -326,6 +326,33 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
+    public Date getAsymmetricKeyCreationDate() throws ClientException {
+        final Exception exception;
+        final String errCode;
+
+        try {
+            return mKeyStore.getCreationDate(KEYSTORE_ENTRY_ALIAS);
+        } catch (final KeyStoreException e) {
+            exception = e;
+            errCode = KEYSTORE_NOT_INITIALIZED;
+        }
+
+        final ClientException clientException = new ClientException(
+                errCode,
+                exception.getMessage(),
+                exception
+        );
+
+        Logger.error(
+                TAG,
+                clientException.getMessage(),
+                clientException
+        );
+
+        throw clientException;
+    }
+
+    @Override
     public boolean clearAsymmetricKey() {
         boolean deleted = false;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -482,12 +482,19 @@ class DevicePopManager implements IDevicePopManager {
             case X_509_SubjectPublicKeyInfo_ASN_1:
                 return getX509SubjectPublicKeyInfo();
             default:
+                final String errMsg = "Unrecognized or unsupported key format: " + format;
+                final ClientException clientException = new ClientException(
+                        UNKNOWN_EXPORT_FORMAT,
+                        errMsg
+                );
+
                 Logger.error(
                         TAG + ":getPublicKey",
-                        "Unrecognized or unsupported key format: " + format,
-                        null
+                        errMsg,
+                        clientException
                 );
-                throw new ClientException(UNKNOWN_EXPORT_FORMAT);
+
+                throw clientException;
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -91,7 +91,6 @@ import static com.microsoft.identity.common.exception.ClientException.NO_SUCH_AL
 import static com.microsoft.identity.common.exception.ClientException.THUMBPRINT_COMPUTATION_FAILURE;
 import static com.microsoft.identity.common.exception.ClientException.UNKNOWN_EXPORT_FORMAT;
 import static com.microsoft.identity.common.internal.net.ObjectMapper.ENCODING_SCHEME;
-import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.PKCS1_RSAPublicKey;
 import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
 
 /**
@@ -482,16 +481,9 @@ class DevicePopManager implements IDevicePopManager {
     public String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
         if (X_509_SubjectPublicKeyInfo_ASN_1 == format) {
             return getX509SubjectPublicKeyInfo();
-        } else if (PKCS1_RSAPublicKey == format) {
-            return getPkcs1RsaPublicKey();
         } else {
             throw new ClientException(UNKNOWN_EXPORT_FORMAT);
         }
-    }
-
-    private String getPkcs1RsaPublicKey() {
-        // TODO
-        return null;
     }
 
     private String getX509SubjectPublicKeyInfo() throws ClientException {

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -571,7 +571,6 @@ class DevicePopManager implements IDevicePopManager {
             signature.initVerify(((KeyStore.PrivateKeyEntry) keyEntry).getCertificate());
             signature.update(inputBytesToVerify);
             final byte[] signatureBytes = Base64.decode(signatureStr, Base64.DEFAULT);
-
             return signature.verify(signatureBytes);
         } catch (final UnsupportedEncodingException e) {
             errCode = UNSUPPORTED_ENCODING;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -91,6 +91,8 @@ import static com.microsoft.identity.common.exception.ClientException.NO_SUCH_AL
 import static com.microsoft.identity.common.exception.ClientException.THUMBPRINT_COMPUTATION_FAILURE;
 import static com.microsoft.identity.common.exception.ClientException.UNKNOWN_EXPORT_FORMAT;
 import static com.microsoft.identity.common.internal.net.ObjectMapper.ENCODING_SCHEME;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.PKCS1_RSAPublicKey;
+import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
 
 /**
  * Concrete class providing convenience functions around AndroidKeystore to support PoP.
@@ -444,20 +446,28 @@ class DevicePopManager implements IDevicePopManager {
 
     @Override
     public String sign(@NonNull final String input) throws ClientException {
-        // TODO
+        // TODO Sign how???
+        // RS256? SHA256withECDSA?
         return null;
     }
 
     @Override
     public String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
-        if (PublicKeyFormat.X_509_ASN_1 == format) {
-            return getPublicKeyX509();
+        if (X_509_SubjectPublicKeyInfo_ASN_1 == format) {
+            return getX509SubjectPublicKeyInfo();
+        } else if (PKCS1_RSAPublicKey == format) {
+            return getPkcs1RsaPublicKey();
         } else {
             throw new ClientException(UNKNOWN_EXPORT_FORMAT);
         }
     }
 
-    private String getPublicKeyX509() throws ClientException {
+    private String getPkcs1RsaPublicKey() {
+        // TODO
+        return null;
+    }
+
+    private String getX509SubjectPublicKeyInfo() throws ClientException {
         final Exception exception;
         final String errCode;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -324,6 +324,7 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
+    @Nullable
     public Date getAsymmetricKeyCreationDate() throws ClientException {
         final Exception exception;
         final String errCode;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -494,7 +494,7 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
-    public String sign(@NonNull final String input) throws ClientException {
+    public @NonNull String sign(@NonNull final String input) throws ClientException {
         final Exception exception;
         final String errCode;
 
@@ -602,7 +602,7 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
-    public String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
+    public @NonNull String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
         switch (format) {
             case X_509_SubjectPublicKeyInfo_ASN_1:
                 return getX509SubjectPublicKeyInfo();
@@ -625,7 +625,7 @@ class DevicePopManager implements IDevicePopManager {
         }
     }
 
-    private String getJwkPublicKey() throws ClientException {
+    private @NonNull String getJwkPublicKey() throws ClientException {
         final Exception exception;
         final String errCode;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -91,7 +91,6 @@ import static com.microsoft.identity.common.exception.ClientException.NO_SUCH_AL
 import static com.microsoft.identity.common.exception.ClientException.THUMBPRINT_COMPUTATION_FAILURE;
 import static com.microsoft.identity.common.exception.ClientException.UNKNOWN_EXPORT_FORMAT;
 import static com.microsoft.identity.common.internal.net.ObjectMapper.ENCODING_SCHEME;
-import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
 
 /**
  * Concrete class providing convenience functions around AndroidKeystore to support PoP.
@@ -479,10 +478,16 @@ class DevicePopManager implements IDevicePopManager {
 
     @Override
     public String getPublicKey(@NonNull final PublicKeyFormat format) throws ClientException {
-        if (X_509_SubjectPublicKeyInfo_ASN_1 == format) {
-            return getX509SubjectPublicKeyInfo();
-        } else {
-            throw new ClientException(UNKNOWN_EXPORT_FORMAT);
+        switch (format) {
+            case X_509_SubjectPublicKeyInfo_ASN_1:
+                return getX509SubjectPublicKeyInfo();
+            default:
+                Logger.error(
+                        TAG + ":getPublicKey",
+                        "Unrecognized or unsupported key format: " + format,
+                        null
+                );
+                throw new ClientException(UNKNOWN_EXPORT_FORMAT);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -108,7 +108,8 @@ class DevicePopManager implements IDevicePopManager {
     private static final String TAG = DevicePopManager.class.getSimpleName();
 
     /**
-     * Commonly used signing algorithms for PoP. Represents a subset of supported algorithms.
+     * Signing algorithms supported by our underlying keystore. Not all algs available at all device
+     * levels.
      */
     public static class SigningAlgorithms {
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -205,7 +205,7 @@ class DevicePopManager implements IDevicePopManager {
         private static final String NONCE = "nonce";
 
         /**
-         * JWK key for inner object.
+         * JWK for inner object.
          */
         public static final String JWK = "jwk";
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -108,37 +108,6 @@ class DevicePopManager implements IDevicePopManager {
     private static final String TAG = DevicePopManager.class.getSimpleName();
 
     /**
-     * Signing algorithms supported by our underlying keystore. Not all algs available at all device
-     * levels.
-     */
-    public static class SigningAlgorithms {
-
-        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-        public static final String MD5_WITH_RSA = "MD5withRSA";
-
-        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-        public static final String NONE_WITH_RSA = "NONEwithRSA";
-
-        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-        public static final String SHA_256_WITH_RSA = "SHA256withRSA";
-
-        @RequiresApi(Build.VERSION_CODES.M)
-        public static final String SHA_256_WITH_RSA_PSS = "SHA256withRSA/PSS";
-
-        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-        public static final String SHA_384_WITH_RSA = "SHA384withRSA";
-
-        @RequiresApi(Build.VERSION_CODES.M)
-        public static final String SHA_384_WITH_RSA_PSS = "SHA384withRSA/PSS";
-
-        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-        public static final String SHA_512_WITH_RSA = "SHA512withRSA";
-
-        @RequiresApi(Build.VERSION_CODES.M)
-        public static final String SHA_512_WITH_RSA_PSS = "SHA512withRSA/PSS";
-    }
-
-    /**
      * The PoP alias in the designated KeyStore.
      */
     private static final String KEYSTORE_ENTRY_ALIAS = "microsoft-device-pop";
@@ -521,7 +490,7 @@ class DevicePopManager implements IDevicePopManager {
 
     @Override
     public @NonNull
-    String sign(@NonNull final String alg,
+    String sign(@NonNull final SigningAlgorithm alg,
                 @NonNull final String input) throws ClientException {
         final String methodName = ":sign";
         final Exception exception;
@@ -539,7 +508,7 @@ class DevicePopManager implements IDevicePopManager {
                 throw new ClientException(INVALID_KEY_MISSING);
             }
 
-            final Signature signature = Signature.getInstance(alg);
+            final Signature signature = Signature.getInstance(alg.toString());
             signature.initSign(((KeyStore.PrivateKeyEntry) keyEntry).getPrivateKey());
             signature.update(inputBytesToSign);
             final byte[] signedBytes = signature.sign();
@@ -580,7 +549,7 @@ class DevicePopManager implements IDevicePopManager {
     }
 
     @Override
-    public boolean verify(@NonNull final String alg,
+    public boolean verify(@NonNull final SigningAlgorithm alg,
                           @NonNull final String plainText,
                           @NonNull final String signatureStr) {
         final String methodName = ":verify";
@@ -599,7 +568,7 @@ class DevicePopManager implements IDevicePopManager {
                 return false;
             }
 
-            final Signature signature = Signature.getInstance(alg);
+            final Signature signature = Signature.getInstance(alg.toString());
             signature.initVerify(((KeyStore.PrivateKeyEntry) keyEntry).getCertificate());
             signature.update(inputBytesToVerify);
             final byte[] signatureBytes = Base64.decode(signatureStr, Base64.DEFAULT);

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -34,7 +34,7 @@ import java.net.URL;
  */
 public interface IDevicePopManager {
 
-    enum PublicKeyFormat{
+    enum PublicKeyFormat {
         X_509_ASN_1;
     }
 
@@ -103,8 +103,10 @@ public interface IDevicePopManager {
     String sign(String input) throws ClientException;
 
     /**
-     * Gets the public key associated with this DevicePoPManager formatted as an X.509 ASN1 Dump.
+     * Gets the public key associated with this DevicePoPManager formatted per the supplied
+     * export param.
      *
+     * @param format The export format of the public key.
      * @return A String of the public key.
      */
     String getPublicKey(PublicKeyFormat format) throws ClientException;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -36,7 +36,8 @@ import java.util.Date;
 public interface IDevicePopManager {
 
     enum PublicKeyFormat {
-        X_509_SubjectPublicKeyInfo_ASN_1
+        X_509_SubjectPublicKeyInfo_ASN_1,
+        JWK
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -112,6 +112,16 @@ public interface IDevicePopManager {
     String sign(String input) throws ClientException;
 
     /**
+     * Verify a signature previously made by our Private Key.
+     *
+     * @param plainText    The input to verify.
+     * @param signatureStr The signature against which the plainText should be evaluated.
+     * @return True if the input was signed by our private key. False otherwise.
+     * @throws ClientException If an error was encountered during verification.
+     */
+    boolean verify(String plainText, String signatureStr) throws ClientException;
+
+    /**
      * Gets the public key associated with this DevicePoPManager formatted per the supplied
      * export param.
      *

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -117,9 +117,8 @@ public interface IDevicePopManager {
      * @param plainText    The input to verify.
      * @param signatureStr The signature against which the plainText should be evaluated.
      * @return True if the input was signed by our private key. False otherwise.
-     * @throws ClientException If an error was encountered during verification.
      */
-    boolean verify(String plainText, String signatureStr) throws ClientException;
+    boolean verify(String plainText, String signatureStr);
 
     /**
      * Gets the public key associated with this DevicePoPManager formatted per the supplied

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 
 import java.net.URL;
+import java.util.Date;
 
 /**
  * Internal convenience class interface for PoP related functions.
@@ -75,6 +76,14 @@ public interface IDevicePopManager {
      * @return The generated RSA KeyPair's thumbprint.
      */
     String generateAsymmetricKey(Context context) throws ClientException;
+
+    /**
+     * Returns the creation date of the asymmetric key entry backing this instance.
+     *
+     * @return The asymmetric key creation date.
+     * @throws ClientException If no asymmetric key exists.
+     */
+    Date getAsymmetricKeyCreationDate() throws ClientException;
 
     /**
      * Clears keys, if present.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -132,21 +132,23 @@ public interface IDevicePopManager {
     void getRequestConfirmation(TaskCompletedCallbackWithError<String, ClientException> callback);
 
     /**
-     * Signs an arbitrary piece of String data. Signing alg is SHA256WithRSA.
+     * Signs an arbitrary piece of String data.
      *
+     * @param alg   The RSA signing algorithm to use.
      * @param input The input to sign.
      * @return The input data, signed by our private key.
      */
-    String sign(String input) throws ClientException;
+    String sign(String alg, String input) throws ClientException;
 
     /**
-     * Verify a signature previously made by our Private Key. Verifies SHA256WithRSA sigs.
+     * Verify a signature previously made by our Private Key.
      *
+     * @param alg          The RSA signing algorithm to use.
      * @param plainText    The input to verify.
      * @param signatureStr The signature against which the plainText should be evaluated.
      * @return True if the input was signed by our private key. False otherwise.
      */
-    boolean verify(String plainText, String signatureStr);
+    boolean verify(String alg, String plainText, String signatureStr);
 
     /**
      * Gets the public key associated with this DevicePoPManager formatted per the supplied

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -35,8 +35,35 @@ import java.util.Date;
  */
 public interface IDevicePopManager {
 
+    /**
+     * The desired export format of our PoP public key.
+     */
     enum PublicKeyFormat {
+        /**
+         * Base64 encoded SubjectPublicKeyInfo of the X.509 Certificate.
+         * <p>
+         * Conforms to the following ASN.1
+         * <pre>
+         * SubjectPublicKeyInfo  ::=  SEQUENCE  {
+         *     algorithm            AlgorithmIdentifier,
+         *     subjectPublicKey     BIT STRING
+         * }
+         * </pre>
+         */
         X_509_SubjectPublicKeyInfo_ASN_1,
+
+        /**
+         * An RFC-7517 compliant public key as a minified JWK.
+         * <p>
+         * Sample value:
+         * <pre>
+         * {
+         * 	"kty": "RSA",
+         * 	"e": "AQAB",
+         * 	"n": "tMqJ7Oxh3PdLaiEc28w....HwES9Q"
+         * }
+         * </pre>
+         */
         JWK
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -137,6 +137,7 @@ public interface IDevicePopManager {
      * @param alg   The RSA signing algorithm to use.
      * @param input The input to sign.
      * @return The input data, signed by our private key.
+     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms
      */
     String sign(String alg, String input) throws ClientException;
 
@@ -147,6 +148,7 @@ public interface IDevicePopManager {
      * @param plainText    The input to verify.
      * @param signatureStr The signature against which the plainText should be evaluated.
      * @return True if the input was signed by our private key. False otherwise.
+     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms
      */
     boolean verify(String alg, String plainText, String signatureStr);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -36,8 +36,7 @@ import java.util.Date;
 public interface IDevicePopManager {
 
     enum PublicKeyFormat {
-        X_509_SubjectPublicKeyInfo_ASN_1,
-        PKCS1_RSAPublicKey
+        X_509_SubjectPublicKeyInfo_ASN_1
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -34,6 +34,10 @@ import java.net.URL;
  */
 public interface IDevicePopManager {
 
+    enum PublicKeyFormat{
+        X_509_ASN_1;
+    }
+
     /**
      * Tests if keys exist.
      *
@@ -89,6 +93,21 @@ public interface IDevicePopManager {
      * @return The req_cnf value.
      */
     void getRequestConfirmation(TaskCompletedCallbackWithError<String, ClientException> callback);
+
+    /**
+     * Signs an arbitrary piece of String data.
+     *
+     * @param input The input to sign.
+     * @return The input data, signed by our private key.
+     */
+    String sign(String input) throws ClientException;
+
+    /**
+     * Gets the public key associated with this DevicePoPManager formatted as an X.509 ASN1 Dump.
+     *
+     * @return A String of the public key.
+     */
+    String getPublicKey(PublicKeyFormat format) throws ClientException;
 
     /**
      * Api to create the signed PoP access token.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -105,7 +105,7 @@ public interface IDevicePopManager {
     void getRequestConfirmation(TaskCompletedCallbackWithError<String, ClientException> callback);
 
     /**
-     * Signs an arbitrary piece of String data.
+     * Signs an arbitrary piece of String data. Signing alg is SHA256WithRSA.
      *
      * @param input The input to sign.
      * @return The input data, signed by our private key.
@@ -113,7 +113,7 @@ public interface IDevicePopManager {
     String sign(String input) throws ClientException;
 
     /**
-     * Verify a signature previously made by our Private Key.
+     * Verify a signature previously made by our Private Key. Verifies SHA256WithRSA sigs.
      *
      * @param plainText    The input to verify.
      * @param signatureStr The signature against which the plainText should be evaluated.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -35,7 +35,8 @@ import java.net.URL;
 public interface IDevicePopManager {
 
     enum PublicKeyFormat {
-        X_509_ASN_1;
+        X_509_SubjectPublicKeyInfo_ASN_1,
+        PKCS1_RSAPublicKey
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -23,6 +23,10 @@
 package com.microsoft.identity.common.internal.platform;
 
 import android.content.Context;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
@@ -65,6 +69,48 @@ public interface IDevicePopManager {
          * </pre>
          */
         JWK
+    }
+
+    /**
+     * Signing algorithms supported by our underlying keystore. Not all algs available at all device
+     * levels.
+     */
+    enum SigningAlgorithm {
+        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+        MD5_WITH_RSA("MD5withRSA"),
+
+        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+        NONE_WITH_RSA("NONEwithRSA"),
+
+        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+        SHA_256_WITH_RSA("SHA256withRSA"),
+
+        @RequiresApi(Build.VERSION_CODES.M)
+        SHA_256_WITH_RSA_PSS("SHA256withRSA/PSS"),
+
+        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+        SHA_384_WITH_RSA("SHA384withRSA"),
+
+        @RequiresApi(Build.VERSION_CODES.M)
+        SHA_384_WITH_RSA_PSS("SHA384withRSA/PSS"),
+
+        @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+        SHA_512_WITH_RSA("SHA512withRSA"),
+
+        @RequiresApi(Build.VERSION_CODES.M)
+        SHA_512_WITH_RSA_PSS("SHA512withRSA/PSS");
+
+        private final String mValue;
+
+        SigningAlgorithm(@NonNull final String value) {
+            mValue = value;
+        }
+
+        @Override
+        @NonNull
+        public String toString() {
+            return mValue;
+        }
     }
 
     /**
@@ -137,9 +183,9 @@ public interface IDevicePopManager {
      * @param alg   The RSA signing algorithm to use.
      * @param input The input to sign.
      * @return The input data, signed by our private key.
-     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms
+     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithm
      */
-    String sign(String alg, String input) throws ClientException;
+    String sign(SigningAlgorithm alg, String input) throws ClientException;
 
     /**
      * Verify a signature previously made by our Private Key.
@@ -148,9 +194,9 @@ public interface IDevicePopManager {
      * @param plainText    The input to verify.
      * @param signatureStr The signature against which the plainText should be evaluated.
      * @return True if the input was signed by our private key. False otherwise.
-     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithms
+     * @see com.microsoft.identity.common.internal.platform.DevicePopManager.SigningAlgorithm
      */
-    boolean verify(String alg, String plainText, String signatureStr);
+    boolean verify(SigningAlgorithm alg, String plainText, String signatureStr);
 
     /**
      * Gets the public key associated with this DevicePoPManager formatted per the supplied


### PR DESCRIPTION
Added in this PR:
- Support for public key export
    * X.509 SubjectPublicKeyInfo
    * JWK ([RFC-7517](https://tools.ietf.org/html/rfc7517#section-4))
- Support for signing/verifying arbitrary data with various algs