### PR TITLE
Add JUnit Rule to get Factory Version of Chrome if needed

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
@@ -41,6 +41,8 @@ public class BrowserChrome extends App implements IBrowser {
     public static final String CHROME_PACKAGE_NAME = "com.android.chrome";
     public static final String CHROME_APP_NAME = "Google Chrome";
 
+    private static final String TAG = BrowserChrome.class.getSimpleName();
+
     public BrowserChrome() {
         super(CHROME_PACKAGE_NAME, CHROME_APP_NAME);
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
@@ -37,8 +37,8 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
  */
 public class BrowserChrome extends App implements IBrowser {
 
-    private static final String CHROME_PACKAGE_NAME = "com.android.chrome";
-    private static final String CHROME_APP_NAME = "Google Chrome";
+    public static final String CHROME_PACKAGE_NAME = "com.android.chrome";
+    public static final String CHROME_APP_NAME = "Google Chrome";
 
     public BrowserChrome() {
         super(CHROME_PACKAGE_NAME, CHROME_APP_NAME);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserChrome.java
@@ -38,10 +38,9 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
  */
 public class BrowserChrome extends App implements IBrowser {
 
+    private static final String TAG = BrowserChrome.class.getSimpleName();
     public static final String CHROME_PACKAGE_NAME = "com.android.chrome";
     public static final String CHROME_APP_NAME = "Google Chrome";
-
-    private static final String TAG = BrowserChrome.class.getSimpleName();
 
     public BrowserChrome() {
         super(CHROME_PACKAGE_NAME, CHROME_APP_NAME);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
@@ -93,8 +93,9 @@ public abstract class BaseSettings implements ISettings {
             launchIntent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, data);
         } catch (final ActivityNotFoundException e) {
             Logger.e(TAG, "Package: " + packageName + " probably not available on device.", e);
-            //Open the generic Apps page:
-            launchIntent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS);
+            // we could probably install the package from PlayStore (but for now let's fail the test
+            // to see if this ever happens in the wild)
+            throw new AssertionError(e);
         }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
@@ -29,6 +29,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.Settings;
 
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.uiautomator.UiObject;
 
@@ -43,8 +44,6 @@ public abstract class BaseSettings implements ISettings {
 
     private final static String TAG = BaseSettings.class.getSimpleName();
     final static String SETTINGS_PKG = "com.android.settings";
-
-    public static final String TAG = BaseSettings.class.getSimpleName();
 
     @Override
     public void launchDeviceAdminSettingsPage() {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/BaseSettings.java
@@ -22,18 +22,18 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.ui.automation.device.settings;
 
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.provider.Settings;
 
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
-import androidx.test.uiautomator.UiObjectNotFoundException;
 
+import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -43,6 +43,8 @@ import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.laun
 public abstract class BaseSettings implements ISettings {
 
     final static String SETTINGS_PKG = "com.android.settings";
+
+    public static final String TAG = BaseSettings.class.getSimpleName();
 
     @Override
     public void launchDeviceAdminSettingsPage() {
@@ -77,5 +79,18 @@ public abstract class BaseSettings implements ISettings {
     @Override
     public void launchScreenLockPage() {
         launchIntent(Settings.ACTION_SECURITY_SETTINGS);
+    }
+
+    @Override
+    public void launchAppInfoPage(@NonNull final String packageName) {
+        try {
+            //Open the specific App Info page:
+            final Uri data = Uri.parse("package:" + packageName);
+            launchIntent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, data);
+        } catch (final ActivityNotFoundException e) {
+            Logger.e(TAG, "Package: " + packageName + " probably not available on device.", e);
+            //Open the generic Apps page:
+            launchIntent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS);
+        }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -103,4 +103,6 @@ public interface ISettings {
      * Launches the security page in Settings app.
      */
     void launchScreenLockPage();
+
+    void launchAppInfoPage(String packageName);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.client.ui.automation.device.settings;
 
 import androidx.annotation.NonNull;
-import androidx.test.uiautomator.UiObjectNotFoundException;
 
 import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
@@ -104,5 +103,10 @@ public interface ISettings {
      */
     void launchScreenLockPage();
 
+    /**
+     * Launch the app info page for the supplied package name.
+     *
+     * @param packageName the package for which to open app info page
+     */
     void launchAppInfoPage(String packageName);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -81,23 +81,6 @@ public class FactoryResetChromeRule implements TestRule {
         };
     }
 
-    private void downgradeChromeToFactoryVersion() {
-        final TestDevice device = TestContext.getTestContext().getTestDevice();
-        device.getSettings().launchAppInfoPage(BrowserChrome.CHROME_PACKAGE_NAME);
-
-        // disable chrome
-        UiAutomatorUtils.handleButtonClick("com.android.settings:id/button1_negative");
-
-        // confirm disable in dialog
-        UiAutomatorUtils.handleButtonClick("android:id/button1");
-
-        // confirm downgrade to factory version
-        UiAutomatorUtils.handleButtonClick("android:id/button1");
-
-        // Enable Chrome
-        UiAutomatorUtils.handleButtonClick("com.android.settings:id/button1_positive");
-    }
-
     private String getPackageMajorVersion(final String packageName) {
         try {
             final Context context = ApplicationProvider.getApplicationContext();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -41,6 +41,9 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+/**
+ * A Test Rule to downgrade Chrome and WebView to factory default version.
+ */
 public class FactoryResetChromeRule implements TestRule {
 
     public static final String TAG = FactoryResetChromeRule.class.getSimpleName();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -1,0 +1,65 @@
+package com.microsoft.identity.client.ui.automation.rules;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.client.ui.automation.TestContext;
+import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
+import com.microsoft.identity.client.ui.automation.device.TestDevice;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class FactoryResetChromeRule implements TestRule {
+
+    public static final String TAG = FactoryResetChromeRule.class.getSimpleName();
+
+    private final static int CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION = 71;
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                final Context context = ApplicationProvider.getApplicationContext();
+                final PackageManager packageManager = context.getPackageManager();
+                final PackageInfo chromePackageInfo = packageManager.getPackageInfo(BrowserChrome.CHROME_PACKAGE_NAME, 0);
+                final String chromeVersion = chromePackageInfo.versionName;
+                final String[] parts = chromeVersion.split("\\.");
+                final String majorVersion = parts[0];
+                Logger.i(TAG, "Chrome Version = " + chromeVersion);
+                Logger.i(TAG, "Chrome major version = " + majorVersion);
+
+                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    downgradeChromeToFactoryVersion();
+                }
+
+                // proceed with the test case
+                base.evaluate();
+            }
+        };
+    }
+
+    private void downgradeChromeToFactoryVersion() {
+        final TestDevice device = TestContext.getTestContext().getTestDevice();
+        device.getSettings().launchAppInfoPage(BrowserChrome.CHROME_PACKAGE_NAME);
+
+        // disable chrome
+        UiAutomatorUtils.handleButtonClick("com.android.settings:id/button1_negative");
+
+        // confirm disable in dialog
+        UiAutomatorUtils.handleButtonClick("android:id/button1");
+
+        // confirm downgrade to factory version
+        UiAutomatorUtils.handleButtonClick("android:id/button1");
+
+        // Enable Chrome
+        UiAutomatorUtils.handleButtonClick("com.android.settings:id/button1_positive");
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -35,6 +35,8 @@ public class FactoryResetChromeRule implements TestRule {
                 final String chromeVersion = getPackageMajorVersion(BrowserChrome.CHROME_PACKAGE_NAME);
                 if (!TextUtils.isEmpty(chromeVersion) &&
                         Integer.parseInt(chromeVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    Logger.w(TAG, "Chrome version on the device is higher than the known version suitable for automation. " +
+                            "We are going to attempt to factory reset Chrome and hope that it will give us the desired version.");
                     // adb uninstall does factory reset for default apps
                     AdbShellUtils.removePackage(BrowserChrome.CHROME_PACKAGE_NAME);
                 }
@@ -42,6 +44,8 @@ public class FactoryResetChromeRule implements TestRule {
                 final String webViewVersion = getPackageMajorVersion(WEB_VIEW_PACKAGE_NAME);
                 if (!TextUtils.isEmpty(webViewVersion) &&
                         Integer.parseInt(webViewVersion) > WEB_VIEW_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    Logger.w(TAG, "Chrome version on the device is higher than the known version suitable for automation. " +
+                            "We are going to attempt to factory reset Chrome and hope that it will give us the desired version.");
                     // adb uninstall does factory reset for default apps
                     AdbShellUtils.removePackage(WEB_VIEW_PACKAGE_NAME);
                 }
@@ -77,10 +81,11 @@ public class FactoryResetChromeRule implements TestRule {
             final String chromeVersion = chromePackageInfo.versionName;
             final String[] parts = chromeVersion.split("\\.");
             final String majorVersion = parts[0];
-            Log.i(TAG, "Chrome Version = " + chromeVersion);
-            Log.i(TAG, "Chrome major version = " + majorVersion);
+            Logger.i(TAG, packageName + " Version = " + chromeVersion);
+            Logger.i(TAG, packageName + " major version = " + majorVersion);
             return majorVersion;
-        } catch (PackageManager.NameNotFoundException e) {
+        } catch (final PackageManager.NameNotFoundException e) {
+            Logger.e(TAG, "Package " + packageName + " not found :(", e);
             return null;
         }
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -3,6 +3,7 @@ package com.microsoft.identity.client.ui.automation.rules;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -11,6 +12,7 @@ import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
 import com.microsoft.identity.client.ui.automation.device.TestDevice;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.AdbShellUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.rules.TestRule;
@@ -22,23 +24,26 @@ public class FactoryResetChromeRule implements TestRule {
     public static final String TAG = FactoryResetChromeRule.class.getSimpleName();
 
     private final static int CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION = 74;
+    private final static int WEB_VIEW_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION = 74;
+    private final static String WEB_VIEW_PACKAGE_NAME = "com.google.android.webview";
 
     @Override
     public Statement apply(Statement base, Description description) {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                final Context context = ApplicationProvider.getApplicationContext();
-                final PackageManager packageManager = context.getPackageManager();
-                final PackageInfo chromePackageInfo = packageManager.getPackageInfo(BrowserChrome.CHROME_PACKAGE_NAME, 0);
-                final String chromeVersion = chromePackageInfo.versionName;
-                final String[] parts = chromeVersion.split("\\.");
-                final String majorVersion = parts[0];
-                Log.i(TAG, "Chrome Version = " + chromeVersion);
-                Log.i(TAG, "Chrome major version = " + majorVersion);
+                final String chromeVersion = getPackageMajorVersion(BrowserChrome.CHROME_PACKAGE_NAME);
+                if (!TextUtils.isEmpty(chromeVersion) &&
+                        Integer.parseInt(chromeVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    // adb uninstall does factory reset for default apps
+                    AdbShellUtils.removePackage(BrowserChrome.CHROME_PACKAGE_NAME);
+                }
 
-                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
-                    downgradeChromeToFactoryVersion();
+                final String webViewVersion = getPackageMajorVersion(WEB_VIEW_PACKAGE_NAME);
+                if (!TextUtils.isEmpty(webViewVersion) &&
+                        Integer.parseInt(webViewVersion) > WEB_VIEW_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    // adb uninstall does factory reset for default apps
+                    AdbShellUtils.removePackage(WEB_VIEW_PACKAGE_NAME);
                 }
 
                 // proceed with the test case
@@ -62,5 +67,21 @@ public class FactoryResetChromeRule implements TestRule {
 
         // Enable Chrome
         UiAutomatorUtils.handleButtonClick("com.android.settings:id/button1_positive");
+    }
+
+    private String getPackageMajorVersion(final String packageName) {
+        try {
+            final Context context = ApplicationProvider.getApplicationContext();
+            final PackageManager packageManager = context.getPackageManager();
+            final PackageInfo chromePackageInfo = packageManager.getPackageInfo(packageName, 0);
+            final String chromeVersion = chromePackageInfo.versionName;
+            final String[] parts = chromeVersion.split("\\.");
+            final String majorVersion = parts[0];
+            Log.i(TAG, "Chrome Version = " + chromeVersion);
+            Log.i(TAG, "Chrome major version = " + majorVersion);
+            return majorVersion;
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -26,23 +26,24 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
-import com.microsoft.identity.client.ui.automation.device.TestDevice;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.AdbShellUtils;
-import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * A Test Rule to downgrade Chrome and WebView to factory default version.
+ * A Test Rule to downgrade Chrome and WebView to factory default version. The newer versions of
+ * Chrome & WebView seem to be not so suitable for automation and we run into resource id not found
+ * error. Basically it seems that Chrome rolled out an update due to which automation frameworks are
+ * not able to find elements on the web-page (at least this is the case for ESTS UX page). To
+ * mitigate this, if we find that Chrome or WebView version on the device is above the known version
+ * suitable for automation, then we would factory reset Chrome.
  */
 public class FactoryResetChromeRule implements TestRule {
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client.ui.automation.rules;
 
 import android.content.Context;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -95,7 +95,9 @@ public class FactoryResetChromeRule implements TestRule {
             return majorVersion;
         } catch (final PackageManager.NameNotFoundException e) {
             Logger.e(TAG, "Package " + packageName + " not found :(", e);
-            return null;
+            // we could probably install the package from PlayStore (but for now let's fail the test
+            // to see if this ever happens in the wild)
+            throw new AssertionError(e);
         }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -36,9 +36,9 @@ public class FactoryResetChromeRule implements TestRule {
                 Logger.i(TAG, "Chrome Version = " + chromeVersion);
                 Logger.i(TAG, "Chrome major version = " + majorVersion);
 
-                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
-                    downgradeChromeToFactoryVersion();
-                }
+//                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+//                    downgradeChromeToFactoryVersion();
+//                }
 
                 // proceed with the test case
                 base.evaluate();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -21,7 +21,7 @@ public class FactoryResetChromeRule implements TestRule {
 
     public static final String TAG = FactoryResetChromeRule.class.getSimpleName();
 
-    private final static int CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION = 71;
+    private final static int CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION = 74;
 
     @Override
     public Statement apply(Statement base, Description description) {
@@ -37,9 +37,9 @@ public class FactoryResetChromeRule implements TestRule {
                 Log.i(TAG, "Chrome Version = " + chromeVersion);
                 Log.i(TAG, "Chrome major version = " + majorVersion);
 
-//                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
-//                    downgradeChromeToFactoryVersion();
-//                }
+                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
+                    downgradeChromeToFactoryVersion();
+                }
 
                 // proceed with the test case
                 base.evaluate();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/FactoryResetChromeRule.java
@@ -3,6 +3,7 @@ package com.microsoft.identity.client.ui.automation.rules;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.util.Log;
 
 import androidx.test.core.app.ApplicationProvider;
 
@@ -33,8 +34,8 @@ public class FactoryResetChromeRule implements TestRule {
                 final String chromeVersion = chromePackageInfo.versionName;
                 final String[] parts = chromeVersion.split("\\.");
                 final String majorVersion = parts[0];
-                Logger.i(TAG, "Chrome Version = " + chromeVersion);
-                Logger.i(TAG, "Chrome major version = " + majorVersion);
+                Log.i(TAG, "Chrome Version = " + chromeVersion);
+                Log.i(TAG, "Chrome major version = " + majorVersion);
 
 //                if (Integer.parseInt(majorVersion) > CHROME_MAJOR_VERSION_SUITABLE_FOR_AUTOMATION) {
 //                    downgradeChromeToFactoryVersion();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -73,6 +73,9 @@ public class RulesHelper {
             ));
         }
 
+        Log.i(TAG, "Adding FactoryResetChromeRule");
+        ruleChain = ruleChain.around(new FactoryResetChromeRule());
+
         Log.i(TAG, "Adding RemoveBrokersBeforeTestRule");
         ruleChain = ruleChain.around(new RemoveBrokersBeforeTestRule());
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
@@ -32,7 +32,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
 
-import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
@@ -172,6 +171,7 @@ public class CommonUtils {
 
     /**
      * Launches an activity specified by the action.
+     *
      * @param action action is which operation to be performed.
      */
     public static void launchIntent(@NonNull final String action) {
@@ -183,8 +183,10 @@ public class CommonUtils {
     }
 
     /**
-     * Launches an activity specified by the action.
-     * @param action action is which operation to be performed.
+     * Launches an activity specified by the action and data.
+     *
+     * @param action action is which operation to be performed
+     * @param data   the data to pass to the intent
      */
     public static void launchIntent(@NonNull final String action, @NonNull final Uri data) {
         final Context context = ApplicationProvider.getApplicationContext();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -168,6 +169,18 @@ public class CommonUtils {
         final Context context = ApplicationProvider.getApplicationContext();
         final Intent intent = new Intent(action);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        context.startActivity(intent);
+    }
+
+    /**
+     * Launches an activity specified by the action.
+     * @param action action is which operation to be performed.
+     */
+    public static void launchIntent(@NonNull final String action, @NonNull final Uri data) {
+        final Context context = ApplicationProvider.getApplicationContext();
+        final Intent intent = new Intent(action);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        intent.setData(data);
         context.startActivity(intent);
     }
 }


### PR DESCRIPTION
Add a Test Rule to downgrade Chrome and WebView to factory default version. The newer versions of Chrome & WebView seem to be not so suitable for automation and we run into resource id not found error. Basically it seems that Chrome rolled out an update due to which automation frameworks are not able to find elements on the web-page (at least this is the case for ESTS UX page). To mitigate this, if we find that Chrome or WebView version on the device is above the known version suitable for automation, then we would factory reset Chrome.