### PR TITLE
Added a check for UNSET OpenIdConnectPromptParameter value

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -107,8 +107,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .extraQueryStringParameter(
                         parameters.getExtraQueryStringParameters() != null ?
                                 QueryParamsAdapter._toJson(parameters.getExtraQueryStringParameters())
-                                : null
-                ).prompt(parameters.getPrompt().name())
+                                : null)
+                .prompt((OpenIdConnectPromptParameter.UNSET.name().equals(parameters.getPrompt().name())) ? null : parameters.getPrompt().name())
                 .claims(parameters.getClaimsRequestJson())
                 .forceRefresh(parameters.isForceRefresh())
                 .correlationId(parameters.getCorrelationId())


### PR DESCRIPTION
If the new Msal versions send UNSET Value to old Brokers, the UNSET value would be converted to null and then converted back to the UNSET OpenIdConnectPromptParameter value.

Older versions of MSALs would fare well with new brokers as no deleteions were made from the OpenIdConnectPromptParameter values in the newer Brokers