### PR TITLE
Wrap powerlift incident id in Throwable on test failure

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IPowerLiftIntegratedApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IPowerLiftIntegratedApp.java
@@ -29,7 +29,9 @@ public interface IPowerLiftIntegratedApp {
 
     /**
      * Create a PowerLift Incident using this app.
+     *
+     * @return a String message containing PowerLift incident details
      */
-    void createPowerLiftIncident();
+    String createPowerLiftIncident();
 
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -100,7 +100,7 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     }
 
     @Override
-    public void createPowerLiftIncident() {
+    public String createPowerLiftIncident() {
         Logger.i(TAG, "Creating Power Lift Incident..");
         launch();
         if (shouldHandleFirstRun) {
@@ -141,6 +141,8 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
             Assert.assertTrue(incidentIdBox.exists());
 
             Logger.w(TAG, "Incident Created with ID: " + incidentIdBox.getText());
+
+            return incidentIdBox.getText();
         } catch (final UiObjectNotFoundException e) {
             throw new AssertionError(e);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -31,7 +31,7 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.TestContext;
-import com.microsoft.identity.client.ui.automation.app.IPowerLiftIntegratedApp;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
 import com.microsoft.identity.client.ui.automation.device.settings.SamsungSettings;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -140,9 +140,11 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
 
             Assert.assertTrue(incidentIdBox.exists());
 
-            Logger.w(TAG, "Incident Created with ID: " + incidentIdBox.getText());
+            final String incidentDetails = incidentIdBox.getText();
 
-            return incidentIdBox.getText();
+            Logger.w(TAG, "Incident Created with ID: " + incidentDetails);
+
+            return incidentDetails;
         } catch (final UiObjectNotFoundException e) {
             throw new AssertionError(e);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -198,7 +198,7 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     }
 
     @Override
-    public void createPowerLiftIncident() {
+    public String createPowerLiftIncident() {
         Logger.i(TAG, "Creating Power Lift Incident..");
         launch();
         if (shouldHandleFirstRun) {
@@ -206,13 +206,13 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
         }
 
         if (isInSharedDeviceMode) {
-            createPowerLiftIncidentInSharedDeviceMode();
+            return createPowerLiftIncidentInSharedDeviceMode();
         } else {
-            createPowerLiftIncidentInNonSharedMode();
+            return createPowerLiftIncidentInNonSharedMode();
         }
     }
 
-    private void createPowerLiftIncidentInNonSharedMode() {
+    private String createPowerLiftIncidentInNonSharedMode() {
         // click the 3 dot menu icon in top right
         UiAutomatorUtils.handleButtonClick("com.azure.authenticator:id/menu_overflow");
 
@@ -258,12 +258,14 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
 
             // This will post the incident id in text logs
             Logger.w(TAG, incidentIdText);
+
+            return incidentIdText;
         } catch (final UiObjectNotFoundException e) {
             throw new AssertionError(e);
         }
     }
 
-    private void createPowerLiftIncidentInSharedDeviceMode() {
+    private String createPowerLiftIncidentInSharedDeviceMode() {
         try {
             final UiObject settingsBtn = UiAutomatorUtils.obtainUiObjectWithClassAndDescription(
                     Button.class,
@@ -286,6 +288,8 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
             final String incidentIdText = postLogSubmissionText.getText();
             // This will post the incident id in text logs
             Logger.w(TAG, incidentIdText);
+
+            return incidentIdText;
         } catch (final UiObjectNotFoundException e) {
             throw new AssertionError(e);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -35,7 +35,7 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import com.microsoft.identity.client.ui.automation.app.IPowerLiftIntegratedApp;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/powerlift/IPowerLiftIntegratedApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/powerlift/IPowerLiftIntegratedApp.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.ui.automation.app;
+package com.microsoft.identity.client.ui.automation.powerlift;
 
 /**
  * A model representing an app that supports creating PowerLift incidents.

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/powerlift/ThrowableWithPowerLiftIncident.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/powerlift/ThrowableWithPowerLiftIncident.java
@@ -1,0 +1,64 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.powerlift;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.ui.automation.app.App;
+
+import lombok.Getter;
+
+/**
+ * A throwable that contains the incident id details for a PowerLift incident. This throwable should
+ * only be used when a PowerLift Incident is created and a PowerLift incident is typically created
+ * by an {@link IPowerLiftIntegratedApp}.
+ */
+@Getter
+public class ThrowableWithPowerLiftIncident extends Throwable {
+
+    private final IPowerLiftIntegratedApp mPowerLiftIntegratedApp;
+    private final String mIncidentId;
+    private final Throwable mOriginalThrowable;
+
+    public ThrowableWithPowerLiftIncident(@NonNull final IPowerLiftIntegratedApp powerLiftIntegratedApp,
+                                          @NonNull final String incidentId,
+                                          @NonNull final Throwable throwable
+    ) {
+        super(
+                createMessageWithIncidentId(powerLiftIntegratedApp, incidentId, throwable),
+                throwable
+        );
+        mPowerLiftIntegratedApp = powerLiftIntegratedApp;
+        mIncidentId = incidentId;
+        mOriginalThrowable = throwable;
+    }
+
+    private static String createMessageWithIncidentId(@NonNull final IPowerLiftIntegratedApp powerLiftIntegratedApp,
+                                                      @NonNull final String incidentId,
+                                                      @NonNull final Throwable throwable) {
+        return throwable.getMessage() + "\n" +
+                "PowerLift Incident Created via " +
+                ((App) powerLiftIntegratedApp).getAppName() +
+                " - " + incidentId.trim();
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
@@ -1,7 +1,8 @@
 package com.microsoft.identity.client.ui.automation.rules;
 
-import android.util.Log;
+import android.text.TextUtils;
 
+import com.microsoft.identity.client.ui.automation.app.App;
 import com.microsoft.identity.client.ui.automation.app.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 
@@ -31,13 +32,14 @@ public class PowerLiftIncidentRule implements TestRule {
                 try {
                     base.evaluate();
                 } catch (final Throwable originalThrowable) {
+                    String powerLiftIncidentDetails = null;
                     try {
                         Logger.e(
                                 TAG,
                                 "Encountered error during test....creating PowerLift incident.",
                                 originalThrowable
                         );
-                        powerLiftIntegratedApp.createPowerLiftIncident();
+                        powerLiftIncidentDetails = powerLiftIntegratedApp.createPowerLiftIncident();
                     } catch (final Throwable powerLiftError) {
                         Logger.e(
                                 TAG,
@@ -45,7 +47,18 @@ public class PowerLiftIncidentRule implements TestRule {
                                 powerLiftError
                         );
                     }
-                    throw originalThrowable;
+                    if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
+                        throw originalThrowable;
+                    } else {
+                        final String message = originalThrowable.getMessage() + "\n" +
+                                "PowerLift Incident Created via " +
+                                ((App) powerLiftIntegratedApp).getAppName() +
+                                " - " + powerLiftIncidentDetails.trim();
+                        throw new Throwable(
+                                message,
+                                originalThrowable
+                        );
+                    }
                 }
             }
         };

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
@@ -3,8 +3,9 @@ package com.microsoft.identity.client.ui.automation.rules;
 import android.text.TextUtils;
 
 import com.microsoft.identity.client.ui.automation.app.App;
-import com.microsoft.identity.client.ui.automation.app.IPowerLiftIntegratedApp;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.powerlift.ThrowableWithPowerLiftIncident;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -50,12 +51,10 @@ public class PowerLiftIncidentRule implements TestRule {
                     if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
                         throw originalThrowable;
                     } else {
-                        final String message = originalThrowable.getMessage() + "\n" +
-                                "PowerLift Incident Created via " +
-                                ((App) powerLiftIntegratedApp).getAppName() +
-                                " - " + powerLiftIncidentDetails.trim();
-                        throw new Throwable(
-                                message,
+                        assert powerLiftIncidentDetails != null;
+                        throw new ThrowableWithPowerLiftIncident(
+                                powerLiftIntegratedApp,
+                                powerLiftIncidentDetails,
                                 originalThrowable
                         );
                     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -27,7 +27,7 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
-import com.microsoft.identity.client.ui.automation.app.IPowerLiftIntegratedApp;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;


### PR DESCRIPTION
The output would look something like this:

java.lang.Throwable: androidx.test.uiautomator.UiObjectNotFoundException: UiSelector[RESOURCE_ID=i0118]
**PowerLift Incident Created via Intune Company Portal - 2K7S2K6Y**
at com.microsoft.identity.client.ui.automation.rules.PowerLiftIncidentRule$1.evaluate(PowerLiftIncidentRule.java:57)
at com.microsoft.identity.client.ui.automation.rules.InstallBrokerTestRule$1.evaluate(InstallBrokerTestRule.java:58)
at com.microsoft.identity.client.ui.automation.rules.BrokerSupportRule$1.evaluate(BrokerSupportRule.java:85)
at com.microsoft.identity.client.ui.automation.rules.RemoveBrokersBeforeTestRule$1.evaluate(RemoveBrokersBeforeTestRule.java:61)
at com.microsoft.identity.client.ui.automation.rules.FactoryResetChromeRule$1.evaluate(FactoryResetChromeRule.java:68)
at com.microsoft.identity.client.ui.automation.rules.CopyPreInstalledApkRule$1.evaluate(CopyPreInstalledApkRule.java:77)
at com.microsoft.identity.client.ui.automation.rules.DevicePinSetupRule$1.evaluate(DevicePinSetupRule.java:81)
at com.microsoft.identity.client.ui.automation.rules.ResetAutomaticTimeZoneTestRule$1.evaluate(ResetAutomaticTimeZoneTestRule.java:48)
at com.microsoft.identity.client.ui.automation.rules.UiAutomatorTestRule$1.evaluate(UiAutomatorTestRule.java:52)
at com.microsoft.identity.client.ui.automation.rules.RetryTestRule$1.evaluate(RetryTestRule.java:67)
at com.microsoft.identity.client.ui.automation.rules.AutomationLoggingRule$1.evaluate(AutomationLoggingRule.java:54)
at org.junit.rules.RunRules.evaluate(RunRules.java:20)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:392)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2145)
Caused by: java.lang.AssertionError: androidx.test.uiautomator.UiObjectNotFoundException: UiSelector[RESOURCE_ID=i0118]
at com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils.handleInput(UiAutomatorUtils.java:295)
at com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler.handlePasswordField(AadLoginComponentHandler.java:56)
at com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler.handlePrompt(MicrosoftStsPromptHandler.java:81)
at com.microsoft.identity.client.msal.automationapp.testpass.broker.TestCase833526$1.handleUserInteraction(TestCase833526.java:88)
at com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk.acquireTokenInteractive(MsalSdk.java:89)
at com.microsoft.identity.client.msal.automationapp.testpass.broker.TestCase833526.test_833526(TestCase833526.java:71)
at java.lang.reflect.Method.invoke(Native Method)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
at androidx.test.internal.runner.junit4.statement.RunBefores.evaluate(RunBefores.java:80)
at androidx.test.internal.runner.junit4.statement.RunAfters.evaluate(RunAfters.java:61)
at com.microsoft.identity.client.msal.automationapp.MsalLoggingRule$1.evaluate(MsalLoggingRule.java:60)
at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:531)
at com.microsoft.identity.client.ui.automation.rules.DeviceEnrollmentFailureRecoveryRule$1.evaluate(DeviceEnrollmentFailureRecoveryRule.java:50)
at com.microsoft.identity.client.ui.automation.rules.PowerLiftIncidentRule$1.evaluate(PowerLiftIncidentRule.java:33)
... 37 more
Caused by: androidx.test.uiautomator.UiObjectNotFoundException: UiSelector[RESOURCE_ID=i0118]
at androidx.test.uiautomator.UiObject.setText(UiObject.java:666)
at com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils.handleInput(UiAutomatorUtils.java:292)
... 53 more