### PR TITLE
Add the ability to access key managers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ V.Next
 ----------
 - [MINOR] Hide Switch Account in Broker interactive flows (#1284)
 - [MINOR] Enables removeAccount api to remove account records from all environments (#1248)
-- [MINOR] Adds the ability for KeyAccessors to expose their manager.
+- [MINOR] Adds the ability for KeyAccessors to expose their manager (#1285)
 
 Version 3.2.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ----------
 - [MINOR] Hide Switch Account in Broker interactive flows (#1284)
 - [MINOR] Enables removeAccount api to remove account records from all environments (#1248)
+- [MINOR] Adds the ability for KeyAccessors to expose their manager.
 
 Version 3.2.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.common.adal.internal;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -51,7 +50,7 @@ public final class AuthenticationConstants {
     /**
      * The Constant CHARSET_UTF8.
      */
-    public static final Charset CHARSET_UTF8 = StandardCharsets.UTF_8; //Charset.forName("UTF-8");
+    public static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
     /**
      * Bundle message.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -22,6 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.adal.internal;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -46,6 +49,11 @@ public final class AuthenticationConstants {
     public static final String ENCODING_UTF8 = "UTF-8";
 
     /**
+     * The Constant CHARSET_UTF8.
+     */
+    public static final Charset CHARSET_UTF8 = StandardCharsets.UTF_8; //Charset.forName("UTF-8");
+
+    /**
      * Bundle message.
      */
     public static final String BUNDLE_MESSAGE = "Message";
@@ -54,6 +62,11 @@ public final class AuthenticationConstants {
      * Default access token expiration time in seconds.
      */
     public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
+
+    /**
+     * The constant label for SP800-108.
+     */
+    public static final String SP800_108_LABEL = "AzureAD-SecureConversation";
 
     /**
      * Holding all the constant value involved in the webview.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AsymmetricKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AsymmetricKeyAccessor.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.platform;
 
 import com.microsoft.identity.common.exception.ClientException;
 
+import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -33,7 +34,7 @@ import java.security.UnrecoverableEntryException;
  * An accessor for asymmetric keys.  The main differnce between this an a KeyAccessor is that
  * this accessor allows for retrieval of the public key of the key pair.
  */
-public interface AsymmetricKeyAccessor extends KeyAccessor {
+public interface AsymmetricKeyAccessor extends IManagedKeyAccessor<KeyStore.PrivateKeyEntry> {
     /**
      * Return a public key in the specified format.
      * @param format a format according to {@link IDevicePopManager.PublicKeyFormat}.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -240,12 +240,16 @@ class DevicePopManager implements IDevicePopManager {
         this(DEFAULT_KEYSTORE_ENTRY_ALIAS);
     }
 
+    @Override
+    public IKeyManager<KeyStore.PrivateKeyEntry> getKeyManager() {
+        return mKeyManager;
+    }
+
     DevicePopManager(@NonNull final String alias) throws KeyStoreException, CertificateException,
             NoSuchAlgorithmException, IOException {
-        String keyAlias = alias;
         final KeyStore instance = KeyStore.getInstance(ANDROID_KEYSTORE);
         instance.load(null);
-        mKeyManager = DeviceKeyManager.<KeyStore.PrivateKeyEntry>builder().keyAlias(keyAlias)
+        mKeyManager = DeviceKeyManager.<KeyStore.PrivateKeyEntry>builder().keyAlias(alias)
                                                    .keyStore(instance)
                                                    .thumbprintSupplier(new Supplier<byte[]>() {
                                                        @SneakyThrows(ClientException.class)

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IDevicePopManager.java
@@ -460,4 +460,12 @@ public interface IDevicePopManager {
                                  String nonce,
                                  String clientClaims
     ) throws ClientException;
+
+
+    /**
+     * Get the key manager that this device pop manager uses for key provisioning and
+     * management.  This is exposed mainly in order to allow uses beyond POP.
+     * @return the key manager that backs this DevicePopManager.
+     */
+    IKeyManager<KeyStore.PrivateKeyEntry> getKeyManager();
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/IManagedKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/IManagedKeyAccessor.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.platform;
+
+import java.security.KeyStore;
+
+/**
+ * An extension of the KeyAccessor interface that provides access to the key
+ * manager that created the key.
+ */
+public interface IManagedKeyAccessor<K extends KeyStore.Entry> extends KeyAccessor {
+    /**
+     * If this key is managed, return a manager instance that can be used
+     * to perform operations on it.
+     * @return a IKeyManager for this key.  If this returns null, it should be
+     * regarded as an error.
+     */
+    IKeyManager<K> getManager();
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyStoreAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyStoreAccessor.java
@@ -112,6 +112,11 @@ public class KeyStoreAccessor {
         return new AsymmetricKeyAccessor() {
 
             @Override
+            public IKeyManager<KeyStore.PrivateKeyEntry> getManager() {
+                return popManager.getKeyManager();
+            }
+
+            @Override
             public String getPublicKey(IDevicePopManager.PublicKeyFormat format) throws ClientException {
                 return popManager.getPublicKey(format);
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/RawKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/RawKeyAccessor.java
@@ -224,4 +224,26 @@ public class RawKeyAccessor implements KeyAccessor {
         }
     }
 
+    /**
+     * Given this raw key, generate a derived key from it.  If we close on a KDF for hardware keys,
+     * this can get promoted to the symmetric key interface.
+     * @param label the label for the generated key.
+     * @param ctx the context bytes for the generated key.
+     * @param suite the ciphersuite to use for the generated key.
+     * @return a new key, generated from the previous one.
+     * @throws ClientException if something goes wrong during generation.
+     */
+    public KeyAccessor generateDerivedKey(@NonNull final byte[] label, @NonNull final byte[] ctx,
+                                          @NonNull final CryptoSuite suite) throws ClientException{
+        try {
+            return new RawKeyAccessor(suite, SP800108KeyGen.generateDerivedKey(key, label, ctx));
+        } catch (IOException e) {
+            throw new ClientException(IO_ERROR, e.getMessage(), e);
+        } catch (InvalidKeyException e) {
+            throw new ClientException(INVALID_KEY, e.getMessage(), e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new ClientException(NO_SUCH_ALGORITHM, e.getMessage(), e);
+        }
+    }
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/SecretKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/SecretKeyAccessor.java
@@ -61,7 +61,7 @@ import static com.microsoft.identity.common.exception.ClientException.NO_SUCH_PA
 
 @Builder
 @Accessors(prefix = "m")
-public class SecretKeyAccessor implements KeyAccessor {
+public class SecretKeyAccessor implements IManagedKeyAccessor<KeyStore.SecretKeyEntry> {
     private static final Charset UTF8 = Charset.forName("UTF-8");
     private final DeviceKeyManager<KeyStore.SecretKeyEntry> mKeyManager;
     private final CryptoSuite suite;
@@ -191,5 +191,10 @@ public class SecretKeyAccessor implements KeyAccessor {
     @Override
     public SecureHardwareState getSecureHardwareState() throws ClientException {
         return mKeyManager.getSecureHardwareState();
+    }
+
+    @Override
+    public IKeyManager<KeyStore.SecretKeyEntry> getManager() {
+        return mKeyManager;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/SymmetricCipher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/SymmetricCipher.java
@@ -37,13 +37,16 @@ import java.security.KeyStore;
  */
 public enum SymmetricCipher implements CryptoSuite {
 
-    @RequiresApi(Build.VERSION_CODES.M)
+    @RequiresApi(Build.VERSION_CODES.KITKAT)
     AES_GCM_NONE_HMACSHA256(SymmetricAlgorithm.Builder.of("AES/GCM/NoPadding"), "HmacSHA256", 256) {
-
-        public  KeyGenParameterSpec.Builder decorateKeyGenerator(@NonNull final KeyGenParameterSpec.Builder spec) {
-            return spec.setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                    .setKeySize(keySize());
+        public KeyGenParameterSpec.Builder decorateKeyGenerator(@NonNull final KeyGenParameterSpec.Builder spec) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                return spec.setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .setKeySize(keySize());
+            } else {
+                return spec;
+            }
         }
     };
 


### PR DESCRIPTION
While working with this code, I discovered that I'd inadvertently
made it difficult to remove keys from the keystore when you were
finished with them.  You could still do it, but you'd need to create
your own separate key manager to make it happen.  It's probably
OK to save the reference to the original manager that created it,
so lets just provide access to accessors that are created in ways
that need cleanup.