### PR TITLE
Authenticator app automation UI fixes

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -25,8 +25,8 @@ package com.microsoft.identity.client.ui.automation.broker;
 import android.Manifest;
 import android.os.Build;
 import android.util.Log;
+import android.widget.Button;
 import android.widget.EditText;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -41,7 +41,6 @@ import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
-import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -201,42 +200,47 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
 
         try {
             // select Help from drop down
-            final UiObject settings = UiAutomatorUtils.obtainUiObjectWithText("Help");
+            final UiObject settings = UiAutomatorUtils.obtainUiObjectWithText("Send Feedback");
             settings.click();
 
-            // scroll down the recycler view to find Send logs btn
-            final UiObject sendLogs = UiAutomatorUtils.obtainChildInScrollable(
-                    android.widget.ScrollView.class,
-                    "Send logs"
+            final UiObject sendLogs = UiAutomatorUtils.obtainUiObjectWithClassAndDescription(
+                    Button.class,
+                    "Having trouble?Report it"
             );
 
-            assert sendLogs != null;
+            Assert.assertTrue(sendLogs.exists());
 
             // click the send logs button
             sendLogs.click();
 
-            final UiObject sendLogMsgField = UiAutomatorUtils.obtainUiObjectWithClassAndIndex(
-                    EditText.class,
-                    1
+            UiAutomatorUtils.handleButtonClickForObjectWithText("Select an option");
+
+            UiAutomatorUtils.handleButtonClickForObjectWithText("Other");
+
+            final UiObject describeIssueBox = UiAutomatorUtils.obtainUiObjectWithTextAndClassType(
+                    "Please don't include your name, phone number, or other personal information.",
+                    EditText.class
             );
 
-            sendLogMsgField.setText("Broker Automation Incident");
+            describeIssueBox.setText("Broker Automation Incident");
 
-            final UiObject sendBtn = UiAutomatorUtils.obtainEnabledUiObjectWithExactText(
-                    "SEND"
-            );
+            final UiObject sendBtn = UiAutomatorUtils.obtainUiObjectWithDescription("Send feedback");
             sendBtn.click();
 
-            final UiObject postLogSubmissionMsg = UiAutomatorUtils.obtainUiObjectWithClassAndIndex(
-                    TextView.class,
-                    3
+            final UiObject postLogSubmissionMsg = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                    "android:id/parentPanel"
             );
 
             Assert.assertTrue(postLogSubmissionMsg.exists());
 
+            final UiObject incidentDetails = UiAutomatorUtils.obtainUiObjectWithResourceId("android:id/message");
+            Assert.assertTrue(incidentDetails.exists());
+
+            final String incidentIdText = incidentDetails.getText();
+
             // This will post the incident id in text logs
-            Log.w(TAG, postLogSubmissionMsg.getText());
-        } catch (UiObjectNotFoundException e) {
+            Log.w(TAG, incidentIdText);
+        } catch (final UiObjectNotFoundException e) {
             throw new AssertionError(e);
         }
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -124,6 +124,10 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
                 "com.azure.authenticator:id/shared_device_registration_button"
         );
 
+        // There is a data privacy dialog that shows up when shared device registration finishes.
+        // But why? This should really not pop up at this time.
+        UiAutomatorUtils.handleButtonClick("android:id/button1");
+
         final UiDevice device =
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -241,18 +241,41 @@ public class GoogleSettings extends BaseSettings {
     }
 
     @Override
-    public void setPinOnDevice(final String password) throws UiObjectNotFoundException {
-        UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
-        launchScreenLockPage();
-        final UiObject screenLock = UiAutomatorUtils.obtainUiObjectWithText("Screen lock");
-        Assert.assertTrue(screenLock.exists());
-        screenLock.click();
-        UiAutomatorUtils.handleButtonClick("com.android.settings:id/lock_pin");
-        UiAutomatorUtils.handleInput("com.android.settings:id/password_entry", password);
-        device.pressEnter();
-        UiAutomatorUtils.handleInput("com.android.settings:id/password_entry", password);
-        device.pressEnter();
-        handleDoneButton();
+    public void setPinOnDevice(final String pin) {
+        try {
+            final UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            launchScreenLockPage();
+            final UiObject screenLock = UiAutomatorUtils.obtainUiObjectWithText("Screen lock");
+            Assert.assertTrue(screenLock.exists());
+            screenLock.click();
+            UiAutomatorUtils.handleButtonClick("com.android.settings:id/lock_pin");
+            UiAutomatorUtils.handleInput("com.android.settings:id/password_entry", pin);
+            device.pressEnter();
+            UiAutomatorUtils.handleInput("com.android.settings:id/password_entry", pin);
+            device.pressEnter();
+            handleDoneButton();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public void removePinFromDevice(final String pin) {
+        try {
+            final UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+            launchScreenLockPage();
+            final UiObject screenLock = UiAutomatorUtils.obtainUiObjectWithText("Screen lock");
+            Assert.assertTrue(screenLock.exists());
+            screenLock.click();
+            UiAutomatorUtils.handleInput("com.android.settings:id/password_entry", pin);
+            device.pressEnter();
+            // Click Lock None
+            UiAutomatorUtils.handleButtonClick("com.android.settings:id/lock_none");
+            // confirm removal of screen lock
+            UiAutomatorUtils.handleButtonClick("android:id/button1");
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
     }
 
     private void handleDoneButton() throws UiObjectNotFoundException {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -92,7 +92,12 @@ public interface ISettings {
     /**
      * Adds screen lock to the device.
      */
-    void setPinOnDevice(final String password) throws UiObjectNotFoundException;
+    void setPinOnDevice(final String pin);
+
+    /**
+     * Remove screen lock from the device.
+     */
+    void removePinFromDevice(final String pin);
 
     /**
      * Launches the security page in Settings app.

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -191,6 +191,11 @@ public class SamsungSettings extends BaseSettings {
 
     @Override
     public void setPinOnDevice(final String password) {
-        //TODO: implement addPinSetup for samsung device.
+        //TODO: implement addPinSetup for SAMSUNG device.
+    }
+
+    @Override
+    public void removePinFromDevice(String pin) {
+        //TODO: implement removing PIN for SAMSUNG device.
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -63,7 +63,7 @@ public class RulesHelper {
         ruleChain = ruleChain.around(new ResetAutomaticTimeZoneTestRule());
 
         Log.i(TAG, "Adding DeviceLockSetRule");
-        ruleChain = ruleChain.around(new DevicePinSetupRule());
+        ruleChain = ruleChain.around(new DevicePinSetupRule(broker));
 
         if (com.microsoft.identity.client.ui.automation.BuildConfig.PREFER_PRE_INSTALLED_APKS) {
             Log.i(TAG, "Adding CopyPreInstalledApkRule");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -61,7 +61,7 @@ public class UiAutomatorUtils {
     /**
      * Obtain an instance of an enabled UiObject for the resource Id.
      *
-     * @param text the text of the element to obtain
+     * @param resourceId the resource Id of the element to obtain
      * @return the UiObject associated to the supplied resource id
      */
     @NonNull
@@ -111,6 +111,42 @@ public class UiAutomatorUtils {
 
         final UiObject uiObject = device.findObject(new UiSelector()
                 .textContains(text));
+
+        uiObject.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+        return uiObject;
+    }
+
+    /**
+     * Obtain an instance of the UiObject for the given text.
+     *
+     * @param description the description of the element to obtain
+     * @return the UiObject associated to the supplied text
+     */
+    public static UiObject obtainUiObjectWithDescription(@NonNull final String description) {
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiObject uiObject = device.findObject(new UiSelector()
+                .description(description));
+
+        uiObject.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+        return uiObject;
+    }
+
+    /**
+     * Obtain an instance of the UiObject for the given text.
+     *
+     * @param description the content description of the element to obtain
+     * @return the UiObject associated to the supplied text
+     */
+    public static UiObject obtainUiObjectWithClassAndDescription(@NonNull final Class clazz,
+                                                                 @NonNull final String description) {
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiObject uiObject = device.findObject(new UiSelector()
+                .className(clazz)
+                .descriptionContains(description));
 
         uiObject.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
         return uiObject;
@@ -257,6 +293,21 @@ public class UiAutomatorUtils {
      */
     public static void handleButtonClick(@NonNull final String resourceId) {
         final UiObject button = obtainUiObjectWithResourceId(resourceId);
+
+        try {
+            button.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Clicks the button element associated to the supplied resource id.
+     *
+     * @param text the text on the button to click
+     */
+    public static void handleButtonClickForObjectWithText(@NonNull final String text) {
+        final UiObject button = obtainUiObjectWithText(text);
 
         try {
             button.click();


### PR DESCRIPTION
- Handle UI for privacy dialog that pops up during shared device registration
- Change logic for setting PIN on the device to handle Authenticator app lock (see javadoc in DevicePinSetupRule to understand why)
  - Only set PIN if CP is being used
  - Remove PIN if Authenticator is being
- Fix for creating powerlift incidents due to UI change in Auth App