### PR TITLE
Do not silently swallow exception in requestAuthorization(), Launch AuthorizationActivity with different flags for broker and non-broker auth

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -26,6 +26,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ArgumentException;
@@ -69,9 +72,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.WorkerThread;
 
 import lombok.EqualsAndHashCode;
 
@@ -409,8 +409,7 @@ public class LocalMSALController extends BaseController {
                         .putApiId(TelemetryEventStrings.Api.LOCAL_GET_ACCOUNTS)
         );
 
-        @SuppressWarnings(WarningType.unchecked_warning)
-        final List<ICacheRecord> accountsInCache =
+        @SuppressWarnings(WarningType.unchecked_warning) final List<ICacheRecord> accountsInCache =
                 parameters
                         .getOAuth2TokenCache()
                         .getAccountsWithAggregatedAccountData(
@@ -544,8 +543,7 @@ public class LocalMSALController extends BaseController {
 
             validateServiceResult(authorizationResult);
 
-        }
-        catch (Exception error){
+        } catch (Exception error) {
             Telemetry.emit(
                     new ApiEndEvent()
                             .putException(error)
@@ -673,8 +671,7 @@ public class LocalMSALController extends BaseController {
                             false
                     )
             );
-        }
-        catch (Exception error){
+        } catch (Exception error) {
             Telemetry.emit(
                     new ApiEndEvent()
                             .putException(error)
@@ -697,6 +694,7 @@ public class LocalMSALController extends BaseController {
 
     /**
      * Returns true if the given error shows authorization is pending.
+     *
      * @param errorCode error from response
      * @return true or false if error is pending
      */
@@ -707,6 +705,7 @@ public class LocalMSALController extends BaseController {
     /**
      * Helper method to check if a result object is valid (was a success). If not, an exception will be generated and thrown.
      * This method is called in both parts of the DCF protocol.
+     *
      * @param result result object to be checked
      * @throws ServiceException MsalServiceException object reflecting error code returned by the result
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.providers.microsoft.activedirecto
 
 import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.WarningType;
+import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.net.HttpResponse;
@@ -68,7 +69,7 @@ public class ActiveDirectoryFederationServices2012R2OAuth2Strategy extends OAuth
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) {
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, authorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.providers.microsoft.activedirecto
 
 import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.WarningType;
+import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.net.HttpResponse;
@@ -66,7 +67,7 @@ public class ActiveDirectoryFederationServices2016OAuth2Strategy extends OAuth2S
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) {
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, authorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.providers.microsoft.azureactivedi
 
 import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.WarningType;
+import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.net.HttpResponse;
@@ -66,7 +67,7 @@ public class AzureActiveDirectoryB2COAuth2Strategy extends OAuth2Strategy {
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) {
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, AuthorizationStrategy authorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, authorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.events.UiStartEvent;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
+import com.microsoft.identity.common.internal.util.ProcessUtil;
 
 import java.util.HashMap;
 
@@ -58,6 +59,16 @@ public final class AuthorizationActivity extends DualScreenActivity {
                                            final boolean webViewZoomEnabled,
                                            final boolean webViewZoomControlsEnabled) {
         final Intent intent = new Intent(context, AuthorizationActivity.class);
+
+        // For broker request we need to clear all activities in the task and bring Authorization Activity to the
+        // top. If we do not add FLAG_ACTIVITY_CLEAR_TASK, Authorization Activity on finish can land on
+        // Authenticator's or Company Portal's active activity which would be confusing to the user.
+        if (ProcessUtil.isBrokerProcess(context)) {
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+        } else {
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        }
+
         intent.putExtra(AUTH_INTENT, authIntent);
         intent.putExtra(REQUEST_URL, requestUrl);
         intent.putExtra(REDIRECT_URI, redirectUri);
@@ -69,9 +80,9 @@ public final class AuthorizationActivity extends DualScreenActivity {
         return intent;
     }
 
-    public static AuthorizationFragment getAuthorizationFragmentFromStartIntent(@NonNull final Intent intent){
+    public static AuthorizationFragment getAuthorizationFragmentFromStartIntent(@NonNull final Intent intent) {
         AuthorizationFragment fragment;
-        final AuthorizationAgent authorizationAgent = (AuthorizationAgent)intent.getSerializableExtra(AUTHORIZATION_AGENT);
+        final AuthorizationAgent authorizationAgent = (AuthorizationAgent) intent.getSerializableExtra(AUTHORIZATION_AGENT);
         Telemetry.emit(new UiStartEvent().putUserAgent(authorizationAgent));
 
         if (authorizationAgent == AuthorizationAgent.WEBVIEW) {
@@ -83,7 +94,7 @@ public final class AuthorizationActivity extends DualScreenActivity {
         fragment.setInstanceState(intent.getExtras());
         return fragment;
     }
-    
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -93,7 +104,7 @@ public final class AuthorizationActivity extends DualScreenActivity {
 
     @Override
     public void onBackPressed() {
-        if (!mFragment.onBackPressed()){
+        if (!mFragment.onBackPressed()) {
             super.onBackPressed();
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationStrategy.java
@@ -92,7 +92,7 @@ public abstract class AuthorizationStrategy<GenericOAuth2Strategy extends OAuth2
      */
     public abstract Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
                                                                      GenericOAuth2Strategy oAuth2Strategy)
-            throws ClientException, UnsupportedEncodingException;
+            throws ClientException;
 
     public abstract void completeAuthorization(int requestCode, int resultCode, final Intent data);
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -124,23 +124,16 @@ public abstract class OAuth2Strategy
      * @param authorizationStrategy generic authorization strategy.
      * @return GenericAuthorizationResponse
      */
-    public Future<AuthorizationResult> requestAuthorization(
+    public @NonNull Future<AuthorizationResult> requestAuthorization(
             final GenericAuthorizationRequest request,
-            final GenericAuthorizationStrategy authorizationStrategy) {
+            final GenericAuthorizationStrategy authorizationStrategy) throws ClientException {
         validateAuthorizationRequest(request);
-        Future<AuthorizationResult> future = null;
-        try {
 
-            // Suppressing unchecked warnings due to casting an object in reference of current class to the child class GenericOAuth2Strategy while calling method requestAuthorization()
-            @SuppressWarnings(WarningType.unchecked_warning)
-            Future<AuthorizationResult> authorizationFuture = authorizationStrategy.requestAuthorization(request, this);
+        // Suppressing unchecked warnings due to casting an object in reference of current class to the child class GenericOAuth2Strategy while calling method requestAuthorization()
+        @SuppressWarnings(WarningType.unchecked_warning)
+        final Future<AuthorizationResult> authorizationFuture = authorizationStrategy.requestAuthorization(request, this);
 
-            future = authorizationFuture;
-        } catch (final UnsupportedEncodingException | ClientException exc) {
-            //TODO
-        }
-
-        return future;
+        return authorizationFuture;
     }
 
     public abstract AuthorizationResultFactory getAuthorizationResultFactory();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
@@ -63,7 +63,6 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
                 parameters.getAuthorizationAgent(),
                 context
         );
-        boolean isBrokerRequest = (parameters instanceof BrokerInteractiveTokenCommandParameters);
 
         if (validatedAuthorizationAgent == AuthorizationAgent.WEBVIEW) {
             Logger.info(TAG, "Use webView for authorization.");
@@ -84,8 +83,7 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
             final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
                     context,
                     parameters.getActivity(),
-                    parameters.getFragment(),
-                    isBrokerRequest
+                    parameters.getFragment()
             );
 
             // Suppressing unchecked warnings due to generic type not provided for parameters
@@ -104,8 +102,7 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
             final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
                     context,
                     parameters.getActivity(),
-                    parameters.getFragment(),
-                    isBrokerRequest
+                    parameters.getFragment()
             );
 
             browserAuthorizationStrategySetBrowserSafeList(browserAuthorizationStrategy, parameters.getBrowserSafeList());

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -59,14 +59,11 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
     private boolean mDisposed;
     private GenericOAuth2Strategy mOAuth2Strategy; //NOPMD
     private GenericAuthorizationRequest mAuthorizationRequest; //NOPMD
-    private boolean mIsRequestFromBroker;
 
     public BrowserAuthorizationStrategy(@NonNull Context applicationContext,
                                         @NonNull Activity activity,
-                                        @Nullable Fragment fragment,
-                                        @NonNull boolean isRequestFromBroker) {
+                                        @Nullable Fragment fragment) {
         super(applicationContext, activity, fragment);
-        mIsRequestFromBroker = isRequestFromBroker;
     }
 
     public void setBrowserSafeList(final List<BrowserDescriptor> browserSafeList) {
@@ -77,7 +74,7 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
     public Future<AuthorizationResult> requestAuthorization(
             GenericAuthorizationRequest authorizationRequest,
             GenericOAuth2Strategy oAuth2Strategy)
-            throws ClientException, UnsupportedEncodingException {
+            throws ClientException {
         final String methodName = ":requestAuthorization";
         checkNotDisposed();
         mOAuth2Strategy = oAuth2Strategy;
@@ -110,17 +107,6 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
         authIntent.setData(requestUrl);
 
         final Intent intent = buildAuthorizationActivityStartIntent(authIntent, requestUrl);
-        // singleTask launchMode is required for the authorization redirect is from an external browser
-        // in the browser authorization flow
-        // For broker request we need to clear all activities in the task and bring Authorization Activity to the
-        // top. If we do not add FLAG_ACTIVITY_CLEAR_TASK, Authorization Activity on finish can land on
-        // Authenticator's or Company Portal's active activity which would be confusing to the user.
-        if(mIsRequestFromBroker) {
-            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-        }else {
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        }
-
         launchIntent(intent);
 
         return mAuthorizationResultFuture;
@@ -130,14 +116,14 @@ public class BrowserAuthorizationStrategy<GenericOAuth2Strategy extends OAuth2St
     @SuppressWarnings(WarningType.unchecked_warning)
     private Intent buildAuthorizationActivityStartIntent(Intent authIntent, Uri requestUrl) {
         return AuthorizationActivity.createStartIntent(
-                    getApplicationContext(),
-                    authIntent,
-                    requestUrl.toString(),
-                    mAuthorizationRequest.getRedirectUri(),
-                    mAuthorizationRequest.getRequestHeaders(),
-                    AuthorizationAgent.BROWSER,
-                    true,
-                    true);
+                getApplicationContext(),
+                authIntent,
+                requestUrl.toString(),
+                mAuthorizationRequest.getRedirectUri(),
+                mAuthorizationRequest.getRequestHeaders(),
+                AuthorizationAgent.BROWSER,
+                true,
+                true);
     }
 
     private void checkNotDisposed() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -75,7 +75,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
      */
     @Override
     public Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
-                                                            GenericOAuth2Strategy oAuth2Strategy) throws UnsupportedEncodingException {
+                                                            GenericOAuth2Strategy oAuth2Strategy) {
         mAuthorizationResultFuture = new ResultFuture<>();
         mOAuth2Strategy = oAuth2Strategy;
         mAuthorizationRequest = authorizationRequest;


### PR DESCRIPTION
1. Do not silently swallow exception in requestAuthorization(),
- I accidentally hit this error when I disabled chrome and re enable it (making the 'emulator browser' the default browser). MSAL throws an NPE on the future object. 
- After debugging, I found out that we only pull 'default browser that ~~supports custom tabs~~ that is in the browser safe list'. 
- In this case, the emulator browser ~~does not support custom tabs~~ is not in the safe list, and chrome is no longer the default browser, so a ClientException with NO_AVAILABLE_BROWSER_FOUND is thrown.
- However, that NO_AVAILABLE_BROWSER_FOUND is silently swallowed. the future object is never set and therefore we hit an NPE down the line.

2. Launch AuthorizationActivity with different flags for broker and non-broker auth
- This is a regression from https://github.com/AzureAD/ad-accounts-for-android/pull/1399, will only happen if MSAL is used inside the broker host app. (ipphone CP is in the progress to consume MSAL).
- AuthorizationActivity has to be launched with Intent.FLAG_ACTIVITY_CLEAR_TASK too, otherwise Authorization Activity on finish can land on the broker host app's activity (if it's in the background).
