### PR TITLE
Keystore Localization Workaround for Non-Gregorian Calendar Types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ vNext
     * JWK (RFC-7517)
 - Added support for signing and verifying arbitrary String data with select RSA algorithms.
 - Added support for multiple software/hardware backed RSA keys using AsymmetricKey, AsymmetricKeyFactory.
+- Bugfix: Added a workaround for keypair generation on API < 23 devices using locales with non-Gregorian calendars. (#1075)
 
 Version 3.0.4
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -81,6 +81,7 @@ import javax.security.auth.x500.X500Principal;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.internal.util.DateUtilities.LOCALE_CHANGE_LOCK;
+import static com.microsoft.identity.common.internal.util.DateUtilities.isLocaleCalendarNonGregorian;
 
 public class StorageHelper implements IStorageHelper {
     private static final String TAG = "StorageHelper";
@@ -666,7 +667,7 @@ public class StorageHelper implements IStorageHelper {
             throws GeneralSecurityException, IOException {
         final String methodName = ":generateKeyPairFromAndroidKeyStore";
 
-        synchronized (LOCALE_CHANGE_LOCK) {
+        synchronized (isLocaleCalendarNonGregorian(Locale.getDefault()) ? LOCALE_CHANGE_LOCK : new Object()) {
             // Due to the following bug in lower API versions of keystore, locale workarounds may
             // need to be applied
             // https://issuetracker.google.com/issues/37095309

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -715,7 +715,7 @@ public class StorageHelper implements IStorageHelper {
         }
     }
 
-    private static synchronized void applyKeyStoreLocaleWorkarounds(@NonNull final Locale currentLocale) {
+    public static synchronized void applyKeyStoreLocaleWorkarounds(@NonNull final Locale currentLocale) {
         // See: https://issuetracker.google.com/issues/37095309
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M
                 && DateUtilities.isLocaleCalendarNonGregorian(currentLocale)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -115,6 +115,7 @@ import static com.microsoft.identity.common.exception.ClientException.THUMBPRINT
 import static com.microsoft.identity.common.exception.ClientException.UNKNOWN_EXPORT_FORMAT;
 import static com.microsoft.identity.common.exception.ClientException.UNSUPPORTED_ENCODING;
 import static com.microsoft.identity.common.internal.util.DateUtilities.LOCALE_CHANGE_LOCK;
+import static com.microsoft.identity.common.internal.util.DateUtilities.isLocaleCalendarNonGregorian;
 
 /**
  * Concrete class providing convenience functions around AndroidKeystore to support PoP.
@@ -1139,7 +1140,7 @@ class DevicePopManager implements IDevicePopManager {
     private KeyPair generateNewKeyPair(@NonNull final Context context, final boolean useStrongbox)
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
             NoSuchProviderException, StrongBoxUnavailableException {
-        synchronized (LOCALE_CHANGE_LOCK) {
+        synchronized (isLocaleCalendarNonGregorian(Locale.getDefault()) ? LOCALE_CHANGE_LOCK : new Object()) {
             // See: https://issuetracker.google.com/issues/37095309
             final Locale currentLocale = Locale.getDefault();
             applyKeyStoreLocaleWorkarounds(currentLocale);

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
 
 public final class DateUtilities {
 
+    public static final Object LOCALE_CHANGE_LOCK = new Object();
+
     private static final String LOCALE_PREFIX_ARABIC = "ar";
     private static final String LOCALE_PREFIX_ASSAMESE = "as";
     private static final String LOCALE_PREFIX_BENGALI = "bn";

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.util;
 
 import androidx.annotation.NonNull;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
@@ -53,23 +54,23 @@ public final class DateUtilities {
 
     // This list may not be exhaustive, but represents the set of non-Gregorian locales
     // available as of AOSP API 24
-    private static final Set<String> NON_GREGORIAN_CALENDAR_LOCALES = new HashSet<>();
-
-    static {
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ARABIC);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ASSAMESE);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_BENGALI);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ALGERIAN);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PERSIAN);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_KASHMIRI);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_MARATHI);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_BURMESE);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_NEPALI);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PUNJABI);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PASHTO);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_URDU);
-        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_UZBEK);
-    }
+    private static final Set<String> NON_GREGORIAN_CALENDAR_LOCALES = new HashSet<>(
+            Arrays.asList(
+                    LOCALE_PREFIX_ARABIC,
+                    LOCALE_PREFIX_ASSAMESE,
+                    LOCALE_PREFIX_BENGALI,
+                    LOCALE_PREFIX_ALGERIAN,
+                    LOCALE_PREFIX_PERSIAN,
+                    LOCALE_PREFIX_KASHMIRI,
+                    LOCALE_PREFIX_MARATHI,
+                    LOCALE_PREFIX_BURMESE,
+                    LOCALE_PREFIX_NEPALI,
+                    LOCALE_PREFIX_PUNJABI,
+                    LOCALE_PREFIX_PASHTO,
+                    LOCALE_PREFIX_URDU,
+                    LOCALE_PREFIX_UZBEK
+            )
+    );
 
     private DateUtilities() {
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -32,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 
 public final class DateUtilities {
 
+    /**
+     * Static lock object to use when performing operations that modify locale state of JVM.
+     */
     public static final Object LOCALE_CHANGE_LOCK = new Object();
 
     private static final String LOCALE_PREFIX_ARABIC = "ar";
@@ -48,7 +51,7 @@ public final class DateUtilities {
     private static final String LOCALE_PREFIX_URDU = "ur";
     private static final String LOCALE_PREFIX_UZBEK = "uz";
 
-    // This list may not be exhaustive, but is represents the set of non-Gregorian locales
+    // This list may not be exhaustive, but represents the set of non-Gregorian locales
     // available as of AOSP API 24
     private static final Set<String> NON_GREGORIAN_CALENDAR_LOCALES = new HashSet<>();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -101,8 +101,7 @@ public final class DateUtilities {
      * @return True, if the provided locale's default calendar format is non-Gregorian. False otherwise.
      */
     public static boolean isLocaleCalendarNonGregorian(@NonNull final Locale inputLocale) {
-        final String localeStr = inputLocale.toString();
-        final String localePrefix = localeStr.split("_")[0];
+        final String localePrefix = inputLocale.getLanguage();
         return NON_GREGORIAN_CALENDAR_LOCALES.contains(localePrefix);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -89,6 +89,12 @@ public final class DateUtilities {
         return currentTimeSecs + expiresIn;
     }
 
+    /**
+     * Checks if the provided locale has a default calendar format that is non-Gregorian.
+     *
+     * @param inputLocale A locale to inspect.
+     * @return True, if the provided locale's default calendar format is non-Gregorian. False otherwise.
+     */
     public static boolean isLocaleCalendarNonGregorian(@NonNull final Locale inputLocale) {
         final String localeStr = inputLocale.toString();
         final String localePrefix = localeStr.split("_")[0];

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/DateUtilities.java
@@ -22,10 +22,49 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.util;
 
+import androidx.annotation.NonNull;
+
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public final class DateUtilities {
+
+    private static final String LOCALE_PREFIX_ARABIC = "ar";
+    private static final String LOCALE_PREFIX_ASSAMESE = "as";
+    private static final String LOCALE_PREFIX_BENGALI = "bn";
+    private static final String LOCALE_PREFIX_ALGERIAN = "dz";
+    private static final String LOCALE_PREFIX_PERSIAN = "fa";
+    private static final String LOCALE_PREFIX_KASHMIRI = "ks";
+    private static final String LOCALE_PREFIX_MARATHI = "mr";
+    private static final String LOCALE_PREFIX_BURMESE = "my";
+    private static final String LOCALE_PREFIX_NEPALI = "ne";
+    private static final String LOCALE_PREFIX_PUNJABI = "pa";
+    private static final String LOCALE_PREFIX_PASHTO = "ps";
+    private static final String LOCALE_PREFIX_URDU = "ur";
+    private static final String LOCALE_PREFIX_UZBEK = "uz";
+
+    // This list may not be exhaustive, but is represents the set of non-Gregorian locales
+    // available as of AOSP API 24
+    private static final Set<String> NON_GREGORIAN_CALENDAR_LOCALES = new HashSet<>();
+
+    static {
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ARABIC);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ASSAMESE);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_BENGALI);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_ALGERIAN);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PERSIAN);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_KASHMIRI);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_MARATHI);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_BURMESE);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_NEPALI);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PUNJABI);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_PASHTO);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_URDU);
+        NON_GREGORIAN_CALENDAR_LOCALES.add(LOCALE_PREFIX_UZBEK);
+    }
 
     private DateUtilities() {
     }
@@ -48,6 +87,12 @@ public final class DateUtilities {
         final long currentTimeMillis = System.currentTimeMillis();
         final long currentTimeSecs = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis);
         return currentTimeSecs + expiresIn;
+    }
+
+    public static boolean isLocaleCalendarNonGregorian(@NonNull final Locale inputLocale) {
+        final String localeStr = inputLocale.toString();
+        final String localePrefix = localeStr.split("_")[0];
+        return NON_GREGORIAN_CALENDAR_LOCALES.contains(localePrefix);
     }
 }
 


### PR DESCRIPTION
Related:
- [Android AAD Sign-in fails with "Invalid data string: Unparseable data: 'b`a``dabehbhGMT+00:00' (at offset 0)" when language set to Arabic](https://portal.microsofticm.com/imp/v3/incidents/details/208587579/home) (corpnet reqd)
- [ADAL Wiki Issue](https://github.com/AzureAD/azure-activedirectory-library-for-android/wiki/Common-Issues-With-AndroidKeyStore#key-store-issue-with-arabic-or-persian)