### PR TITLE
Creation utility for thread pools

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -82,6 +82,8 @@ public class ThreadUtils {
         }
     }
 
+    //Nice thought, but if you're using executors, you're using ThreadGroup whether you want to or not.
+    @SuppressWarnings("PMD.AvoidThreadGroup")
     private static ThreadFactory getNamedThreadFactory(@NonNull final String poolName, final SecurityManager securityManager) {
         return new ThreadFactory() {
             private final String poolPrefix = poolName + "-";

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -92,7 +92,7 @@ public class ThreadUtils {
 
             @Override
             public Thread newThread(Runnable r) {
-                Thread thread = new Thread(group, r, poolPrefix + threadNumber.getAndIncrement(), 0);
+                final Thread thread = new Thread(group, r, poolPrefix + threadNumber.getAndIncrement(), 0);
                 thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
                     @Override
                     public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -104,7 +104,7 @@ public class ThreadUtils {
                 final Thread thread = new Thread(group, r, poolPrefix + threadNumber.getAndIncrement(), 0);
                 thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
                     @Override
-                    public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
+                    public void uncaughtException(@NonNull final Thread t, @NonNull final Throwable e) {
                         if (e instanceof ThreadDeath) {
                             Logger.info("ThreadPool[" + poolName + "]", null,
                                     "Thread Death Exception in thread pool " + poolName);

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -61,7 +61,7 @@ public class ThreadUtils {
     }
 
     /**
-     * Construct a thread pool with specified name and bounded size.
+     * Construct a thread pool with specified name and optionally bounded size.
      * @param corePool The smallest number of threads to keep alive in the pool.
      * @param maxPool The maximum number of threads to allow in the thread pool, after which RejectedExecutionException will occur.
      * @param queueSize The number of items to keep in the queue.  If this is < 0, the queue is unbounded.

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -62,23 +62,31 @@ public class ThreadUtils {
 
     /**
      * Construct a thread pool with specified name and optionally bounded size.
-     * @param corePool The smallest number of threads to keep alive in the pool.
-     * @param maxPool The maximum number of threads to allow in the thread pool, after which RejectedExecutionException will occur.
-     * @param queueSize The number of items to keep in the queue.  If this is < 0, the queue is unbounded.
+     *
+     * @param corePool      The smallest number of threads to keep alive in the pool.
+     * @param maxPool       The maximum number of threads to allow in the thread pool, after which RejectedExecutionException will occur.
+     * @param queueSize     The number of items to keep in the queue.  If this is < 0, the queue is unbounded.
      * @param keepAliveTime The amount of time to keep excess (greater than corePool size) threads alive before terminating them.
      * @param keepAliveUnit The time unit on that time.
-     * @param poolName The name of the thread pool in use.
+     * @param poolName      The name of the thread pool in use.
      * @return An executor service with the specified properties.
      */
-    public static ExecutorService getNamedThreadPoolExecutor(final int corePool, final int maxPool, final int queueSize, final long keepAliveTime, @NonNull final TimeUnit keepAliveUnit, @NonNull final String poolName) {
-        final SecurityManager securityManager = System.getSecurityManager();
+    public static ExecutorService getNamedThreadPoolExecutor(final int corePool, final int maxPool,
+                                                             final int queueSize, final long keepAliveTime,
+                                                             @NonNull final TimeUnit keepAliveUnit,
+                                                             @NonNull final String poolName) {
         if (queueSize > 0) {
             return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
-                    new ArrayBlockingQueue<Runnable>(queueSize), getNamedThreadFactory(poolName, securityManager));
+                                          new ArrayBlockingQueue<Runnable>(queueSize),
+                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
         } else if (queueSize == 0) {
-            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit, new SynchronousQueue<Runnable>(), getNamedThreadFactory(poolName, securityManager));
+            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
+                                          new SynchronousQueue<Runnable>(),
+                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
         } else { // (queueSize < 0)
-            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit, new LinkedBlockingQueue<Runnable>(), getNamedThreadFactory(poolName, securityManager));
+            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
+                                          new LinkedBlockingQueue<Runnable>(),
+                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
         }
     }
 
@@ -88,7 +96,8 @@ public class ThreadUtils {
         return new ThreadFactory() {
             private final String poolPrefix = poolName + "-";
             private final AtomicLong threadNumber = new AtomicLong(1);
-            private final ThreadGroup group = securityManager == null ? Thread.currentThread().getThreadGroup() : securityManager.getThreadGroup();
+            private final ThreadGroup group = securityManager == null ? Thread.currentThread().getThreadGroup()
+                                                                      : securityManager.getThreadGroup();
 
             @Override
             public Thread newThread(Runnable r) {
@@ -97,9 +106,11 @@ public class ThreadUtils {
                     @Override
                     public void uncaughtException(@NonNull Thread t, @NonNull Throwable e) {
                         if (e instanceof ThreadDeath) {
-                            Logger.info("ThreadPool[" + poolName + "]", null, "Thread Death Exception in thread pool " + poolName);
+                            Logger.info("ThreadPool[" + poolName + "]", null,
+                                    "Thread Death Exception in thread pool " + poolName);
                         } else {
-                            Logger.error("ThreadPool[" + poolName + "]", null, "Uncaught Exception in thread pool " + poolName, e);
+                            Logger.error("ThreadPool[" + poolName + "]", null,
+                                    "Uncaught Exception in thread pool " + poolName, e);
                         }
                     }
                 });

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -1,3 +1,20 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.unit;
 
 import com.microsoft.identity.common.internal.util.ThreadUtils;

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -36,7 +36,7 @@ public class ThreadUtilsTests {
     @Test
     public void basicPoolTest() throws Exception {
         ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
-        Future<String> result = s.submit(new Callable<String>() {
+        final Future<String> result = s.submit(new Callable<String>() {
             @Override
             public String call() {
                 return Thread.currentThread().getName();

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class ThreadUtilsTests {
     @Test
     public void basicPoolTest() throws Exception {
-        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
         final Future<String> result = s.submit(new Callable<String>() {
             @Override
             public String call() {

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -1,0 +1,81 @@
+package com.microsoft.identity.common.unit;
+
+import com.microsoft.identity.common.internal.util.ThreadUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for classes in the ThreadUtils package.
+ */
+public class ThreadUtilsTests {
+    @Test
+    public void basicPoolTest() throws Exception {
+        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
+        Future<String> result = s.submit(new Callable<String>() {
+            @Override
+            public String call() {
+                return Thread.currentThread().getName();
+            }
+        });
+        Assert.assertTrue(result.get().startsWith("testPool"));
+        s.shutdownNow();
+    }
+
+    @Test
+    public void capacityOneTest() throws Exception {
+        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 1, 5, TimeUnit.SECONDS, "testPool");
+        Future<?> result = s.submit(hangThread());
+        Future<?> result2 = s.submit(hangThread());
+        boolean caught = false;
+        try {
+            s.submit(new Runnable() {
+                @Override
+                public void run() {
+
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            caught = true;
+        }
+        Assert.assertTrue("Execution should have been rejected", caught);
+        result.cancel(true);
+        result2.cancel(true);
+        s.shutdownNow();
+    }
+    @Test
+    public void capacityZeroTest() throws Exception {
+        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 0, 5, TimeUnit.SECONDS, "testPool");
+        Future<?> result = s.submit(hangThread());
+        boolean caught = false;
+        try {
+            s.submit(new Runnable() {
+                @Override
+                public void run() {
+
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            caught = true;
+        }
+        Assert.assertTrue("Execution should have been rejected", caught);
+        result.cancel(true);
+        s.shutdownNow();
+    }
+
+    private Runnable hangThread() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                ThreadUtils.sleepSafely(10_000_000, "foo", "Pretty much expecting it.");
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -48,9 +48,9 @@ public class ThreadUtilsTests {
 
     @Test
     public void capacityOneTest() throws Exception {
-        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 1, 5, TimeUnit.SECONDS, "testPool");
-        Future<?> result = s.submit(hangThread());
-        Future<?> result2 = s.submit(hangThread());
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 1, 5, TimeUnit.SECONDS, "testPool");
+        final Future<?> result = s.submit(hangThread());
+        final Future<?> result2 = s.submit(hangThread());
         boolean caught = false;
         try {
             s.submit(new Runnable() {
@@ -69,8 +69,8 @@ public class ThreadUtilsTests {
     }
     @Test
     public void capacityZeroTest() throws Exception {
-        ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 0, 5, TimeUnit.SECONDS, "testPool");
-        Future<?> result = s.submit(hangThread());
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 0, 5, TimeUnit.SECONDS, "testPool");
+        final Future<?> result = s.submit(hangThread());
         boolean caught = false;
         try {
             s.submit(new Runnable() {


### PR DESCRIPTION
While extracting accessors for the keyStore contained in the DevicePop* classes, I noticed that the executors defined therein didn't have naming applied to them.  Remembering that this is something that bothered me in the rest of the code, I wrote a utility to make it easier to name these things and apply bounds to their resource consumption without requiring an arbitrary developer to dive into the details of thread factory construction.