### PR TITLE
Validate ATs before writing to MSALCPP cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 vNext
 ----------
-
 - Add requested_claims to access tokens, and allow credentials to be filtered by RC (#1187)
 - Sends CP version to ESTS and handle WebCP uri. (#1137)
 - Check for eligible for caching when putting command in executing command map
@@ -13,6 +12,7 @@ vNext
 - Remove connection close from http request to AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN issue on emulators.
 - Replace deprecated HttpRequest.sendGet usage with HttpClient.get (#1038)
 - Replace deprecated HttpRequest.sendPost usage with HttpClient.post (#1037)
+- (MSALCPP) Validate ATs before persisting to the cache (#1192)
 
 Version 3.0.8
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -314,4 +314,15 @@ public class MsalCppOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         Assert.assertTrue(credentials.contains(mTestBundle.mGeneratedIdToken));
         Assert.assertTrue(credentials.contains(mTestBundle.mGeneratedRefreshToken));
     }
+
+    @Test(expected = ClientException.class)
+    public void saveATSansTargetThrowsException() throws ClientException {
+        mTestBundle.mGeneratedAccessToken.setTarget(null);
+        mCppCache.saveCredentials(
+                null,
+                mTestBundle.mGeneratedAccessToken,
+                mTestBundle.mGeneratedIdToken,
+                mTestBundle.mGeneratedRefreshToken
+        );
+    }
 }

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -54,7 +54,6 @@ import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.M
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -415,7 +414,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         assertNotNull(entry.getRefreshToken());
     }
 
-    @Ignore //Test failing on travis instrumented tests
     @Test
     public void saveTokensWithAggregationSingleEntryWithMalformedDataInCache() throws ClientException {
         // Prepopulate the cache with unparseable, junk data
@@ -961,7 +959,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     }
 
     @Test
-    @Ignore //Failing test
     public void getAccountsWithDeletion() throws ClientException {
         getAccountsWithDeletion(IdToken);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.common.BaseAccount;
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.dto.AccessTokenRecord;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.dto.Credential;
 import com.microsoft.identity.common.internal.dto.CredentialType;
@@ -45,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.microsoft.identity.common.exception.ErrorStrings.CREDENTIAL_IS_SCHEMA_NONCOMPLIANT;
 import static com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal.SCHEME_BEARER;
 
 /**
@@ -127,7 +129,17 @@ public class MsalCppOAuth2TokenCache
             if (credential instanceof RefreshTokenRecord) {
                 refreshTokenRecord = (RefreshTokenRecord) credential;
             }
+
+            if (credential instanceof AccessTokenRecord) {
+                if (!isAccessTokenSchemaCompliant((AccessTokenRecord) credential)) {
+                    throw new ClientException(
+                            CREDENTIAL_IS_SCHEMA_NONCOMPLIANT,
+                            "AT is missing a required property."
+                    );
+                }
+            }
         }
+
         if (accountRecord != null && refreshTokenRecord != null) {
             // MSAL C++ writes credentials first and then the account.
             // For a new account, this will not be true as the accountRecord will be null.

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalCppOAuth2TokenCache.java
@@ -130,13 +130,12 @@ public class MsalCppOAuth2TokenCache
                 refreshTokenRecord = (RefreshTokenRecord) credential;
             }
 
-            if (credential instanceof AccessTokenRecord) {
-                if (!isAccessTokenSchemaCompliant((AccessTokenRecord) credential)) {
-                    throw new ClientException(
-                            CREDENTIAL_IS_SCHEMA_NONCOMPLIANT,
-                            "AT is missing a required property."
-                    );
-                }
+            if (credential instanceof AccessTokenRecord
+                    && !isAccessTokenSchemaCompliant((AccessTokenRecord) credential)) {
+                throw new ClientException(
+                        CREDENTIAL_IS_SCHEMA_NONCOMPLIANT,
+                        "AT is missing a required property."
+                );
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -1771,7 +1771,7 @@ public class MsalOAuth2TokenCache
         return isSchemaCompliant(account.getClass(), params);
     }
 
-    private boolean isAccessTokenSchemaCompliant(@NonNull final AccessTokenRecord accessToken) {
+    boolean isAccessTokenSchemaCompliant(@NonNull final AccessTokenRecord accessToken) {
         // Required fields...
         final String[][] params = new String[][]{
                 {Credential.SerializedNames.CREDENTIAL_TYPE, accessToken.getCredentialType()},


### PR DESCRIPTION
Impetus:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1221073/

In this PR:
- Reenables `MsalOAuth2TokenCache` tests previously disabled due to mysterious failures on Travis-CI infrastructure
- Adds AT validation when saving via `MsalCppOAuth2TokenCache`