### PR TITLE
Testing command dispatcher tests

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -214,7 +214,7 @@ dependencies {
 // Create tasks to generate javadoc
 android.libraryVariants.all { variant ->
     task("${variant.name}Javadoc", type: Javadoc, dependsOn: "assemble${variant.name.capitalize()}") {
-        source = variant.javaCompiler.source
+        source = variant.javaCompileProvider.get().source
 
         title = "Microsoft Identity Android Common"
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -242,7 +242,7 @@ android.libraryVariants.all { variant ->
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
-    destinationDir = reporting.file("$project.buildDir/outputs/jar/")
+    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
 }
 
 def configDir = new File(buildscript.sourceFile.parentFile.parentFile, 'config')

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -125,7 +125,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     public void setUp() throws Exception {
         super.setUp();
 
-        MockitoAnnotations.openMocks(this);
+        MockitoAnnotations.initMocks(this);
 
         // Our test context
         final Context context = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getTargetContext();

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrowserSelectorTest.java
@@ -102,7 +102,7 @@ public class BrowserSelectorTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        MockitoAnnotations.initMocks(this);
         when(mContext.getPackageManager()).thenReturn(mPackageManager);
     }
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -337,7 +337,8 @@ public class CommandDispatcherTest {
         final ConcurrentHashMap<Integer, String> map = new ConcurrentHashMap<>();
         for (int i = 0; i < nTasks; i++) {
             final int j = i;
-            executor.submit(() -> {
+            executor.submit(new Runnable() {
+                public void run() {
                 try {
                     map.put(j, "foo");
                     testSubmitSilentWithParamMutationSameCommand(new Consumer<String>() {
@@ -355,7 +356,7 @@ public class CommandDispatcherTest {
                 } finally {
                     latch.countDown();
                 }
-            });
+            }});
         }
         System.out.println("Waiting on latch");
         while (!latch.await(30, TimeUnit.SECONDS)) {

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -69,16 +69,6 @@ public class CommandDispatcherTest {
     private static final AtomicInteger INTEGER = new AtomicInteger(1);
     private static final String TEST_RESULT_STR = "test_result_str";
 
-    @Before
-    public void setUp() throws Exception {
-        //CommandDispatcher.clearState();
-    }
-
-    @After
-    public void cleanUp() throws Exception {
-        //CommandDispatcher.clearState();
-    }
-
     @Test
     public void testCanSubmitSilently() throws InterruptedException {
         final CountDownLatch testLatch = new CountDownLatch(1);

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.common.internal.result.GenerateShrResult;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,12 +71,12 @@ public class CommandDispatcherTest {
 
     @Before
     public void setUp() throws Exception {
-        CommandDispatcher.clearState();
+        //CommandDispatcher.clearState();
     }
 
     @After
     public void cleanUp() throws Exception {
-        CommandDispatcher.clearState();
+        //CommandDispatcher.clearState();
     }
 
     @Test
@@ -242,7 +243,12 @@ public class CommandDispatcherTest {
                 }));
     }
 
-
+    /**
+     * This test takes a while to run.  But it should always work.  Just put it here in order
+     * to save anyone else from having to write it.
+     * @throws Exception
+     */
+    @Ignore
     @Test
     public void iterateTests() throws Exception {
         final int nThreads = 100;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -102,7 +102,7 @@ public class CommandDispatcher {
     private static void cleanMap(BaseCommand command) {
         ConcurrentMap<BaseCommand, FinalizableResultFuture<CommandResult>> newMap = new ConcurrentHashMap<>();
         for (Map.Entry<BaseCommand, FinalizableResultFuture<CommandResult>> e : sExecutingCommandMap.entrySet()) {
-            if (command != e.getKey()) {
+            if (! (command == e.getKey())) {
                 newMap.put(e.getKey(), e.getValue());
             }
         }
@@ -113,6 +113,19 @@ public class CommandDispatcher {
     public static int outstandingCommands() {
         synchronized (mapAccessLock) {
             return sExecutingCommandMap.size();
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public static boolean isCommandOutstanding(BaseCommand c) {
+        synchronized (mapAccessLock) {
+            for (Map.Entry<BaseCommand, ?> e : sExecutingCommandMap.entrySet()) {
+                if (e.getKey() == c) {
+                    System.out.println("Command out there " + c);
+                    return true;
+                }
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
The command dispatcher tests were disabled because of occasional failures.  This makes me nervous, so I want to get the
tests re-enabled.  What was seemingly happening was that the executing command map could end up with commands in it that were not part of the current test.  We could clear the map, but that might break concurrently running tests, and junit can be configured to do that.

Rather than insist that the command map was empty at the close of an execution pass, this does a few things - it makes certain that subsequent runs of the tests don't collide with previous ones, and we add a few tests that work by just submitting 10_000 requests to a pool of 100 threads and retiring all of them safely both for distinct commands and potentially duplicative ones.  These have run for up to 1M iterations locally for me without incident.