### PR TITLE
Add new overload for onReceivedError (deprecation warning)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ vNext
 - Replace deprecated HttpRequest.sendGet usage with HttpClient.get (#1038)
 - Replace deprecated HttpRequest.sendPost usage with HttpClient.post (#1037)
 - (MSALCPP) Validate ATs before persisting to the cache (#1192)
+- Adds API23 WebViewClient#onReceivedError overload (#1197)
 
 Version 3.0.8
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -119,7 +119,6 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
                                 final int errorCode,
                                 final String description,
                                 final String failingUrl) {
-        super.onReceivedError(view, errorCode, description, failingUrl);
         sendErrorToCallback(view, errorCode, description);
     }
 
@@ -128,7 +127,6 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     public void onReceivedError(@NonNull final WebView view,
                                 @NonNull final WebResourceRequest request,
                                 @NonNull final WebResourceError error) {
-        super.onReceivedError(view, request, error);
         sendErrorToCallback(view, error.getErrorCode(), error.getDescription().toString());
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -27,13 +27,17 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.net.http.SslError;
+import android.os.Build;
 import android.view.View;
 import android.webkit.HttpAuthHandler;
 import android.webkit.SslErrorHandler;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -116,7 +120,21 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
                                 final String description,
                                 final String failingUrl) {
         super.onReceivedError(view, errorCode, description, failingUrl);
+        sendErrorToCallback(view, errorCode, description);
+    }
 
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public void onReceivedError(@NonNull final WebView view,
+                                @NonNull final WebResourceRequest request,
+                                @NonNull final WebResourceError error) {
+        super.onReceivedError(view, request, error);
+        sendErrorToCallback(view, error.getErrorCode(), error.getDescription().toString());
+    }
+
+    private void sendErrorToCallback(@NonNull final WebView view,
+                                     final int errorCode,
+                                     @NonNull final String description) {
         view.stopLoading();
 
         // Create result intent when webView received an error.


### PR DESCRIPTION
Impetus:
https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1226175

To Do:
- Add docs on 'Maintenance Best Practices' to `/docs` clarifying overload implementations re: lifecycle/event callbacks
    * (This will be a separate PR to MSAL)
- Update the follow classes:
    * `BasicWebViewClient`
    * PR is [here](https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1580)