### PR TITLE
Add the actual aar to the package

### DIFF
--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -79,26 +79,11 @@ project.afterEvaluate{
     publishing {
         publications {
             aar(MavenPublication) {
+                artifact "$buildDir/outputs/aar/testutils-release.aar"
                 artifact sourcesJar
                 groupId 'com.microsoft.identity'
                 artifactId = 'testutils'
                 version = getAppVersionName()
-
-                pom.withXml {
-
-                    // Dependencies
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                    configurations.implementation.allDependencies.each {
-                        if (it.group != null && it.name != null) {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
-                        }
-                    }
-                }
             }
         }
 

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -84,6 +84,22 @@ project.afterEvaluate{
                 groupId 'com.microsoft.identity'
                 artifactId = 'testutils'
                 version = getAppVersionName()
+
+                  pom.withXml {
+ 
+                      // Dependencies
+                      def dependenciesNode = asNode().appendNode('dependencies')
+ 
+                      //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                      configurations.implementation.allDependencies.each {
+                          if (it.group != null && it.name != null) {
+                              def dependencyNode = dependenciesNode.appendNode('dependency')
+                              dependencyNode.appendNode('groupId', it.group)
+                              dependencyNode.appendNode('artifactId', it.name)
+                              dependencyNode.appendNode('version', it.version)
+                          }
+                      }
+                  }
             }
         }
 

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -85,21 +85,21 @@ project.afterEvaluate{
                 artifactId = 'testutils'
                 version = getAppVersionName()
 
-                  pom.withXml {
- 
-                      // Dependencies
-                      def dependenciesNode = asNode().appendNode('dependencies')
- 
-                      //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                      configurations.implementation.allDependencies.each {
-                          if (it.group != null && it.name != null) {
-                              def dependencyNode = dependenciesNode.appendNode('dependency')
-                              dependencyNode.appendNode('groupId', it.group)
-                              dependencyNode.appendNode('artifactId', it.name)
-                              dependencyNode.appendNode('version', it.version)
-                          }
-                      }
-                  }
+                pom.withXml {
+
+                    // Dependencies
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                    configurations.implementation.allDependencies.each {
+                        if (it.group != null && it.name != null) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                    }
+                }
             }
         }
 

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -78,26 +78,11 @@ project.afterEvaluate{
     publishing {
         publications {
             aar(MavenPublication) {
+                artifact "$buildDir/outputs/aar/uiautomationutilities-release.aar"
                 artifact sourcesJar
                 groupId 'com.microsoft.identity'
                 artifactId = 'uiautomationutilities'
                 version = getAppVersionName()
-
-                pom.withXml {
-
-                    // Dependencies
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                    configurations.implementation.allDependencies.each {
-                        if (it.group != null && it.name != null) {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
-                        }
-                    }
-                }
             }
         }
 

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -97,9 +97,9 @@ project.afterEvaluate{
                             dependencyNode.appendNode('artifactId', it.name)
                             dependencyNode.appendNode('version', it.version)
                         }
-                   }
-               }
-          }
+                    }
+                }
+            }
         }
 
         repositories {

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -83,7 +83,23 @@ project.afterEvaluate{
                 groupId 'com.microsoft.identity'
                 artifactId = 'uiautomationutilities'
                 version = getAppVersionName()
-            }
+
+                pom.withXml {
+
+                    // Dependencies
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                    configurations.implementation.allDependencies.each {
+                        if (it.group != null && it.name != null) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                   }
+               }
+          }
         }
 
         repositories {


### PR DESCRIPTION
Adding the classifier just results in a missing aar.  Add it back.

If you look at this package, you'll notice that there's no non-sources artifact.

https://identitydivision.visualstudio.com/IDDP/_packaging?_a=package&feed=Android&package=com.microsoft.identity%3Atestutils&protocolType=maven&version=0.0.72&view=overview

After a while of playing with it, this change seems to do what I need, though I don't have permission to run it (permissions), but was attempting to upload the correctly named AAR.

To verify that this fixes my problem with the Gradle build I broke my cache - I built the release aar in the testutils package, and pulled the classes.jar out of it, then injected it into my cache, replacing testutils-0.0.69.jar.  At that point, my compile errors stopped.