### PR TITLE
Log key thumbprints less often

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.adal.internal.AndroidTestHelper;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -185,6 +186,31 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
         assertEquals("Same as initial text", decrypted, decrypted3);
         Log.d(TAG, "Finished testEncryptSameText");
     }
+
+    @Test
+    public void testKeyThumbprint() throws GeneralSecurityException, IOException {
+        Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        for (int i = 0; i < 1000; i++) {
+            Assert.assertEquals(storageHelper.testThumbprint(), storageHelper.testThumbprint());
+        }
+    }
+
+    @Test
+    public void testKeyChange() throws GeneralSecurityException, IOException {
+        Context context = getInstrumentation().getTargetContext();
+        final StorageHelper storageHelper = new StorageHelper(context);
+        Assert.assertFalse(storageHelper.testKeyChange());
+        for (int i = 0; i < 500; i++) {
+            Assert.assertFalse(storageHelper.testKeyChange());
+        }
+        StorageHelper.LAST_KNOWN_THUMBPRINT.set("");
+        Assert.assertTrue(storageHelper.testKeyChange());
+        for (int i = 0; i < 500; i++) {
+            Assert.assertFalse(storageHelper.testKeyChange());
+        }
+    }
+
 
     @Test
     public void testTampering() throws GeneralSecurityException, IOException {

--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -191,9 +191,7 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
     public void testKeyThumbprint() throws GeneralSecurityException, IOException {
         Context context = getInstrumentation().getTargetContext();
         final StorageHelper storageHelper = new StorageHelper(context);
-        for (int i = 0; i < 1000; i++) {
-            Assert.assertEquals(storageHelper.testThumbprint(), storageHelper.testThumbprint());
-        }
+        Assert.assertEquals(storageHelper.testThumbprint(), storageHelper.testThumbprint());
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -539,7 +539,7 @@ public class StorageHelper implements IStorageHelper {
         if (!LAST_KNOWN_THUMBPRINT.get().equals(keyThumbPrint)) {
             LAST_KNOWN_THUMBPRINT.set(keyThumbPrint);
             if(!FIRST_TIME.compareAndSet(false, true)) {
-                Logger.info(TAG + ":decryptWithSecretKey", "Using key with thumbprint that has changed " + keyThumbPrint);
+                Logger.info(TAG + ":logIfKeyHasChanged", "Using key with thumbprint that has changed " + keyThumbPrint);
                 return true;
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -32,6 +32,7 @@ import android.util.Base64;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
@@ -70,6 +71,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -89,6 +92,9 @@ import static com.microsoft.identity.common.internal.util.DateUtilities.isLocale
 
 public class StorageHelper implements IStorageHelper {
     private static final String TAG = "StorageHelper";
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public static final AtomicReference<String> LAST_KNOWN_THUMBPRINT = new AtomicReference<>("");
+    private static final AtomicBoolean FIRST_TIME = new AtomicBoolean(false);
 
     /**
      * A flag to turn on/off keystore encryption on Broker apps.
@@ -126,6 +132,13 @@ public class StorageHelper implements IStorageHelper {
      * probably doing PKCS7. We decide to go with Java default string.
      */
     private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    /**
+     * We are going to attempt to track key changes when performing encryption/decryption.
+     * To do this, we're actually going to run this in ECB mode on a fixed input, and that
+     * should be OK only because we're going to further hash that value.
+     */
+    private static final String CIPHER_ALGORITHM_FOR_KEY_TRACKING = "AES/ECB/PKCS5Padding";
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
 
@@ -242,8 +255,7 @@ public class StorageHelper implements IStorageHelper {
         // load key for encryption if not loaded
         mEncryptionKey = loadSecretKeyForEncryption();
         mEncryptionHMACKey = getHMacKey(mEncryptionKey);
-        Logger.info(TAG + methodName, "Using key with thumbprint " + getKeyThumbPrint(mEncryptionKey, mEncryptionHMACKey));
-
+        logIfKeyHasChanged(mEncryptionKey, mEncryptionHMACKey);
 
         Logger.verbose(TAG + methodName, "Encrypt version:" + mBlobVersion);
         final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.ENCODING_UTF8);
@@ -288,11 +300,22 @@ public class StorageHelper implements IStorageHelper {
         return getEncodeVersionLengthPrefix() + ENCODE_VERSION + encryptedText;
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public String testThumbprint() throws IOException, GeneralSecurityException {
+        final SecretKey secretKey = loadSecretKeyForEncryption();
+        return getKeyThumbPrint(secretKey, getHMacKey(secretKey));
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public boolean testKeyChange() throws IOException, GeneralSecurityException {
+        final SecretKey secretKey = loadSecretKeyForEncryption();
+        return logIfKeyHasChanged(secretKey, getHMacKey(secretKey));
+    }
     private String getKeyThumbPrint(final @NonNull SecretKey secretKey, final @NonNull SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
-        final Cipher thumbPrintCipher = Cipher.getInstance(CIPHER_ALGORITHM);
+        final Cipher thumbPrintCipher = Cipher.getInstance(CIPHER_ALGORITHM_FOR_KEY_TRACKING);
         final byte[] thumbprintBytes = "012345678910111213141516".getBytes();
         thumbPrintCipher.init(Cipher.ENCRYPT_MODE, secretKey);
-        byte[] bytesOut = thumbPrintCipher.doFinal();
+        byte[] bytesOut = thumbPrintCipher.doFinal(thumbprintBytes);
         Mac thumbprintMac = Mac.getInstance(HMAC_ALGORITHM);
         thumbprintMac.init(hmacKey);
         byte[] thumprintFinal = thumbprintMac.doFinal(bytesOut);
@@ -482,7 +505,8 @@ public class StorageHelper implements IStorageHelper {
         mac.init(hmacKey);
         mac.update(bytes, 0, macIndex);
         final byte[] macDigest = mac.doFinal();
-        Logger.info(TAG + ":decryptWithSecretKey", "Using key with thumbprint " + getKeyThumbPrint(secretKey, hmacKey));
+
+        logIfKeyHasChanged(secretKey, hmacKey);
 
         // Compare digest of input message and calculated digest
         assertHMac(bytes, macIndex, bytes.length, macDigest);
@@ -508,6 +532,18 @@ public class StorageHelper implements IStorageHelper {
         );
 
         return decrypted;
+    }
+
+    private boolean logIfKeyHasChanged(@NonNull SecretKey secretKey, SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        final String keyThumbPrint = getKeyThumbPrint(secretKey, hmacKey);
+        if (!LAST_KNOWN_THUMBPRINT.get().equals(keyThumbPrint)) {
+            LAST_KNOWN_THUMBPRINT.set(keyThumbPrint);
+            if(!FIRST_TIME.compareAndSet(false, true)) {
+                Logger.info(TAG + ":decryptWithSecretKey", "Using key with thumbprint that has changed " + keyThumbPrint);
+                return true;
+            }
+        }
+        return false;
     }
 
     private void validateEncodeVersion(String encryptedBlob, int encodeVersionLength) {


### PR DESCRIPTION
We are currently attempting to track changes in the encryption key used by MSAL, since changes in that
key will cause failures when reading that are difficult to detect that may be due to other problems.  To isolate
this, we were logging a hashed, fixed-value encryption every time we wrote an entry.

This was noisy for one of our customers, so we went to turn it down, and looking at the logs it wasn't working properly, because the cipher was being run in CBC mode, meaning that every value was different.  

This code corrects that flaw and only logs if it detects that there has been a change in the key.