### PR TITLE
Expose ADAL Legacy Cache Name & Utility Method for Migration Usage in OneAuth

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -184,7 +184,7 @@ public enum AuthenticationSettings {
     /**
      * For test cases only.
      */
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public void clearSecretKeysForTestCases() {
         clearLegacySecretKeyConfiguration();
     }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.adal.internal;
 
 import android.os.Build;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -41,6 +43,8 @@ public enum AuthenticationSettings {
      * Singleton setting instance.
      */
     INSTANCE;
+
+    private static final String TAG = AuthenticationSettings.class.getSimpleName();
 
     private static final int SECRET_RAW_KEY_LENGTH = 32;
 
@@ -169,6 +173,10 @@ public enum AuthenticationSettings {
      * Clears any secret keys set by legacy {@link #setSecretKey(byte[])} API.
      */
     public void clearLegacySecretKeyConfiguration() {
+        Logger.info(
+                TAG + ":clearLegacySecretKeyConfiguration",
+                "Clearing legacy secret key configuration."
+        );
         mBrokerSecretKeys.clear();
         mSecretKeyData.set(null);
     }
@@ -176,6 +184,7 @@ public enum AuthenticationSettings {
     /**
      * For test cases only.
      */
+    @VisibleForTesting
     public void clearSecretKeysForTestCases() {
         clearLegacySecretKeyConfiguration();
     }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -166,11 +166,18 @@ public enum AuthenticationSettings {
     }
 
     /**
+     * Clears any secret keys set by legacy {@link #setSecretKey(byte[])} API.
+     */
+    public void clearLegacySecretKeyConfiguration() {
+        mBrokerSecretKeys.clear();
+        mSecretKeyData.set(null);
+    }
+
+    /**
      * For test cases only.
      */
     public void clearSecretKeysForTestCases() {
-        mBrokerSecretKeys.clear();
-        mSecretKeyData.set(null);
+        clearLegacySecretKeyConfiguration();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -75,7 +75,7 @@ public class ADALOAuth2TokenCache
     static final String ERR_UNSUPPORTED_OPERATION = "This method is unsupported.";
 
     private static final String TAG = ADALOAuth2TokenCache.class.getSimpleName();
-    private static final String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
+    public static final String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
 
     private Gson mGson = new GsonBuilder()
             .registerTypeAdapter(Date.class, new DateTimeAdapter())

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -75,7 +75,7 @@ public class ADALOAuth2TokenCache
     static final String ERR_UNSUPPORTED_OPERATION = "This method is unsupported.";
 
     private static final String TAG = ADALOAuth2TokenCache.class.getSimpleName();
-    public static final String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
+    private static final String SHARED_PREFERENCES_FILENAME = "com.microsoft.aad.adal.cache";
 
     private Gson mGson = new GsonBuilder()
             .registerTypeAdapter(Date.class, new DateTimeAdapter())
@@ -398,5 +398,13 @@ public class ADALOAuth2TokenCache
         Logger.warn(TAG, "getSingleSignOnState was called, but is not implemented.");
         final RefreshToken refreshToken = null;
         return refreshToken;
+    }
+
+    public static String getAdalCacheFilename() {
+        Logger.info(
+                TAG + ":getAdalCacheFilename",
+                "Getting ADAL cache file name..."
+        );
+        return SHARED_PREFERENCES_FILENAME;
     }
 }


### PR DESCRIPTION
Impetus:
- https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1300836

Summary of changes:
- Expose ADAL's default cache name for use by OneAuth in migration API
- Expose method on `AuthenticationSettings` to allow for clearing of secretKey data once set (cannot otherwise be unset)