### PR TITLE
Add StorageHelper logging change to changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Version 3.1.0
 - [PATCH] Discontinue using Settings.Secure.ANDROID_ID in telemetry. Instead, generate & cache a random GUID. (#1214)
 - [MINOR] Add refresh_on to access tokens(#1190)
 - [MINOR] Add requested_claims to access tokens, and allow credentials to be filtered by RC (#1187)
+- [PATCH] Logging change: only log encryption key thumbprint if a key-change occurs (#1213)
 
 Version 3.0.9
 ----------


### PR DESCRIPTION
Update the `3.1.0` changelog to mention work done in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1213.

Related:
- https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1308