### PR TITLE
Revert "Do not allow for missing secret key data to cause an NPE"

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -22,13 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.adal.internal;
 
-import androidx.annotation.GuardedBy;
-import androidx.collection.ArrayMap;
-
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,10 +48,9 @@ public enum AuthenticationSettings {
     // This is used to accept two broker key. Today we have company portal and azure authenticator apps,
     // and each app is also going to send the other app's keys. They need to set package name and corresponding
     // keys in the map. used by broker.
-    private final Map<String, byte[]> mBrokerSecretKeys = new ArrayMap<String, byte[]>(2);
+    private final Map<String, byte[]> mBrokerSecretKeys = new HashMap<String, byte[]>(2);
 
-    @GuardedBy("this")
-    private byte[] mSecretKeyData;
+    private AtomicReference<byte[]> mSecretKeyData = new AtomicReference<>();
 
     private String mBrokerPackageName = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 
@@ -93,8 +88,8 @@ public enum AuthenticationSettings {
      *
      * @return byte[] secret data
      */
-    public synchronized byte[] getSecretKeyData() {
-        return mSecretKeyData == null ? null : Arrays.copyOf(mSecretKeyData, mSecretKeyData.length);
+    public byte[] getSecretKeyData() {
+        return mSecretKeyData.get();
     }
 
     /**
@@ -113,12 +108,12 @@ public enum AuthenticationSettings {
      *
      * @param rawKey App related key to use in encrypt/decrypt
      */
-    public synchronized void setSecretKey(byte[] rawKey) {
+    public void setSecretKey(byte[] rawKey) {
         if (rawKey == null || rawKey.length != SECRET_RAW_KEY_LENGTH) {
             throw new IllegalArgumentException("rawKey");
         }
 
-        mSecretKeyData = Arrays.copyOf(rawKey, SECRET_RAW_KEY_LENGTH);
+        mSecretKeyData.set(rawKey);
     }
 
     /**
@@ -156,9 +151,9 @@ public enum AuthenticationSettings {
     /**
      * For test cases only.
      * */
-    public synchronized void clearSecretKeysForTestCases(){
+    public void clearSecretKeysForTestCases(){
         mBrokerSecretKeys.clear();
-        mSecretKeyData = null;
+        mSecretKeyData.set(null);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -590,12 +590,7 @@ public class StorageHelper implements IStorageHelper {
                 return getSecretKey(AuthenticationSettings.INSTANCE.getBrokerSecretKeys().get(COMPANY_PORTAL_APP_PACKAGE_NAME));
 
             case ADAL_USER_DEFINED_KEY:
-                final byte[] secretKeyData = AuthenticationSettings.INSTANCE.getSecretKeyData();
-                if (secretKeyData == null) {
-                    Logger.error("StorageHelper:loadSecretKey", "Went looking for a key that wasn't there.", null);
-                    return null;
-                }
-                return getSecretKey(secretKeyData);
+                return getSecretKey(AuthenticationSettings.INSTANCE.getSecretKeyData());
 
             case KEYSTORE_ENCRYPTED_KEY:
                 return loadKeyStoreEncryptedKey();


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-common-for-android#1068

Reverting this PR until more testing can be applied -- ran into unexpected issue in upstream MSAL