### PR TITLE
[IPC part 4] test cases for IPC strategies.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.java
@@ -23,11 +23,45 @@
 
 package com.microsoft.identity.common.exception;
 
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+
+import lombok.Getter;
+
 /**
  * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or AccountManager).
  */
 public class BrokerCommunicationException extends BaseException {
     private static final long serialVersionUID = 4959278068787428329L;
+
+    public enum Category {
+        // The operation is not supported on the client (calling) side of IPC connection.
+        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE("ipc_operation_not_supported_on_client_side"),
+
+        // The operation is not supported on the server (target) side of IPC connection.
+        OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE("ipc_operation_not_supported_on_server_side"),
+
+        // IPC connection failed due to an error.
+        CONNECTION_ERROR("ipc_connection_error");
+
+        final String name;
+
+        Category(@NonNull final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public @NonNull String toString(){
+            return this.name;
+        }
+    }
+
+    @Getter
+    private final Category category;
+
+    @Getter
+    private final IIpcStrategy.Type strategyType;
 
     /**
      * Initiates the {@link BrokerCommunicationException} with error message and throwable.
@@ -35,7 +69,16 @@ public class BrokerCommunicationException extends BaseException {
      * @param errorMessage The error message contained in the exception.
      * @param throwable    The {@link Throwable} contains the cause for the exception.
      */
-    public BrokerCommunicationException(final String errorMessage, final Throwable throwable) {
-        super(ErrorStrings.IO_ERROR, errorMessage, throwable);
+    public BrokerCommunicationException(final Category category,
+                                        final IIpcStrategy.Type strategyType,
+                                        final String errorMessage, final Throwable throwable) {
+        super(category.toString(), errorMessage, throwable);
+        this.category = category;
+        this.strategyType = strategyType;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[" + category.toString() +"] [" +  strategyType.toString() +"] :" + super.getMessage();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAccountServiceClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerAccountServiceClient.java
@@ -32,8 +32,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.aad.adal.IBrokerAccountService;
-import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
 
 /**
  * Client that wraps the code necessary to bind to the a service that implements IBrokerAccountService.aidl
@@ -82,14 +85,18 @@ public class BrokerAccountServiceClient extends BoundServiceClient<IBrokerAccoun
     @Override
     public @Nullable Bundle performOperationInternal(@NonNull BrokerOperationBundle brokerOperationBundle,
                                                      @NonNull IBrokerAccountService brokerAccountService)
-            throws RemoteException, BaseException {
+            throws RemoteException, BrokerCommunicationException {
         final Bundle inputBundle = brokerOperationBundle.getBundle();
         switch (brokerOperationBundle.getOperation()) {
             case BROKER_GET_KEY_FROM_INACTIVE_BROKER:
                 return brokerAccountService.getInactiveBrokerKey(inputBundle);
 
             default:
-                throw new BaseException("Operation not supported. Wrong service bound.");
+                throw new BrokerCommunicationException(
+                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                        BOUND_SERVICE,
+                        "Operation not supported. Wrong BoundServiceClient used.",
+                        null);
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/MicrosoftAuthClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/MicrosoftAuthClient.java
@@ -33,9 +33,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.IMicrosoftAuthService;
-import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
-import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
 
 /**
  * Client that wraps the code necessary to bind to the a service that implements IMicrosoftAuthService.aidl
@@ -72,7 +74,7 @@ public class MicrosoftAuthClient extends BoundServiceClient<IMicrosoftAuthServic
     @Override
     @Nullable Bundle performOperationInternal(@NonNull final BrokerOperationBundle brokerOperationBundle,
                                               @NonNull final IMicrosoftAuthService microsoftAuthService)
-            throws RemoteException, BaseException {
+            throws RemoteException, BrokerCommunicationException {
 
         final Bundle inputBundle = brokerOperationBundle.getBundle();
         switch (brokerOperationBundle.getOperation()) {
@@ -102,7 +104,11 @@ public class MicrosoftAuthClient extends BoundServiceClient<IMicrosoftAuthServic
                 return microsoftAuthService.removeAccountFromSharedDevice(inputBundle);
 
             default:
-                throw new BaseException("Operation not supported. Wrong service bound.");
+                final String errorMessage = "Operation " + brokerOperationBundle.getOperation().name() + " is not supported by MicrosoftAuthClient.";
+                throw new BrokerCommunicationException(
+                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                        BOUND_SERVICE,
+                        errorMessage, null);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
@@ -34,12 +34,14 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.util.ProcessUtil;
 
 import java.io.IOException;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.ACCOUNT_MANAGER_ADD_ACCOUNT;
 
 /**
  * A strategy for communicating with the targeted broker via AccountManager's addAccount().
@@ -60,7 +62,7 @@ public class AccountManagerAddAccountStrategy implements IIpcStrategy {
 
     @Override
     @Nullable public Bundle communicateToBroker(@NonNull final BrokerOperationBundle brokerOperationBundle)
-            throws BaseException {
+            throws BrokerCommunicationException {
         final String methodName = brokerOperationBundle.getOperation().name();
         try {
             final AccountManagerFuture<Bundle> resultBundle =
@@ -78,7 +80,12 @@ public class AccountManagerAddAccountStrategy implements IIpcStrategy {
             return resultBundle.getResult();
         } catch (final AuthenticatorException | IOException | OperationCanceledException e) {
             Logger.error(TAG + methodName, e.getMessage(), e);
-            throw new BrokerCommunicationException("Failed to connect to AccountManager", e);
+            throw new BrokerCommunicationException(CONNECTION_ERROR, getType(), "Failed to connect to AccountManager", e);
         }
+    }
+
+    @Override
+    public Type getType() {
+        return ACCOUNT_MANAGER_ADD_ACCOUNT;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -37,6 +37,10 @@ import com.microsoft.identity.common.internal.logging.Logger;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.ACCOUNT_MANAGER_ADD_ACCOUNT;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
+
 /**
  * An object that acts as a bridge between business logic and communication layer.
  * - Business logic will provide a request bundle, and specify which operation it wants to perform.
@@ -118,7 +122,11 @@ public class BrokerOperationBundle {
             default:
                 final String errorMessage = "Operation " + operation.name() + " is not supported by AccountManager addAccount().";
                 Logger.warn(TAG + methodName, errorMessage);
-                throw new BrokerCommunicationException(errorMessage, null);
+                throw new BrokerCommunicationException(
+                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                        ACCOUNT_MANAGER_ADD_ACCOUNT,
+                        errorMessage,
+                        null);
         }
     }
 
@@ -153,7 +161,11 @@ public class BrokerOperationBundle {
             default:
                 final String errorMessage = "Operation " + operation.name() + " is not supported by ContentProvider.";
                 Logger.warn(TAG + methodName, errorMessage);
-                throw new BrokerCommunicationException(errorMessage, null);
+                throw new BrokerCommunicationException(
+                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                        CONTENT_PROVIDER,
+                        errorMessage,
+                        null);
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
@@ -32,7 +32,6 @@ import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.util.ParcelableUtil;
@@ -41,6 +40,8 @@ import java.util.List;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.AUTHORITY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.CONTENT_SCHEME;
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
 
 /**
  * A strategy for communicating with the targeted broker via Content Provider.
@@ -56,7 +57,7 @@ public class ContentProviderStrategy implements IIpcStrategy {
 
     @Override
     @Nullable public Bundle communicateToBroker(@NonNull BrokerOperationBundle brokerOperationBundle)
-            throws BaseException {
+            throws BrokerCommunicationException {
 
         final String methodName = brokerOperationBundle.getOperation().name();
 
@@ -92,8 +93,13 @@ public class ContentProviderStrategy implements IIpcStrategy {
         } else {
             final String message = "Failed to get result from Broker Content Provider, cursor is null";
             Logger.error(TAG + methodName, message, null);
-            throw new BrokerCommunicationException(message, null);
+            throw new BrokerCommunicationException(CONNECTION_ERROR, getType(), message, null);
         }
+    }
+
+    @Override
+    public Type getType() {
+        return CONTENT_PROVIDER;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/IIpcStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/IIpcStrategy.java
@@ -6,16 +6,41 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 
 /**
  * an interface for inter-process communication strategies.
  */
 public interface IIpcStrategy {
+
+    enum Type {
+        BOUND_SERVICE("bound_service"),
+        ACCOUNT_MANAGER_ADD_ACCOUNT("account_manager_add_account"),
+        CONTENT_PROVIDER("content_provider");
+
+        final String name;
+
+        Type(@NonNull final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public @NonNull String toString() {
+            return this.name;
+        }
+    }
+
     /**
      * Communicates with the target broker.
      *
      * @param bundle a {@link BrokerOperationBundle} object.
      * @return a response bundle (returned from the active broker).
      */
-    @Nullable Bundle communicateToBroker(@NonNull final BrokerOperationBundle bundle) throws BaseException;
+    @Nullable
+    Bundle communicateToBroker(@NonNull final BrokerOperationBundle bundle) throws BrokerCommunicationException;
+
+    /**
+     * Gets this strategy type.
+     */
+    Type getType();
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/brokeroperationexecutor/BrokerOperationExecutorTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/brokeroperationexecutor/BrokerOperationExecutorTests.java
@@ -1,0 +1,352 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.brokeroperationexecutor;
+
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.exception.ServiceException;
+import com.microsoft.identity.common.exception.UserCancelException;
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.controllers.BrokerOperationExecutor;
+import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N})
+public class BrokerOperationExecutorTests {
+
+    final String SERVICE_EXCEPTION_BUNDLE_KEY = "service_exception_key";
+    final String SUCCESS_BUNDLE_KEY = "success_key";
+    final String USER_CANCEL_BUNDLE_KEY = "user_cancel_key";
+
+    final String SERVICE_EXCEPTION_BUNDLE_ERROR_CODE = "service_exception";
+    final String CORRUPTED_BUNDLE_ERROR_CODE = "corrupted_bundle";
+    final String NULL_BUNDLE_ERROR_CODE = "null_bundle";
+
+    final IIpcStrategy.Type MOCK_TYPE = BOUND_SERVICE;
+
+    // No strategy is provided. executor should fail.
+    @Test
+    public void testZeroStrategy() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+
+        expectBindFailureException(strategyList);
+    }
+
+    // Providing 1 strategy and it returns a valid result.
+    @Test
+    public void testOneStrategyWithValidResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithValidResult());
+
+        expectValidResult(strategyList);
+    }
+
+    // Providing 1 strategy and it returns a corrupted result.
+    @Test
+    public void testOneStrategyWithCorruptedResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithCorruptedResult());
+
+        expectCorruptedBundleException(strategyList);
+    }
+
+    // Providing 1 strategy and it returns a service exception result.
+    @Test
+    public void testOneStrategyWithServiceExceptionResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithServiceExceptionResult());
+
+        expectServiceException(strategyList);
+    }
+
+    // Providing 1 strategy and it returns a user cancelled result.
+    @Test
+    public void testOneStrategyWithUserCancelledResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithUserCanceledResult());
+
+        expectUserCancelledException(strategyList);
+    }
+    
+    // Providing 1 strategy and it fails with BrokerCommunicationException inside IIpcStrategy.
+    @Test
+    public void testOneStrategyWithBrokerCommunicationException() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithBrokerCommunicationException());
+
+        expectBindFailureException(strategyList);
+    }
+
+    // Providing 2 strategies and the first one fails with BrokerCommunicationException inside IIpcStrategy.
+    @Test
+    public void testTwoStrategiesWithTheFirstOneThrowingBrokerCommunicationException() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithBrokerCommunicationException());
+        strategyList.add(getStrategyWithValidResult());
+
+        expectValidResult(strategyList);
+    }
+
+    // Providing 2 strategies and the first one returns a corrupted result.
+    // NOTE: This should never happen in real life. broker should return the same values regardless of communication strategy.
+    @Test
+    public void testTwoStrategiesWithTheFirstOneReturningCorruptedResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithCorruptedResult());
+        strategyList.add(getStrategyWithValidResult());
+
+        expectCorruptedBundleException(strategyList);
+    }
+
+    // Providing 2 strategies and the last one failed with BrokerCommunicationException inside IIpcStrategy.
+    @Test
+    public void testTwoStrategiesWithTheLastOneThrowingBrokerCommunicationException() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithValidResult());
+        strategyList.add(getStrategyWithBrokerCommunicationException());
+
+        expectValidResult(strategyList);
+    }
+
+    // Providing 2 strategies and the last one returns a corrupted result.
+    // NOTE: This should never happen in real life. broker should return the same values regardless of communication strategy.
+    @Test
+    public void testTwoStrategiesWithTheLastOneThrowingCorruptedResult() {
+        final List<IIpcStrategy> strategyList = new ArrayList<>();
+        strategyList.add(getStrategyWithValidResult());
+        strategyList.add(getStrategyWithCorruptedResult());
+
+        expectValidResult(strategyList);
+    }
+
+    private void expectValidResult(final List<IIpcStrategy> strategyList) {
+        try {
+            final BrokerOperationExecutor executor = new BrokerOperationExecutor(strategyList);
+            Assert.assertTrue(executor.execute(getMockParameter(), getBrokerOperation()));
+        } catch (final BaseException e) {
+            Assert.fail("Unexpected exception.");
+        }
+    }
+
+    private void expectBindFailureException(final List<IIpcStrategy> strategyList) {
+        try {
+            final BrokerOperationExecutor executor = new BrokerOperationExecutor(strategyList);
+            executor.execute(getMockParameter(), getBrokerOperation());
+            Assert.fail("Failure is expected.");
+        } catch (final BaseException e) {
+            Assert.assertTrue(e instanceof ClientException);
+            Assert.assertEquals(e.getErrorCode(), ErrorStrings.BROKER_BIND_SERVICE_FAILED);
+            Assert.assertEquals(e.getSuppressed().length, strategyList.size());
+        }
+    }
+
+    private void expectCorruptedBundleException(final List<IIpcStrategy> strategyList) {
+        try {
+            final BrokerOperationExecutor executor = new BrokerOperationExecutor(strategyList);
+            executor.execute(getMockParameter(), getBrokerOperation());
+            Assert.fail("Failure is expected.");
+        } catch (final BaseException e) {
+            Assert.assertTrue(e instanceof ClientException);
+            Assert.assertEquals(e.getErrorCode(), CORRUPTED_BUNDLE_ERROR_CODE);
+        }
+    }
+
+    private void expectServiceException(final List<IIpcStrategy> strategyList) {
+        try {
+            final BrokerOperationExecutor executor = new BrokerOperationExecutor(strategyList);
+            executor.execute(getMockParameter(), getBrokerOperation());
+            Assert.fail("Failure is expected.");
+        } catch (final BaseException e) {
+            Assert.assertTrue(e instanceof ServiceException);
+            Assert.assertEquals(e.getErrorCode(), SERVICE_EXCEPTION_BUNDLE_ERROR_CODE);
+        }
+    }
+
+    private void expectUserCancelledException(final List<IIpcStrategy> strategyList) {
+        try {
+            final BrokerOperationExecutor executor = new BrokerOperationExecutor(strategyList);
+            executor.execute(getMockParameter(), getBrokerOperation());
+            Assert.fail("Failure is expected.");
+        } catch (final BaseException e) {
+            Assert.assertTrue(e instanceof UserCancelException);
+        }
+    }
+
+    private CommandParameters getMockParameter() {
+        return CommandParameters.builder().build();
+    }
+
+    private IIpcStrategy getStrategyWithValidResult() {
+        return new IIpcStrategy() {
+            @Override
+            @Nullable
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                final Bundle result = new Bundle();
+                result.putBoolean(SUCCESS_BUNDLE_KEY, true);
+                return result;
+            }
+
+            @Override
+            public Type getType() {
+                return MOCK_TYPE;
+            }
+        };
+    }
+
+    // Gets a bundle back, the bundle contains a valid result.
+    private IIpcStrategy getStrategyWithCorruptedResult() {
+        return new IIpcStrategy() {
+            @Override
+            @Nullable
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                return new Bundle();
+            }
+
+            @Override
+            public Type getType() {
+                return MOCK_TYPE;
+            }
+        };
+    }
+
+    // Gets a bundle back, the bundle contains a service exception result.
+    private IIpcStrategy getStrategyWithServiceExceptionResult() {
+        return new IIpcStrategy() {
+            @Override
+            @Nullable
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                final Bundle result = new Bundle();
+                result.putBoolean(SERVICE_EXCEPTION_BUNDLE_KEY, true);
+                return result;
+            }
+
+            @Override
+            public Type getType() {
+                return MOCK_TYPE;
+            }
+        };
+    }
+
+    // Gets a bundle back, the bundle contains a user cancelled result.
+    private IIpcStrategy getStrategyWithUserCanceledResult() {
+        return new IIpcStrategy() {
+            @Override
+            @Nullable
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                final Bundle result = new Bundle();
+                result.putBoolean(USER_CANCEL_BUNDLE_KEY, true);
+                return result;
+            }
+
+            @Override
+            public Type getType() {
+                return MOCK_TYPE;
+            }
+        };
+    }
+
+    // Fails to get the bundle. (Failure to communicate).
+    private IIpcStrategy getStrategyWithBrokerCommunicationException() {
+        return new IIpcStrategy() {
+            @Override
+            @Nullable
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                throw new BrokerCommunicationException(CONNECTION_ERROR, BOUND_SERVICE, "Some connection error", null);
+            }
+
+            @Override
+            public Type getType() {
+                return MOCK_TYPE;
+            }
+        };
+    }
+
+    // This will throw if the result is corrupted..
+    private BrokerOperationExecutor.BrokerOperation<Boolean> getBrokerOperation() {
+        return new BrokerOperationExecutor.BrokerOperation<Boolean>() {
+            @Override
+            public void performPrerequisites(@NonNull IIpcStrategy strategy) throws BaseException {
+            }
+
+            @Override
+            @NonNull
+            public BrokerOperationBundle getBundle() {
+                return null;
+            }
+
+            @Override
+            @NonNull
+            public Boolean extractResultBundle(@Nullable Bundle resultBundle) throws BaseException {
+                if (resultBundle == null)
+                    throw new ClientException(NULL_BUNDLE_ERROR_CODE);
+                else if (resultBundle.containsKey(SUCCESS_BUNDLE_KEY))
+                    return resultBundle.getBoolean(SUCCESS_BUNDLE_KEY);
+                else if (resultBundle.containsKey(SERVICE_EXCEPTION_BUNDLE_KEY))
+                    throw new ServiceException(SERVICE_EXCEPTION_BUNDLE_ERROR_CODE, null, null);
+                else if (resultBundle.containsKey(USER_CANCEL_BUNDLE_KEY))
+                    throw new UserCancelException();
+                else
+                    throw new ClientException(CORRUPTED_BUNDLE_ERROR_CODE);
+
+            }
+
+            @Override
+            @NonNull
+            public String getMethodName() {
+                return "";
+            }
+
+            @Override
+            @Nullable
+            public String getTelemetryApiId() {
+                return null;
+            }
+
+            @Override
+            public void putValueInSuccessEvent(ApiEndEvent event, Boolean result) {
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerAddAccountStrategyTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerAddAccountStrategyTest.java
@@ -1,0 +1,117 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerAddAccountStrategy;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowAccountManagerAddAccountConnectionFailed;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowAccountManagerAddAccountWithSuccessResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.BROKER_GET_KEY_FROM_INACTIVE_BROKER;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_DEVICE_MODE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_HELLO;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_REMOVE_ACCOUNT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SIGN_OUT_FROM_SHARED_DEVICE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N}, shadows = {ShadowAccountManagerAddAccountWithSuccessResult.class})
+public class AccountManagerAddAccountStrategyTest extends IpcStrategyTests {
+    @Override IIpcStrategy getStrategy() {
+        return new AccountManagerAddAccountStrategy(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    @Override
+    public void testMsalHello() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_HELLO));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetIntentForInteractiveRequest() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST));
+    }
+
+    @Test
+    @Override
+    public void testMsalAcquireTokenSilent() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_ACQUIRE_TOKEN_SILENT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_ACCOUNTS));
+    }
+
+    @Test
+    @Override
+    public void testMsalRemoveAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_REMOVE_ACCOUNT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetDeviceMode() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_DEVICE_MODE));
+    }
+
+    @Test
+    @Override
+    public void testGetCurrentAccountInSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testMsalSignOutFromSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_SIGN_OUT_FROM_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testBrokerGetKeyFromInactiveBroker() {
+        testOperationNotSupportedOnClientSide(getMockRequestBundle(BROKER_GET_KEY_FROM_INACTIVE_BROKER));
+    }
+
+    @Test
+    @Override
+    @Config(shadows = {ShadowAccountManagerAddAccountConnectionFailed.class})
+    public void testIpcFailed() {
+        testIpcConnectionFailed(getMockRequestBundle(MSAL_HELLO));
+    }
+}
+

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerBoundServiceTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerBoundServiceTests.java
@@ -1,0 +1,117 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
+import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientConnectionFailed;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientWithSuccessResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.BROKER_GET_KEY_FROM_INACTIVE_BROKER;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_DEVICE_MODE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_HELLO;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_REMOVE_ACCOUNT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SIGN_OUT_FROM_SHARED_DEVICE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N}, shadows = {ShadowBoundServiceClientWithSuccessResult.class})
+public class AccountManagerBoundServiceTests extends IpcStrategyTests {
+    @Override IIpcStrategy getStrategy() {
+        return new BoundServiceStrategy<>(new MicrosoftAuthClient(ApplicationProvider.getApplicationContext()));
+    }
+
+    @Test
+    @Override
+    public void testMsalHello() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_HELLO));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetIntentForInteractiveRequest() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST));
+    }
+
+    @Test
+    @Override
+    public void testMsalAcquireTokenSilent() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_ACQUIRE_TOKEN_SILENT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_ACCOUNTS));
+    }
+
+    @Test
+    @Override
+    public void testMsalRemoveAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_REMOVE_ACCOUNT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetDeviceMode() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_DEVICE_MODE));
+    }
+
+    @Test
+    @Override
+    public void testGetCurrentAccountInSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testMsalSignOutFromSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_SIGN_OUT_FROM_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testBrokerGetKeyFromInactiveBroker() {
+        testOperationNotSupportedOnClientSide(getMockRequestBundle(BROKER_GET_KEY_FROM_INACTIVE_BROKER));
+    }
+
+    @Test
+    @Override
+    @Config(shadows = {ShadowBoundServiceClientConnectionFailed.class})
+    public void testIpcFailed() {
+        testIpcConnectionFailed(getMockRequestBundle(MSAL_HELLO));
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/ContentProviderStrategyTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/ContentProviderStrategyTests.java
@@ -1,0 +1,116 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowContentResolverConnectionFailed;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowContentResolverWithSuccessResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.BROKER_GET_KEY_FROM_INACTIVE_BROKER;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_DEVICE_MODE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_HELLO;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_REMOVE_ACCOUNT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SIGN_OUT_FROM_SHARED_DEVICE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N}, shadows = {ShadowContentResolverWithSuccessResult.class})
+public class ContentProviderStrategyTests extends IpcStrategyTests {
+    @Override IIpcStrategy getStrategy() {
+        return new ContentProviderStrategy(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    @Override
+    public void testMsalHello() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_HELLO));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetIntentForInteractiveRequest() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST));
+    }
+
+    @Test
+    @Override
+    public void testMsalAcquireTokenSilent() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_ACQUIRE_TOKEN_SILENT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_ACCOUNTS));
+    }
+
+    @Test
+    @Override
+    public void testMsalRemoveAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_REMOVE_ACCOUNT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetDeviceMode() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_DEVICE_MODE));
+    }
+
+    @Test
+    @Override
+    public void testGetCurrentAccountInSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testMsalSignOutFromSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_SIGN_OUT_FROM_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testBrokerGetKeyFromInactiveBroker() {
+        testOperationNotSupportedOnClientSide(getMockRequestBundle(BROKER_GET_KEY_FROM_INACTIVE_BROKER));
+    }
+
+    @Test
+    @Override
+    @Config(shadows = {ShadowContentResolverConnectionFailed.class})
+    public void testIpcFailed() {
+        testIpcConnectionFailed(getMockRequestBundle(MSAL_HELLO));
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/IpcStrategyTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/IpcStrategyTests.java
@@ -1,0 +1,146 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.os.BaseBundle;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.util.ObjectUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE;
+
+/**
+ * IMPORTANT: This class must cover EVERY {@link com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation}.
+ */
+public abstract class IpcStrategyTests {
+
+    abstract IIpcStrategy getStrategy();
+
+    @Test
+    public abstract void testMsalHello();
+
+    @Test
+    public abstract void testMsalGetIntentForInteractiveRequest();
+
+    @Test
+    public abstract void testMsalAcquireTokenSilent();
+
+    @Test
+    public abstract void testMsalGetAccounts();
+
+    @Test
+    public abstract void testMsalRemoveAccounts();
+
+    @Test
+    public abstract void testMsalGetDeviceMode();
+
+    @Test
+    public abstract void testGetCurrentAccountInSharedDevice();
+
+    @Test
+    public abstract void testMsalSignOutFromSharedDevice();
+
+    @Test
+    public abstract void testBrokerGetKeyFromInactiveBroker();
+
+    @Test
+    public abstract void testIpcFailed();
+
+    protected BrokerOperationBundle getMockRequestBundle(final BrokerOperationBundle.Operation operation) {
+        final Bundle bundle = new Bundle();
+        bundle.putBoolean("REQUEST_BUNDLE", true);
+
+        return new BrokerOperationBundle(operation, "MOCK_BROKER", bundle);
+    }
+
+    public static Bundle getMockIpcResultBundle() {
+        final Bundle bundle = new Bundle();
+        bundle.putBoolean("MOCK_SUCCESS", true);
+        return bundle;
+    }
+
+    protected void testOperationSucceeds(@NonNull final BrokerOperationBundle bundle) {
+        final IIpcStrategy strategy = getStrategy();
+        try {
+            final Bundle resultBundle = strategy.communicateToBroker(bundle);
+            Assert.assertTrue(isBundleEqual(resultBundle, getMockIpcResultBundle()));
+        } catch (BaseException e) {
+            Assert.fail("Exception is not expected.");
+        }
+    }
+
+    protected void testOperationNotSupportedOnClientSide(@NonNull final BrokerOperationBundle bundle) {
+        final IIpcStrategy strategy = getStrategy();
+        try {
+            strategy.communicateToBroker(bundle);
+            Assert.fail("Operation should fail.");
+        } catch (BaseException e) {
+            Assert.assertTrue(e instanceof BrokerCommunicationException);
+            Assert.assertSame(((BrokerCommunicationException) e).getCategory(), OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE);
+            Assert.assertSame(((BrokerCommunicationException) e).getStrategyType(), strategy.getType());
+        }
+    }
+
+    protected void testIpcConnectionFailed(@NonNull final BrokerOperationBundle bundle) {
+        final IIpcStrategy strategy = getStrategy();
+        try {
+            strategy.communicateToBroker(bundle);
+            Assert.fail("Operation should fail.");
+        } catch (BaseException e) {
+            Assert.assertTrue(e instanceof BrokerCommunicationException);
+            Assert.assertSame(((BrokerCommunicationException) e).getCategory(), CONNECTION_ERROR);
+            Assert.assertSame(((BrokerCommunicationException) e).getStrategyType(), strategy.getType());
+        }
+    }
+
+    public static boolean isBundleEqual(@NonNull final Bundle resultBundle,
+                                        @NonNull final Bundle expectedBundle) {
+
+        if (resultBundle.size() != expectedBundle.size()) {
+            return false;
+        }
+
+        for (final String key : resultBundle.keySet()) {
+            final Object objA = expectedBundle.get(key);
+            final Object objB = resultBundle.get(key);
+
+            if (objA instanceof Bundle && objB instanceof Bundle) {
+                return isBundleEqual((Bundle) objA, (Bundle) objB);
+            } else if (!ObjectUtils.equals(objA, objB)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountConnectionFailed.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountConnectionFailed.java
@@ -1,0 +1,68 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Implements(AccountManager.class)
+public class ShadowAccountManagerAddAccountConnectionFailed {
+
+    public AccountManagerFuture<Bundle> addAccount(final String accountType,
+                                                   final String authTokenType, final String[] requiredFeatures,
+                                                   final Bundle addAccountOptions,
+                                                   final Activity activity, AccountManagerCallback<Bundle> callback, Handler handler) {
+        return new AccountManagerFuture<Bundle>() {
+            @Override public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override public boolean isCancelled() {
+                return true;
+            }
+
+            @Override public boolean isDone() {
+                return false;
+            }
+
+            @Override public Bundle getResult() throws AuthenticatorException, IOException, OperationCanceledException {
+                throw new AuthenticatorException("Failed to bind");
+            }
+
+            @Override public Bundle getResult(long timeout, TimeUnit unit) throws AuthenticatorException, IOException, OperationCanceledException {
+                throw new AuthenticatorException("Failed to bind");
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountWithSuccessResult.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountWithSuccessResult.java
@@ -1,0 +1,70 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Implements(AccountManager.class)
+public class ShadowAccountManagerAddAccountWithSuccessResult {
+
+    public AccountManagerFuture<Bundle> addAccount(final String accountType,
+                                                   final String authTokenType, final String[] requiredFeatures,
+                                                   final Bundle addAccountOptions,
+                                                   final Activity activity, AccountManagerCallback<Bundle> callback, Handler handler) {
+        return new AccountManagerFuture<Bundle>() {
+            @Override public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override public boolean isCancelled() {
+                return false;
+            }
+
+            @Override public boolean isDone() {
+                return true;
+            }
+
+            @Override public Bundle getResult() throws AuthenticatorException, IOException, OperationCanceledException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle getResult(long timeout, TimeUnit unit) throws AuthenticatorException, IOException, OperationCanceledException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientConnectionFailed.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientConnectionFailed.java
@@ -1,0 +1,43 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.os.IInterface;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.broker.BoundServiceClient;
+
+import org.robolectric.annotation.Implements;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+@Implements(BoundServiceClient.class)
+public class ShadowBoundServiceClientConnectionFailed<T extends IInterface> {
+    protected @NonNull T connect(@NonNull final String targetServicePackageName)
+            throws ClientException, InterruptedException, TimeoutException, ExecutionException {
+        throw new TimeoutException("Connection timed out");
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithSuccessResult.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithSuccessResult.java
@@ -1,0 +1,89 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.broker.BoundServiceClient;
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+@Implements(BoundServiceClient.class)
+public class ShadowBoundServiceClientWithSuccessResult<T extends IInterface> {
+    protected @NonNull T connect(@NonNull final String targetServicePackageName)
+            throws ClientException, InterruptedException, TimeoutException, ExecutionException {
+        final IMicrosoftAuthService authService = new IMicrosoftAuthService() {
+            @Override public IBinder asBinder() {
+                return null;
+            }
+
+            @Override public Bundle hello(Bundle bundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle getAccounts(Bundle bundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle acquireTokenSilently(Bundle requestBundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Intent getIntentForInteractiveRequest() throws RemoteException {
+                final Intent intent = new Intent();
+                intent.putExtras(IpcStrategyTests.getMockIpcResultBundle());
+                return intent;
+            }
+
+            @Override public Bundle removeAccount(Bundle bundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle getDeviceMode() throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle getCurrentAccount(Bundle bundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle removeAccountFromSharedDevice(Bundle bundle) throws RemoteException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+        };
+
+        return (T) authService;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowContentResolverConnectionFailed.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowContentResolverConnectionFailed.java
@@ -1,0 +1,42 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(ContentResolver.class)
+public class ShadowContentResolverConnectionFailed {
+    public final @Nullable Cursor query(@RequiresPermission.Read @NonNull Uri uri,
+                                        @Nullable String[] projection, @Nullable String selection,
+                                        @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowContentResolverWithSuccessResult.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowContentResolverWithSuccessResult.java
@@ -1,0 +1,55 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.content.ContentResolver;
+import android.database.CharArrayBuffer;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.database.DataSetObserver;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
+
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(ContentResolver.class)
+public class ShadowContentResolverWithSuccessResult {
+    public final @Nullable Cursor query(@RequiresPermission.Read @NonNull Uri uri,
+                                        @Nullable String[] projection, @Nullable String selection,
+                                        @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+
+        return new MatrixCursor(new String[0]) {
+            @Override
+            public Bundle getExtras() {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+        };
+    }
+}


### PR DESCRIPTION
part 1: #1088
part 2: #1090
part 3: #1092 

- Add test cases that covers the 3 IPC strategies.
    - Also add enum 'Type' in BrokerCommunicationException.
- Add test cases to cover BrokerOperationExecutor
    - Also change the thrown exception type of IIpcStrategy.communicateToBroker() from BaseException to BrokerCommunicationException (make it more specific).
- ~~exclude 'asm' module in org.robolectric:robolectric~~ Issue only shows up in Android Studio 4.1, will figure it out later.
   - nimbus-jose-jwt is using asm 5.0.4, while Robolectric uses 7.0