### PR TITLE
Unbreak mockito tests for cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V.Next
 - [PATCH] Use requested claims as a cache key when overwriting an AT (#1225)
 - [PATCH] Fix InteractiveRequest Bound Service backcompat (#1215)
 - [Minor] Adds support for cache property merging (#1224)
+- [Minor] Adds workaround for Mockito.openMocks() desugaring issue (#1229)
 
 Version 3.1.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -223,13 +223,11 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
             mFociCredentialCache.clearAll();
         }
 
-        if (null != mOtherAppCredentialCaches)
-            for (final IAccountCredentialCache cache : mOtherAppCredentialCaches) {
-                cache.clearAll();
-            }
+        for (final IAccountCredentialCache cache : mOtherAppCredentialCaches) {
+            cache.clearAll();
+        }
 
-        if (null != mApplicationMetadataCache)
-            mApplicationMetadataCache.clear();
+        mApplicationMetadataCache.clear();
     }
 
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -55,11 +55,9 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,16 +89,12 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     private static final int TEST_APP_UID = 1337;
 
-    @Mock
     MicrosoftStsOAuth2Strategy mockStrategy;
 
-    @Mock
     MicrosoftStsAuthorizationRequest mockRequest;
 
-    @Mock
     MicrosoftStsTokenResponse mockResponse;
 
-    @Mock
     IAccountCredentialAdapter mMockCredentialAdapter;
 
     private MicrosoftFamilyOAuth2TokenCache mFociCache;
@@ -125,7 +119,12 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     public void setUp() throws Exception {
         super.setUp();
 
-        MockitoAnnotations.initMocks(this);
+        //MockitoAnnotations.openMocks(this);
+        mockStrategy = Mockito.mock(MicrosoftStsOAuth2Strategy.class);
+        mockRequest = Mockito.mock(MicrosoftStsAuthorizationRequest.class);
+        mockResponse = Mockito.mock(MicrosoftStsTokenResponse.class);
+        mMockCredentialAdapter = Mockito.mock(IAccountCredentialAdapter.class);
+
 
         // Our test context
         final Context context = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getTargetContext();
@@ -224,11 +223,13 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
             mFociCredentialCache.clearAll();
         }
 
-        for (final IAccountCredentialCache cache : mOtherAppCredentialCaches) {
-            cache.clearAll();
-        }
+        if (null != mOtherAppCredentialCaches)
+            for (final IAccountCredentialCache cache : mOtherAppCredentialCaches) {
+                cache.clearAll();
+            }
 
-        mApplicationMetadataCache.clear();
+        if (null != mApplicationMetadataCache)
+            mApplicationMetadataCache.clear();
     }
 
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -119,7 +119,6 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     public void setUp() throws Exception {
         super.setUp();
 
-        //MockitoAnnotations.openMocks(this);
         mockStrategy = Mockito.mock(MicrosoftStsOAuth2Strategy.class);
         mockRequest = Mockito.mock(MicrosoftStsAuthorizationRequest.class);
         mockResponse = Mockito.mock(MicrosoftStsTokenResponse.class);

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -56,8 +56,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,16 +101,12 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
             MicrosoftRefreshToken> mOauth2TokenCache;
     private ISharedPreferencesFileManager mSharedPreferencesFileManager;
 
-    @Mock
     MicrosoftStsOAuth2Strategy mockStrategy;
 
-    @Mock
     MicrosoftStsAuthorizationRequest mockRequest;
 
-    @Mock
     MicrosoftStsTokenResponse mockResponse;
-
-    @Mock
+    
     IAccountCredentialAdapter<
             MicrosoftStsOAuth2Strategy,
             MicrosoftStsAuthorizationRequest,
@@ -196,7 +191,10 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        MockitoAnnotations.initMocks(this);
+        mockStrategy = Mockito.mock(MicrosoftStsOAuth2Strategy.class);
+        mockRequest = Mockito.mock(MicrosoftStsAuthorizationRequest.class);
+        mockResponse = Mockito.mock(MicrosoftStsTokenResponse.class);
+        mockCredentialAdapter = Mockito.mock(IAccountCredentialAdapter.class);
 
         // Used by mocks
         defaultTestBundleV1 = new AccountCredentialTestBundle(


### PR DESCRIPTION
Something was broken between incrementing the mockito version and reversion back/forth between Java 1.7 & 1.8 source compat. Something inside of Mockito needs to be desugared when using `Mockito.openMocks()` so for now switching away from an annotation based test implementation