### PR TITLE
Hide Switch Account in interactive flows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Hide Switch Account in Broker interactive flows (#1284)
 - [MINOR] Enables removeAccount api to remove account records from all environments (#1248)
 
 Version 3.2.0

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -32,7 +32,9 @@ import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequest<MicrosoftStsAuthorizationRequest> {
@@ -167,9 +169,21 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
             }
         }
 
+        List<Pair<String, String>> extraQueryParams = getExtraQueryParams();
+
+        // If login_hint is provided, block the user from switching user during login.
+        // hsu = HideSwitchUser
+        if (!TextUtils.isEmpty(getLoginHint())) {
+            if (extraQueryParams == null) {
+                extraQueryParams = new ArrayList<>();
+            }
+
+            extraQueryParams.add(new Pair<>("hsu", "1"));
+        }
+
         // Add extra qp, if present...
-        if (null != getExtraQueryParams() && !getExtraQueryParams().isEmpty()) {
-            for (final Pair<String, String> queryParam : getExtraQueryParams()) {
+        if (null != extraQueryParams && !extraQueryParams.isEmpty()) {
+            for (final Pair<String, String> queryParam : extraQueryParams) {
                 //Skip appending for duplicated extra query parameters
                 if (!qpMap.containsKey(queryParam.first)) {
                     qpMap.put(queryParam.first, queryParam.second);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -32,9 +32,7 @@ import com.microsoft.identity.common.internal.net.ObjectMapper;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequest<MicrosoftStsAuthorizationRequest> {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -85,6 +85,11 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         public static final String CONSENT = "consent";
     }
 
+    /**
+     * If hsu=1 is passed, eSTS will hide the option which allows user to switch login hint.
+     * This can only be passed if login_hint is provided.
+     */
+    public static final String HIDE_SWITCH_USER_QUERY_PARAMETER = "hsu";
 
     protected MicrosoftStsAuthorizationRequest(final Builder builder) {
         super(builder);
@@ -149,7 +154,9 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         return mPrompt;
     }
 
-    public String getTokenScope() {return mTokenScope;}
+    public String getTokenScope() {
+        return mTokenScope;
+    }
 
     @Override
     public Uri getAuthorizationRequestAsHttpRequest() {
@@ -169,21 +176,15 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
             }
         }
 
-        List<Pair<String, String>> extraQueryParams = getExtraQueryParams();
-
         // If login_hint is provided, block the user from switching user during login.
         // hsu = HideSwitchUser
         if (!TextUtils.isEmpty(getLoginHint())) {
-            if (extraQueryParams == null) {
-                extraQueryParams = new ArrayList<>();
-            }
-
-            extraQueryParams.add(new Pair<>("hsu", "1"));
+            qpMap.put(HIDE_SWITCH_USER_QUERY_PARAMETER, "1");
         }
 
         // Add extra qp, if present...
-        if (null != extraQueryParams && !extraQueryParams.isEmpty()) {
-            for (final Pair<String, String> queryParam : extraQueryParams) {
+        if (null != getExtraQueryParams() && !getExtraQueryParams().isEmpty()) {
+            for (final Pair<String, String> queryParam : getExtraQueryParams()) {
                 //Skip appending for duplicated extra query parameters
                 if (!qpMap.containsKey(queryParam.first)) {
                     qpMap.put(queryParam.first, queryParam.second);
@@ -194,7 +195,7 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         final Uri.Builder uriBuilder = Uri.parse(getAuthorizationEndpoint()).buildUpon();
 
         for (Map.Entry<String, Object> entry : qpMap.entrySet()) {
-            if(entry.getKey() != null && entry.getValue() != null) {
+            if (entry.getKey() != null && entry.getValue() != null) {
                 uriBuilder.appendQueryParameter(entry.getKey(), entry.getValue().toString());
             }
         }


### PR DESCRIPTION
Fix https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1002

by sending hsu=1, we're telling eSTS to hide the account switching option.