### PR TITLE
Expose expiresIn in MSAL Device Code flow callback

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- Expose expiresIn in MSAL Device Code flow callback (#1064)
 - Removed constructor param for TokenShareUtility: MSA RefreshToken ingestion always queries WW /consumers.
 - Added support for exporting public keys in the following formats:
     * X.509 SubjectPublicKeyInfo

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/DeviceCodeFlowCommandCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/DeviceCodeFlowCommandCallback.java
@@ -24,11 +24,16 @@ package com.microsoft.identity.common.internal.commands;
 
 import androidx.annotation.NonNull;
 
+import java.util.Date;
+
 /**
  * Extension of the CommandCallback class to allow Device Code Flow to display the user_code,
  * verification_uri, and message midway through the protocol. This is done through the
  * getUserCode() method shown below
  */
 public interface DeviceCodeFlowCommandCallback<T, U> extends CommandCallback<T, U> {
-    void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message);
+    void onUserCodeReceived(@NonNull String vUri,
+                            @NonNull String userCode,
+                            @NonNull String message,
+                            @NonNull final Date sessionExpirationDate);
 }


### PR DESCRIPTION
MSTeams would like to display the 'time until expires' on their device.

related PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1169