### PR TITLE
Expand the MockHttpClient request matching scenarios.

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/HttpRequestMatcher.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/HttpRequestMatcher.java
@@ -27,6 +27,7 @@ import com.microsoft.identity.common.internal.net.HttpClient;
 import java.net.URL;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -38,10 +39,40 @@ import lombok.NonNull;
 @Builder
 public class HttpRequestMatcher {
 
-    private Predicate<Map<String, String>> headers = header -> true;
-    private Predicate<byte[]> body = content -> true;
-    private Predicate<URL> url = s -> true;
-    private Predicate<HttpClient.HttpMethod> method = s -> true;
+    @NonNull
+    @Builder.Default
+    private Predicate<Map<String, String>> headers = new Predicate<Map<String, String>>() {
+        @Override
+        public boolean test(Map<String, String> header) {
+            return true;
+        }
+    };
+    @NonNull
+    @Builder.Default
+    private Predicate<byte[]> body = new Predicate<byte[]>() {
+        @Override
+        public boolean test(byte[] content) {
+            return true;
+        }
+    };
+
+    @NonNull
+    @Builder.Default
+    private Predicate<URL> url = new Predicate<URL>() {
+        @Override
+        public boolean test(URL s) {
+            return true;
+        }
+    };
+
+    @NonNull
+    @Builder.Default
+    private Predicate<HttpClient.HttpMethod> method = new Predicate<HttpClient.HttpMethod>() {
+        @Override
+        public boolean test(HttpClient.HttpMethod s) {
+            return true;
+        }
+    };
 
 
     /**
@@ -58,9 +89,114 @@ public class HttpRequestMatcher {
             @NonNull final URL url,
             final Map<String, String> requestHeaders,
             final byte[] requestContent) {
-        return (null == this.method || this.method.test(method))
-                && (null == this.url || this.url.test(url))
-                && (null == this.headers || this.headers.test(requestHeaders))
-                && (null == this.body || this.body.test(requestContent));
+        return this.method.test(method) && this.url.test(url)
+                && this.headers.test(requestHeaders) && this.body.test(requestContent);
+    }
+
+    public static class HttpRequestMatcherBuilder {
+
+        /**
+         * CHeck for the TRACE http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isTRACE() {
+            return methodIs(HttpClient.HttpMethod.TRACE);
+        }
+
+        /**
+         * CHeck for the OPTIONS http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isOPTIONS() {
+            return methodIs(HttpClient.HttpMethod.OPTIONS);
+        }
+
+        /**
+         * CHeck for the HEAD http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isHEAD() {
+            return methodIs(HttpClient.HttpMethod.HEAD);
+        }
+
+        /**
+         * CHeck for the DELETE http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isDELETE() {
+            return methodIs(HttpClient.HttpMethod.DELETE);
+        }
+
+        /**
+         * CHeck for the PATCH http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isPATCH() {
+            return methodIs(HttpClient.HttpMethod.PATCH);
+        }
+
+        /**
+         * CHeck for the PUT http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isPUT() {
+            return methodIs(HttpClient.HttpMethod.PUT);
+        }
+
+        /**
+         * CHeck for the GET http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isGET() {
+            return methodIs(HttpClient.HttpMethod.GET);
+        }
+
+        /**
+         * CHeck for the POST http method
+         *
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder isPOST() {
+            return methodIs(HttpClient.HttpMethod.POST);
+        }
+
+        /**
+         * Check for the Http Method
+         *
+         * @param method the Http method
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder methodIs(HttpClient.HttpMethod method) {
+            method(new Predicate<HttpClient.HttpMethod>() {
+                @Override
+                public boolean test(HttpClient.HttpMethod _method) {
+                    return _method == method;
+                }
+            });
+            return this;
+        }
+
+        /**
+         * Check for a URL pattern
+         *
+         * @param pattern the pattern
+         * @return the builder
+         */
+        public HttpRequestMatcherBuilder urlPattern(Pattern pattern) {
+            url(new Predicate<URL>() {
+                @Override
+                public boolean test(URL url) {
+                    return pattern.matcher(url.toExternalForm()).matches();
+                }
+            });
+            return this;
+        }
     }
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Class to set a mock request interceptor at runtime.
@@ -106,7 +107,12 @@ public class MockHttpClient {
     public void intercept(@NonNull final URL url, @NonNull final HttpRequestInterceptor interceptor) {
         intercept(
                 HttpRequestMatcher.builder()
-                        .url(u -> u.toString().equals(url.toString()))
+                        .url(new Predicate<URL>() {
+                            @Override
+                            public boolean test(URL u) {
+                                return u.toString().equals(url.toString());
+                            }
+                        })
                         .build(),
                 interceptor
         );
@@ -125,8 +131,18 @@ public class MockHttpClient {
             @NonNull final HttpRequestInterceptor interceptor) {
         intercept(
                 HttpRequestMatcher.builder()
-                        .url(u -> u.toString().equals(url.toString()))
-                        .method(m -> m.compareTo(method) == 0).build(),
+                        .url(new Predicate<URL>() {
+                            @Override
+                            public boolean test(URL u) {
+                                return u.toString().equals(url.toString());
+                            }
+                        })
+                        .method(new Predicate<HttpMethod>() {
+                            @Override
+                            public boolean test(HttpMethod m) {
+                                return m == method;
+                            }
+                        }).build(),
                 interceptor
         );
     }
@@ -143,7 +159,12 @@ public class MockHttpClient {
     ) {
         intercept(
                 HttpRequestMatcher.builder()
-                        .method(m -> m.compareTo(method) == 0)
+                        .method(new Predicate<HttpMethod>() {
+                            @Override
+                            public boolean test(HttpMethod m) {
+                                return m == method;
+                            }
+                        })
                         .build(),
                 interceptor
         );
@@ -158,7 +179,16 @@ public class MockHttpClient {
     public void intercept(HttpRequestMatcher matcher, HttpResponse httpResponse) {
         intercept(
                 matcher,
-                (httpMethod, requestUrl, requestHeaders, requestContent) -> httpResponse
+                new HttpRequestInterceptor() {
+                    @Override
+                    public HttpResponse intercept(
+                            @NonNull HttpMethod httpMethod,
+                            @NonNull URL requestUrl,
+                            @NonNull Map<String, String> requestHeaders,
+                            @Nullable byte[] requestContent) throws IOException {
+                        return httpResponse;
+                    }
+                }
         );
     }
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
@@ -87,6 +87,24 @@ public class MockHttpClient {
 
     private final List<HttpRequestMatcher> matchers = new ArrayList<>(); // store a list of matchers for a single MockHttpClient object instance
 
+    /**
+     * Quickly match all the http requests and respond with the specified http response
+     *
+     * @param httpResponse the http response
+     */
+    public void intercept(@NonNull final HttpResponse httpResponse) {
+        intercept(HttpRequestMatcher.builder().build(), new HttpRequestInterceptor() {
+            @Override
+            public HttpResponse intercept(
+                    @NonNull HttpMethod httpMethod,
+                    @NonNull URL requestUrl,
+                    @NonNull Map<String, String> requestHeaders,
+                    @Nullable byte[] requestContent) throws IOException {
+                return httpResponse;
+            }
+        });
+    }
+
 
     /**
      * Quickly match all the http requests with the specified interceptor

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 public class MockTokenCreator {
 
@@ -61,8 +62,8 @@ public class MockTokenCreator {
     public static final String MOCK_ENCODING_UTF8_VALUE = "UTF-8";
     public static final String MOCK_ISSUER_PREFIX_VALUE = "https://test.authority/";
     public static final String MOCK_ISSUER_SUFFIX_VALUE = "/v2.0";
-    public static final String CLOUD_DISCOVERY_ENDPOINT_REGEX = "^https:\\/\\/login.microsoftonline.com\\/common\\/discovery\\/instance\\?api-version=1.1\\&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize$";
-    public static final String MOCK_TOKEN_URL_REGEX = "https:\\/\\/login.microsoftonline.com\\/.*";
+    public static final Pattern CLOUD_DISCOVERY_ENDPOINT_REGEX = Pattern.compile("^https:\\/\\/login.microsoftonline.com\\/common\\/discovery\\/instance\\?api-version=1.1\\&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize$");
+    public static final Pattern MOCK_TOKEN_URL_REGEX = Pattern.compile("https:\\/\\/login.microsoftonline.com\\/.*");
 
     private static String createMockToken(final String issuer,
                                           final String subject,

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/shadows/ShadowHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/shadows/ShadowHttpClient.java
@@ -41,6 +41,13 @@ import java.util.Map;
 
 /**
  * Allows us to mock http request responses by shadowing the {@link HttpClient}.
+ * <p>
+ * <p>
+ * We need to shadow the {@link AbstractHttpClient} because we are using an instance of the
+ * {@link UrlConnectionHttpClient} in the method here
+ * {@link ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])} therefore using the
+ * {@link UrlConnectionHttpClient} as the shadow would prevent us from making an actual http request
+ * when there are no interceptors defined for the request.
  *
  * @see MockHttpClient for setting up interceptors and mock responses
  * @see HttpRequestInterceptor an implementation for intercepting http requests.
@@ -57,14 +64,13 @@ public class ShadowHttpClient {
      * @param requestContent the request body
      * @return the mocked response or the actual response
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see HttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      */
     public HttpResponse method(@NonNull HttpClient.HttpMethod httpMethod,
                                @NonNull URL requestUrl,
                                @NonNull Map<String, String> requestHeaders,
                                @Nullable byte[] requestContent) throws IOException {
-        HttpRequestInterceptor interceptor = MockHttpClient.intercept(httpMethod, requestUrl);
+        HttpRequestInterceptor interceptor = MockHttpClient.intercept(httpMethod, requestUrl, requestHeaders, requestContent);
         if (interceptor == null) {
             return UrlConnectionHttpClient.getDefaultInstance().method(httpMethod, requestUrl, requestHeaders, requestContent);
         } else {
@@ -80,7 +86,6 @@ public class ShadowHttpClient {
      * @param requestContent the request body
      * @return the mocked response or the actual response
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#put(URL, Map, byte[])
      */
@@ -98,9 +103,7 @@ public class ShadowHttpClient {
      * @param requestHeaders the request headers
      * @param requestContent the request body
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#patch(URL, Map, byte[])
      */
@@ -117,9 +120,7 @@ public class ShadowHttpClient {
      * @param requestUrl     the request url
      * @param requestHeaders the request headers
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#options(URL, Map)
      */
@@ -136,9 +137,7 @@ public class ShadowHttpClient {
      * @param requestHeaders the request headers
      * @param requestContent the request body content
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#post(URL, Map, byte[])
      */
@@ -156,9 +155,7 @@ public class ShadowHttpClient {
      * @param requestHeaders the request headers
      * @param requestContent the request body content
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#delete(URL, Map, byte[])
      */
@@ -175,9 +172,7 @@ public class ShadowHttpClient {
      * @param requestUrl     the request url
      * @param requestHeaders the request headers
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#get(URL, Map)
      */
@@ -193,9 +188,7 @@ public class ShadowHttpClient {
      * @param requestUrl     the request url
      * @param requestHeaders the request headers
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#head(URL, Map)
      */
@@ -211,9 +204,7 @@ public class ShadowHttpClient {
      * @param requestUrl     the request url
      * @param requestHeaders the request headers
      * @return the mocked response or the actual response
-     *
      * @throws IOException throw an IOException when an error occurred
-     *
      * @see ShadowHttpClient#method(HttpClient.HttpMethod, URL, Map, byte[])
      * @see HttpClient#trace(URL, Map)
      */


### PR DESCRIPTION
## What does this PR do?
- Expands the capability of the MockHttpClient to cater for matching of:
1. Request URL
2. Request headers
3. Request method
4. Request body/content.

The original implementation was done here: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1205