### PR TITLE
Clean up tokens after writing the new one, to avoid having cache momentarily empty of RTs

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -311,15 +311,11 @@ public class MsalOAuth2TokenCache
                 idTokenToSave
         );
 
-        // remove old refresh token if it's MRRT or FRT
-        // removeRefreshTokenIfNeeded(accountToSave, refreshTokenToSave);
-
         // Save the Account and Credentials...
         saveAccounts(accountToSave);
         saveCredentialsInternal(accessTokenToSave, refreshTokenToSave, idTokenToSave);
 
-        // Add a new method, where we delete all of the refresh tokens in the cache
-        // except for the one that we just created....
+        // Remove old refresh tokens (except for the one we just saved) if it's MRRT or FRT
         removeAllRefreshTokensExcept(accountToSave, refreshTokenToSave);
 
         final CacheRecord result = new CacheRecord();

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -409,7 +409,7 @@ public class MsalOAuth2TokenCache
                 CredentialType.RefreshToken,
                 accountRecord,
                 true,
-                deletionExemptRefreshTokenRecord
+                deletionExemptRefreshTokenRecord // The RT we want to preserve
         );
     }
 
@@ -448,6 +448,7 @@ public class MsalOAuth2TokenCache
                 );
 
         for (final Credential credentialToRemove : credentialsToRemove) {
+            // Do not delete the record, if it is the supplied exempted Credential.
             if (!deletionExemptRecord.equals(credentialToRemove)
                     && mAccountCredentialCache.removeCredential(credentialToRemove)) {
                 credentialsRemoved++;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1811,6 +1811,9 @@ public class MsalOAuth2TokenCache
                 idToken
         );
 
+        saveAccounts(accountDto);
+        saveCredentialsInternal(idToken, rt);
+
         final boolean isFamilyRefreshToken = !StringExtensions.isNullOrBlank(
                 refreshToken.getFamilyId()
         );
@@ -1820,12 +1823,12 @@ public class MsalOAuth2TokenCache
         );
 
         if (isFamilyRefreshToken || isMultiResourceCapable) {
-            // TODO Consider updating this method for Teams' fix
-            final int refreshTokensRemoved = removeRefreshTokensForAccount(
+            final int refreshTokensRemoved = removeRefreshTokensForAccountExcept(
                     accountDto,
                     isFamilyRefreshToken,
                     accountDto.getEnvironment(),
-                    rt.getClientId()
+                    rt.getClientId(),
+                    rt
             );
 
             Logger.info(
@@ -1840,9 +1843,6 @@ public class MsalOAuth2TokenCache
                 );
             }
         }
-
-        saveAccounts(accountDto);
-        saveCredentialsInternal(idToken, rt);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -328,11 +328,11 @@ public class MsalOAuth2TokenCache
     }
 
     private void removeAllRefreshTokensExcept(@NonNull final AccountRecord accountRecord,
-                                              @NonNull final RefreshTokenRecord refreshTokenRecord) {
+                                              @NonNull final RefreshTokenRecord deletionExemptRefreshToken) {
         // Delete all of the refresh tokens associated with this account, except for the provided one
         final String methodName = ":removeAllRefreshTokensExcept";
         final boolean isFamilyRefreshToken = !StringExtensions.isNullOrBlank(
-                refreshTokenRecord.getFamilyId()
+                deletionExemptRefreshToken.getFamilyId()
         );
 
         Logger.info(
@@ -351,14 +351,14 @@ public class MsalOAuth2TokenCache
 
         if (isFamilyRefreshToken || isMultiResourceCapable) {
             final String environment = accountRecord.getEnvironment();
-            final String clientId = refreshTokenRecord.getClientId();
+            final String clientId = deletionExemptRefreshToken.getClientId();
 
             final int refreshTokensRemoved = removeRefreshTokensForAccountExcept(
                     accountRecord,
                     isFamilyRefreshToken,
                     environment,
                     clientId,
-                    refreshTokenRecord
+                    deletionExemptRefreshToken
             );
 
             Logger.info(

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -327,6 +327,13 @@ public class MsalOAuth2TokenCache
         return result;
     }
 
+    /**
+     * Removes the refresh tokens in the cache for the provided {@link AccountRecord}; will not
+     * remove the deletionExempt credential.
+     *
+     * @param accountRecord              The AccountRecord for which RTs should be removed.
+     * @param deletionExemptRefreshToken The RT record we wish to exempt from deletion.
+     */
     private void removeAllRefreshTokensExcept(@NonNull final AccountRecord accountRecord,
                                               @NonNull final RefreshTokenRecord deletionExemptRefreshToken) {
         // Delete all of the refresh tokens associated with this account, except for the provided one


### PR DESCRIPTION
Because shared preferences is not atomic like a database, there is a moment between cleaning up old RTs and writing new ones where the cache may contain no RTs for a given account. If, for whatever reason, the app were to crash or otherwise stop execution in this state, `getAccounts()` would return "no accounts" for subsequent calls, as the RT is required to acquire tokens for a user.

This change reorders the writing and deletion of credentials such that new credentials are written before the old ones are cleaned up. In the event that multiple RTs exist on disk, they will be removed from the cache upon next call to `save()`