### PR TITLE
Revert #1087, Subclass AuthorizationActivity in :auth process

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
@@ -46,7 +46,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
 
-public final class AuthorizationActivity extends DualScreenActivity {
+public class AuthorizationActivity extends DualScreenActivity {
 
     private AuthorizationFragment mFragment;
 
@@ -58,15 +58,11 @@ public final class AuthorizationActivity extends DualScreenActivity {
                                            final AuthorizationAgent authorizationAgent,
                                            final boolean webViewZoomEnabled,
                                            final boolean webViewZoomControlsEnabled) {
-        final Intent intent = new Intent(context, AuthorizationActivity.class);
-
-        // For broker request we need to clear all activities in the task and bring Authorization Activity to the
-        // top. If we do not add FLAG_ACTIVITY_CLEAR_TASK, Authorization Activity on finish can land on
-        // Authenticator's or Company Portal's active activity which would be confusing to the user.
+        Intent intent;
         if (ProcessUtil.isBrokerProcess(context)) {
-            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent = new Intent(context, BrokerAuthorizationActivity.class);
         } else {
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent = new Intent(context, AuthorizationActivity.class);
         }
 
         intent.putExtra(AUTH_INTENT, authIntent);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrokerAuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrokerAuthorizationActivity.java
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.providers.oauth2;
+
+/**
+ * Declares as a separate class so that we can specify attributes exclusively to :auth process
+ * in AndroidManifest without overriding MSAL's (In case where MSAL and broker is shipped together).
+ */
+public class BrokerAuthorizationActivity extends AuthorizationActivity {
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AuthorizationStrategyFactory.java
@@ -64,6 +64,8 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
                 context
         );
 
+        boolean isBrokerRequest = (parameters instanceof BrokerInteractiveTokenCommandParameters);
+
         if (validatedAuthorizationAgent == AuthorizationAgent.WEBVIEW) {
             Logger.info(TAG, "Use webView for authorization.");
             return getGenericAuthorizationStrategy(parameters, context);
@@ -83,7 +85,8 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
             final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
                     context,
                     parameters.getActivity(),
-                    parameters.getFragment()
+                    parameters.getFragment(),
+                    isBrokerRequest
             );
 
             // Suppressing unchecked warnings due to generic type not provided for parameters
@@ -102,7 +105,8 @@ public class AuthorizationStrategyFactory<GenericAuthorizationStrategy extends A
             final BrowserAuthorizationStrategy browserAuthorizationStrategy = new BrowserAuthorizationStrategy(
                     context,
                     parameters.getActivity(),
-                    parameters.getFragment()
+                    parameters.getFragment(),
+                    isBrokerRequest
             );
 
             browserAuthorizationStrategySetBrowserSafeList(browserAuthorizationStrategy, parameters.getBrowserSafeList());


### PR DESCRIPTION
Fix a regression in JoinActivity.

**Background**
- CP will be shipping MSAL with Broker, and they ran into a weird issue.
- What happened was that ad-accounts declares in the manifest that AuthorizationActivity will be run **exclusively** in :auth process. This means the non-broker auth MSAL will never get the response back... since the authentication happens in :auth process, and it was waiting for the result on the main process.
- I tried to fix the issue by making AuthorizationActivity runs on multiple processes (https://github.com/AzureAD/ad-accounts-for-android/pull/1399), side effect of this is that if Authenticator/CP is running in the background, once the AuthorizationActivity is popped from the back stack, those activity of Authenticator/CP is next in line. 
- I mitigated this issue in #1087 (which is what Browser flow in Broker - exclusively to COBO - is doing), by clearing related activity that might be in the Task/stack when launching an activity (Intent.FLAG_ACTIVITY_CLEAR_TASK).
- This introduces a regression in JoinActivity - being in :auth process also, Intent.FLAG_ACTIVITY_CLEAR_TASK also kills JoinActivity.

**Changes**
1. Undo the changes in #1087. Move back the Intent.FLAG_ACTIVITY_CLEAR_TASK logic to Browser flow only.
2. Subclasses AuthorizationActivity (BrokerAuthorizationActivity), so that we can force this process to run on :auth without messing up with MSAL local flow.

related broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1421/files