### PR TITLE
Increase Travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ before_script:
   - adb shell input keyevent 82 &
 
 script:
-  - travis_wait ./gradlew clean build connectedCheck
+  - travis_wait 30 ./gradlew clean build connectedCheck


### PR DESCRIPTION
CI has too many instrumented tests. Increasing timeout as we migrate tests to improve build time