### PR TITLE
Add escape sequence test and ensure .trim() lookup rules are applied to in-mem filtering logic

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+vNext
+----------
+- Adds unit test to verify .trim() behavior of cache keys.
+
 Version 3.0.6
 ----------
 - Expose expiresIn in MSAL Device Code flow callback (#1064)

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -72,6 +72,7 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
     static final String EXPIRES_ON = "0";
     static final String SECRET = "3642fe2f-2c46-4824-9f27-e44b0e3e1278";
     static final String REALM2 = "20d3e9fa-982a-40bc-bea4-26bbe3fd332e";
+    public static final String ESCAPE_SEQ_CHARS = "\r\f\n\t";
 
     private static final String ENVIRONMENT_LEGACY = "login.windows.net";
     private static final String REALM3 = "fc5171ec-2889-4ba6-bd1f-216fe87a8613";
@@ -104,6 +105,10 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
     public void tearDown() {
         // Wipe the SharedPreferences between tests...
         mSharedPreferencesAccountCredentialCache.clearAll();
+    }
+
+    private static String wrapInEscapeSequenceChars(final String inputString) {
+        return ESCAPE_SEQ_CHARS + inputString + ESCAPE_SEQ_CHARS;
     }
 
     @Test
@@ -202,6 +207,27 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
         refreshToken.setClientId(CLIENT_ID);
         refreshToken.setSecret(SECRET);
         refreshToken.setTarget(TARGET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+    }
+
+    @Test
+    public void saveCredentialWithEscapeChars() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(wrapInEscapeSequenceChars(CredentialType.RefreshToken.name()));
+        refreshToken.setEnvironment(wrapInEscapeSequenceChars(ENVIRONMENT));
+        refreshToken.setHomeAccountId(wrapInEscapeSequenceChars(HOME_ACCOUNT_ID));
+        refreshToken.setClientId(wrapInEscapeSequenceChars(CLIENT_ID));
+        refreshToken.setSecret(wrapInEscapeSequenceChars(SECRET));
+        refreshToken.setTarget(wrapInEscapeSequenceChars(TARGET));
 
         // Save the Credential
         mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
@@ -97,15 +97,15 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             boolean matches = true;
 
             if (mustMatchOnHomeAccountId) {
-                matches = homeAccountId.equalsIgnoreCase(account.getHomeAccountId());
+                matches = homeAccountId.equalsIgnoreCase(account.getHomeAccountId().trim());
             }
 
             if (mustMatchOnEnvironment) {
-                matches = matches && environment.equalsIgnoreCase(account.getEnvironment());
+                matches = matches && environment.equalsIgnoreCase(account.getEnvironment().trim());
             }
 
             if (mustMatchOnRealm) {
-                matches = matches && realm.equalsIgnoreCase(account.getRealm());
+                matches = matches && realm.equalsIgnoreCase(account.getRealm().trim());
             }
 
             if (matches) {
@@ -160,38 +160,38 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             boolean matches = true;
 
             if (mustMatchOnHomeAccountId) {
-                matches = homeAccountId.equalsIgnoreCase(credential.getHomeAccountId());
+                matches = homeAccountId.equalsIgnoreCase(credential.getHomeAccountId().trim());
             }
 
             if (mustMatchOnEnvironment) {
-                matches = matches && environment.equalsIgnoreCase(credential.getEnvironment());
+                matches = matches && environment.equalsIgnoreCase(credential.getEnvironment().trim());
             }
 
             if (mustMatchOnCredentialType) {
-                matches = matches && credentialType.name().equalsIgnoreCase(credential.getCredentialType());
+                matches = matches && credentialType.name().equalsIgnoreCase(credential.getCredentialType().trim());
             }
 
             if (mustMatchOnClientId) {
-                matches = matches && clientId.equalsIgnoreCase(credential.getClientId());
+                matches = matches && clientId.equalsIgnoreCase(credential.getClientId().trim());
             }
 
             if (mustMatchOnRealm && credential instanceof AccessTokenRecord) {
                 final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                matches = matches && realm.equalsIgnoreCase(accessToken.getRealm());
+                matches = matches && realm.equalsIgnoreCase(accessToken.getRealm().trim());
             }
 
             if (mustMatchOnRealm && credential instanceof IdTokenRecord) {
                 final IdTokenRecord idToken = (IdTokenRecord) credential;
-                matches = matches && realm.equalsIgnoreCase(idToken.getRealm());
+                matches = matches && realm.equalsIgnoreCase(idToken.getRealm().trim());
             }
 
             if (mustMatchOnTarget) {
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, accessToken.getTarget(), true);
+                    matches = matches && targetsIntersect(target, accessToken.getTarget().trim(), true);
                 } else if (credential instanceof RefreshTokenRecord) {
                     final RefreshTokenRecord refreshToken = (RefreshTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, refreshToken.getTarget(), true);
+                    matches = matches && targetsIntersect(target, refreshToken.getTarget().trim(), true);
                 } else {
                     Logger.verbose(TAG, "Query specified target-match, but no target to match.");
                 }
@@ -199,7 +199,13 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
 
             if (mustMatchOnAuthScheme && credential instanceof AccessTokenRecord) {
                 final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                matches = matches && authScheme.equalsIgnoreCase(accessToken.getAccessTokenType());
+                String atType = accessToken.getAccessTokenType();
+
+                if (null != atType) {
+                    atType = atType.trim();
+                }
+
+                matches = matches && authScheme.equalsIgnoreCase(atType);
             }
 
             if (matches) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/AbstractAccountCredentialCache.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import static com.microsoft.identity.common.internal.controllers.BaseController.DEFAULT_SCOPES;
+import static com.microsoft.identity.common.internal.util.StringUtil.equalsIgnoreCaseTrim;
 
 public abstract class AbstractAccountCredentialCache implements IAccountCredentialCache {
 
@@ -97,15 +98,15 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             boolean matches = true;
 
             if (mustMatchOnHomeAccountId) {
-                matches = homeAccountId.equalsIgnoreCase(account.getHomeAccountId().trim());
+                matches = equalsIgnoreCaseTrim(homeAccountId, account.getHomeAccountId());
             }
 
             if (mustMatchOnEnvironment) {
-                matches = matches && environment.equalsIgnoreCase(account.getEnvironment().trim());
+                matches = matches && equalsIgnoreCaseTrim(environment, account.getEnvironment());
             }
 
             if (mustMatchOnRealm) {
-                matches = matches && realm.equalsIgnoreCase(account.getRealm().trim());
+                matches = matches && equalsIgnoreCaseTrim(realm, account.getRealm());
             }
 
             if (matches) {
@@ -160,38 +161,38 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             boolean matches = true;
 
             if (mustMatchOnHomeAccountId) {
-                matches = homeAccountId.equalsIgnoreCase(credential.getHomeAccountId().trim());
+                matches = equalsIgnoreCaseTrim(homeAccountId, credential.getHomeAccountId());
             }
 
             if (mustMatchOnEnvironment) {
-                matches = matches && environment.equalsIgnoreCase(credential.getEnvironment().trim());
+                matches = matches && equalsIgnoreCaseTrim(environment, credential.getEnvironment());
             }
 
             if (mustMatchOnCredentialType) {
-                matches = matches && credentialType.name().equalsIgnoreCase(credential.getCredentialType().trim());
+                matches = matches && equalsIgnoreCaseTrim(credentialType.name(), credential.getCredentialType());
             }
 
             if (mustMatchOnClientId) {
-                matches = matches && clientId.equalsIgnoreCase(credential.getClientId().trim());
+                matches = matches && equalsIgnoreCaseTrim(clientId, credential.getClientId());
             }
 
             if (mustMatchOnRealm && credential instanceof AccessTokenRecord) {
                 final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                matches = matches && realm.equalsIgnoreCase(accessToken.getRealm().trim());
+                matches = matches && equalsIgnoreCaseTrim(realm, accessToken.getRealm());
             }
 
             if (mustMatchOnRealm && credential instanceof IdTokenRecord) {
                 final IdTokenRecord idToken = (IdTokenRecord) credential;
-                matches = matches && realm.equalsIgnoreCase(idToken.getRealm().trim());
+                matches = matches && equalsIgnoreCaseTrim(realm, idToken.getRealm());
             }
 
             if (mustMatchOnTarget) {
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, accessToken.getTarget().trim(), true);
+                    matches = matches && targetsIntersect(target, accessToken.getTarget(), true);
                 } else if (credential instanceof RefreshTokenRecord) {
                     final RefreshTokenRecord refreshToken = (RefreshTokenRecord) credential;
-                    matches = matches && targetsIntersect(target, refreshToken.getTarget().trim(), true);
+                    matches = matches && targetsIntersect(target, refreshToken.getTarget(), true);
                 } else {
                     Logger.verbose(TAG, "Query specified target-match, but no target to match.");
                 }
@@ -233,8 +234,8 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
         // It may contain more, but it must contain minimally those
         // Matching is case-insensitive
         final String splitCriteria = "\\s+";
-        final String[] targetToMatchArray = targetToMatch.split(splitCriteria);
-        final String[] credentialTargetArray = credentialTarget.split(splitCriteria);
+        final String[] targetToMatchArray = targetToMatch.trim().split(splitCriteria);
+        final String[] credentialTargetArray = credentialTarget.trim().split(splitCriteria);
 
         // Declare Sets to contain these scopes
         final Set<String> soughtTargetSet = new HashSet<>();

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
@@ -31,7 +31,6 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
@@ -221,5 +220,16 @@ public final class StringUtil {
      */
     public static boolean equalsIgnoreCase(@Nullable final String one, @Nullable final String two) {
         return one == two || (one != null && one.equalsIgnoreCase(two));
+    }
+
+    /**
+     * Utility to null-safe-compare string in a case-insensitive manner, trimming the second input.
+     *
+     * @param one The first string to compare.
+     * @param two The second string to compare.
+     * @return
+     */
+    public static boolean equalsIgnoreCaseTrim(@Nullable final String one, @Nullable final String two) {
+        return one == two || equalsIgnoreCase(one, two.trim());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
@@ -66,12 +66,17 @@ public class CacheKeyValueDelegateTest {
     private static final String FIRST_NAME = "Jane";
     private static final String FAMILY_NAME = "Doe";
     private static final String AVATAR_URL = "https://fake.cdn.microsoft.com/avatars/1";
+    public static final String ESCAPE_SEQ_CHARS = "\r\f\n\t";
 
     private ICacheKeyValueDelegate mDelegate;
 
     @Before
     public void setUp() {
         mDelegate = new CacheKeyValueDelegate();
+    }
+
+    private static String wrapInEscapeSequenceChars(final String inputString) {
+        return ESCAPE_SEQ_CHARS + inputString + ESCAPE_SEQ_CHARS;
     }
 
     // AccessTokens
@@ -98,12 +103,12 @@ public class CacheKeyValueDelegateTest {
     @Test
     public void accessTokenCreateCacheKeyCompleteWithEscapeSequences() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
-        accessToken.setEnvironment("\r\f\n\t" + ENVIRONMENT + "\r\f\n\t");
-        accessToken.setCredentialType(CredentialType.AccessToken.name());
-        accessToken.setClientId(CLIENT_ID);
-        accessToken.setRealm(REALM);
-        accessToken.setTarget(TARGET);
+        accessToken.setHomeAccountId(wrapInEscapeSequenceChars(HOME_ACCOUNT_ID));
+        accessToken.setEnvironment(wrapInEscapeSequenceChars(ENVIRONMENT));
+        accessToken.setCredentialType(wrapInEscapeSequenceChars(CredentialType.AccessToken.name()));
+        accessToken.setClientId(wrapInEscapeSequenceChars(CLIENT_ID));
+        accessToken.setRealm(wrapInEscapeSequenceChars(REALM));
+        accessToken.setTarget(wrapInEscapeSequenceChars(TARGET));
 
         final String expectedKey = "" // just for formatting
                 + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR

--- a/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/CacheKeyValueDelegateTest.java
@@ -96,6 +96,26 @@ public class CacheKeyValueDelegateTest {
     }
 
     @Test
+    public void accessTokenCreateCacheKeyCompleteWithEscapeSequences() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment("\r\f\n\t" + ENVIRONMENT + "\r\f\n\t");
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setTarget(TARGET);
+
+        final String expectedKey = "" // just for formatting
+                + HOME_ACCOUNT_ID + CACHE_VALUE_SEPARATOR
+                + ENVIRONMENT + CACHE_VALUE_SEPARATOR
+                + CREDENTIAL_TYPE_ACCESS_TOKEN + CACHE_VALUE_SEPARATOR
+                + CLIENT_ID + CACHE_VALUE_SEPARATOR
+                + REALM + CACHE_VALUE_SEPARATOR
+                + TARGET;
+        assertEquals(expectedKey, mDelegate.generateCacheKey(accessToken));
+    }
+
+    @Test
     public void accessTokenCreateCacheKeyNoHomeAccountId() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
         accessToken.setEnvironment(ENVIRONMENT);


### PR DESCRIPTION
Adds a test to demonstrate that escape sequences are trimmed from cache keys