### PR TITLE
Delete the getMockActivity method

### DIFF
--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.internal.testutils;
 
-import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
@@ -90,16 +89,6 @@ public class TestUtils {
         if (keyToRemove != null) {
             sharedPreferences.remove(keyToRemove);
         }
-    }
-
-    public static Activity getMockActivity(final Context context) {
-        Activity activity = new Activity() {
-            @Override
-            public Context getApplicationContext() {
-                return context;
-            }
-        };
-        return activity;
     }
 
     public static Context getContext() {


### PR DESCRIPTION
What I was trying to do with activity in the previous commit does not work.  
Seems like the best path just delete the method and do it yourself in the 5 places
that we use these two lines of code, rather than continue to struggle with dependencies.