### PR TITLE
Add in-memory caching to shared preferences file

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ V.Next
 - [PATCH] Fix MSAL-CPP injecting javascript loop (#1238)
 - [MINOR] Device PoP keys are now generated with attestation flags and expose a certificate chain getter (#1247)
 - [PATCH] Fixes deprecated NetworkInfo class (#847)
+- [MINOR] Implement an in-memory cache to avoid multiple decryptions of shared preferences
 
 Version 3.1.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -294,17 +294,19 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
     private ISharedPreferencesFileManager getAppUidFileManager(final Context context,
                                                                final int appUid) {
-        return new SharedPreferencesFileManager(
+        return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 getBrokerUidSequesteredFilename(appUid),
+                -1,
                 new StorageHelper(context)
         );
     }
 
     private ISharedPreferencesFileManager getFociFileManager(final Context context) {
-        return new SharedPreferencesFileManager(
+        return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                -1,
                 new StorageHelper(context)
         );
     }

--- a/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
@@ -120,9 +120,11 @@ public class DefaultSharedPrefsFileManagerReencrypterTest {
     @Before
     public void setUp() {
         mContext = InstrumentationRegistry.getTargetContext();
-        mTestCacheFile = new SharedPreferencesFileManager(
+        mTestCacheFile = SharedPreferencesFileManager.getSharedPreferences(
                 mContext,
-                TEST_CACHE_FILENAME
+                TEST_CACHE_FILENAME,
+                -1,
+                null
         );
         mFileManagerReencrypter = new DefaultSharedPrefsFileManagerReencrypter();
         try {

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -257,9 +257,10 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
 
         // Context and related init
         final Context context = InstrumentationRegistry.getTargetContext();
-        mSharedPreferencesFileManager = new SharedPreferencesFileManager(
+        mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 "test_prefs",
+                -1,
                 new StorageHelper(context)
         );
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -97,9 +97,10 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
         super.setUp();
         final Context testContext = InstrumentationRegistry.getTargetContext();
         mDelegate = new CacheKeyValueDelegate();
-        mSharedPreferencesFileManager = new SharedPreferencesFileManager(
+        mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 testContext,
                 sAccountCredentialSharedPreferences,
+                -1,
                 new StorageHelper(testContext) // Use encrypted storage for tests...
         );
         mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -53,13 +53,15 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
     @Parameterized.Parameters
     public static Iterable<ISharedPreferencesFileManager> testParams() {
         return Arrays.asList(new ISharedPreferencesFileManager[]{
-                new SharedPreferencesFileManager(
-                        InstrumentationRegistry.getTargetContext(),
-                        sTEST_SHARED_PREFS_NAME
-                ),
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         InstrumentationRegistry.getTargetContext(),
                         sTEST_SHARED_PREFS_NAME,
+                        -1, null
+                ),
+                SharedPreferencesFileManager.getSharedPreferences(
+                        InstrumentationRegistry.getTargetContext(),
+                        sTEST_SHARED_PREFS_NAME,
+                        -1,
                         new StorageHelper(InstrumentationRegistry.getTargetContext())
                 )
         });

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -312,6 +312,7 @@ public class StorageHelper implements IStorageHelper {
         final SecretKey secretKey = loadSecretKeyForEncryption();
         return logIfKeyHasChanged(secretKey, getHMacKey(secretKey));
     }
+
     private String getKeyThumbPrint(final @NonNull SecretKey secretKey, final @NonNull SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
         final Cipher thumbPrintCipher = Cipher.getInstance(CIPHER_ALGORITHM_FOR_KEY_TRACKING);
         final byte[] thumbprintBytes = "012345678910111213141516".getBytes();

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -116,9 +116,10 @@ public class ADALOAuth2TokenCache
         Logger.verbose(TAG, "Initializing SharedPreferencesFileManager");
         Logger.verbosePII(TAG, "Initializing with name: " + fileName);
         mISharedPreferencesFileManager =
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         getContext(),
                         fileName,
+                        -1,
                         new StorageHelper(getContext())
                 );
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -1613,10 +1613,11 @@ public class BrokerOAuth2TokenCache
 
         final IStorageHelper storageHelper = new StorageHelper(context);
         final ISharedPreferencesFileManager sharedPreferencesFileManager =
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         SharedPreferencesAccountCredentialCache
                                 .getBrokerUidSequesteredFilename(bindingProcessUid),
+                        -1,
                         storageHelper
                 );
 
@@ -1631,9 +1632,10 @@ public class BrokerOAuth2TokenCache
         );
         final IStorageHelper storageHelper = new StorageHelper(context);
         final ISharedPreferencesFileManager sharedPreferencesFileManager =
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                        -1,
                         storageHelper
                 );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
@@ -77,7 +77,7 @@ public class HelloCache {
     public HelloCache(final @NonNull Context context,
                       final @NonNull String protocolName,
                       final @NonNull String targetAppPackageName) {
-        mFileManager = new SharedPreferencesFileManager(context, SHARED_PREFERENCE_NAME);
+        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME, -1, null);
         mContext = context;
         mProtocolName = protocolName;
         mTargetAppPackageName = targetAppPackageName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -137,9 +137,10 @@ public class MsalOAuth2TokenCache
         final ICacheKeyValueDelegate cacheKeyValueDelegate = new CacheKeyValueDelegate();
         final IStorageHelper storageHelper = new StorageHelper(context);
         final ISharedPreferencesFileManager sharedPreferencesFileManager =
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                        -1,
                         storageHelper
                 );
         final IAccountCredentialCache accountCredentialCache =

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
@@ -214,9 +214,11 @@ public class EstsTelemetry {
         );
 
         final ISharedPreferencesFileManager sharedPreferencesFileManager =
-                new SharedPreferencesFileManager(
+                SharedPreferencesFileManager.getSharedPreferences(
                         context,
-                        LAST_REQUEST_TELEMETRY_SHARED_PREFERENCES
+                        LAST_REQUEST_TELEMETRY_SHARED_PREFERENCES,
+                        -1,
+                        null
                 );
 
         return new SharedPreferencesLastRequestTelemetryCache(sharedPreferencesFileManager);

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
@@ -30,8 +30,8 @@ public final class DiagnosticContext {
     private DiagnosticContext() {
     }
 
-    private static final ThreadLocal<IRequestContext> REQUEST_CONTEXT_THREAD_LOCAL =
-            new ThreadLocal<IRequestContext>() {
+    private static final InheritableThreadLocal<IRequestContext> REQUEST_CONTEXT_THREAD_LOCAL =
+            new InheritableThreadLocal<IRequestContext>() {
                 @Override // This is the default value for the RequestContext if it's unset
                 protected RequestContext initialValue() {
                     final RequestContext defaultRequestContext = new RequestContext();

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/DiagnosticContext.java
@@ -30,8 +30,8 @@ public final class DiagnosticContext {
     private DiagnosticContext() {
     }
 
-    private static final InheritableThreadLocal<IRequestContext> REQUEST_CONTEXT_THREAD_LOCAL =
-            new InheritableThreadLocal<IRequestContext>() {
+    private static final ThreadLocal<IRequestContext> REQUEST_CONTEXT_THREAD_LOCAL =
+            new ThreadLocal<IRequestContext>() {
                 @Override // This is the default value for the RequestContext if it's unset
                 protected RequestContext initialValue() {
                     final RequestContext defaultRequestContext = new RequestContext();

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryPropertiesCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryPropertiesCache.java
@@ -48,7 +48,7 @@ class TelemetryPropertiesCache {
     private final SharedPreferencesFileManager mSharedPrefs;
 
     TelemetryPropertiesCache(@NonNull final Context context) {
-        mSharedPrefs = new SharedPreferencesFileManager(context, SHARED_PREFS_NAME);
+        mSharedPrefs = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFS_NAME, -1, null);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -44,9 +44,11 @@ public class ClockSkewManager implements IClockSkewManager {
     private SharedPreferencesFileManager mClockSkewPreferences;
 
     public ClockSkewManager(@NonNull final Context context) {
-        mClockSkewPreferences = new SharedPreferencesFileManager(
+        mClockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
                 context,
-                PreferencesMetadata.SKEW_PREFERENCES_FILENAME
+                PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
+                -1,
+                null
         );
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ versionName=1.5.9
 
 # For OneAuth default abiSelection
 abiSelection=x86_64
+
+org.gradle.dependency.verification=off


### PR DESCRIPTION
Currently we read a lot of data out of shared preferences and decrypt it.  