### PR TITLE
Fix InteractiveRequest Bound Service backcompat

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- Fix InteractiveRequest Bound Service backcompat (#1215)
 - Add refresh_on to access tokens(#1190)
 - Add requested_claims to access tokens, and allow credentials to be filtered by RC (#1187)
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/MicrosoftAuthClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/MicrosoftAuthClient.java
@@ -89,11 +89,11 @@ public class MicrosoftAuthClient extends BoundServiceClient<IMicrosoftAuthServic
                 final Bundle bundle = intent.getExtras();
 
                 //older brokers (pre-ContentProvider) are ONLY sending these values in the intent itself.
-                final String packageName = intent.getPackage();
-                final String className = intent.getComponent().getClassName();
-                if (!TextUtils.isEmpty(packageName) && !TextUtils.isEmpty(className)){
-                    bundle.putString(BROKER_PACKAGE_NAME, packageName);
-                    bundle.putString(BROKER_ACTIVITY_NAME, className);
+                if (intent.getComponent() != null &&
+                        !TextUtils.isEmpty(intent.getPackage()) &&
+                        !TextUtils.isEmpty(intent.getComponent().getClassName())){
+                    bundle.putString(BROKER_PACKAGE_NAME, intent.getPackage());
+                    bundle.putString(BROKER_ACTIVITY_NAME, intent.getComponent().getClassName());
                 }
 
                 return bundle;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -332,7 +332,9 @@ public class BrokerMsalController extends BaseController {
                             throw mResultAdapter.getExceptionForEmptyResultBundle();
                         }
 
-                        final Intent intent = mResultAdapter.getIntentForInteractiveRequestFromResultBundle(resultBundle);
+                        final Intent intent = mResultAdapter.getIntentForInteractiveRequestFromResultBundle(
+                                resultBundle,
+                                negotiatedBrokerProtocolVersion);
                         intent.putExtras(
                                 mRequestAdapter.getRequestBundleForAcquireTokenInteractive(parameters, negotiatedBrokerProtocolVersion)
                         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.common.adal.internal.util.HashMapExtensions;
 import com.microsoft.identity.common.adal.internal.util.JsonExtensions;
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException;
@@ -63,7 +64,13 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_GENERATE_SHR_RESULT;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_RESULT_V2_COMPRESSED;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_VERSION;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CALLER_INFO_UID;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE;
 import static com.microsoft.identity.common.exception.ClientException.INVALID_BROKER_BUNDLE;
+import static com.microsoft.identity.common.exception.ClientException.UNKNOWN_ERROR;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
 import static com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter.sRequestAdapterGsonInstance;
 import static com.microsoft.identity.common.internal.util.GzipUtil.compressString;
 
@@ -498,7 +505,8 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     }
 
 
-    public @NonNull Intent getIntentForInteractiveRequestFromResultBundle( @NonNull final Bundle resultBundle) throws ClientException {
+    public @NonNull Intent getIntentForInteractiveRequestFromResultBundle(@NonNull final Bundle resultBundle,
+                                                                          @NonNull final String negotiatedBrokerProtocolVersion) throws ClientException {
         final Bundle interactiveRequestBundle = extractInteractiveRequestBundleFromResultBundle(resultBundle);
 
         final String packageName = interactiveRequestBundle.getString(BROKER_PACKAGE_NAME);
@@ -515,6 +523,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 className
         );
         intent.putExtras(interactiveRequestBundle);
+        intent.putExtra(NEGOTIATED_BP_VERSION_KEY, negotiatedBrokerProtocolVersion);
         return intent;
     }
 
@@ -527,6 +536,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (interactiveRequestIntent != null) {
             return interactiveRequestIntent.getExtras();
         }
+
         return resultBundle;
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerBoundServiceTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerBoundServiceTests.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
 import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy;
 import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
 import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientConnectionFailed;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientWithLegacyBroker;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientWithCurrentBroker;
 import com.microsoft.identity.common.internal.ipc.mock.ShadowBoundServiceClientWithSuccessResult;
 
 import org.junit.Test;
@@ -113,5 +115,21 @@ public class AccountManagerBoundServiceTests extends IpcStrategyTests {
     @Config(shadows = {ShadowBoundServiceClientConnectionFailed.class})
     public void testIpcFailed() {
         testIpcConnectionFailed(getMockRequestBundle(MSAL_HELLO));
+    }
+
+    @Test
+    @Config(shadows = {ShadowBoundServiceClientWithLegacyBroker.class})
+    public void testInteractiveFlowBackCompatWithLegacyBroker() {
+        testOperationSucceeds(
+                getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST),
+                getMockInteractiveRequestResultBundle());
+    }
+
+    @Test
+    @Config(shadows = {ShadowBoundServiceClientWithCurrentBroker.class})
+    public void testInteractiveFlowWithNewBroker() {
+        testOperationSucceeds(
+                getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST),
+                getMockInteractiveRequestResultBundle());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithCurrentBroker.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithCurrentBroker.java
@@ -1,0 +1,93 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.broker.BoundServiceClient;
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+@Implements(BoundServiceClient.class)
+public class ShadowBoundServiceClientWithCurrentBroker<T extends IInterface> {
+    protected @NonNull
+    T connect(@NonNull final String targetServicePackageName)
+            throws ClientException, InterruptedException, TimeoutException, ExecutionException {
+        final IMicrosoftAuthService authService = new IMicrosoftAuthService() {
+            @Override public IBinder asBinder() {
+                return null;
+            }
+
+            @Override public Bundle hello(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getAccounts(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle acquireTokenSilently(Bundle requestBundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Intent getIntentForInteractiveRequest() throws RemoteException {
+                return IpcStrategyTests.getMockInteractiveRequestResultIntent();
+            }
+
+            @Override public Bundle removeAccount(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getDeviceMode() throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getCurrentAccount(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle removeAccountFromSharedDevice(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override
+            public Bundle generateSignedHttpRequest(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+        };
+
+        return (T) authService;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithLegacyBroker.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowBoundServiceClientWithLegacyBroker.java
@@ -1,0 +1,93 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.broker.BoundServiceClient;
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+@Implements(BoundServiceClient.class)
+public class ShadowBoundServiceClientWithLegacyBroker<T extends IInterface> {
+    protected @NonNull
+    T connect(@NonNull final String targetServicePackageName)
+            throws ClientException, InterruptedException, TimeoutException, ExecutionException {
+        final IMicrosoftAuthService authService = new IMicrosoftAuthService() {
+            @Override public IBinder asBinder() {
+                return null;
+            }
+
+            @Override public Bundle hello(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getAccounts(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle acquireTokenSilently(Bundle requestBundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Intent getIntentForInteractiveRequest() throws RemoteException {
+                return IpcStrategyTests.getMockLegacyInteractiveRequestResultIntent();
+            }
+
+            @Override public Bundle removeAccount(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getDeviceMode() throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle getCurrentAccount(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override public Bundle removeAccountFromSharedDevice(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+
+            @Override
+            public Bundle generateSignedHttpRequest(Bundle bundle) throws RemoteException {
+                throw new RemoteException("Not Implemented");
+            }
+        };
+
+        return (T) authService;
+    }
+}


### PR DESCRIPTION
**Issue**
In older, pre-ContentProvider, version of broker. We're not sending `class name` and `activity name` as part of the Interactive  Request Bundle (this [pr](https://github.com/AzureAD/ad-accounts-for-android/pull/1298), line 255).

In 2.0.4, we regressed this - MSAL 2.0.4+ will throw an error since those name can't be found anywhere in the bundle.

(Pre 2.0.4, we have separate strategies for ContentProvider and BoundService, and BoundService Strategy actually handles this - so this is a new issue.)

**Fix**
In MicrosoftAuthClient (used by Bound Service IPC Strategy in MSAL), extracts class and activity name and put those in bundle if not null.

**Test**
1. Commented out ContentProviderStrategy (so that MSAL uses Bound Service)
2. Remove BROKER_PACKAGE_NAME and BROKER_ACTIVITY_NAME from getBundleForInteractiveRequest on the broker side, and see if AcquireToken flow can be launched properly in MSAL.

