### PR TITLE
Closes #1144 (Incorrect Error Code Sent to Caller When User Clicks WebView 'back' button)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - Expose IAccountCredentialCache for accessing lower-level cache functions.
 - Adds unit test to verify .trim() behavior of cache keys.
 - Make CacheRecord immutable, insist on NonNull AccountRecord (#1225)
+- Bugfix for incorrect error code when cancelling requests (#1144)
 
 Version 3.0.7
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/BrowserAuthorizationFragment.java
@@ -202,7 +202,7 @@ public class BrowserAuthorizationFragment extends AuthorizationFragment {
                 && resultIntent.getStringExtra(AuthenticationConstants.Browser.RESPONSE_ERROR_SUBCODE).equalsIgnoreCase("cancel")) {
             //when the user click the "cancel" button in the UI, server will send the the redirect uri with "cancel" error sub-code and redirects back to the calling app
             Telemetry.emit(new UiEndEvent().isUserCancelled());
-            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_SDK_CANCEL, resultIntent);
+            sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_CANCEL, resultIntent);
         } else {
             Telemetry.emit(new UiEndEvent().isUiCancelled());
             sendResult(AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR, resultIntent);


### PR DESCRIPTION
Resolves #1144 - found during investigation of https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1239

I do not presently believe _this_ is the root cause of the white-screen issue in https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1239, though this bug causes the wrong error message to be returned