### PR TITLE
Hello() cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ vNext
     - [Part 4] test cases for IPC strategies (#1093)
     - [Part 5.5] make changes to support the Broker API work (#1101)
 - Make change to support Broker API's updateBrokerRT() functionality (#1107).
+- Introduce a cache for Hello() protocol (#1108)
 
 Version 3.0.4
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -645,9 +645,19 @@ public final class AuthenticationConstants {
         public static final String BROKER_ACTIVITY_NAME = "broker.activity.name";
 
         /**
+         * The Msal-To-Broker protocol name.
+         */
+        public static final String MSAL_TO_BROKER_PROTOCOL_NAME = "msal.to.broker";
+
+        /**
          * The newest Msal-To-Broker protocol version.
          */
         public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "5.0";
+
+        /**
+         * The BrokerAPI-To-Broker protocol name.
+         */
+        public static final String BROKER_API_TO_BROKER_PROTOCOL_NAME = "broker.api.to.broker";
 
         /**
          * The newest BrokerAPI-To-Broker protocol version.

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
@@ -1,0 +1,168 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.cache;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.microsoft.identity.common.internal.logging.Logger;
+
+/**
+ * Persisted cache for the IPC hello() protocol.
+ * Use client's protocol version and the targeted app's package name and app version as a key
+ * to cache the negotiated protocol version.
+ * <p>
+ * This means a new hello() call will ONLY be triggered only when.
+ * 1. IPC operation is invoked for the very first time.
+ * 2. Client bumps up protocol version.
+ * 3. The targeted app is updated, uninstalled, reinstalled.
+ */
+public class HelloCache {
+    private static final String TAG = HelloCache.class.getSimpleName();
+
+    private static final String SHARED_PREFERENCE_NAME = "com.microsoft.common.ipc.hello.cache";
+
+    private final SharedPreferencesFileManager mFileManager;
+    private final Context mContext;
+    private final String mProtocolName;
+    private final String mTargetAppPackageName;
+    private static boolean sIsEnabled = true;
+
+    /**
+     * If set to false, Hello cache will be disabled.
+     * When you're developing protocol change, you might not want the cache to be enabled.
+     * <p>
+     * For debugging only.
+     */
+    public static void setIsEnabled(final boolean value) {
+        synchronized (HelloCache.class) {
+            sIsEnabled = value;
+        }
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param context              application context.
+     * @param protocolName         name of the protocol that invokes hello().
+     * @param targetAppPackageName package name of the app that this client will hello() with.
+     */
+    public HelloCache(final @NonNull Context context,
+                      final @NonNull String protocolName,
+                      final @NonNull String targetAppPackageName) {
+        mFileManager = new SharedPreferencesFileManager(context, SHARED_PREFERENCE_NAME);
+        mContext = context;
+        mProtocolName = protocolName;
+        mTargetAppPackageName = targetAppPackageName;
+    }
+
+    /**
+     * Gets the cached negotiated protocol version. Returns null if there is none.
+     *
+     * @param clientMinimumProtocolVersion minimum version of the protocol that the client supports.
+     * @param clientMaximumProtocolVersion maximum version of the protocol that to be advertised by the client.
+     */
+    public @Nullable String tryGetNegotiatedProtocolVersion(final @Nullable String clientMinimumProtocolVersion,
+                                                            final @NonNull String clientMaximumProtocolVersion) {
+        final String methodName = ":tryGetNegotiatedProtocolVersion";
+
+        if (!sIsEnabled) {
+            Logger.infoPII(TAG + methodName, "hello cache is not enabled.");
+            return null;
+        }
+
+        final String key;
+        try {
+            key = getNegotiatedProtocolVersionCacheKey(clientMinimumProtocolVersion, clientMaximumProtocolVersion);
+        } catch (final PackageManager.NameNotFoundException e) {
+            Logger.error(TAG + methodName, "Failed to retrieve key", e);
+            return null;
+        }
+
+        return mFileManager.getString(key);
+    }
+
+    /**
+     * Store the given negotiated protocol version into the cache.
+     *
+     * @param clientMinimumProtocolVersion minimum version of the protocol that the client supports.
+     * @param clientMaximumProtocolVersion maximum version of the protocol that to be advertised by the client.
+     * @param negotiatedProtocolVersion    the negotiated protocol version as returned from hello().
+     */
+    public void saveNegotiatedProtocolVersion(final @Nullable String clientMinimumProtocolVersion,
+                                              final @NonNull String clientMaximumProtocolVersion,
+                                              final @NonNull String negotiatedProtocolVersion) {
+        final String methodName = ":saveNegotiatedProtocolVersion";
+
+        if (!sIsEnabled) {
+            Logger.infoPII(TAG + methodName, "hello cache is not enabled.");
+            return;
+        }
+
+        final String key;
+        try {
+            key = getNegotiatedProtocolVersionCacheKey(clientMinimumProtocolVersion, clientMaximumProtocolVersion);
+        } catch (final PackageManager.NameNotFoundException e) {
+            Logger.error(TAG + methodName, "Failed to retrieve key", e);
+            return;
+        }
+
+        mFileManager.putString(key, negotiatedProtocolVersion);
+    }
+
+    /**
+     * Generates {@link SharedPreferencesFileManager}'s s cache key for the negotiated protocol version.
+     *
+     * @param clientMinimumProtocolVersion minimum version of the protocol that the client supports.
+     * @param clientMaximumProtocolVersion maximum version of the protocol that to be advertised by the client.
+     */
+    private @NonNull String getNegotiatedProtocolVersionCacheKey(final @Nullable String clientMinimumProtocolVersion,
+                                                                 final @NonNull String clientMaximumProtocolVersion)
+            throws PackageManager.NameNotFoundException {
+        return mProtocolName +
+                "[" + clientMinimumProtocolVersion + "," + clientMaximumProtocolVersion + "]:"
+                + mTargetAppPackageName + "[" + getVersionCode() + "]";
+    }
+
+    @VisibleForTesting
+    public void clearCache() {
+        mFileManager.clear();
+    }
+
+    @VisibleForTesting
+    public @NonNull String getVersionCode() throws PackageManager.NameNotFoundException {
+        final PackageInfo packageInfo = mContext.getPackageManager().getPackageInfo(mTargetAppPackageName, 0);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return String.valueOf(packageInfo.getLongVersionCode());
+        } else {
+            return String.valueOf(packageInfo.versionCode);
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
@@ -1,0 +1,235 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.cache.HelloCache;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.common.internal.util.StringUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N})
+public class HelloCacheTests {
+
+    public static String protocolA = "MOCK_PROTOCOL_A";
+    public static String protocolB = "MOCK_PROTOCOL_B";
+    public static String brokerAppName = "MOCK_BROKER_APP_NAME";
+    public static String appVersion = "1.0";
+    public static String newAppVersion = "2.0";
+
+    @After
+    public void cleanUp() {
+        getHelloCache(protocolA).clearCache();
+        getHelloCache(protocolB).clearCache();
+    }
+
+    @Test
+    public void testReadWrite() {
+        final HelloCache cacheWrite = getHelloCache(protocolA);
+        final HelloCache cacheRead = getHelloCache(protocolA);
+
+        final String minimumVer = "1.0";
+        final String maximumVer = "2.5";
+        final String negotiatedVer = "2.0";
+
+        cacheWrite.saveNegotiatedProtocolVersion(minimumVer, maximumVer, negotiatedVer);
+        Assert.assertEquals(cacheRead.tryGetNegotiatedProtocolVersion(minimumVer, maximumVer), negotiatedVer);
+    }
+
+    @Test
+    public void testReadAfterUpdateMinVersion() {
+        final HelloCache cacheWrite = getHelloCache(protocolA);
+        final HelloCache cacheRead = getHelloCache(protocolA);
+
+        final String minimumVer = "1.0";
+        final String maximumVer = "2.5";
+        final String negotiatedVer = "2.0";
+
+        final String newMinimumVer = "1.2";
+
+        cacheWrite.saveNegotiatedProtocolVersion(minimumVer, maximumVer, negotiatedVer);
+        Assert.assertNull(cacheRead.tryGetNegotiatedProtocolVersion(newMinimumVer, maximumVer));
+    }
+
+    @Test
+    public void testReadAfterUpdateMaxVersion() {
+        final HelloCache cacheWrite = getHelloCache(protocolA);
+        final HelloCache cacheRead = getHelloCache(protocolA);
+
+        final String minimumVer = "1.0";
+        final String maximumVer = "2.5";
+        final String negotiatedVer = "2.0";
+
+        final String newMaximumVer = "2.7";
+
+        cacheWrite.saveNegotiatedProtocolVersion(minimumVer, maximumVer, negotiatedVer);
+        Assert.assertNull(cacheRead.tryGetNegotiatedProtocolVersion(minimumVer, newMaximumVer));
+    }
+
+    @Test
+    public void testReadForProtocolAAfterWritingForProtocolB() {
+        final HelloCache cacheProtocolA = getHelloCache(protocolA);
+        final HelloCache cacheProtocolB = getHelloCache(protocolB);
+
+        final String minimumVerProtocolA = "1.0";
+        final String maximumVerProtocolA = "2.5";
+        final String negotiatedVerProtocolA = "2.0";
+
+        final String minimumVerProtocolB = "100.0";
+        final String maximumVerProtocolB = "200.5";
+        final String negotiatedVerProtocolB = "200.0";
+
+        cacheProtocolA.saveNegotiatedProtocolVersion(minimumVerProtocolA, maximumVerProtocolA, negotiatedVerProtocolA);
+        cacheProtocolB.saveNegotiatedProtocolVersion(minimumVerProtocolB, maximumVerProtocolB, negotiatedVerProtocolB);
+
+        Assert.assertEquals(cacheProtocolA.tryGetNegotiatedProtocolVersion(minimumVerProtocolA, maximumVerProtocolA), negotiatedVerProtocolA);
+        Assert.assertNull(cacheProtocolA.tryGetNegotiatedProtocolVersion(minimumVerProtocolB, maximumVerProtocolB));
+
+        Assert.assertEquals(cacheProtocolB.tryGetNegotiatedProtocolVersion(minimumVerProtocolB, maximumVerProtocolB), negotiatedVerProtocolB);
+        Assert.assertNull(cacheProtocolB.tryGetNegotiatedProtocolVersion(minimumVerProtocolA, maximumVerProtocolA));
+    }
+
+    @Test
+    public void testReadAfterUpdateTargetApp() {
+        final HelloCache cacheBeforeUpdate = getHelloCache(protocolA);
+        final String minimumVer = "1.0";
+        final String maximumVer = "2.5";
+        final String negotiatedVer = "2.0";
+
+        cacheBeforeUpdate.saveNegotiatedProtocolVersion(minimumVer, maximumVer, negotiatedVer);
+
+        final HelloCache cacheAfterUpdate = getHelloCache(protocolA, newAppVersion);
+        Assert.assertNull(cacheAfterUpdate.tryGetNegotiatedProtocolVersion(minimumVer, maximumVer));
+    }
+
+    @Test
+    public void testReadAfterTargetAppUninstalled() {
+        final HelloCache cacheBeforeUninstall = getHelloCache(protocolA);
+        final String minimumVer = "1.0";
+        final String maximumVer = "2.5";
+        final String negotiatedVer = "2.0";
+
+        cacheBeforeUninstall.saveNegotiatedProtocolVersion(minimumVer, maximumVer, negotiatedVer);
+
+        final HelloCache cacheAfterUninstall = getHelloCache(protocolA, null);
+        Assert.assertNull(cacheAfterUninstall.tryGetNegotiatedProtocolVersion(minimumVer, maximumVer));
+    }
+
+    @Test
+    public void testHelloShouldOnlyTriggerOnce() {
+
+        final String minimumVer = "1.0";
+        final String negotiatedVer = "2.5";
+
+        class MockStrategy implements IIpcStrategy {
+            int triggered = 0;
+
+            @Nullable @Override public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                triggered += 1;
+                if (triggered == 2) {
+                    Assert.fail("Should never be triggered");
+                }
+
+                final Bundle resultBundle = new Bundle();
+                resultBundle.putString(NEGOTIATED_BP_VERSION_KEY, negotiatedVer);
+                return resultBundle;
+            }
+
+            @Override public Type getType() {
+                return Type.CONTENT_PROVIDER;
+            }
+        }
+
+        class MockController extends BrokerMsalController {
+            public MockController(Context applicationContext) {
+                super(applicationContext);
+            }
+
+            @Override
+            public HelloCache getHelloCache() {
+                return HelloCacheTests.this.getHelloCache(protocolA);
+            }
+
+            @Override public String getActiveBrokerPackageName() {
+                return brokerAppName;
+            }
+        }
+
+        final MockController controller = new MockController(ApplicationProvider.getApplicationContext());
+        final MockStrategy strategy = new MockStrategy();
+        final CommandParameters parameters = CommandParameters.builder().requiredBrokerProtocolVersion(minimumVer).build();
+
+        try {
+            final String negotiatedProtocolVersion = controller.hello(strategy, parameters);
+            final String negotiatedProtocolVersion2 = controller.hello(strategy, parameters);
+            Assert.assertEquals(negotiatedProtocolVersion, negotiatedProtocolVersion2);
+        } catch (BaseException e) {
+            Assert.fail();
+        }
+    }
+
+    private HelloCache getHelloCache(@NonNull final String protocol) {
+        return getHelloCache(protocol, appVersion);
+    }
+
+    private HelloCache getHelloCache(@NonNull final String protocol,
+                                     @Nullable final String appVersionCode) {
+
+        class HelloCacheMock extends HelloCache {
+            public HelloCacheMock(@NonNull Context context, @NonNull String protocolName, @NonNull String targetAppPackageName) {
+                super(context, protocolName, targetAppPackageName);
+            }
+
+            @NonNull @Override public String getVersionCode() throws PackageManager.NameNotFoundException {
+                if (StringUtil.isEmpty(appVersionCode)) {
+                    throw new PackageManager.NameNotFoundException("error!");
+                }
+                return appVersionCode;
+            }
+        }
+
+        return new HelloCacheMock(ApplicationProvider.getApplicationContext(), protocol, brokerAppName);
+    }
+}


### PR DESCRIPTION
**Changes**
Introduces a cache for cutting down the amount of redundant hello().

It can be deduced that a negotiated protocol version ***might*** change when one (or more) the following criteria changes.
1. The client (app) bumps minimum version support in config file 
2. The client (MSAL) bumps maximum/curent protocol version.
3. When the targeted broker app changes 
   (i.e. Authenticator app is uninstalled and CP became the new broker)
4. When the targeted app is updated.
   - We do not have an access to the actual protocol version the broker supports - it might or might not be the same, so we make sure nothing breaks by re-negotiating.

This cache will use all the following criterias to create a key - for storing negotiated protocol version in SharedPref.

This should cut the amount of hello() down to lower single digit ***per month***.

I also integrate the cache with BrokerMsalController in this PR.