### PR TITLE
Sanitize error message for csv to avoid spilling to multiple lines

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/kusto/CaptureKustoTestResultRule.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/kusto/CaptureKustoTestResultRule.java
@@ -83,6 +83,6 @@ public class CaptureKustoTestResultRule implements TestRule {
     }
 
     private String sanitizeErrorMessage(@NonNull final String msg) {
-        return msg.replaceAll("\n", " ").replaceAll("\r"," ");
+        return msg.replaceAll("[\n\r]", " ");
     }
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/kusto/CaptureKustoTestResultRule.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/kusto/CaptureKustoTestResultRule.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.internal.testutils.kusto;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.microsoft.identity.common.BuildConfig;
 
 import org.junit.rules.TestRule;
@@ -69,7 +71,7 @@ public class CaptureKustoTestResultRule implements TestRule {
                                     .runnerVersion(runnerVersion)
                                     .result(result)
                                     .scaleUnit(scaleUnit)
-                                    .errorMessage(errorMessage)
+                                    .errorMessage(sanitizeErrorMessage(errorMessage))
                                     .build();
 
                     TestResultFileUtils.writeTestResultsToCsv(
@@ -78,5 +80,9 @@ public class CaptureKustoTestResultRule implements TestRule {
                 }
             }
         };
+    }
+
+    private String sanitizeErrorMessage(@NonNull final String msg) {
+        return msg.replaceAll("\n", " ").replaceAll("\r"," ");
     }
 }


### PR DESCRIPTION
We don't fields in csv to span multiple lines due to newline or return characters