### PR TITLE
Only pass required data to hello bundle creation.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -191,19 +191,8 @@ public class BrokerMsalController extends BaseController {
             );
         }
 
-        final String minimumProtocolVersion = bundle.getString(CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY);
-        final String maximumProtocolVersion = bundle.getString(CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY);
-
-        // This should be part of the bundle.
-        // If we're hitting this, it means that the hello protocol changed. see getRequestBundleForHello().
-        if (StringUtil.isEmpty(maximumProtocolVersion)){
-            throw new ClientException(ClientException.MISSING_PARAMETER,
-                    "maximum protocol version should never be null or empty");
-        }
-
         final String cachedProtocolVersion = mHelloCache.tryGetNegotiatedProtocolVersion(
-                minimumProtocolVersion,
-                maximumProtocolVersion);
+                minRequestedVersion, MSAL_TO_BROKER_PROTOCOL_VERSION_CODE);
 
         if (!StringUtil.isEmpty(cachedProtocolVersion)) {
             return cachedProtocolVersion;
@@ -219,8 +208,8 @@ public class BrokerMsalController extends BaseController {
         );
 
         mHelloCache.saveNegotiatedProtocolVersion(
-                minimumProtocolVersion,
-                maximumProtocolVersion,
+                minRequestedVersion,
+                MSAL_TO_BROKER_PROTOCOL_VERSION_CODE,
                 negotiatedProtocolVersion);
 
         return negotiatedProtocolVersion;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -171,7 +171,7 @@ public class BrokerMsalController extends BaseController {
      * MSAL-Broker handshake operation.
      *
      * @param strategy   an {@link IIpcStrategy}
-     * @param minRequestedVersion
+     * @param minRequestedVersion the minimum allowed broker protocol version, may be null.
      * @return a protocol version negotiated by MSAL and Broker.
      */
     @VisibleForTesting

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -178,6 +178,13 @@ public class BrokerMsalController extends BaseController {
     public @NonNull String hello(final @NonNull IIpcStrategy strategy,
                                  final @Nullable String minRequestedVersion) throws BaseException {
 
+        final String cachedProtocolVersion = mHelloCache.tryGetNegotiatedProtocolVersion(
+                minRequestedVersion, MSAL_TO_BROKER_PROTOCOL_VERSION_CODE);
+
+        if (!StringUtil.isEmpty(cachedProtocolVersion)) {
+            return cachedProtocolVersion;
+        }
+
         final Bundle bundle = new Bundle();
         bundle.putString(
                 CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY,
@@ -189,13 +196,6 @@ public class BrokerMsalController extends BaseController {
                     CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY,
                     minRequestedVersion
             );
-        }
-
-        final String cachedProtocolVersion = mHelloCache.tryGetNegotiatedProtocolVersion(
-                minRequestedVersion, MSAL_TO_BROKER_PROTOCOL_VERSION_CODE);
-
-        if (!StringUtil.isEmpty(cachedProtocolVersion)) {
-            return cachedProtocolVersion;
         }
 
         final BrokerOperationBundle helloBundle = new BrokerOperationBundle(

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -86,6 +86,7 @@ import lombok.EqualsAndHashCode;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GENERATE_SHR;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
@@ -170,14 +171,26 @@ public class BrokerMsalController extends BaseController {
      * MSAL-Broker handshake operation.
      *
      * @param strategy   an {@link IIpcStrategy}
-     * @param parameters a {@link CommandParameters}
+     * @param minRequestedVersion
      * @return a protocol version negotiated by MSAL and Broker.
      */
     @VisibleForTesting
     public @NonNull String hello(final @NonNull IIpcStrategy strategy,
-                                 final @NonNull CommandParameters parameters) throws BaseException {
+                                 final @Nullable String minRequestedVersion) throws BaseException {
 
-        final Bundle bundle = mRequestAdapter.getRequestBundleForHello(parameters);
+        final Bundle bundle = new Bundle();
+        bundle.putString(
+                CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY,
+                MSAL_TO_BROKER_PROTOCOL_VERSION_CODE
+        );
+
+        if (!StringUtil.isEmpty(minRequestedVersion)) {
+            bundle.putString(
+                    CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY,
+                    minRequestedVersion
+            );
+        }
+
         final String minimumProtocolVersion = bundle.getString(CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY);
         final String maximumProtocolVersion = bundle.getString(CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY);
 
@@ -199,7 +212,7 @@ public class BrokerMsalController extends BaseController {
         final BrokerOperationBundle helloBundle = new BrokerOperationBundle(
                 BrokerOperationBundle.Operation.MSAL_HELLO,
                 mActiveBrokerPackageName,
-                mRequestAdapter.getRequestBundleForHello(parameters));
+                bundle);
 
         final String negotiatedProtocolVersion = mResultAdapter.verifyHelloFromResultBundle(
                 strategy.communicateToBroker(helloBundle)
@@ -319,7 +332,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -378,7 +391,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -434,7 +447,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -490,7 +503,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -601,7 +614,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -675,7 +688,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Override
                     public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                        negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                        negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
                     }
 
                     @Override
@@ -771,7 +784,7 @@ public class BrokerMsalController extends BaseController {
 
             @Override
             public void performPrerequisites(final @NonNull IIpcStrategy strategy) throws BaseException {
-                negotiatedBrokerProtocolVersion = hello(strategy, parameters);
+                negotiatedBrokerProtocolVersion = hello(strategy, parameters.getRequiredBrokerProtocolVersion());
             }
 
             @NonNull

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
@@ -202,8 +202,8 @@ public class HelloCacheTests {
         final CommandParameters parameters = CommandParameters.builder().requiredBrokerProtocolVersion(minimumVer).build();
 
         try {
-            final String negotiatedProtocolVersion = controller.hello(strategy, parameters);
-            final String negotiatedProtocolVersion2 = controller.hello(strategy, parameters);
+            final String negotiatedProtocolVersion = controller.hello(strategy, parameters.getRequiredBrokerProtocolVersion());
+            final String negotiatedProtocolVersion2 = controller.hello(strategy, parameters.getRequiredBrokerProtocolVersion());
             Assert.assertEquals(negotiatedProtocolVersion, negotiatedProtocolVersion2);
         } catch (BaseException e) {
             Assert.fail();


### PR DESCRIPTION
This is basically about not requiring a grab-bag of information to construct the hello bundle.  While I was looking at this, we construct it twice, so maybe don't do that.