### PR TITLE
Stabilize the storage helper key change detection test

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -197,8 +197,9 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
     @Test
     public void testKeyChange() throws GeneralSecurityException, IOException {
         Context context = getInstrumentation().getTargetContext();
+        StorageHelper.LAST_KNOWN_THUMBPRINT.set("");
         final StorageHelper storageHelper = new StorageHelper(context);
-        Assert.assertFalse(storageHelper.testKeyChange());
+        Assert.assertTrue(storageHelper.testKeyChange());
         for (int i = 0; i < 500; i++) {
             Assert.assertFalse(storageHelper.testKeyChange());
         }


### PR DESCRIPTION
Depending on how this test was running, it was unstable.  Make
a change to have it be deterministic.

It was passing when I ran the tests through common, but failing when I ran the connectedAndroidTest target in MSAL.