### PR TITLE
Revert change to not pass environment as part of removeAccount bundle

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -446,7 +446,7 @@ public class LocalMSALController extends BaseController {
         final boolean localRemoveAccountSuccess = !parameters
                 .getOAuth2TokenCache()
                 .removeAccount(
-                        parameters.getAccount() == null ? null : parameters.getAccount().getEnvironment(),
+                        null, // remove account from all environment
                         parameters.getClientId(),
                         parameters.getAccount() == null ? null : parameters.getAccount().getHomeAccountId(),
                         realm

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -568,6 +568,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         final Bundle requestBundle = new Bundle();
         if (null != parameters.getAccount()) {
             requestBundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
+            requestBundle.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
             requestBundle.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
         }
         requestBundle.putString(NEGOTIATED_BP_VERSION_KEY, negotiatedBrokerProtocolVersion);


### PR DESCRIPTION
Reverting the change to not pass  "environment" as part of remove Account bundle request. As this will result in breaking remove account scenarios because the current broker code rejects the request as invalid if environment is passed as null.

Making a separate change in broker to remove the null environment check and also to override the environment value to null [PR 1507](https://github.com/AzureAD/ad-accounts-for-android/pull/1507/files). This will ensure that older versions of broker will continue to work as-is and newer versions of broker will support removing account across all environments.