### PR TITLE
Undo constant rename as part of #1189.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1499,7 +1499,7 @@ public final class AuthenticationConstants {
 
         public static final String REQUEST_HEADERS = "com.microsoft.identity.request.headers";
 
-        public static final String POST_PAGE_LOADED_JAVASCRIPT = "com.microsoft.identity.post.page.loaded.javascript";
+        public static final String POST_PAGE_LOADED_URL = "com.microsoft.identity.post.page.loaded.url";
 
         public static final String AUTHORIZATION_AGENT = "com.microsoft.identity.client.authorization.agent";
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -103,7 +103,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putString(REQUEST_URL, mAuthorizationRequestUrl);
         outState.putSerializable(REQUEST_HEADERS, mRequestHeaders);
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
-        outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -116,7 +116,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mAuthorizationRequestUrl = state.getString(REQUEST_URL);
         mRedirectUri = state.getString(REDIRECT_URI);
         mRequestHeaders = getRequestHeaders(state);
-        mPostPageLoadedUrl = state.getString(POST_PAGE_LOADED_URL);
+        mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -82,7 +82,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     private HashMap<String, String> mRequestHeaders;
 
     // For MSAL CPP test cases only
-    private String mPostPageLoadedUrl;
+    private String mPostPageLoadedJavascript;
 
     private boolean webViewZoomControlsEnabled;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -136,17 +136,17 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     public void onPageLoaded() {
                         mProgressBar.setVisibility(View.INVISIBLE);
 
-                       // Inject the javascript string from testing. This should only be evaluated if we haven't sent
-                          // an auth result already.
-                          if (mAuthResultSent == false && !StringExtensions.isNullOrBlank(mPostPageLoadedJavascript)) {
-                              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                                  mWebView.evaluateJavascript(mPostPageLoadedJavascript, null);
-                              } else {
-                                  // On earlier versions of Android, javascript has to be loaded with a custom scheme.
-                                  // In these cases, Android will helpfully unescape any octects it finds. Unfortunately,
-                                  // our javascript may contain the '%' character, so we escape it again, to undo that.
-                                  mWebView.loadUrl("javascript:" + mPostPageLoadedJavascript.replace("%", "%25"));
-                              }
+                        // Inject the javascript string from testing. This should only be evaluated if we haven't sent
+                        // an auth result already.
+                        if (mAuthResultSent == false && !StringExtensions.isNullOrBlank(mPostPageLoadedJavascript)) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                                mWebView.evaluateJavascript(mPostPageLoadedJavascript, null);
+                            } else {
+                                // On earlier versions of Android, javascript has to be loaded with a custom scheme.
+                                // In these cases, Android will helpfully unescape any octects it finds. Unfortunately,
+                                // our javascript may contain the '%' character, so we escape it again, to undo that.
+                                mWebView.loadUrl("javascript:" + mPostPageLoadedJavascript.replace("%", "%25"));
+                            }
                         }
                     }
                 },

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -102,8 +102,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putString(REDIRECT_URI, mRedirectUri);
         outState.putString(REQUEST_URL, mAuthorizationRequestUrl);
         outState.putSerializable(REQUEST_HEADERS, mRequestHeaders);
-        outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedUrl);
-        outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedUrl);
+        outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
+        outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -136,10 +136,17 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     public void onPageLoaded() {
                         mProgressBar.setVisibility(View.INVISIBLE);
 
-                        // Inject string from test suites.
-                        // if result already sent don't load url again
-                        if (mAuthResultSent == false && !StringExtensions.isNullOrBlank(mPostPageLoadedUrl)) {
-                            mWebView.loadUrl(mPostPageLoadedUrl);
+                       // Inject the javascript string from testing. This should only be evaluated if we haven't sent
+                          // an auth result already.
+                          if (mAuthResultSent == false && !StringExtensions.isNullOrBlank(mPostPageLoadedJavascript)) {
+                              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                                  mWebView.evaluateJavascript(mPostPageLoadedJavascript, null);
+                              } else {
+                                  // On earlier versions of Android, javascript has to be loaded with a custom scheme.
+                                  // In these cases, Android will helpfully unescape any octects it finds. Unfortunately,
+                                  // our javascript may contain the '%' character, so we escape it again, to undo that.
+                                  mWebView.loadUrl("javascript:" + mPostPageLoadedJavascript.replace("%", "%25"));
+                              }
                         }
                     }
                 },

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;


### PR DESCRIPTION
Partially reverts AzureAD/microsoft-authentication-library-common-for-android#1189

This parameter change has not yet been released, but altering it amounts to a parameter removal.  The niceness of being truthful with parameter names is somewhat outweighed by the multiple dependencies on this internal constant.