### PR TITLE
Add refresh_on to access tokens

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 
+- Add refresh_on to access tokens(#1190)
 - Add requested_claims to access tokens, and allow credentials to be filtered by RC (#1187)
 - Sends CP version to ESTS and handle WebCP uri. (#1137)
 - Check for eligible for caching when putting command in executing command map

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -41,6 +41,7 @@ import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.Seria
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.REALM;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.TARGET;
 import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.TOKEN_TYPE;
+import static com.microsoft.identity.common.internal.dto.AccessTokenRecord.SerializedNames.REFRESH_ON;
 import static com.microsoft.identity.common.internal.dto.Credential.SerializedNames.EXPIRES_ON;
 
 @EqualsAndHashCode(callSuper = true)
@@ -87,6 +88,11 @@ public class AccessTokenRecord extends Credential {
          * The claims string (if present) that was sent to server to produce this AT.
          */
         public static final String REQUESTED_CLAIMS = "requested_claims";
+
+        /**
+         * String of refresh_in.
+         */
+        public static final String REFRESH_ON = "refresh_on";
     }
 
     /**
@@ -145,6 +151,15 @@ public class AccessTokenRecord extends Credential {
      */
     @SerializedName(EXPIRES_ON)
     private String mExpiresOn;
+
+    /**
+     * Token recommended refresh time. This value should be calculated based on the current UTC time
+     * measured locally and the value refresh_in returned from the service. Measured in milliseconds from
+     * epoch (1970). Note that this value will not always be present, and is only a recommendation to
+     * kick off an async token refresh. The token is still valid until the expires_on value.
+     */
+    @SerializedName(REFRESH_ON)
+    private String mRefreshOn;
 
     /**
      * Gets the kid.
@@ -293,6 +308,24 @@ public class AccessTokenRecord extends Credential {
      */
     public void setExpiresOn(final String expiresOn) {
         mExpiresOn = expiresOn;
+    }
+
+    /**
+     * Gets the refresh_on timestamp.
+     *
+     * @return The refresh_on to get.
+     */
+    public String getRefreshOn() {
+        return mRefreshOn;
+    }
+
+    /**
+     * Sets the refresh_on timestamp.
+     *
+     * @param refreshOn The refresh_on to set.
+     */
+    public void setRefreshOn(final String refreshOn) {
+        mRefreshOn = refreshOn;
     }
 
     private boolean isExpired(final String expires) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -361,6 +361,9 @@ public class AccessTokenRecord extends Credential {
         if (refreshOn != null && !refreshOn.isEmpty()) {
             return isExpired(refreshOn);
         }
-        return isExpired();
+        else if(getRefreshOn() != null) {
+            return isExpired();
+        }
+        return true;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -361,6 +361,6 @@ public class AccessTokenRecord extends Credential {
         if (refreshOn != null && !refreshOn.isEmpty()) {
             return isExpired(refreshOn);
         }
-        return false;
+        return isExpired();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -344,4 +344,23 @@ public class AccessTokenRecord extends Credential {
     public boolean isExpired() {
         return isExpired(getExpiresOn());
     }
+
+    /**
+     * If the AT has a refresh_on timestamp (typically used for LLT's),
+     * this function will return true after the server recommended refresh
+     * interval has elapsed, prompting the library to kick off a background refresh operation.
+     *
+     * If the AT does NOT have a refresh_on timestamp, this function will always
+     * return false. Fallback to standard token expiration/refresh logic.
+     *
+     * @return Should the library kick off a background token refresh operation for this token
+     * after returning the token to the caller.
+     */
+    public boolean shouldRefresh() {
+        final String refreshOn = getRefreshOn();
+        if(refreshOn != null && !refreshOn.isEmpty()) {
+            return isExpired(refreshOn);
+        }
+        return false;
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/dto/AccessTokenRecord.java
@@ -358,7 +358,7 @@ public class AccessTokenRecord extends Credential {
      */
     public boolean shouldRefresh() {
         final String refreshOn = getRefreshOn();
-        if(refreshOn != null && !refreshOn.isEmpty()) {
+        if (refreshOn != null && !refreshOn.isEmpty()) {
             return isExpired(refreshOn);
         }
         return false;

--- a/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
@@ -24,11 +24,12 @@ package com.microsoft.identity.common;
 
 import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 
-import junit.framework.Assert;
-
 import org.junit.Test;
 
 import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AccessTokenTest {
 
@@ -36,7 +37,18 @@ public class AccessTokenTest {
     public void testExpiry() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
         accessToken.setExpiresOn(getCurrentTimeStr());
-        Assert.assertTrue(accessToken.isExpired());
+        assertTrue(accessToken.isExpired());
+    }
+
+    @Test
+    public void testRefreshOn() {
+        // As refresh_on is only being implemented by MSAL C++ at the time of writing, I'm getting
+        // unused method warnings. This test is to shut the compiler up and exercise the getter/setter,
+        // without messing around with unrelated tests
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setRefreshOn("TestValue");
+        assertEquals("TestValue", accessToken.getRefreshOn());
     }
 
     private String getCurrentTimeStr() {

--- a/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 
 import java.util.Calendar;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class AccessTokenTest {
 
@@ -41,14 +41,16 @@ public class AccessTokenTest {
     }
 
     @Test
-    public void testRefreshOn() {
-        // As refresh_on is only being implemented by MSAL C++ at the time of writing, I'm getting
-        // unused method warnings. This test is to shut the compiler up and exercise the getter/setter,
-        // without messing around with unrelated tests
-
+    public void testShouldRefreshWhenSet() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setRefreshOn("TestValue");
-        assertEquals("TestValue", accessToken.getRefreshOn());
+        accessToken.setRefreshOn(getCurrentTimeStr());
+        assertTrue(accessToken.shouldRefresh());
+    }
+
+    @Test
+    public void testShouldRefreshWhenNotSet() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        assertFalse(accessToken.shouldRefresh());
     }
 
     private String getCurrentTimeStr() {

--- a/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/AccessTokenTest.java
@@ -41,16 +41,23 @@ public class AccessTokenTest {
     }
 
     @Test
-    public void testShouldRefreshWhenSet() {
+    public void testShouldRefreshAfterExpiration() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
         accessToken.setRefreshOn(getCurrentTimeStr());
         assertTrue(accessToken.shouldRefresh());
     }
 
     @Test
-    public void testShouldRefreshWhenNotSet() {
+    public void testShouldRefreshWhileStillValid() {
         final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setRefreshOn("2524608000"); // 1/1/2050
         assertFalse(accessToken.shouldRefresh());
+    }
+
+    @Test
+    public void testShouldRefreshWhenNoPropertiesAreSet() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        assertTrue(accessToken.shouldRefresh());
     }
 
     private String getCurrentTimeStr() {


### PR DESCRIPTION
Implementing the refresh_on optional field per the schema: https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?version=GBdev&path=%2FSSO%2FSchema.md

Documentation of the refresh_in header can be found here: https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/RefreshAtExpirationPercentage/overview.md&_a=preview

As a note, just as expires_on is a calculated value based on the server value (expires_in) + local time, refresh_on works the same way, being returned from the server as refresh_in, and requiring a calculation to be made by the library to save a unix timestamp.