### PR TITLE
Remove about:blank initial page load from WebViewAuthorizationFragment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ vNext
 - Adds unit test to verify .trim() behavior of cache keys.
 - Make CacheRecord immutable, insist on NonNull AccountRecord (#1225)
 - Bugfix for incorrect error code when cancelling requests (#1144)
+- Remove initial about:blank page load when using WebView based auth.
 
 Version 3.0.7
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -148,8 +148,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                // load blank first to avoid error for not loading webView
-                mWebView.loadUrl("about:blank");
                 Logger.info(TAG + methodName, "Launching embedded WebView for acquiring auth code.");
                 Logger.infoPII(TAG + methodName, "The start url is " + mAuthorizationRequestUrl);
                 mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
@@ -171,18 +169,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @Override
     public boolean onBackPressed() {
         Logger.info(TAG, "Back button is pressed");
-        if (null != mWebView && mWebView.canGoBack()) {
-            // User should be able to click back button to cancel. Counting blank page as well.
-            final int BACK_PRESSED_STEPS = -2;
-            if (!mWebView.canGoBackOrForward(BACK_PRESSED_STEPS)) {
-                cancelAuthorization(true);
-            } else {
-                mWebView.goBack();
-            }
-            return true;
+
+        if (mWebView.canGoBack()) {
+            mWebView.goBack();
+        } else {
+            cancelAuthorization(true);
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Impetus:
https://portal.microsofticm.com/imp/v3/incidents/details/212200669/home

Current behavior:
- After creating the `WebView` in `onCreateView()`, `about:blank` is loaded -- it is unclear why this is being done...
- When handling `onBackPressed()` events, this page _should_ be factored in when determining if the hosting `Activity` is being dismissed or not however, this seems to not be totally reliable as I can intermittently 'back' onto this blank screen
- Reference incident ID: `UBT8DZ5P` for incorrect behavior

New behavior:
- Don't load `about:blank` -- this view would have just been created, as `onCreateView()` is at the beginning of the lifecycle (see graphic below)
- Remove this `-2` history check and go `goBack()` if possible or `cancel()` if you can't
- Reference incident ID: `S57C2G76` for correct behavior

![image](https://user-images.githubusercontent.com/990063/101230459-448d4e80-365a-11eb-89db-c3a107aca112.png)

>Note: I'm not clear on what the original purpose of this `about:blank` page load was, it does not seem to serve a purpose and the accompanying comment is too vague for me to determine what issue it's trying to solve