### PR TITLE
Enabling the MFA setup using Authenticator app

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ vNext
 - Remove connection close from http request to AUTHORIZATION_CODE_NOT_EXCHANGED_FOR_TOKEN issue on emulators.
 - Replace deprecated HttpRequest.sendGet usage with HttpClient.get (#1038)
 - Replace deprecated HttpRequest.sendPost usage with HttpClient.post (#1037)
+- Fixes for MFA setup using Authenticator app.
 
 Version 3.0.8
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1079,6 +1079,11 @@ public final class AuthenticationConstants {
         public static final String BROWSER_EXT_WEB_CP = "companyportal://";
 
         /**
+         * Prefix in the redirect from WebCP.
+         */
+        public static final String AUTHENTICATOR_MFA_LINKING = "microsoft-authenticator://activatemfa";
+
+        /**
          * Redirect URL from WebCP that should launch the Intune Company Portal app.
          */
         public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = BROWSER_EXT_WEB_CP + "enrollment";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1170,6 +1170,16 @@ public final class AuthenticationConstants {
         public static final String REDIRECT_SSL_PREFIX = "https://";
 
         /**
+         * Prefix in the redirect for PlayStore.
+         */
+        public static final String PLAY_STORE_INSTALL_PREFIX = "market://details?id=";
+
+        /**
+         * Prefix in the redirect for PlayStore through Browser.
+         */
+        public static final String PLAY_STORE_BROWSER_INSTALL_PREFIX = REDIRECT_SSL_PREFIX + "play.google.com/store/apps/details?id=";
+
+        /**
          * String for expiration buffer.
          * Integer for token expiration buffer. see {@link AuthenticationSettings#mExpirationBuffer}
          */

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1180,11 +1180,6 @@ public final class AuthenticationConstants {
         public static final String PLAY_STORE_INSTALL_PREFIX = "market://details?id=";
 
         /**
-         * Prefix in the redirect for PlayStore through Browser.
-         */
-        public static final String PLAY_STORE_BROWSER_INSTALL_PREFIX = REDIRECT_SSL_PREFIX + "play.google.com/store/apps/details?id=";
-
-        /**
          * String for expiration buffer.
          * Integer for token expiration buffer. see {@link AuthenticationSettings#mExpirationBuffer}
          */

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1079,9 +1079,9 @@ public final class AuthenticationConstants {
         public static final String BROWSER_EXT_WEB_CP = "companyportal://";
 
         /**
-         * Prefix in the redirect from WebCP.
+         * Prefix for the Authenticator MFA linking.
          */
-        public static final String AUTHENTICATOR_MFA_LINKING = "microsoft-authenticator://activatemfa";
+        public static final String AUTHENTICATOR_MFA_LINKING_PREFIX = "microsoft-authenticator://activatemfa";
 
         /**
          * Redirect URL from WebCP that should launch the Intune Company Portal app.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -335,7 +335,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_INSTALL_PREFIX + appPackageName));
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             getActivity().startActivity(intent);
-            return true;
         } catch (android.content.ActivityNotFoundException e) {
             //if GooglePlay is not present on the device.
             Logger.error(TAG + methodName, "Failed to launch the PlayStore.", e);
@@ -351,7 +350,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             getActivity().startActivity(intent);
-            return true;
         } catch (android.content.ActivityNotFoundException e) {
             Logger.error(TAG, "Failed to open the Authenticator application.", e);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -330,6 +330,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         view.stopLoading();
         if (!(url.startsWith(PLAY_STORE_INSTALL_PREFIX + COMPANY_PORTAL_PROD_APP_PACKAGE_NAME))
                 && !(url.startsWith(PLAY_STORE_INSTALL_PREFIX + AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))) {
+            Logger.info(TAG + methodName, "The URI is either trying to open an unknown application or contains unknown query parameters");
             return false;
         }
         final String appPackageName = (url.contains(COMPANY_PORTAL_PROD_APP_PACKAGE_NAME) ?

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -441,7 +441,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     private void processInvalidRedirectUri(@NonNull final WebView view, @NonNull final String url) {
-        final String methodName = "#processRedirectUriCheck";
+        final String methodName = "#processInvalidRedirectUri";
 
         Logger.error(TAG + methodName, "The RedirectUri is not as expected.", null);
         Logger.errorPII(TAG, String.format("Received %s and expected %s", url, mRedirectUrl), null);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -346,7 +346,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.verbose(TAG + methodName, "Linking Account in Broker for MFA.");
         try {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             getActivity().startActivity(intent);
         } catch (android.content.ActivityNotFoundException e) {
             Logger.error(TAG, "Failed to open the Authenticator application.", e);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -155,46 +155,38 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 returnError(exception.getErrorCode(), exception.getMessage());
                 view.stopLoading();
             }
-            return true;
         } else if (isRedirectUrl(formattedURL)) {
             Logger.info(TAG, "Navigation starts with the redirect uri.");
             processRedirectUrl(view, url);
-            return true;
         } else if (isWebsiteRequestUrl(formattedURL)) {
             Logger.info(TAG, "It is an external website request");
             processWebsiteRequest(view, url);
-            return true;
         } else if (isInstallRequestUrl(formattedURL)) {
             Logger.info(TAG, "It is an install request");
             processInstallRequest(view, url);
-            return true;
         } else if (isWebCpUrl(formattedURL)) {
             Logger.info(TAG, "It is a request from WebCP");
             processWebCpRequest(view, url);
-            return true;
         } else if (isPlayStoreUrl(formattedURL)){
             Logger.info(TAG, "Request to open PlayStore.");
             return processPlayStoreURL(view, url);
         } else if (isAuthAppMFAUrl(formattedURL)){
             Logger.info(TAG, "Request to link account with Authenticator.");
             processAuthAppMFAUrl(url);
-            return true;
-        } else if (isValidRedirectUri(url)){
+        } else if (isInvalidRedirectUri(url)){
             Logger.info(TAG, "Check for Redirect Uri.");
             processInvalidRedirectUri(view, url);
-            return true;
         } else if (isBlankPageRequest(formattedURL)){
-            Logger.verbose(TAG, "It is an blank page request");
-            return true;
+            Logger.info(TAG, "It is an blank page request");
         } else if (isUriSSLProtected(formattedURL)){
-            Logger.verbose(TAG, "Check for SSL protection");
+            Logger.info(TAG, "Check for SSL protection");
             processSSLProtectionCheck(view, url);
-            return true;
         } else {
             Logger.info(TAG, "This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
             processInvalidUrl(url);
             return false;
         }
+        return true;
     }
 
     private boolean isUriSSLProtected(@NonNull final String url) {
@@ -205,13 +197,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return "about:blank".equals(url);
     }
 
-    private boolean isValidRedirectUri(@NonNull final String url) {
+    private boolean isInvalidRedirectUri(@NonNull final String url) {
         return isBrokerRequest(getActivity().getIntent())
                 && url.startsWith(AuthenticationConstants.Broker.REDIRECT_PREFIX);
     }
 
     private boolean isAuthAppMFAUrl(@NonNull final String url) {
-        return url.startsWith(AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING);
+        return url.startsWith(AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX);
     }
 
     private boolean isPlayStoreUrl(@NonNull final String url) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.webkit.WebView;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.IAuthorizationCompletionCallback;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_PROD_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(RobolectricTestRunner.class)
+public class AzureActiveDirectoryWebViewClientTest {
+    private WebView mMockWebView;
+    private AzureActiveDirectoryWebViewClient mWebViewClient;
+    private Context mContext;
+    private Activity mActivity;
+    private static final String TEST_REDIRECT_URI = "abc12";
+
+    // Test strings initialized.
+    private static final String TEST_PLAY_STORE_INSTALL_AUTH_APP_URL =
+            PLAY_STORE_INSTALL_PREFIX + AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
+    private static final String TEST_PLAY_STORE_INSTALL_CP_URL =
+            PLAY_STORE_INSTALL_PREFIX + COMPANY_PORTAL_PROD_APP_PACKAGE_NAME;
+    private static final String TEST_PLAY_STORE_INSTALL_INVALID_APP =
+            PLAY_STORE_INSTALL_PREFIX + "com.azure.xyz";
+    private static final String AUTHENTICATOR_MFA_LINKING_INVALID_URI =
+            AUTHENTICATOR_MFA_LINKING_PREFIX + "xyz";
+    private static final String TEST_SSL_PROTECTION_HTTP_URL = "http://foo";
+    private static final String TEST_SSL_PROTECTION_FTP_URL = "ftp://foo";
+    private static final String TEST_REDIRECT_URL = "ABC12/xyz";
+    private static final String TEST_WEBSITE_REQUEST_URL = "browser://abcxyz/a";
+    private static final String TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "browser://abcxyz/xyz&ismdmurl=1";
+    private static final String TEST_INSTALL_REQUEST_URL = "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11Z";
+    private static final String TEST_BLANK_PAGE_REQUEST_URL = "about:blank";
+    private static final String TEST_PKEY_AUTH_URL = "urn:http-auth:PKeyAuth/xyz";
+    private static final String TEST_WEB_CP_URL = "companyportal://abc/123";
+    private static final String TEST_INVALID_URL = "https://play.google.com/store/apps/details?id=com.azure.authenticator";
+
+    @Before
+    public void setup() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mMockWebView = new WebView(mContext);
+        mActivity = Robolectric.buildActivity(Activity.class).get();
+        mWebViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                new IAuthorizationCompletionCallback() {
+                    @Override
+                    public void onChallengeResponseReceived(int returnCode, Intent responseIntent) {
+                        return;
+                    }
+
+                    @Override
+                    public void setPKeyAuthStatus(boolean status) {
+                        return;
+                    }
+                },
+                new OnPageLoadedCallback() {
+                    @Override
+                    public void onPageLoaded() {
+                        return;
+                    }
+                },
+                TEST_REDIRECT_URI);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUrlOverrideHandlesEmptyString() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, ""));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUrlOverrideHandlesNullString() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, (String) null));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesPkeyAuthUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PKEY_AUTH_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesWebsiteRequestUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEBSITE_REQUEST_URL));
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesInstallRequest() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INSTALL_REQUEST_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesWebCpUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesRedirectUriString() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_REDIRECT_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesPlayStoreRedirect() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAY_STORE_INSTALL_AUTH_APP_URL));
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAY_STORE_INSTALL_CP_URL));
+        assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAY_STORE_INSTALL_INVALID_APP));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesAuthAppMFAUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, AUTHENTICATOR_MFA_LINKING_INVALID_URI));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesSSLProtectionCheck() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_SSL_PROTECTION_HTTP_URL));
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_SSL_PROTECTION_FTP_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesBlankPageRequest() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_BLANK_PAGE_REQUEST_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesInvalidUrl() {
+        assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INVALID_URL));
+    }
+
+
+}


### PR DESCRIPTION
The MFA setup using the webview through Authenticator app was broken. Users had to resort to browser flow to complete the MFA setup as a workaround. This PR aims to fix the mentioned issue.

Related ADAL PR : https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1579