### PR TITLE
Replaced deprecated versionCode with getLongVersionCode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.Next
 - [MINOR] Changes to Broker Validation to allow setting whether to trust debug brokers (prod brokers are always trusted).
 - [MINOR] Adds support for launching Broker auth Activity without an Activity Context from OneAuth-MSAL by setting FLAG_ACTIVITY_NEW_TASK (#1236)
 - [MINOR] Adds PRT storage support for MSALCPP(#1177)
+- [PATCH] Replaced deprecated PackageInfo.versionCode with PackageInfoCompat.getLongVersionCode(packageInfo) (#1239)
 
 Version 3.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryContext.java
@@ -28,6 +28,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.pm.PackageInfoCompat;
 
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -79,9 +80,7 @@ public class TelemetryContext extends Properties {
             put(App.NAME, packageInfo.applicationInfo.packageName);
             put(App.VERSION, packageInfo.versionName);
 
-            // Suppressing deprecation warnings due to deprecated property versionCode. There is already an existing issue for this: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/863
-            @SuppressWarnings(WarningType.deprecation_warning)
-            int versionCode = packageInfo.versionCode;
+            long versionCode = PackageInfoCompat.getLongVersionCode(packageInfo);
 
             put(App.BUILD, String.valueOf(versionCode));
 


### PR DESCRIPTION
Replaced the deprecated `PackageInfo.versionCode` with `PackageInfoCompat.getLongVersionCode(packageInfo)`. Used PackageInfoCompat for compatibility reasons.

Work Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1226174
Issue: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/issues/863