### PR TITLE
Get sdk version from ADAL request

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/AdalBrokerRequestAdapter.java
@@ -159,6 +159,7 @@ public class AdalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .activity(callingActivity)
                 .androidApplicationContext(callingActivity.getApplicationContext())
                 .sdkType(SdkType.ADAL)
+                .sdkVersion(intent.getStringExtra(AuthenticationConstants.Broker.ADAL_VERSION_KEY))
                 .callerUid(callingAppUid)
                 .callerPackageName(getPackageNameFromBundle(
                         intent.getExtras(), callingActivity.getApplicationContext()


### PR DESCRIPTION
**Problem**
- We recently made a change in Broker to send the actual ADAL/MSAL version to eSTS via query parameter x-client-ver (it used to be hardcoded).
- We forgot to make the change in AdalBrokerRequestAdapter, so sdkVersion is never set.
- We ended up sending a request **without** it, and this triggers a weird behavior in MAM flow (see below - we should be seeing the WPJ register page)

<img width="441" alt="Screen Shot 2020-11-06 at 4 15 02 PM" src="https://user-images.githubusercontent.com/19558668/98348410-4b20aa00-204b-11eb-98ae-9c103ca3f612.png">

