### PR TITLE
Update base64 encoding flag -- set NO_WRAP

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -542,7 +542,7 @@ class DevicePopManager implements IDevicePopManager {
             signature.initSign(((KeyStore.PrivateKeyEntry) keyEntry).getPrivateKey());
             signature.update(inputBytesToSign);
             final byte[] signedBytes = signature.sign();
-            return Base64.encodeToString(signedBytes, Base64.DEFAULT);
+            return Base64.encodeToString(signedBytes, Base64.NO_WRAP);
         } catch (final KeyStoreException e) {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
@@ -601,7 +601,7 @@ class DevicePopManager implements IDevicePopManager {
             final Signature signature = Signature.getInstance(alg.toString());
             signature.initVerify(((KeyStore.PrivateKeyEntry) keyEntry).getCertificate());
             signature.update(inputBytesToVerify);
-            final byte[] signatureBytes = Base64.decode(signatureStr, Base64.DEFAULT);
+            final byte[] signatureBytes = Base64.decode(signatureStr, Base64.NO_WRAP);
             return signature.verify(signatureBytes);
         } catch (final UnsupportedEncodingException e) {
             errCode = UNSUPPORTED_ENCODING;


### PR DESCRIPTION
Ask from OneAuth team -- signatures should pass the NO_WRAP flag, as `\n` chars in the sig can cause issues over the wire