### PR TITLE
Perform browser sign out on MSAL side

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -576,6 +576,9 @@ public class BrokerMsalController extends BaseController {
      * Invoke the logout endpoint on the specified browser.
      * If there are more than 1 session in the browser, an account picker will be displayed.
      * (Alternatively, we could pass the optional sessionID as one of the query string parameter, but we're not storing that at the moment).
+     *
+     * @param context    {@link Context} application context.
+     * @param parameters {@link RemoveAccountCommandParameters} parameters of the remove command call.
      */
     private void logOutFromBrowser(@NonNull final Context context,
                                    @NonNull final RemoveAccountCommandParameters parameters) {
@@ -600,8 +603,8 @@ public class BrokerMsalController extends BaseController {
             context.startActivity(intent);
 
         } catch (final ActivityNotFoundException e) {
-            Logger.info(TAG + methodName,
-                    "Browser package [" + browserPackageName + "] not found. Skipping browser sign out.");
+            Logger.error(TAG + methodName,
+                    "Failed to launch browser sign out with browser=[" + browserPackageName + "]. Skipping.", e);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -36,7 +36,6 @@ import androidx.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.internal.authorities.Environment;
@@ -52,14 +51,11 @@ import com.microsoft.identity.common.internal.commands.parameters.InteractiveTok
 import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.TokenCommandParameters;
-import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
-import com.microsoft.identity.common.internal.ui.browser.Browser;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
-import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.util.BrokerProtocolVersionUtil;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
 import com.microsoft.identity.common.internal.util.IClockSkewManager;
@@ -79,7 +75,6 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_ACTIVITY_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_PACKAGE_NAME;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.DEFAULT_BROWSER_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.internal.util.GzipUtil.compressString;
@@ -591,14 +586,6 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     public Bundle getRequestBundleForRemoveAccountFromSharedDevice(@NonNull final RemoveAccountCommandParameters parameters,
                                                                    @Nullable final String negotiatedBrokerProtocolVersion) {
         final Bundle requestBundle = new Bundle();
-
-        try {
-            Browser browser = BrowserSelector.select(parameters.getAndroidApplicationContext(), parameters.getBrowserSafeList());
-            requestBundle.putString(DEFAULT_BROWSER_PACKAGE_NAME, browser.getPackageName());
-        } catch (ClientException e) {
-            // Best effort. If none is passed to broker, then it will let the OS decide.
-            Logger.error(TAG, e.getErrorCode(), e);
-        }
         requestBundle.putString(
                 AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY,
                 negotiatedBrokerProtocolVersion


### PR DESCRIPTION
In the FLW sign out scenario, we've been trying to let the broker do all the work, and this includes launching default browser to Sign off the device.

However, [this change in API 29](https://developer.android.com/guide/components/activities/background-starts) seems to break this. Having said that, it's not totally broken - it still works, but unreliable. (e.g. if you sign in, then sign out right away, it seems to work fine. However, if you sign in, close the app (or launch another app), and then sign out, it doesn't seem to work).

This fix is to move that operation (that was being run in the background (auth) process) to foreground process.

I'll keep the change on the broker side for now since Android is smart enough to try to launch chrome twice - which means we do not need to bump protocol version.
