### PR TITLE
Implement equals and hash code for the pop-command paths.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/AbstractAuthenticationScheme.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/AbstractAuthenticationScheme.java
@@ -26,12 +26,19 @@ import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
 
 /**
  * Abstract base class for AuthenticationSchemes.
  */
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
+@Accessors(prefix = "m")
+@Getter
 public abstract class AbstractAuthenticationScheme implements INameable {
 
     private static final long serialVersionUID = -2437270903389813253L;
@@ -53,15 +60,6 @@ public abstract class AbstractAuthenticationScheme implements INameable {
      */
     public AbstractAuthenticationScheme(@NonNull final String name) {
         mName = name;
-    }
-
-    /**
-     * Gets the name of this AbstractAuthenticationScheme.
-     *
-     * @return The name to get.
-     */
-    public final String getName() {
-        return mName;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -32,6 +32,9 @@ import com.microsoft.identity.common.internal.util.IClockSkewManager;
 
 import java.net.URL;
 
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
 import static com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal.SerializedNames.CLIENT_CLAIMS;
 import static com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal.SerializedNames.HTTP_METHOD;
 import static com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal.SerializedNames.NONCE;
@@ -40,6 +43,8 @@ import static com.microsoft.identity.common.internal.authscheme.PopAuthenticatio
 /**
  * Internal representation of PoP Authentication Scheme.
  */
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
 public class PopAuthenticationSchemeInternal
         extends TokenAuthenticationScheme
         implements IPoPAuthenticationSchemeParams {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.internal.util.IClockSkewManager;
 import java.net.URL;
 
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
 
 import static com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal.SerializedNames.CLIENT_CLAIMS;
@@ -45,6 +46,7 @@ import static com.microsoft.identity.common.internal.authscheme.PopAuthenticatio
  */
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
+@Accessors(prefix = "m")
 public class PopAuthenticationSchemeInternal
         extends TokenAuthenticationScheme
         implements IPoPAuthenticationSchemeParams {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/TokenAuthenticationScheme.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/TokenAuthenticationScheme.java
@@ -24,9 +24,17 @@ package com.microsoft.identity.common.internal.authscheme;
 
 import androidx.annotation.NonNull;
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
 /**
  * Abstract representation of any Authentication Scheme which may be token based.
  */
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@Accessors(prefix = "m")
 public abstract class TokenAuthenticationScheme
         extends AbstractAuthenticationScheme
         implements ITokenAuthenticationSchemeInternal {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MapBackedPreferencesManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MapBackedPreferencesManager.java
@@ -1,0 +1,100 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache;
+
+import androidx.annotation.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+@RequiredArgsConstructor
+public class MapBackedPreferencesManager implements ISharedPreferencesFileManager {
+
+    private final String mName;
+
+    private final Map<String, String> mBackingStore = new HashMap<>();
+
+    @Override
+    public void putString(String key, String value) {
+        mBackingStore.put(key, value);
+    }
+
+    @Override
+    public String getString(String key) {
+        return mBackingStore.get(key);
+    }
+
+    @Override
+    public void putLong(String key, long value) {
+        mBackingStore.put(key, Long.toString(value));
+    }
+
+    @Override
+    public long getLong(String key) {
+        String s = mBackingStore.get(key);
+        return s == null ? 0 : Long.parseLong(s);
+    }
+
+    @Override
+    public String getSharedPreferencesFileName() {
+        return mName;
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return new HashMap(mBackingStore);
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> getAllFilteredByKey(SharedPreferencesFileManager.Predicate<String> keyFilter) {
+        Map<String, String> newMap = new HashMap<>();
+        for (Map.Entry<String, String> entry: mBackingStore.entrySet()) {
+            if (keyFilter.test(entry.getKey())) {
+                newMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newMap.entrySet().iterator();
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return mBackingStore.containsKey(key);
+    }
+
+    @Override
+    public void clear() {
+        mBackingStore.clear();
+    }
+
+    @Override
+    public void remove(String key) {
+        mBackingStore.remove(key);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MapBackedPreferencesManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MapBackedPreferencesManager.java
@@ -35,6 +35,10 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @VisibleForTesting(otherwise = VisibleForTesting.NONE)
 @RequiredArgsConstructor
+/**
+ * A SharedPreferencesFileManager backed by a HashMap.  This is mainly for testing purposes,
+ * where it doesn't make sense to instantiate shared preferences files.
+ */
 public class MapBackedPreferencesManager implements ISharedPreferencesFileManager {
 
     private final String mName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/BaseCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/BaseCommand.java
@@ -33,22 +33,29 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 // Suppressing rawtype warnings due to the generic types CommandCallback, BaseController
 @SuppressWarnings(WarningType.rawtype_warning)
 @Getter
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
 public abstract class BaseCommand<T> implements Command<T> {
 
+    @NonNull
     private final CommandParameters parameters;
 
+    @NonNull
     @EqualsAndHashCode.Exclude
     private final CommandCallback callback;
 
+    @NonNull
     private final List<BaseController> controllers;
 
+    @NonNull
     @EqualsAndHashCode.Exclude
     private final String publicApiId;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
@@ -33,11 +33,18 @@ import com.microsoft.identity.common.internal.result.GenerateShrResult;
 
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
 import static com.microsoft.identity.common.exception.ErrorStrings.NO_ACCOUNT_FOUND;
 
 /**
  * Command class to perform generation of AT-less SHRs on behalf of a user.
  */
+@SuperBuilder()
+@Accessors(prefix = "m")
+@EqualsAndHashCode(callSuper = true)
 public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
 
     private static final String TAG = GenerateShrCommand.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParameters.java
@@ -24,23 +24,27 @@ package com.microsoft.identity.common.internal.commands.parameters;
 
 import com.microsoft.identity.common.internal.authscheme.IPoPAuthenticationSchemeParams;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.experimental.Accessors;
 import lombok.experimental.SuperBuilder;
 
 /**
  * Parameter class for generating SHRs.
  */
 @Getter
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@Accessors(prefix = "m")
 public class GenerateShrCommandParameters extends CommandParameters {
 
     /**
      * The home_account_id of the account for which we will generate the resulting SHR.
      */
-    private String homeAccountId;
+    private String mHomeAccountId;
 
     /**
      * The {@link IPoPAuthenticationSchemeParams} used to produce the resulting SHR.
      */
-    private IPoPAuthenticationSchemeParams popParameters;
+    private IPoPAuthenticationSchemeParams mPopParameters;
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -25,7 +25,9 @@ package com.microsoft.identity.common.internal.util;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 
 import java.util.Calendar;
@@ -41,7 +43,12 @@ public class ClockSkewManager implements IClockSkewManager {
         private static final String KEY_SKEW = "skew";
     }
 
-    private SharedPreferencesFileManager mClockSkewPreferences;
+    private ISharedPreferencesFileManager mClockSkewPreferences;
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public ClockSkewManager(@NonNull final ISharedPreferencesFileManager manager) {
+        mClockSkewPreferences = manager;
+    }
 
     public ClockSkewManager(@NonNull final Context context) {
         mClockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(

--- a/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
@@ -58,7 +58,7 @@ public class PopAuthenticationSchemeTest {
 
     @Test
     public void testHashCode_notEquals() throws Exception {
-        Assert.assertEquals(AUTHSCHEME_ONE.hashCode(), AUTHSCHEME_ONE_CLONE.hashCode());
+        Assert.assertNotEquals(AUTHSCHEME_ONE.hashCode(), AUTHSCHEME_TWO.hashCode());
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
@@ -22,32 +22,27 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authscheme;
 
-import androidx.annotation.NonNull;
+import org.junit.Assert;
+import org.junit.Test;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- * Internal representation of a Bearer Auth Scheme.
- */
-@Getter
-@Accessors(prefix = "m")
-public class BearerAuthenticationSchemeInternal
-        extends TokenAuthenticationScheme
-        implements ITokenAuthenticationSchemeInternal {
+public class PopAuthenticationSchemeTest {
+    @Test
+    public void testMappability() throws Exception {
+        PopAuthenticationSchemeInternal one = PopAuthenticationSchemeInternal.builder().httpMethod("GET").nonce("one")
+                .url(new URL("http://url"))
+            .build();
+        PopAuthenticationSchemeInternal two = PopAuthenticationSchemeInternal.builder().httpMethod("GET").url(new URL("http://url")).nonce("two").build();
 
-    public static final String SCHEME_BEARER = "Bearer";
-    private static final long serialVersionUID = 823164758655077118L;
+        Map<PopAuthenticationSchemeInternal, Boolean> testMap = new HashMap<>();
 
-    /**
-     * Constructs a new BearerAuthenticationSchemeInternal.
-     */
-    public BearerAuthenticationSchemeInternal() {
-        super(SCHEME_BEARER);
-    }
+        testMap.put(one, true);
 
-    @Override
-    public String getAccessTokenForScheme(@NonNull final String accessToken) {
-        return accessToken;
+        Assert.assertEquals(1, testMap.size());
+        testMap.put(two, true);
+        Assert.assertEquals(2, testMap.size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeTest.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authscheme;
 
+import com.microsoft.identity.common.internal.util.UrlUtils;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,19 +32,50 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PopAuthenticationSchemeTest {
+
+    public static final PopAuthenticationSchemeInternal AUTHSCHEME_ONE = PopAuthenticationSchemeInternal.builder().httpMethod("GET").nonce("one")
+            .url(UrlUtils.makeUrlSilent("http://url"))
+            .build();
+    public static final PopAuthenticationSchemeInternal AUTHSCHEME_ONE_CLONE = PopAuthenticationSchemeInternal.builder().httpMethod("GET").nonce("one")
+            .url(UrlUtils.makeUrlSilent("http://url"))
+            .build();
+    public static final PopAuthenticationSchemeInternal AUTHSCHEME_TWO = PopAuthenticationSchemeInternal.builder().httpMethod("GET").url(UrlUtils.makeUrlSilent("http://url")).nonce("two").build();
+
     @Test
     public void testMappability() throws Exception {
-        PopAuthenticationSchemeInternal one = PopAuthenticationSchemeInternal.builder().httpMethod("GET").nonce("one")
-                .url(new URL("http://url"))
-            .build();
-        PopAuthenticationSchemeInternal two = PopAuthenticationSchemeInternal.builder().httpMethod("GET").url(new URL("http://url")).nonce("two").build();
-
         Map<PopAuthenticationSchemeInternal, Boolean> testMap = new HashMap<>();
-
-        testMap.put(one, true);
-
+        
+        testMap.put(AUTHSCHEME_ONE, true);
         Assert.assertEquals(1, testMap.size());
-        testMap.put(two, true);
+        testMap.put(AUTHSCHEME_TWO, true);
         Assert.assertEquals(2, testMap.size());
     }
+    
+    @Test
+    public void testHashCode_equals() throws Exception {
+        Assert.assertEquals(AUTHSCHEME_ONE.hashCode(), AUTHSCHEME_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testHashCode_notEquals() throws Exception {
+        Assert.assertEquals(AUTHSCHEME_ONE.hashCode(), AUTHSCHEME_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testEquals_equals() throws Exception {
+        Assert.assertEquals(AUTHSCHEME_ONE, AUTHSCHEME_ONE_CLONE);
+    }
+    @Test
+    public void testEquals_notEqualNull() throws Exception {
+        Assert.assertNotEquals(AUTHSCHEME_ONE, null);
+    }
+    @Test
+    public void testEquals_equalsSame() throws Exception {
+        Assert.assertEquals(AUTHSCHEME_ONE, AUTHSCHEME_ONE);
+    }
+    @Test
+    public void testEquals_notEqualDifferenceInNonce() {
+        Assert.assertNotEquals(AUTHSCHEME_ONE, AUTHSCHEME_TWO);
+    }
+
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
@@ -1,0 +1,100 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.commands;
+
+import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
+import com.microsoft.identity.common.internal.cache.MapBackedPreferencesManager;
+import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.GenerateShrCommandParameters;
+import com.microsoft.identity.common.internal.controllers.BaseController;
+import com.microsoft.identity.common.internal.util.ClockSkewManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GenerateShrCommandTest {
+
+    public static final CommandCallback EMPTY_CALLBACK = new CommandCallback() {
+        @Override
+        public void onCancel() {
+
+        }
+
+        @Override
+        public void onError(Object error) {
+
+        }
+
+        @Override
+        public void onTaskCompleted(Object o) {
+
+        }
+    };
+
+    @Test
+    public void testMappability() throws Exception {
+        GenerateShrCommandParameters paramsOne = GenerateShrCommandParameters.builder()
+                .homeAccountId("One")
+                .popParameters(PopAuthenticationSchemeInternal.builder()
+                        .clientClaims("claims")
+                        .httpMethod("GET")
+                        .url(new URL("https://url"))
+                        .nonce("one")
+                        .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                        .build())
+                .build();
+        GenerateShrCommand commandOne = GenerateShrCommand.builder()
+                .parameters(paramsOne)
+                .callback(EMPTY_CALLBACK)
+                .publicApiId("ID")
+                .controllers(Collections.<BaseController>emptyList())
+                .build();
+
+        GenerateShrCommandParameters paramsTwo = GenerateShrCommandParameters.builder()
+                .homeAccountId("One")
+                .popParameters(PopAuthenticationSchemeInternal.builder()
+                        .clientClaims("claims")
+                        .httpMethod("GET")
+                        .url(new URL("https://url"))
+                        .nonce("two")
+                        .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                        .build())
+                .build();
+        GenerateShrCommand commandTwo = GenerateShrCommand.builder()
+                .parameters(paramsTwo)
+                .callback(EMPTY_CALLBACK)
+                .publicApiId("ID")
+                .controllers(Collections.<BaseController>emptyList())
+                .build();
+        Map<BaseCommand, Boolean> map = new HashMap<>();
+        map.put(commandOne, true);
+        Assert.assertEquals(1, map.size());
+        map.put(commandTwo, true);
+        Assert.assertEquals(2, map.size());
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
@@ -24,38 +24,24 @@ package com.microsoft.identity.common.internal.commands;
 
 import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.cache.MapBackedPreferencesManager;
-import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.GenerateShrCommandParameters;
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
+import com.microsoft.identity.common.internal.util.UrlUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GenerateShrCommandTest {
 
-    public static final CommandCallback EMPTY_CALLBACK = new CommandCallback() {
-        @Override
-        public void onCancel() {
-
-        }
-
-        @Override
-        public void onError(Object error) {
-
-        }
-
-        @Override
-        public void onTaskCompleted(Object o) {
-
-        }
+    private static final CommandCallback EMPTY_CALLBACK = new CommandCallback() {
+        @Override public void onCancel() {  }
+        @Override public void onError(Object error) {  }
+        @Override public void onTaskCompleted(Object o) {  }
     };
 
     public static final GenerateShrCommandParameters PARAMS_ONE = GenerateShrCommandParameters.builder()
@@ -63,7 +49,7 @@ public class GenerateShrCommandTest {
             .popParameters(PopAuthenticationSchemeInternal.builder()
                     .clientClaims("claims")
                     .httpMethod("GET")
-                    .url(makeUrl("https://url"))
+                    .url(UrlUtils.makeUrlSilent("https://url"))
                     .nonce("one")
                     .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                     .build())
@@ -79,7 +65,7 @@ public class GenerateShrCommandTest {
             .popParameters(PopAuthenticationSchemeInternal.builder()
                     .clientClaims("claims")
                     .httpMethod("GET")
-                    .url(makeUrl("https://url"))
+                    .url(UrlUtils.makeUrlSilent("https://url"))
                     .nonce("one")
                     .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                     .build())
@@ -95,7 +81,7 @@ public class GenerateShrCommandTest {
             .popParameters(PopAuthenticationSchemeInternal.builder()
                     .clientClaims("claims")
                     .httpMethod("GET")
-                    .url(makeUrl("https://url"))
+                    .url(UrlUtils.makeUrlSilent("https://url"))
                     .nonce("two")
                     .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                     .build())
@@ -106,14 +92,6 @@ public class GenerateShrCommandTest {
             .publicApiId("ID")
             .controllers(Collections.<BaseController>emptyList())
             .build();
-
-    static URL makeUrl(String url) {
-        try {
-            return new URL(url);
-        } catch (final MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     @Test
     public void testMappability() throws Exception {
@@ -130,7 +108,7 @@ public class GenerateShrCommandTest {
                 .popParameters(PopAuthenticationSchemeInternal.builder()
                         .clientClaims("claims")
                         .httpMethod("GET")
-                        .url(makeUrl("https://url"))
+                        .url(UrlUtils.makeUrlSilent("https://url"))
                         .nonce("two")
                         .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                         .build())

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
@@ -133,7 +133,7 @@ public class GenerateShrCommandTest {
 
     @Test
     public void testHashCode_notEquals() throws Exception {
-        Assert.assertEquals(COMMAND_ONE.hashCode(), COMMAND_ONE_CLONE.hashCode());
+        Assert.assertNotEquals(COMMAND_ONE.hashCode(), COMMAND_TWO.hashCode());
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
@@ -32,6 +32,8 @@ import com.microsoft.identity.common.internal.util.ClockSkewManager;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,18 +58,66 @@ public class GenerateShrCommandTest {
         }
     };
 
+    public static final GenerateShrCommandParameters PARAMS_ONE = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(makeUrl("https://url"))
+                    .nonce("one")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+    public static final GenerateShrCommand COMMAND_ONE = GenerateShrCommand.builder()
+            .parameters(PARAMS_ONE)
+            .callback(EMPTY_CALLBACK)
+            .publicApiId("ID")
+            .controllers(Collections.<BaseController>emptyList())
+            .build();
+    public static final GenerateShrCommandParameters PARAMS_ONE_CLONE = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(makeUrl("https://url"))
+                    .nonce("one")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+    public static final GenerateShrCommand COMMAND_ONE_CLONE = GenerateShrCommand.builder()
+            .parameters(PARAMS_ONE_CLONE)
+            .callback(EMPTY_CALLBACK)
+            .publicApiId("ID")
+            .controllers(Collections.<BaseController>emptyList())
+            .build();
+    public static final GenerateShrCommandParameters PARAMS_TWO = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(makeUrl("https://url"))
+                    .nonce("two")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+    public static final GenerateShrCommand COMMAND_TWO = GenerateShrCommand.builder()
+            .parameters(PARAMS_TWO)
+            .callback(EMPTY_CALLBACK)
+            .publicApiId("ID")
+            .controllers(Collections.<BaseController>emptyList())
+            .build();
+
+    static URL makeUrl(String url) {
+        try {
+            return new URL(url);
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testMappability() throws Exception {
-        GenerateShrCommandParameters paramsOne = GenerateShrCommandParameters.builder()
-                .homeAccountId("One")
-                .popParameters(PopAuthenticationSchemeInternal.builder()
-                        .clientClaims("claims")
-                        .httpMethod("GET")
-                        .url(new URL("https://url"))
-                        .nonce("one")
-                        .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
-                        .build())
-                .build();
+        GenerateShrCommandParameters paramsOne = PARAMS_ONE;
         GenerateShrCommand commandOne = GenerateShrCommand.builder()
                 .parameters(paramsOne)
                 .callback(EMPTY_CALLBACK)
@@ -80,7 +130,7 @@ public class GenerateShrCommandTest {
                 .popParameters(PopAuthenticationSchemeInternal.builder()
                         .clientClaims("claims")
                         .httpMethod("GET")
-                        .url(new URL("https://url"))
+                        .url(makeUrl("https://url"))
                         .nonce("two")
                         .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                         .build())
@@ -96,5 +146,32 @@ public class GenerateShrCommandTest {
         Assert.assertEquals(1, map.size());
         map.put(commandTwo, true);
         Assert.assertEquals(2, map.size());
+    }
+
+    @Test
+    public void testHashCode_equals() throws Exception {
+        Assert.assertEquals(COMMAND_ONE.hashCode(), COMMAND_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testHashCode_notEquals() throws Exception {
+        Assert.assertEquals(COMMAND_ONE.hashCode(), COMMAND_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testEquals_equals() throws Exception {
+        Assert.assertEquals(COMMAND_ONE, COMMAND_ONE_CLONE);
+    }
+    @Test
+    public void testEquals_notEqualNull() throws Exception {
+        Assert.assertNotEquals(COMMAND_ONE, null);
+    }
+    @Test
+    public void testEquals_equalsSame() throws Exception {
+        Assert.assertEquals(COMMAND_ONE, COMMAND_ONE);
+    }
+    @Test
+    public void testEquals_notEqualDifferenceInNonce() {
+        Assert.assertNotEquals(COMMAND_ONE, COMMAND_TWO);
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
@@ -25,19 +25,60 @@ package com.microsoft.identity.common.internal.commands.parameters;
 import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.cache.MapBackedPreferencesManager;
 import com.microsoft.identity.common.internal.commands.Command;
+import com.microsoft.identity.common.internal.commands.CommandCallback;
 import com.microsoft.identity.common.internal.commands.GenerateShrCommand;
+import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
 import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.internal.util.UrlUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GenerateShrCommandParametersTest {
+    private static final CommandCallback EMPTY_CALLBACK = new CommandCallback() {
+        @Override public void onCancel() {  }
+        @Override public void onError(Object error) {  }
+        @Override public void onTaskCompleted(Object o) {  }
+    };
+
+    public static final GenerateShrCommandParameters PARAMS_ONE = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(UrlUtils.makeUrlSilent("https://url"))
+                    .nonce("one")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+    public static final GenerateShrCommandParameters PARAMS_ONE_CLONE = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(UrlUtils.makeUrlSilent("https://url"))
+                    .nonce("one")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+    public static final GenerateShrCommandParameters PARAMS_TWO = GenerateShrCommandParameters.builder()
+            .homeAccountId("One")
+            .popParameters(PopAuthenticationSchemeInternal.builder()
+                    .clientClaims("claims")
+                    .httpMethod("GET")
+                    .url(UrlUtils.makeUrlSilent("https://url"))
+                    .nonce("two")
+                    .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                    .build())
+            .build();
+
     @Test
     public void testMappability() throws Exception {
         GenerateShrCommandParameters commandOne = GenerateShrCommandParameters.builder()
@@ -45,7 +86,7 @@ public class GenerateShrCommandParametersTest {
                 .popParameters(PopAuthenticationSchemeInternal.builder()
                         .clientClaims("claims")
                         .httpMethod("GET")
-                        .url(new URL("https://url"))
+                        .url(UrlUtils.makeUrlSilent("https://url"))
                         .nonce("one")
                         .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                         .build())
@@ -55,7 +96,7 @@ public class GenerateShrCommandParametersTest {
                 .popParameters(PopAuthenticationSchemeInternal.builder()
                         .clientClaims("claims")
                         .httpMethod("GET")
-                        .url(new URL("https://url"))
+                        .url(UrlUtils.makeUrlSilent("https://url"))
                         .nonce("two")
                         .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
                         .build())
@@ -67,4 +108,31 @@ public class GenerateShrCommandParametersTest {
         map.put(commandTwo, true);
         Assert.assertEquals(2, map.size());
     }
+    @Test
+    public void testHashCode_equals() throws Exception {
+        Assert.assertEquals(PARAMS_ONE.hashCode(), PARAMS_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testHashCode_notEquals() throws Exception {
+        Assert.assertEquals(PARAMS_ONE.hashCode(), PARAMS_ONE_CLONE.hashCode());
+    }
+
+    @Test
+    public void testEquals_equals() throws Exception {
+        Assert.assertEquals(PARAMS_ONE, PARAMS_ONE_CLONE);
+    }
+    @Test
+    public void testEquals_notEqualNull() throws Exception {
+        Assert.assertNotEquals(PARAMS_ONE, null);
+    }
+    @Test
+    public void testEquals_equalsSame() throws Exception {
+        Assert.assertEquals(PARAMS_ONE, PARAMS_ONE);
+    }
+    @Test
+    public void testEquals_notEqualDifferenceInNonce() {
+        Assert.assertNotEquals(PARAMS_ONE, PARAMS_TWO);
+    }
+
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
@@ -67,5 +67,4 @@ public class GenerateShrCommandParametersTest {
         map.put(commandTwo, true);
         Assert.assertEquals(2, map.size());
     }
-
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
@@ -115,7 +115,7 @@ public class GenerateShrCommandParametersTest {
 
     @Test
     public void testHashCode_notEquals() throws Exception {
-        Assert.assertEquals(PARAMS_ONE.hashCode(), PARAMS_ONE_CLONE.hashCode());
+        Assert.assertNotEquals(PARAMS_ONE.hashCode(), PARAMS_TWO.hashCode());
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
@@ -1,0 +1,71 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.commands.parameters;
+
+import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
+import com.microsoft.identity.common.internal.cache.MapBackedPreferencesManager;
+import com.microsoft.identity.common.internal.commands.Command;
+import com.microsoft.identity.common.internal.commands.GenerateShrCommand;
+import com.microsoft.identity.common.internal.util.ClockSkewManager;
+import com.microsoft.identity.common.internal.util.IClockSkewManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GenerateShrCommandParametersTest {
+    @Test
+    public void testMappability() throws Exception {
+        GenerateShrCommandParameters commandOne = GenerateShrCommandParameters.builder()
+                .homeAccountId("One")
+                .popParameters(PopAuthenticationSchemeInternal.builder()
+                        .clientClaims("claims")
+                        .httpMethod("GET")
+                        .url(new URL("https://url"))
+                        .nonce("one")
+                        .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                        .build())
+                .build();
+        GenerateShrCommandParameters commandTwo = GenerateShrCommandParameters.builder()
+                .homeAccountId("One")
+                .popParameters(PopAuthenticationSchemeInternal.builder()
+                        .clientClaims("claims")
+                        .httpMethod("GET")
+                        .url(new URL("https://url"))
+                        .nonce("two")
+                        .clockSkewManager(new ClockSkewManager(new MapBackedPreferencesManager("name")))
+                        .build())
+                .build();
+
+        Map<CommandParameters, Boolean> map = new HashMap<>();
+        map.put(commandOne, true);
+        Assert.assertEquals(1, map.size());
+        map.put(commandTwo, true);
+        Assert.assertEquals(2, map.size());
+    }
+
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/util/UrlUtils.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/util/UrlUtils.java
@@ -1,0 +1,44 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * A place for gathering utilities for use with URLs.
+ */
+public class UrlUtils {
+    /**
+     * This creates a url from a String, rewriting any malformedUrlExceptions to runtime.
+     * @param urlString the string to convert.
+     * @return the corresponding {@link URL}.
+     */
+    public static URL makeUrlSilent(String urlString) {
+        try {
+            return new URL(urlString);
+        } catch (final MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
One of our early adopters noticed that these were missing, because their PoP requests that used a new nonce were being returned precisely the same results.  This ends up changing a lot of files, because there are 7 classes changed, three tests added, and one additional test utility class created.