### PR TITLE
Sends CP version to ESTS and handle WebCP uri.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 vNext
 ----------
+
+- Sends CP version to ESTS and handle WebCP uri. (#1137)
 - Check for eligible for caching when putting command in executing command map
 - Expose IAccountCredentialCache for accessing lower-level cache functions.
 - Adds unit test to verify .trim() behavior of cache keys.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1081,7 +1081,7 @@ public final class AuthenticationConstants {
         /**
          * Redirect URL from WebCP that should launch the Intune Company Portal app.
          */
-        public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = "companyportal://enrollment";
+        public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = BROWSER_EXT_WEB_CP + "enrollment";
 
         /**
          * A query param indicating that this is an intune device CA link.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1074,6 +1074,16 @@ public final class AuthenticationConstants {
         public static final String BROWSER_EXT_INSTALL_PREFIX = "msauth://";
 
         /**
+         * Prefix in the redirect from WebCP.
+         */
+        public static final String BROWSER_EXT_WEB_CP = "companyportal://";
+
+        /**
+         * Redirect URL from WebCP that should launch the Intune Company Portal app.
+         */
+        public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = "companyportal://enrollment";
+
+        /**
          * A query param indicating that this is an intune device CA link.
          */
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1091,7 +1091,7 @@ public final class AuthenticationConstants {
         /**
          * Activity name to launch company portal.
          */
-        public static final String COMPANY_PORTAL_APP_LAUNCH_ACTIVITY_NAME = AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME + ".views.SplashActivity";
+        public static final String COMPANY_PORTAL_APP_LAUNCH_ACTIVITY_NAME = Broker.COMPANY_PORTAL_PROD_APP_PACKAGE_NAME + ".views.SplashActivity";
 
         /**
          * Redirect URI parameter key to get link to install broker

--- a/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/ErrorStrings.java
@@ -236,6 +236,11 @@ public final class ErrorStrings {
     public static final String DEVELOPER_REDIRECTURI_INVALID = "The redirectUri for broker is invalid";
 
     /**
+     * The uri from WebCP is invalid.
+     */
+    public static final String WEBCP_URI_INVALID = "webcp_uri_invalid";
+
+    /**
      * WebView  redirect url is not SSL protected.
      */
     public static final String WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED = "Redirect url scheme not SSL protected";

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -246,6 +246,8 @@ public abstract class BaseController {
                 interactiveTokenCommandParameters.isWebViewZoomEnabled()
         ).setWebViewZoomControlsEnabled(
                 interactiveTokenCommandParameters.isWebViewZoomControlsEnabled()
+        ).setCpInstallationDetail(
+                parameters.getAndroidApplicationContext()
         );
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_PROD_APP_PACKAGE_NAME;
 
 /**
  * A class holding the state of the Authorization Request (OAuth 2.0).
@@ -253,7 +253,7 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         public Builder<B> setCpInstallationDetail(final @NonNull Context context) {
             try {
                 final PackageInfo packageInfo =
-                        context.getPackageManager().getPackageInfo(COMPANY_PORTAL_APP_PACKAGE_NAME, 0);
+                        context.getPackageManager().getPackageInfo(COMPANY_PORTAL_PROD_APP_PACKAGE_NAME, 0);
                 mCpVersion = packageInfo.versionName;
             } catch (final PackageManager.NameNotFoundException e) {
                 // CP is not installed. No need to do anything.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -22,8 +22,13 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2;
 
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Pair;
+
+import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
@@ -35,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 
 /**
  * A class holding the state of the Authorization Request (OAuth 2.0).
@@ -99,13 +106,18 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
     @SerializedName("claims")
     private String mClaims;
 
+    /**
+     * Version name of the installed Company Portal app.
+     * */
     @Expose()
-    @SerializedName("web_view_zoom_controls_enabled")
-    private boolean webViewZoomControlsEnabled;
+    @SerializedName("cpVersion")
+    private String mCpVersion;
 
     @Expose()
-    @SerializedName("web_view_zoom_enabled")
-    private boolean webViewZoomEnabled;
+    transient private boolean webViewZoomControlsEnabled;
+
+    @Expose()
+    transient private boolean webViewZoomEnabled;
 
     /**
      * Header of the request.
@@ -135,8 +147,9 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         mExtraQueryParams = extraQueryParams;
         mClaims = builder.mClaims;
         mRequestHeaders = requestHeaders;
-        webViewZoomEnabled = builder.webViewZoomEnabled;
-        webViewZoomControlsEnabled = builder.webViewZoomControlsEnabled;
+        webViewZoomEnabled = builder.mWebViewZoomEnabled;
+        webViewZoomControlsEnabled = builder.mWebViewZoomControlsEnabled;
+        mCpVersion = builder.mCpVersion;
     }
 
     public static final class ResponseType {
@@ -151,8 +164,9 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
         private String mScope;
         private String mClaims;
         private HashMap<String, String> mRequestHeaders;
-        private boolean webViewZoomControlsEnabled;
-        private boolean webViewZoomEnabled;
+        private boolean mWebViewZoomControlsEnabled;
+        private boolean mWebViewZoomEnabled;
+        private String mCpVersion;
 
         /**
          * Can be used to pre-fill the username/email address field of the sign-in page for the user, if you know their username ahead of time.
@@ -221,18 +235,32 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
             return self();
         }
 
-        public B setRequestHeaders(HashMap<String, String> requestHeaders){
+        public B setRequestHeaders(HashMap<String, String> requestHeaders) {
             mRequestHeaders = requestHeaders;
             return self();
         }
 
         public Builder<B> setWebViewZoomEnabled(boolean webViewZoomEnabled) {
-            this.webViewZoomEnabled = webViewZoomEnabled;
+            mWebViewZoomEnabled = webViewZoomEnabled;
             return self();
         }
 
         public Builder<B> setWebViewZoomControlsEnabled(boolean webViewZoomControlsEnabled) {
-            this.webViewZoomControlsEnabled = webViewZoomControlsEnabled;
+            mWebViewZoomControlsEnabled = webViewZoomControlsEnabled;
+            return self();
+        }
+
+        public Builder<B> setCpInstallationDetail(final @NonNull Context context) {
+            try {
+                // Do not use COMPANY_PORTAL_APP_PACKAGE_NAME, since we actually want this to be
+                // CP's package name - not brokerHost's - even in localDebug mode.
+                final PackageInfo packageInfo =
+                        context.getPackageManager().getPackageInfo("com.microsoft.windowsintune.companyportal", 0);
+                mCpVersion = packageInfo.versionName;
+            } catch (final PackageManager.NameNotFoundException e) {
+                // CP is not installed. No need to do anything.
+            }
+
             return self();
         }
 
@@ -240,7 +268,6 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
 
         @SuppressWarnings(WarningType.rawtype_warning)
         public abstract AuthorizationRequest build();
-
     }
 //
 //    /**
@@ -283,6 +310,7 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
     public String getRedirectUri() {
         return mRedirectUri;
     }
+
     /**
      * @return mState of the authorization request.
      */

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationRequest.java
@@ -252,10 +252,8 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
 
         public Builder<B> setCpInstallationDetail(final @NonNull Context context) {
             try {
-                // Do not use COMPANY_PORTAL_APP_PACKAGE_NAME, since we actually want this to be
-                // CP's package name - not brokerHost's - even in localDebug mode.
                 final PackageInfo packageInfo =
-                        context.getPackageManager().getPackageInfo("com.microsoft.windowsintune.companyportal", 0);
+                        context.getPackageManager().getPackageInfo(COMPANY_PORTAL_APP_PACKAGE_NAME, 0);
                 mCpVersion = packageInfo.versionName;
             } catch (final PackageManager.NameNotFoundException e) {
                 // CP is not installed. No need to do anything.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -58,7 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.AUTHORIZATION_FINAL_URL;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_PROD_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_SIGNATURE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.SUB_ERROR_UI_CANCEL;
@@ -256,7 +256,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             //       Until that comes, we'll only handle this in ipphone.
             if (packageHelper.isPackageInstalledAndEnabled(applicationContext, IPPHONE_APP_PACKAGE_NAME) &&
                     IPPHONE_APP_SIGNATURE.equals(packageHelper.getCurrentSignatureForPackage(IPPHONE_APP_PACKAGE_NAME)) &&
-                    packageHelper.isPackageInstalledAndEnabled(applicationContext, COMPANY_PORTAL_APP_PACKAGE_NAME)) {
+                    packageHelper.isPackageInstalledAndEnabled(applicationContext, COMPANY_PORTAL_PROD_APP_PACKAGE_NAME)) {
                 try {
                     launchCompanyPortal();
                     return true;
@@ -286,7 +286,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.verbose(TAG + methodName, "Sending intent to launch the CompanyPortal.");
         final Intent intent = new Intent();
         intent.setComponent(new ComponentName(
-                COMPANY_PORTAL_APP_PACKAGE_NAME,
+                COMPANY_PORTAL_PROD_APP_PACKAGE_NAME,
                 AuthenticationConstants.Broker.COMPANY_PORTAL_APP_LAUNCH_ACTIVITY_NAME));
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         getActivity().startActivity(intent);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -128,6 +128,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      * <li>A url that starts with the same prefix as the tenant's redirect url</li>
      * <li>An explicit request to open the browser (starts with "browser://")</li>
      * <li>A request to install the auth broker (starts with "msauth://")</li>
+     * <li>A request from WebCP (starts with "companyportal://")</li>
      * <li>It is a request that has the intent of starting the broker and the url starts with "browser://"</li>
      * <li>It <strong>does not</strong> begin with "https://".</li></ul>
      *


### PR DESCRIPTION
## Current experience
- Whenever you run into Device Enrollment CA during sign in.... Webview is launched -> You have to sign in (again) -> it shows a page that redirects you to play store.
- The experience is bad, and even more so when Work Profile comes into play (because you'll see this if you're trying to log in in your personal profile - even if you already have everything set up in work profile)
- The scope is originally for duo, but eventually we want to improve this experience for everyone (Duo comes with Broker installed).
	
## The proposed fix
- Broker + MSAL (and soon ADAL) detects the existence of company portal in the current profile.
- It sends the installed version of CP as a query parameter along with the auth request to eSTS. (cpVersion=x)
- eSTS passes that information to WebCP. WebCP uses that information to decide how it should proceed with the flow.
	-There are 4 possible states
		1) the webview does not support CP deeplink.
		2) CP is not installed.
		3) CP is installed, but it's an older version
		4) CP is installed, and it contains the latest change with improved UX. (here)
	- If no values is passed to WebCP, then it's either 1,2 or 3 . In this case, we will proceed with the improved browser flow (extra login no longer required)
- For 4), WebCP will tell eSTS (to redirect us) to companyportal://enrollment. To avoid potential phishing, we hardcoded this url in common - saying that if this link appears, launch CP.
