### PR TITLE
Fix Exception casting issue

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -253,7 +253,7 @@ public class CommandDispatcher {
     // Suppressing unchecked warnings due to casting of Throwable to the generic type of TaskCompletedCallbackWithError
     @SuppressWarnings(WarningType.unchecked_warning)
     private static void commandCallBackOnError(@SuppressWarnings(WarningType.rawtype_warning) @NonNull BaseCommand command, Throwable throwable) {
-        command.getCallback().onError(throwable);
+        command.getCallback().onError(ExceptionAdapter.baseExceptionFromException(throwable));
     }
 
     static void clearCommandCache() {
@@ -337,7 +337,7 @@ public class CommandDispatcher {
     // Suppressing unchecked warnings due to casting of the result to the generic type of TaskCompletedCallbackWithError
     @SuppressWarnings(WarningType.unchecked_warning)
     private static void commandCallbackOnError(@SuppressWarnings("rawtypes") BaseCommand command, CommandResult result) {
-        command.getCallback().onError(result.getResult());
+        command.getCallback().onError(ExceptionAdapter.baseExceptionFromException((Throwable) result.getResult()));
     }
 
     // Suppressing unchecked warnings due to casting of the result to the generic type of TaskCompletedCallback

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -49,6 +49,7 @@ import com.microsoft.identity.common.internal.util.StringUtil;
 import org.json.JSONException;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 public class ExceptionAdapter {
 
@@ -239,7 +240,12 @@ public class ExceptionAdapter {
         return null;
     }
 
-    public static BaseException baseExceptionFromException(final Exception e) {
+    public static BaseException baseExceptionFromException(final Throwable exception) {
+        Throwable e = exception;
+        if (exception instanceof ExecutionException){
+            e = exception.getCause();
+        }
+
         if (e instanceof IOException) {
             return new ClientException(
                     ClientException.IO_ERROR,

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,3 +1,3 @@
 #Thu Aug 02 12:03:16 PDT 2018
-versionName=3.0.6
+versionName=3.0.7
 versionCode=1


### PR DESCRIPTION
CP ran into the following error 

```
java.lang.ClassCastException: java.util.concurrent.ExecutionException cannot be cast to com.microsoft.identity.common.exception.BaseException
        at com.microsoft.identity.client.PublicClientApplication$17.onError(PublicClientApplication.java:1753)
        at com.microsoft.identity.common.internal.controllers.CommandDispatcher.commandCallBackOnError(CommandDispatcher.java:256)
        at com.microsoft.identity.common.internal.controllers.CommandDispatcher.access$900(CommandDispatcher.java:74)
        at com.microsoft.identity.common.internal.controllers.CommandDispatcher$2$1.run(CommandDispatcher.java:241)
        at android.os.Handler.handleCallback(Handler.java:789)
```

Basically, we suppress warnings and silently cast exceptions.

This PR is meant to be a short-term fix. Long term wise, I'd like us to move away from suppressing warning as much as possible. (Did some prototype and it's relatively big, and I'm not comfortable making such change as a hot fix).