### PR TITLE
Log an informative error message, when broker redirect_uri is mismatched - Closes #1155

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,10 @@ vNext
 ----------
 - Expose IAccountCredentialCache for accessing lower-level cache functions.
 - Adds unit test to verify .trim() behavior of cache keys.
-- Make CacheRecord immutable, insist on NonNull AccountRecord (#1225)
-- Bugfix for incorrect error code when cancelling requests (#1144)
+- Make CacheRecord immutable, insist on NonNull AccountRecord (#1225).
+- Bugfix for incorrect error code when cancelling requests (#1144).
 - Remove initial about:blank page load when using WebView based auth.
+- Log an informative error message when application redirect_uri does not match the broker's expected value (#1155).
 
 Version 3.0.7
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -30,7 +30,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
-import android.text.TextUtils;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
@@ -81,7 +80,7 @@ public class BrokerValidator {
     /**
      * Verifies that the installed broker package's signing certificate hash matches the known
      * release certificate hash.
-     *
+     * <p>
      * If signature hash verification fails, this will throw a Client exception containing the cause of error, which could contain a list of mismatch hashes.
      *
      * @param brokerPackageName The broker package to inspect.
@@ -126,7 +125,7 @@ public class BrokerValidator {
         final String methodName = ":verifySignature";
         try {
             return verifySignatureAndThrow(brokerPackageName) != null;
-        } catch (final ClientException e){
+        } catch (final ClientException e) {
             Logger.error(TAG + methodName, e.getErrorCode() + ": " + e.getMessage(), e);
         }
 
@@ -235,7 +234,7 @@ public class BrokerValidator {
     /**
      * Returns the package that is currently active relative to the Work Account custom account type
      * Note: either the company portal or the authenticator
-     *
+     * <p>
      * There may be multiple packages containing the android authenticator implementation (custom account)
      * but there is only one entry for custom account type currently registered by the AccountManager.
      * If another app tries to install same authenticator (custom account type) type, it will
@@ -257,7 +256,24 @@ public class BrokerValidator {
     public static boolean isValidBrokerRedirect(@Nullable final String redirectUri,
                                                 @NonNull final Context context,
                                                 @NonNull final String packageName) {
-        return StringUtil.equalsIgnoreCase(redirectUri, getBrokerRedirectUri(context, packageName));
+        final String methodName = ":isValidBrokerRedirect";
+        final String expectedBrokerRedirectUri = getBrokerRedirectUri(context, packageName);
+        final boolean isValidBrokerRedirect = StringUtil.equalsIgnoreCase(redirectUri, expectedBrokerRedirectUri);
+
+        if (!isValidBrokerRedirect) {
+            Logger.error(
+                    TAG + methodName,
+                    "Broker redirect uri is invalid."
+                            + "\n"
+                            + "Expected: " + expectedBrokerRedirectUri
+                            + "\n"
+                            + "Actual: " + redirectUri
+                    ,
+                    null
+            );
+        }
+
+        return isValidBrokerRedirect;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -30,6 +30,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
+import android.text.TextUtils;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -266,11 +266,10 @@ public class BrokerValidator {
         if (!isValidBrokerRedirect) {
             Logger.error(
                     TAG + methodName,
-                    "Broker redirect uri is invalid."
-                            + "\n"
-                            + "Expected: " + expectedBrokerRedirectUri
-                            + "\n"
-                            + "Actual: " + redirectUri
+                    "Broker redirect uri is invalid. Expected: "
+                            + expectedBrokerRedirectUri
+                            + " Actual: "
+                            + redirectUri
                     ,
                     null
             );

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
-#Fri Dec 04 19:20:25 UTC 2020
+#Tue Dec 08 20:37:43 UTC 2020
 versionName=3.0.7
 versionCode=1
-latestPatchVersion=66
+latestPatchVersion=67


### PR DESCRIPTION
Closes #1155 

>Note: This message is _not_ being logged as PII/OII, as `redirect_uri` is not a secret value and the package id can be determined from looking at the log output