### PR TITLE
Fix sdk version not being set when ADAL used with Broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
@@ -23,8 +23,11 @@
 package com.microsoft.identity.common.internal.platform;
 
 import android.os.Build;
+import android.text.TextUtils;
 
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
@@ -40,6 +43,11 @@ import java.util.Map;
 public final class Device {
 
     private static IDevicePopManager sDevicePoPManager;
+
+    /**
+     * The String representing the sdk platform version.
+     */
+    public static final String PRODUCT_VERSION = "2.0.2";
 
     /**
      * Private constructor to prevent a help class from being initiated.
@@ -66,6 +74,15 @@ public final class Device {
         platformParameters.put(PlatformIdParameters.DEVICE_MODEL, Build.MODEL);
 
         return Collections.unmodifiableMap(platformParameters);
+    }
+
+    public static String getProductVersion() {
+        final String version = DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION);
+        if (TextUtils.isEmpty(version)) {
+            return PRODUCT_VERSION;
+        } else {
+            return version;
+        }
     }
 
     public static final class PlatformIdParameters {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -274,7 +274,7 @@ public class MicrosoftStsOAuth2Strategy
 
 
         builder.setLibraryName(DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.PRODUCT));
-        builder.setLibraryVersion(DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION));
+        builder.setLibraryVersion(Device.getProductVersion());
         builder.setFlightParameters(mConfig.getFlightParameters());
         builder.setMultipleCloudAware(mConfig.getMultipleCloudsSupported());
 
@@ -466,7 +466,7 @@ public class MicrosoftStsOAuth2Strategy
         headers.put("client-request-id", DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
         headers.putAll(Device.getPlatformIdParameters());
         headers.put(AuthenticationConstants.SdkPlatformFields.PRODUCT, DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.PRODUCT));
-        headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION));
+        headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, Device.getProductVersion());
 
         headers.put(AuthenticationConstants.AAD.APP_PACKAGE_NAME, request.getClientAppName());
         headers.put(AuthenticationConstants.AAD.APP_VERSION, request.getClientAppVersion());

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -192,7 +192,7 @@ public abstract class OAuth2Strategy
         }
         headers.putAll(Device.getPlatformIdParameters());
         headers.put(AuthenticationConstants.SdkPlatformFields.PRODUCT, DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.PRODUCT));
-        headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION));
+        headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, Device.getProductVersion());
         headers.putAll(EstsTelemetry.getInstance().getTelemetryHeaders());
 
         if (request instanceof MicrosoftTokenRequest) {

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=3.0.6-RC3
+versionName=3.0.6-RC4
 versionCode=1


### PR DESCRIPTION
Regressed as part of https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1034