### PR TITLE
Increase http socket timeout for create temp user api to 15 seconds

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -229,7 +229,6 @@ public class LabUserHelper {
     public static String loadTempUser(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
-        createTempUserApi.getApiClient().setConnectTimeout((int) TimeUnit.SECONDS.toMillis(15));
         createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
 
         TempUser tempUser;
@@ -249,7 +248,6 @@ public class LabUserHelper {
     public static TempUser loadTempUserForTest(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
-        createTempUserApi.getApiClient().setConnectTimeout((int) TimeUnit.SECONDS.toMillis(15));
         createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
 
         try {

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -43,6 +43,8 @@ public class LabUserHelper {
     private static final Map<LabUserQuery, LabConfig> sLabConfigCache = new HashMap<>();
     private volatile static ConfidentialClientHelper instance = LabAuthenticationHelper.getInstance();
 
+    private static final int TEMP_USER_API_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(15);
+
     /**
      * Reset the secret in use by the lab authentication helper.  This will rewrite the instance
      * in use to use a specified version of the key vault secret.
@@ -229,7 +231,7 @@ public class LabUserHelper {
     public static String loadTempUser(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
-        createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
+        createTempUserApi.getApiClient().setReadTimeout(TEMP_USER_API_READ_TIMEOUT);
 
         TempUser tempUser;
 
@@ -248,7 +250,7 @@ public class LabUserHelper {
     public static TempUser loadTempUserForTest(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
-        createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
+        createTempUserApi.getApiClient().setReadTimeout(TEMP_USER_API_READ_TIMEOUT);
 
         try {
             return createTempUserApi.post(userType);

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class LabUserHelper {
 
@@ -228,6 +229,8 @@ public class LabUserHelper {
     public static String loadTempUser(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
+        createTempUserApi.getApiClient().setConnectTimeout((int) TimeUnit.SECONDS.toMillis(15));
+        createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
 
         TempUser tempUser;
 
@@ -246,6 +249,8 @@ public class LabUserHelper {
     public static TempUser loadTempUserForTest(final String userType) {
         instance.setupApiClientWithAccessToken();
         CreateTempUserApi createTempUserApi = new CreateTempUserApi();
+        createTempUserApi.getApiClient().setConnectTimeout((int) TimeUnit.SECONDS.toMillis(15));
+        createTempUserApi.getApiClient().setReadTimeout((int) TimeUnit.SECONDS.toMillis(15));
 
         try {
             return createTempUserApi.post(userType);


### PR DESCRIPTION
The default ok http timeout is 10 seconds....increasing to 15 seconds for create temp user api because we're having some test failures with http timeout. Had a chat with Gladwin and his data says that on average temp user api calls are taking about 7 seconds but in some cases can go up to about 14 seconds...that's probably why we are seeing occasional failures with Socket Timeout as the default is 10 seconds...LAB Team will work on making the API more performant....but for now we are going to increase the timeout to 15 seconds