### PR TITLE
Transition jcenter -> mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
@@ -44,7 +43,6 @@ allprojects {
 
         NOTE: When building in Travis packages will be pulled from here
          */
-        jcenter()
         mavenCentral()
         /*
         Required since the DUO sdk is not published to any of the other large android

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Impetus:
- https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1283548

See [JCenter shutdown impact on Gradle builds](https://blog.gradle.org/jcenter-shutdown)