### PR TITLE
Do not allow for missing secret key data to cause an NPE

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -590,7 +590,13 @@ public class StorageHelper implements IStorageHelper {
                 return getSecretKey(AuthenticationSettings.INSTANCE.getBrokerSecretKeys().get(COMPANY_PORTAL_APP_PACKAGE_NAME));
 
             case ADAL_USER_DEFINED_KEY:
-                return getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
+                final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
+                if (secretKeyData == null) {
+                    Logger.error("StorageHelper:loadSecretKey", "Went looking for a key that wasn't there.", null);
+                    return null;
+                }
+                SecretKey key = getSecretKey(secretKeyData);
+                return key;
 
             case KEYSTORE_ENCRYPTED_KEY:
                 return loadKeyStoreEncryptedKey();

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -595,8 +595,7 @@ public class StorageHelper implements IStorageHelper {
                     Logger.error("StorageHelper:loadSecretKey", "Went looking for a key that wasn't there.", null);
                     return null;
                 }
-                SecretKey key = getSecretKey(secretKeyData);
-                return key;
+                return getSecretKey(secretKeyData);
 
             case KEYSTORE_ENCRYPTED_KEY:
                 return loadKeyStoreEncryptedKey();


### PR DESCRIPTION
Check for null data and do not decrypt it.
Properly synchronize and safe-copy the key array.