### PR TITLE
Disable java 1.8

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,19 +22,19 @@ project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") 
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 android {
-
-    testOptions {
-        compileOptions {
-            // Flag to enable support for the new language APIs
-            coreLibraryDesugaringEnabled true
-            // Sets Java compatibility to Java 8
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
-        dependencies {
-            coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
-        }
-    }  
+//
+//    testOptions {
+//        compileOptions {
+//            // Flag to enable support for the new language APIs
+//            coreLibraryDesugaringEnabled true
+//            // Sets Java compatibility to Java 8
+//            sourceCompatibility JavaVersion.VERSION_1_8
+//            targetCompatibility JavaVersion.VERSION_1_8
+//        }
+//        dependencies {
+//            coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
+//        }
+//    }
     /*
     //Commenting out until the next major version of common/msal/etc...
     compileOptions {


### PR DESCRIPTION
For some reason, this is also affect the common library itself - the calling app is still asking for JAVA 1.8.

For now, I'll disable this to unblock the release. Once we have capacity, we could revisit this to have this re-enabled for test projects.

related PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1319