### PR TITLE
Add back pom details

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -294,56 +294,33 @@ afterEvaluate {
                 //Edit the 'version' here for VSTS RC build
                 version = project.version
 
-                pom.withXml {
-                    // Custom values
-
-                    // Description
-                    asNode().appendNode(
-                            'description',
-                            'This library contains code shared between the Active Directory ' +
+                pom {
+                    name = 'common'
+                    description = 'This library contains code shared between the Active Directory ' +
                                     'Authentication Library (ADAL) for Android and the Microsoft ' +
                                     'Authentication Library (MSAL) for Android. This library ' +
                                     'includes only internal classes and is NOT part of the ' +
                                     'public API'
-                    )
-
-                    // Name
-                    asNode().appendNode('name', 'common')
-
-                    // Developers
-                    def developerNode = asNode().appendNode('developers').appendNode('developer')
-                    developerNode.appendNode('id', 'microsoft')
-                    developerNode.appendNode('name', 'Microsoft')
-
-                    // URL
-                    asNode().appendNode('url', 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android')
-
-                    // Licenses
-                    asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
-
-                    // Inception Year
-                    asNode().appendNode('inceptionYear', '2017')
-
-                    // SCM
-                    asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android/tree/master')
-
-                    // Properties
-                    def propertiesNode = asNode().appendNode('properties')
-                    propertiesNode.appendNode('branch', 'master')
-                    propertiesNode.appendNode('version', project.version)
-
-                    // Dependencies
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
-                    configurations.implementation.allDependencies.each {
-                        if (it.group != null && it.name != null) {
-                            def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
+                    url = 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android'
+                    developers {
+                        developer {
+                            id = 'microsoft'
+                            name = 'Microsoft'
                         }
                     }
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                        }
+                    }
+                    inceptionYear = '2017'
+                    scm {
+                        url = 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android/tree/master'
+                    }
+                    properties = [
+                            branch: 'master',
+                            version: project.version
+                    ]
                 }
             }
             debug(MavenPublication) {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -293,6 +293,58 @@ afterEvaluate {
                 artifactId 'common'
                 //Edit the 'version' here for VSTS RC build
                 version = project.version
+
+                pom.withXml {
+                    // Custom values
+
+                    // Description
+                    asNode().appendNode(
+                            'description',
+                            'This library contains code shared between the Active Directory ' +
+                                    'Authentication Library (ADAL) for Android and the Microsoft ' +
+                                    'Authentication Library (MSAL) for Android. This library ' +
+                                    'includes only internal classes and is NOT part of the ' +
+                                    'public API'
+                    )
+
+                    // Name
+                    asNode().appendNode('name', 'common')
+
+                    // Developers
+                    def developerNode = asNode().appendNode('developers').appendNode('developer')
+                    developerNode.appendNode('id', 'microsoft')
+                    developerNode.appendNode('name', 'Microsoft')
+
+                    // URL
+                    asNode().appendNode('url', 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android')
+
+                    // Licenses
+                    asNode().appendNode('licenses').appendNode('license').appendNode('name', 'MIT License')
+
+                    // Inception Year
+                    asNode().appendNode('inceptionYear', '2017')
+
+                    // SCM
+                    asNode().appendNode('scm').appendNode('url', 'https://github.com/AzureAD/microsoft-authentication-library-common-for-android/tree/master')
+
+                    // Properties
+                    def propertiesNode = asNode().appendNode('properties')
+                    propertiesNode.appendNode('branch', 'master')
+                    propertiesNode.appendNode('version', project.version)
+
+                    // Dependencies
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    //Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
+                    configurations.implementation.allDependencies.each {
+                        if (it.group != null && it.name != null) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                    }
+                }
             }
             debug(MavenPublication) {
                 from components.debug


### PR DESCRIPTION
Without this script, our pom file won't have the metadata it used to/supposed to have.

i.e.
```
<description>This library contains code shared between the Active Directory Authentication Library (ADAL) for Android and the Microsoft Authentication Library (MSAL) for Android. This library includes only internal classes and is NOT part of the public API</description>
  <name>common</name>
  <developers>
    <developer>
      <id>microsoft</id>
      <name>Microsoft</name>
    </developer>
  </developers>
  <url>https://github.com/AzureAD/microsoft-authentication-library-common-for-android</url>
  <licenses>
    <license>
      <name>MIT License</name>
    </license>
  </licenses>
  <inceptionYear>2017</inceptionYear>
  <scm>
    <url>https://github.com/AzureAD/microsoft-authentication-library-common-for-android/tree/master</url>
  </scm>
  <properties>
    <branch>master</branch>
    <version>3.0.4</version>
  </properties>
```