### PR TITLE
Expose lower level API IAccountCredentialCache for use by MSALCPP

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- Expose IAccountCredentialCache to MSALCPP for accessing lower-level cache functions.
+- Expose IAccountCredentialCache for accessing lower-level cache functions.
 - Adds unit test to verify .trim() behavior of cache keys.
 
 Version 3.0.6

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+vNext
+----------
+- Expose IAccountCredentialCache to MSALCPP for accessing lower-level cache functions.
+
 Version 3.0.6
 ----------
 - Expose expiresIn in MSAL Device Code flow callback (#1064)

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -106,6 +106,10 @@ public class MsalCppOAuth2TokenCache
         return msalCppOAuth2TokenCache;
     }
 
+    public IAccountCredentialCache getAccountCredentialCache() {
+        return super.getAccountCredentialCache();
+    }
+
     /**
      * @param accountRecord : AccountRecord associated with the input credentials, can be null.
      * @param credentials   : list of Credential which can include AccessTokenRecord, IdTokenRecord and RefreshTokenRecord.


### PR DESCRIPTION
Need method calls available to lower-level cache functions to support MSAL CPP lookup logic where `Credentials` can be stored without having an `Account`. Just calls `super`, as this parent class' function is `protected`.

Additional context:
- This PR supports the work done in https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/1711
- Description: OneAuth/MSALCPP wants to decouple the saving/read/delete relationship between accounts & credentials. As this connection is expressed in the `MsalCppOAuth2TokenCache`'s APIs, having access to the lower-level `IAccountCredentialCache` object is required in order to read/save/delete credentials in this manner