### PR TITLE
Add support for launch Broker auth Activity without an Activity Context

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V.Next
 - [PATCH] Trim() Cache Lookup Input Parameters (#1228)
 - [MINOR] Adds workaround for Mockito.openMocks() desugaring issue (#1229)
 - [PATCH] Fix bug where duplicate BrokerApplicationMetadata entries could be created for a single app (#1232)
+- [MINOR] Adds support for launching Broker auth Activity without an Activity Context from OneAuth-MSAL by setting FLAG_ACTIVITY_NEW_TASK
 
 Version 3.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -236,14 +236,22 @@ public class BrokerMsalController extends BaseController {
         //Get the broker interactive parameters intent
         final Intent interactiveRequestIntent = getBrokerAuthorizationIntent(parameters);
 
+        // To support calling from OneAuth-MSAL, which may be initialized without an Activity
+        // add Flags to start as a NEW_TASK if we are launching from an application Context
+        final boolean startAsNewTask = null == parameters.getActivity();
+
         //Pass this intent to the BrokerActivity which will be used to start this activity
         final Intent brokerActivityIntent = new Intent(parameters.getAndroidApplicationContext(), BrokerActivity.class);
         brokerActivityIntent.putExtra(BrokerActivity.BROKER_INTENT, interactiveRequestIntent);
 
-        mBrokerResultFuture = new BrokerResultFuture();
-
-        //Start the BrokerActivity
-        parameters.getActivity().startActivity(brokerActivityIntent);
+        if (startAsNewTask) {
+            // Start this Activity as a new task, as there is no existing Activity Context
+            brokerActivityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            mApplicationContext.startActivity(brokerActivityIntent);
+        } else {
+            // Start the BrokerActivity using our existing Activity
+            parameters.getActivity().startActivity(brokerActivityIntent);
+        }
 
         //Wait to be notified of the result being returned... we could add a timeout here if we want to
         final Bundle resultBundle = mBrokerResultFuture.get();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -236,16 +236,13 @@ public class BrokerMsalController extends BaseController {
         //Get the broker interactive parameters intent
         final Intent interactiveRequestIntent = getBrokerAuthorizationIntent(parameters);
 
-        // To support calling from OneAuth-MSAL, which may be initialized without an Activity
-        // add Flags to start as a NEW_TASK if we are launching from an application Context
-        final boolean startAsNewTask = null == parameters.getActivity();
-
         //Pass this intent to the BrokerActivity which will be used to start this activity
         final Intent brokerActivityIntent = new Intent(parameters.getAndroidApplicationContext(), BrokerActivity.class);
         brokerActivityIntent.putExtra(BrokerActivity.BROKER_INTENT, interactiveRequestIntent);
 
-        if (startAsNewTask) {
-            // Start this Activity as a new task, as there is no existing Activity Context
+        if (null == parameters.getActivity()) {
+            // To support calling from OneAuth-MSAL, which may be initialized without an Activity
+            // add Flags to start as a NEW_TASK if we are launching from an application Context
             brokerActivityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             mApplicationContext.startActivity(brokerActivityIntent);
         } else {


### PR DESCRIPTION
Impetus:
- https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1192768

Goal:
- OneAuth-MSAL may not have an `Activity` `Context` available after initialization, but _will_ have a `Context` from the application. To support launching broker in this state, `FLAG_ACTIVITY_NEW_TASK` can be set on the request, if there is no `Activity`

This complete changeset to support this functionality will span:
- AndroidCommon
    * This PR
- MSALCPP
    * Changes to `BrokerImpl`
- OneAuth-MSAL
    * Changes to `BrokerFactory` & `OneAuth`