### PR TITLE
Add new broker API support, adopt constant for UTF-8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V.Next
 - [MINOR] Enables removeAccount api to remove account records from all environments (#1248)
 - [MINOR] Adds the ability for KeyAccessors to expose their manager (#1285)
 - [MINOR] Propagate unknown parameters from the server (#1292)
+- [MINOR] Adds new API support for the broker - SSO token and flight support (#1290)
 
 Version 3.2.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -482,8 +482,8 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
         final StorageHelper storageHelper = new StorageHelper(context);
 
         final String keyString = "ABCDEFGH";
-        final SecretKey key = new SecretKeySpec(Base64.decode(keyString.getBytes(AuthenticationConstants.ENCODING_UTF8), Base64.DEFAULT), "AES");
-        final SecretKey anotherKey = new SecretKeySpec(Base64.decode("RANDOM".getBytes(AuthenticationConstants.ENCODING_UTF8), Base64.DEFAULT), "AES");
+        final SecretKey key = new SecretKeySpec(Base64.decode(keyString.getBytes(AuthenticationConstants.CHARSET_UTF8), Base64.DEFAULT), "AES");
+        final SecretKey anotherKey = new SecretKeySpec(Base64.decode("RANDOM".getBytes(AuthenticationConstants.CHARSET_UTF8), Base64.DEFAULT), "AES");
 
         final String serializedKey = storageHelper.serializeSecretKey(key);
         final SecretKey deserializedKey = storageHelper.deserializeSecretKey(serializedKey);

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1268,7 +1268,7 @@ public final class AuthenticationConstants {
         public static final String SET_FLIGHTS_SUCCEEDED = "set_flights_succeeded";
 
         /**
-         * Boolean to return when a Broker RT is successfully updated.
+         * All of the active flights.
          */
         public static final String GET_FLIGHTS_RESULT = "active_flights";
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.common.adal.internal;
 
 import java.nio.charset.Charset;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1425,7 +1425,7 @@ public final class AuthenticationConstants {
                 return mPath;
             }
             public int code() {
-                return mCode == null ? ordinal() + 1: mCode;
+                return mCode == null ? ordinal() + 1 : mCode;
             }
         }
         /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1409,7 +1409,8 @@ public final class AuthenticationConstants {
             BROKER_ADD_FLIGHTS(BROKER_API_ADD_FLIGHTS_PATH),
             BROKER_SET_FLIGHTS(BROKER_API_SET_FLIGHTS_PATH),
             BROKER_GET_FLIGHTS(BROKER_API_GET_FLIGHTS_PATH),
-            GET_SSO_TOKEN(GET_SSO_TOKEN_PATH)
+            GET_SSO_TOKEN(GET_SSO_TOKEN_PATH),
+            UNKNOWN(null)
                 ;
             private String mPath;
             private Integer mCode;

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.adal.internal;
 
 import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -828,6 +829,11 @@ public final class AuthenticationConstants {
         /**
          * String of key for account name.
          */
+        public static final String FLIGHT_INFO = "com.microsoft.identity.broker.flights";
+
+        /**
+         * String of key for account name.
+         */
         public static final String ACCOUNT_NAME = "account.name";
 
         /**
@@ -1258,6 +1264,16 @@ public final class AuthenticationConstants {
         public static final String UPDATE_BROKER_RT_SUCCEEDED = "update_broker_rt_succeeded";
 
         /**
+         * Boolean to return when a Broker RT is successfully updated.
+         */
+        public static final String SET_FLIGHTS_SUCCEEDED = "set_flights_succeeded";
+
+        /**
+         * Boolean to return when a Broker RT is successfully updated.
+         */
+        public static final String GET_FLIGHTS_RESULT = "active_flights";
+
+        /**
          * Time out for the AccountManager's remove account operation in broker.
          */
         public static final int ACCOUNT_MANAGER_REMOVE_ACCOUNT_TIMEOUT_IN_MILLISECONDS = 5000;
@@ -1374,6 +1390,46 @@ public final class AuthenticationConstants {
         public static final String AUTHORITY = "microsoft.identity.broker";
 
         /**
+         * Tie the API paths and codes into a single object structure to stop us from having to keep
+         * them in sync.
+         */
+        public enum API {
+            MSAL_HELLO(MSAL_HELLO_PATH, MSAL_HELLO_URI_CODE),
+            ACQUIRE_TOKEN_INTERACTIVE(MSAL_ACQUIRE_TOKEN_INTERACTIVE_PATH, MSAL_ACQUIRE_TOKEN_INTERACTIVE_CODE),
+            ACQUIRE_TOKEN_SILENT(MSAL_ACQUIRE_TOKEN_SILENT_PATH, MSAL_ACQUIRE_TOKEN_SILENT_CODE),
+            GET_ACCOUNTS(MSAL_GET_ACCOUNTS_PATH, MSAL_GET_ACCOUNTS_CODE),
+            REMOVE_ACCOUNTS(MSAL_REMOVE_ACCOUNTS_PATH, MSAL_REMOVE_ACCOUNTS_CODE),
+            GET_CURRENT_ACCOUNT_SHARED_DEVICE(MSAL_GET_CURRENT_ACCOUNT_SHARED_DEVICE_PATH, MSAL_GET_CURRENT_ACCOUNT_SHARED_DEVICE_CODE),
+            GET_DEVICE_MODE(MSAL_GET_DEVICE_MODE_PATH, MSAL_GET_DEVICE_MODE_CODE),
+            SIGN_OUT_FROM_SHARED_DEVICE(MSAL_SIGN_OUT_FROM_SHARED_DEVICE_PATH, MSAL_SIGN_OUT_FROM_SHARED_DEVICE_CODE),
+            GENERATE_SHR(GENERATE_SHR_PATH, MSAL_GENERATE_SHR_CODE),
+            BROKER_HELLO(BROKER_API_HELLO_PATH, BROKER_API_HELLO_URI_CODE),
+            BROKER_GET_ACCOUNTS(BROKER_API_GET_BROKER_ACCOUNTS_PATH, BROKER_API_GET_BROKER_ACCOUNTS_CODE),
+            BROKER_REMOVE_ACCOUNT(BROKER_API_REMOVE_BROKER_ACCOUNT_PATH, BROKER_API_REMOVE_BROKER_ACCOUNT_CODE),
+            BROKER_UPDATE_BRT(BROKER_API_UPDATE_BRT_PATH, BROKER_API_UPDATE_BRT_CODE),
+            BROKER_ADD_FLIGHTS(BROKER_API_ADD_FLIGHTS_PATH),
+            BROKER_SET_FLIGHTS(BROKER_API_SET_FLIGHTS_PATH),
+            BROKER_GET_FLIGHTS(BROKER_API_GET_FLIGHTS_PATH),
+            GET_SSO_TOKEN(GET_SSO_TOKEN_PATH)
+                ;
+            private String mPath;
+            private Integer mCode;
+            API(String path, int code) {
+                this.mPath = path;
+                this.mCode = code;
+            }
+            API(String path) {
+                this.mPath = path;
+                this.mCode = null;
+            }
+            public String path() {
+                return mPath;
+            }
+            public int code() {
+                return mCode == null ? ordinal() + 1: mCode;
+            }
+        }
+        /**
          * URI Path constant for MSAL-to-Broker hello request using ContentProvider.
          */
         public static final String MSAL_HELLO_PATH = "/hello";
@@ -1439,6 +1495,26 @@ public final class AuthenticationConstants {
         public static final String BROKER_API_UPDATE_BRT_PATH = "/brokerApi/updateBrt";
 
         /**
+         * Broker api path constant for adding flight information.
+         */
+        public static final String BROKER_API_ADD_FLIGHTS_PATH = "/brokerApi/addFlights";
+
+        /**
+         * Broker api path constant for adding flight information.
+         */
+        public static final String BROKER_API_GET_FLIGHTS_PATH = "/brokerApi/getFlights";
+
+        /**
+         * Broker api path constant for adding flight information.
+         */
+        public static final String BROKER_API_SET_FLIGHTS_PATH = "/brokerApi/setFlights";
+
+        /**
+         * Broker api path constant for adding flight information.
+         */
+        public static final String GET_SSO_TOKEN_PATH = "/ssoToken";
+
+        /**
          * BrokerContentProvider URI code constant for MSAL-to-Broker hello request.
          */
         public static final int MSAL_HELLO_URI_CODE = 1;
@@ -1502,6 +1578,7 @@ public final class AuthenticationConstants {
          * BrokerContentProvider URI code constant for MSAL-to-Broker generateSHR request.
          */
         public static final int MSAL_GENERATE_SHR_CODE = 13;
+
     }
 
     public static final class AuthorizationIntentKey {

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/JWSBuilder.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/JWSBuilder.java
@@ -154,20 +154,20 @@ public class JWSBuilder {
             // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-27
             header.mCert = new String[1];
             header.mCert[0] = new String(Base64.encode(cert.getEncoded(), Base64.NO_WRAP),
-                    AuthenticationConstants.ENCODING_UTF8);
+                    AuthenticationConstants.CHARSET_UTF8);
 
             // redundant but current ADFS code base is looking for
             String headerJsonString = gson.toJson(header);
             String claimsJsonString = gson.toJson(claims);
             Logger.verbose(TAG + methodName, "Generate client certificate challenge response JWS Header. ");
             signingInput = StringExtensions.encodeBase64URLSafeString(headerJsonString
-                    .getBytes(AuthenticationConstants.ENCODING_UTF8))
+                    .getBytes(AuthenticationConstants.CHARSET_UTF8))
                     + "."
                     + StringExtensions.encodeBase64URLSafeString(claimsJsonString
-                    .getBytes(AuthenticationConstants.ENCODING_UTF8));
+                    .getBytes(AuthenticationConstants.CHARSET_UTF8));
 
             signature = sign(privateKey,
-                    signingInput.getBytes(AuthenticationConstants.ENCODING_UTF8));
+                    signingInput.getBytes(AuthenticationConstants.CHARSET_UTF8));
         } catch (UnsupportedEncodingException e) {
             throw new ClientException(ErrorStrings.UNSUPPORTED_ENCODING,
                     "Unsupported encoding", e);

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -259,8 +259,8 @@ public class StorageHelper implements IStorageHelper {
         logIfKeyHasChanged(mEncryptionKey, mEncryptionHMACKey);
 
         Logger.verbose(TAG + methodName, "Encrypt version:" + mBlobVersion);
-        final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.ENCODING_UTF8);
-        final byte[] bytes = clearText.getBytes(AuthenticationConstants.ENCODING_UTF8);
+        final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.CHARSET_UTF8);
+        final byte[] bytes = clearText.getBytes(AuthenticationConstants.CHARSET_UTF8);
 
         // IV: Initialization vector that is needed to start CBC
         final byte[] iv = new byte[DATA_KEY_LENGTH];
@@ -295,7 +295,7 @@ public class StorageHelper implements IStorageHelper {
                 + encrypted.length + iv.length, macDigest.length);
 
         final String encryptedText = new String(Base64.encode(blobVerAndEncryptedDataAndIVAndMacDigest,
-                Base64.NO_WRAP), AuthenticationConstants.ENCODING_UTF8);
+                Base64.NO_WRAP), AuthenticationConstants.CHARSET_UTF8);
         Logger.verbose(TAG + methodName, "Finished encryption");
 
         return getEncodeVersionLengthPrefix() + ENCODE_VERSION + encryptedText;
@@ -413,7 +413,6 @@ public class StorageHelper implements IStorageHelper {
      * NOTE: If it cannot verify the keyVersion, it will assume that this data is not encrypted.
      */
     public EncryptionType getEncryptionType(@NonNull final String data) throws UnsupportedEncodingException {
-        final String methodName = ":getEncryptionType";
 
         final byte[] bytes;
         try {
@@ -422,22 +421,17 @@ public class StorageHelper implements IStorageHelper {
             return EncryptionType.UNENCRYPTED;
         }
 
-        try {
-            final String keyVersion = new String(
-                    bytes,
-                    0,
-                    KEY_VERSION_BLOB_LENGTH,
-                    AuthenticationConstants.ENCODING_UTF8
-            );
+        final String keyVersion = new String(
+                bytes,
+                0,
+                KEY_VERSION_BLOB_LENGTH,
+                AuthenticationConstants.CHARSET_UTF8
+        );
 
-            if (VERSION_USER_DEFINED.equalsIgnoreCase(keyVersion)) {
-                return EncryptionType.USER_DEFINED;
-            } else if (VERSION_ANDROID_KEY_STORE.equalsIgnoreCase(keyVersion)) {
-                return EncryptionType.ANDROID_KEY_STORE;
-            }
-        } catch (UnsupportedEncodingException e) {
-            Logger.error(TAG + methodName, "Failed to extract keyVersion.", e);
-            throw e;
+        if (VERSION_USER_DEFINED.equalsIgnoreCase(keyVersion)) {
+            return EncryptionType.USER_DEFINED;
+        } else if (VERSION_ANDROID_KEY_STORE.equalsIgnoreCase(keyVersion)) {
+            return EncryptionType.ANDROID_KEY_STORE;
         }
 
         return EncryptionType.UNENCRYPTED;
@@ -531,7 +525,7 @@ public class StorageHelper implements IStorageHelper {
                         KEY_VERSION_BLOB_LENGTH,
                         encryptedLength
                 ),
-                AuthenticationConstants.ENCODING_UTF8
+                AuthenticationConstants.CHARSET_UTF8
         );
 
         return decrypted;

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -67,7 +67,11 @@ public class BrokerOperationBundle {
         BROKER_API_HELLO,
         BROKER_API_GET_BROKER_ACCOUNTS,
         BROKER_API_REMOVE_BROKER_ACCOUNT,
-        BROKER_API_UPDATE_BRT
+        BROKER_API_UPDATE_BRT,
+        BROKER_SET_FLIGHTS,
+        BROKER_GET_FLIGHTS,
+        BROKER_ADD_FLIGHTS,
+        BROKER_SSO_TOKEN;
     }
 
     @Getter
@@ -180,6 +184,18 @@ public class BrokerOperationBundle {
 
             case MSAL_GENERATE_SHR:
                 return BrokerContentProvider.GENERATE_SHR_PATH;
+
+            case BROKER_ADD_FLIGHTS:
+                return BrokerContentProvider.BROKER_API_ADD_FLIGHTS_PATH;
+
+            case BROKER_GET_FLIGHTS:
+                return BrokerContentProvider.BROKER_API_GET_FLIGHTS_PATH;
+
+            case BROKER_SET_FLIGHTS:
+                return BrokerContentProvider.BROKER_API_SET_FLIGHTS_PATH;
+
+            case BROKER_SSO_TOKEN:
+                return BrokerContentProvider.GET_SSO_TOKEN_PATH;
 
             default:
                 final String errorMessage = "Operation " + operation.name() + " is not supported by ContentProvider.";

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -31,6 +31,7 @@ import androidx.annotation.Nullable;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerAccountManagerOperation;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.API;
 import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.internal.logging.Logger;
 
@@ -54,24 +55,30 @@ public class BrokerOperationBundle {
     private static final String TAG = BrokerOperationBundle.class.getName();
 
     public enum Operation {
-        MSAL_HELLO,
-        MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST,
-        MSAL_ACQUIRE_TOKEN_SILENT,
-        MSAL_GET_ACCOUNTS,
-        MSAL_REMOVE_ACCOUNT,
-        MSAL_GET_DEVICE_MODE,
-        MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE,
-        MSAL_SIGN_OUT_FROM_SHARED_DEVICE,
-        MSAL_GENERATE_SHR,
-        BROKER_GET_KEY_FROM_INACTIVE_BROKER,
-        BROKER_API_HELLO,
-        BROKER_API_GET_BROKER_ACCOUNTS,
-        BROKER_API_REMOVE_BROKER_ACCOUNT,
-        BROKER_API_UPDATE_BRT,
-        BROKER_SET_FLIGHTS,
-        BROKER_GET_FLIGHTS,
-        BROKER_ADD_FLIGHTS,
-        BROKER_SSO_TOKEN;
+        MSAL_HELLO(API.MSAL_HELLO, BrokerAccountManagerOperation.HELLO),
+        MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST(API.ACQUIRE_TOKEN_INTERACTIVE, BrokerAccountManagerOperation.GET_INTENT_FOR_INTERACTIVE_REQUEST),
+        MSAL_ACQUIRE_TOKEN_SILENT(API.ACQUIRE_TOKEN_SILENT, BrokerAccountManagerOperation.ACQUIRE_TOKEN_SILENT),
+        MSAL_GET_ACCOUNTS(API.GET_ACCOUNTS, BrokerAccountManagerOperation.GET_ACCOUNTS),
+        MSAL_REMOVE_ACCOUNT(API.BROKER_REMOVE_ACCOUNT, BrokerAccountManagerOperation.REMOVE_ACCOUNT),
+        MSAL_GET_DEVICE_MODE(API.GET_DEVICE_MODE, BrokerAccountManagerOperation.GET_DEVICE_MODE),
+        MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE(API.GET_CURRENT_ACCOUNT_SHARED_DEVICE, BrokerAccountManagerOperation.GET_CURRENT_ACCOUNT),
+        MSAL_SIGN_OUT_FROM_SHARED_DEVICE(API.SIGN_OUT_FROM_SHARED_DEVICE, BrokerAccountManagerOperation.REMOVE_ACCOUNT_FROM_SHARED_DEVICE),
+        MSAL_GENERATE_SHR(API.GENERATE_SHR, BrokerAccountManagerOperation.GENERATE_SHR),
+        BROKER_GET_KEY_FROM_INACTIVE_BROKER(null, null),
+        BROKER_API_HELLO(API.BROKER_HELLO, null),
+        BROKER_API_GET_BROKER_ACCOUNTS(API.BROKER_GET_ACCOUNTS, null),
+        BROKER_API_REMOVE_BROKER_ACCOUNT(API.BROKER_REMOVE_ACCOUNT, null),
+        BROKER_API_UPDATE_BRT(API.BROKER_UPDATE_BRT, null),
+        BROKER_SET_FLIGHTS(API.BROKER_SET_FLIGHTS, null),
+        BROKER_GET_FLIGHTS(API.BROKER_GET_FLIGHTS, null),
+        BROKER_ADD_FLIGHTS(API.BROKER_ADD_FLIGHTS, null),
+        BROKER_SSO_TOKEN(API.GET_SSO_TOKEN, null);
+        final API contentApi;
+        final String accountManagerOperation;
+        Operation(API contentApi, String accountManagerOperation) {
+            this.contentApi = contentApi;
+            this.accountManagerOperation = accountManagerOperation;
+        }
     }
 
     @Getter
@@ -103,108 +110,32 @@ public class BrokerOperationBundle {
     private String getAccountManagerAddAccountOperationKey() throws BrokerCommunicationException{
         final String methodName = ":getAccountManagerAddAccountOperationKey";
 
-        switch (operation) {
-            case MSAL_HELLO:
-                return BrokerAccountManagerOperation.HELLO;
-
-            case MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST:
-                return BrokerAccountManagerOperation.GET_INTENT_FOR_INTERACTIVE_REQUEST;
-
-            case MSAL_ACQUIRE_TOKEN_SILENT:
-                return BrokerAccountManagerOperation.ACQUIRE_TOKEN_SILENT;
-
-            case MSAL_GET_ACCOUNTS:
-                return BrokerAccountManagerOperation.GET_ACCOUNTS;
-
-            case MSAL_REMOVE_ACCOUNT:
-                return BrokerAccountManagerOperation.REMOVE_ACCOUNT;
-
-            case MSAL_GET_DEVICE_MODE:
-                return BrokerAccountManagerOperation.GET_DEVICE_MODE;
-
-            case MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE:
-                return BrokerAccountManagerOperation.GET_CURRENT_ACCOUNT;
-
-            case MSAL_SIGN_OUT_FROM_SHARED_DEVICE:
-                return BrokerAccountManagerOperation.REMOVE_ACCOUNT_FROM_SHARED_DEVICE;
-
-            case MSAL_GENERATE_SHR:
-                return BrokerAccountManagerOperation.GENERATE_SHR;
-
-            default:
-                final String errorMessage = "Operation " + operation.name() + " is not supported by AccountManager addAccount().";
-                Logger.warn(TAG + methodName, errorMessage);
-                throw new BrokerCommunicationException(
-                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
-                        ACCOUNT_MANAGER_ADD_ACCOUNT,
-                        errorMessage,
-                        null);
+        String accountManagerKey = operation.accountManagerOperation;
+        if (accountManagerKey == null) {
+            final String errorMessage = "Operation " + operation.name() + " is not supported by AccountManager addAccount().";
+            Logger.warn(TAG + methodName, errorMessage);
+            throw new BrokerCommunicationException(
+                    OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                    ACCOUNT_MANAGER_ADD_ACCOUNT,
+                    errorMessage,
+                    null);
         }
+        return accountManagerKey;
     }
 
     public String getContentProviderPath() throws BrokerCommunicationException {
         final String methodName = ":getContentProviderUriPath";
 
-        switch (operation) {
-            case MSAL_HELLO:
-                return BrokerContentProvider.MSAL_HELLO_PATH;
-
-            case MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST:
-                return BrokerContentProvider.MSAL_ACQUIRE_TOKEN_INTERACTIVE_PATH;
-
-            case MSAL_ACQUIRE_TOKEN_SILENT:
-                return BrokerContentProvider.MSAL_ACQUIRE_TOKEN_SILENT_PATH;
-
-            case MSAL_GET_ACCOUNTS:
-                return BrokerContentProvider.MSAL_GET_ACCOUNTS_PATH;
-
-            case MSAL_REMOVE_ACCOUNT:
-                return BrokerContentProvider.MSAL_REMOVE_ACCOUNTS_PATH;
-
-            case MSAL_GET_DEVICE_MODE:
-                return BrokerContentProvider.MSAL_GET_DEVICE_MODE_PATH;
-
-            case MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE:
-                return BrokerContentProvider.MSAL_GET_CURRENT_ACCOUNT_SHARED_DEVICE_PATH;
-
-            case MSAL_SIGN_OUT_FROM_SHARED_DEVICE:
-                return BrokerContentProvider.MSAL_SIGN_OUT_FROM_SHARED_DEVICE_PATH;
-
-            case BROKER_API_HELLO:
-                return BrokerContentProvider.BROKER_API_HELLO_PATH;
-
-            case BROKER_API_GET_BROKER_ACCOUNTS:
-                return BrokerContentProvider.BROKER_API_GET_BROKER_ACCOUNTS_PATH;
-
-            case BROKER_API_REMOVE_BROKER_ACCOUNT:
-                return BrokerContentProvider.BROKER_API_REMOVE_BROKER_ACCOUNT_PATH;
-
-            case BROKER_API_UPDATE_BRT:
-                return BrokerContentProvider.BROKER_API_UPDATE_BRT_PATH;
-
-            case MSAL_GENERATE_SHR:
-                return BrokerContentProvider.GENERATE_SHR_PATH;
-
-            case BROKER_ADD_FLIGHTS:
-                return BrokerContentProvider.BROKER_API_ADD_FLIGHTS_PATH;
-
-            case BROKER_GET_FLIGHTS:
-                return BrokerContentProvider.BROKER_API_GET_FLIGHTS_PATH;
-
-            case BROKER_SET_FLIGHTS:
-                return BrokerContentProvider.BROKER_API_SET_FLIGHTS_PATH;
-
-            case BROKER_SSO_TOKEN:
-                return BrokerContentProvider.GET_SSO_TOKEN_PATH;
-
-            default:
-                final String errorMessage = "Operation " + operation.name() + " is not supported by ContentProvider.";
-                Logger.warn(TAG + methodName, errorMessage);
-                throw new BrokerCommunicationException(
-                        OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
-                        CONTENT_PROVIDER,
-                        errorMessage,
-                        null);
+        final API contentApi = operation.contentApi;
+        if (contentApi == null) {
+            final String errorMessage = "Operation " + operation.name() + " is not supported by ContentProvider.";
+            Logger.warn(TAG + methodName, errorMessage);
+            throw new BrokerCommunicationException(
+                    OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                    CONTENT_PROVIDER,
+                    errorMessage,
+                    null);
         }
+        return contentApi.path();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -72,7 +72,7 @@ public class BrokerOperationBundle {
         BROKER_SET_FLIGHTS(API.BROKER_SET_FLIGHTS, null),
         BROKER_GET_FLIGHTS(API.BROKER_GET_FLIGHTS, null),
         BROKER_ADD_FLIGHTS(API.BROKER_ADD_FLIGHTS, null),
-        BROKER_SSO_TOKEN(API.GET_SSO_TOKEN, null);
+        MSAL_SSO_TOKEN(API.GET_SSO_TOKEN, null);
         final API contentApi;
         final String accountManagerOperation;
         Operation(API contentApi, String accountManagerOperation) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/ObjectMapper.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/ObjectMapper.java
@@ -33,6 +33,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import com.microsoft.identity.common.WarningType;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.commands.parameters.IHasExtraParameters;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.util.StringUtil;
@@ -237,10 +238,38 @@ public final class ObjectMapper {
      * @throws UnsupportedEncodingException thrown if encoding not supported
      */
     public static String serializeObjectToFormUrlEncoded(Object object) throws UnsupportedEncodingException {
+        Map<String, String> fields = constuctMapFromObject(object);
+
+        final StringBuilder builder = new StringBuilder();
+
+        Iterator<TreeMap.Entry<String, String>> iterator = fields.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            TreeMap.Entry<String, String> entry = iterator.next();
+            builder.append(URLEncoder.encode(entry.getKey(), AuthenticationConstants.ENCODING_UTF8));
+            builder.append('=');
+            builder.append(URLEncoder.encode(entry.getValue(), AuthenticationConstants.ENCODING_UTF8));
+
+            if (iterator.hasNext()) {
+                builder.append('&');
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Method for converting the contents of an object into a map.  Important to the implementation of
+     * this method is the behavior of GSON which excludes null fields from the resulting JSON.  A
+     * TreeMap was chosen to simplify testing, and the resulting map is in key order.
+     *
+     * @param object the object to convert.
+     * @return a map representation of the object.
+     */
+    public static Map<String, String> constuctMapFromObject(Object object) {
         String json = ObjectMapper.serializeObjectToJsonString(object);
         Type stringMap = new TypeToken<TreeMap<String, String>>() {
         }.getType();
-        TreeMap<String, String> fields = GSON.fromJson(json, stringMap);
+        TreeMap<String, String> fields = new Gson().fromJson(json, stringMap);
         if (object instanceof IHasExtraParameters) {
             final IHasExtraParameters params = (IHasExtraParameters) object;
             if (params.getExtraParameters() != null) {
@@ -251,22 +280,7 @@ public final class ObjectMapper {
                 }
             }
         }
-
-        final StringBuilder builder = new StringBuilder();
-
-        Iterator<TreeMap.Entry<String, String>> iterator = fields.entrySet().iterator();
-
-        while (iterator.hasNext()) {
-            TreeMap.Entry<String, String> entry = iterator.next();
-            builder.append(URLEncoder.encode(entry.getKey(), ENCODING_SCHEME));
-            builder.append('=');
-            builder.append(URLEncoder.encode(entry.getValue(), ENCODING_SCHEME));
-
-            if (iterator.hasNext()) {
-                builder.append('&');
-            }
-        }
-        return builder.toString();
+        return fields;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/SymmetricCipher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/SymmetricCipher.java
@@ -37,7 +37,7 @@ import java.security.KeyStore;
  */
 public enum SymmetricCipher implements CryptoSuite {
 
-    @RequiresApi(Build.VERSION_CODES.KITKAT)
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
     AES_GCM_NONE_HMACSHA256(SymmetricAlgorithm.Builder.of("AES/GCM/NoPadding"), "HmacSHA256", 256) {
         public KeyGenParameterSpec.Builder decorateKeyGenerator(@NonNull final KeyGenParameterSpec.Builder spec) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -530,7 +530,7 @@ public class MicrosoftStsOAuth2Strategy
             tokenErrorResponse.setResponseBody(response.getBody());
         } else {
             tokenResponse = ObjectMapper.deserializeJsonStringToObject(
-                    response.getBody(),
+                    getBodyFromSuccessfulResponse(response.getBody()),
                     MicrosoftStsTokenResponse.class
             );
         }
@@ -563,6 +563,10 @@ public class MicrosoftStsOAuth2Strategy
         }
 
         return result;
+    }
+
+    protected String getBodyFromSuccessfulResponse(@NonNull final String responseBody) throws ClientException {
+        return responseBody;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -56,6 +56,7 @@ import com.microsoft.identity.common.internal.util.ClockSkewManager;
 import com.microsoft.identity.common.internal.util.IClockSkewManager;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
@@ -182,7 +183,7 @@ public abstract class OAuth2Strategy
                 "Performing token request..."
         );
 
-        final String requestBody = ObjectMapper.serializeObjectToFormUrlEncoded(request);
+        final String requestBody = getRequestBody(request);
         final Map<String, String> headers = new TreeMap<>();
         headers.put(CLIENT_REQUEST_ID, DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
 
@@ -226,6 +227,9 @@ public abstract class OAuth2Strategy
 
     protected String getTokenEndpoint() {
         return mTokenEndpoint;
+
+    protected String getRequestBody(GenericTokenRequest request) throws UnsupportedEncodingException, ClientException {
+        return ObjectMapper.serializeObjectToFormUrlEncoded(request);
     }
 
     private void recordClockSkew(final long referenceTimeMillis) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -228,7 +228,7 @@ public abstract class OAuth2Strategy
     protected String getTokenEndpoint() {
         return mTokenEndpoint;
 
-    protected String getRequestBody(GenericTokenRequest request) throws UnsupportedEncodingException, ClientException {
+    protected String getRequestBody(final GenericTokenRequest request) throws UnsupportedEncodingException, ClientException {
         return ObjectMapper.serializeObjectToFormUrlEncoded(request);
     }
 

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
-#Fri Mar 26 20:11:03 UTC 2021
+#Mon Mar 29 20:23:29 UTC 2021
 versionName=3.2.0
 versionCode=1
-latestPatchVersion=171
+latestPatchVersion=172

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
-#Fri Mar 26 00:19:41 UTC 2021
+#Fri Mar 26 20:11:03 UTC 2021
 versionName=3.2.0
 versionCode=1
-latestPatchVersion=170
+latestPatchVersion=171


### PR DESCRIPTION
We're looking at a few new APIs for Broker, and the way it's structured, we need to change common as well.  We can go ahead and put that support in place, doing no harm.

These are supporting four new APIs, three of which are actually implemented in https://github.com/AzureAD/ad-accounts-for-android/pull/1518 

These are getFlights, setFlights, and addFlights.  The thinking is that we allow our caller to change our runtime behavior based on what they know - iff they're the broker host.  There is an experiment system that is in place that we could ask users to integrate with, or they could use other methods to turn on and off broker features in pre-release from.

The interface to this is just a map of string to string, with getFlights returning the map, setFlights overwriting it, and addFlights overlaying its arguments onto it.  In the implementing review, we could adopt other returns, such as including the resulting map into get and setFlights.

New APIs - flight support from broker host apps: setFlights (take a map of id to status and overwrite the current flight information), addFlights (overlay the map onto the existing structure), and getFlights(return the map).  As well as the get SSO token api, which will get the PRTv3 SSO token.

Additionally, I put in a constant for the UTF-8 charset.