### PR TITLE
Break load url loop on request completion

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -64,7 +64,7 @@ public abstract class AuthorizationFragment extends Fragment {
     /**
      * Determines if authentication result has been sent.
      */
-    private boolean mAuthResultSent = false;
+    protected boolean mAuthResultSent = false;
 
     /**
      * Listens to an operation cancellation event.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -137,7 +137,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                         mProgressBar.setVisibility(View.INVISIBLE);
 
                         // Inject string from test suites.
-                        if (!StringExtensions.isNullOrBlank(mPostPageLoadedUrl)) {
+                        // if result already sent don't load url again
+                        if (mAuthResultSent == false && !StringExtensions.isNullOrBlank(mPostPageLoadedUrl)) {
                             mWebView.loadUrl(mPostPageLoadedUrl);
                         }
                     }


### PR DESCRIPTION
Current behavior: even when the call gets completed, web view try for 50 times to search for the component in UI automation tests which slows down the system and cause timeout in tests.
Fix: if the status already returned don't call loadUrl again -- this will speed avoid unnecessary webView load url calls and improve flakyness in tests.