### PR TITLE
Minor tweak in JWE response class, promote key derivation to first-class.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.Next
 - [MINOR] Adds new API support for the broker - SSO token and flight support (#1290)
 - [MINOR] Elevates AndroidCommon Logger out of internal package (#1279)
 - [MINOR] Automate broker protocol version computation. (#1301)
+- [MAJOR] New API on KeyAccessor (#1309)
 
 Version 3.2.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/JweResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/JweResponse.java
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.internal.platform;
 
 import android.util.Base64;
 
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -32,7 +34,7 @@ import java.nio.charset.Charset;
 
 public class JweResponse {
 
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = AuthenticationConstants.CHARSET_UTF8;
 
     public static class JweHeader {
         public String mHeaderAlg;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyAccessor.java
@@ -78,8 +78,13 @@ public interface KeyAccessor {
     SecureHardwareState getSecureHardwareState() throws ClientException;
 
     /**
-     * Using the provided cryptosuite, generate a new derived key accessor given the label and the
-     * context.
+     * Using the provided {@link CryptoSuite}, generate a new derived key accessor given the label and the
+     * context.  This key will expose a null alias, and generally should not be stored.
+     * @param label the "label" for the derivation.
+     * @param ctx the "context" for the derivation, typically random bytes.
+     * @param suite the {@link CryptoSuite} that the derived key should use.
+     * @return A {link KeyAccessor} that provides access to operations using the derived key.
+     * @throws ClientException if an underlying issue prevents the key generation.
      */
-    KeyAccessor generateDerivedKey(final byte[] label, final byte[] ctx, CryptoSuite suite) throws ClientException;
+    KeyAccessor generateDerivedKey(byte[] label, byte[] ctx, CryptoSuite suite) throws ClientException;
  }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyAccessor.java
@@ -26,6 +26,8 @@ import com.microsoft.identity.common.exception.ClientException;
 
 import java.security.cert.Certificate;
 
+import lombok.NonNull;
+
 /**
  * Interface for utilizing keys.
  */
@@ -74,4 +76,10 @@ public interface KeyAccessor {
      * @return a {@link SecureHardwareState} object representing the status of this key.
      */
     SecureHardwareState getSecureHardwareState() throws ClientException;
+
+    /**
+     * Using the provided cryptosuite, generate a new derived key accessor given the label and the
+     * context.
+     */
+    KeyAccessor generateDerivedKey(final byte[] label, final byte[] ctx, CryptoSuite suite) throws ClientException;
  }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyStoreAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/KeyStoreAccessor.java
@@ -160,6 +160,11 @@ public class KeyStoreAccessor {
             public SecureHardwareState getSecureHardwareState() throws ClientException {
                 return popManager.getSecureHardwareState();
             }
+
+            @Override
+            public KeyAccessor generateDerivedKey(byte[] label, byte[] ctx, CryptoSuite suite) throws ClientException {
+                throw new UnsupportedOperationException("This operation is not supported by asymmetric keys");
+            }
         };
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/RawKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/RawKeyAccessor.java
@@ -233,6 +233,7 @@ public class RawKeyAccessor implements KeyAccessor {
      * @return a new key, generated from the previous one.
      * @throws ClientException if something goes wrong during generation.
      */
+    @Override
     public KeyAccessor generateDerivedKey(@NonNull final byte[] label, @NonNull final byte[] ctx,
                                           @NonNull final CryptoSuite suite) throws ClientException{
         try {

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/SecretKeyAccessor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/SecretKeyAccessor.java
@@ -194,6 +194,11 @@ public class SecretKeyAccessor implements IManagedKeyAccessor<KeyStore.SecretKey
     }
 
     @Override
+    public KeyAccessor generateDerivedKey(final byte[] label, final byte[] ctx, final CryptoSuite suite) throws ClientException {
+        throw new UnsupportedOperationException("This operation is not supported by inaccessible keys");
+    }
+
+    @Override
     public IKeyManager<KeyStore.SecretKeyEntry> getManager() {
         return mKeyManager;
     }


### PR DESCRIPTION
This is mainly promotion of an interface from RawKeyAccessor upwards through the key accessor classes to top-level.  We currently don't have a key derivation for inaccessible, hardware-backed keys, but I think it likely enough that we do so in the future that we should prepare for it.