### PR TITLE
If we end up with a null component name, don't pass it into package manager.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/InteractiveTokenCommand.java
@@ -68,8 +68,9 @@ public class InteractiveTokenCommand extends TokenCommand {
         final Context applicationContext = parameters.getAndroidApplicationContext();
         final PackageManager packageManager = applicationContext.getPackageManager();
         try {
-            final ActivityInfo startActivityInfo = packageManager.getActivityInfo(parameters.getActivity().getComponentName(), 0);
-            if(startActivityInfo.taskAffinity == null){
+            final ComponentName componentName = parameters.getActivity().getComponentName();
+            final ActivityInfo startActivityInfo = componentName != null ? packageManager.getActivityInfo(componentName, 0) : null;
+            if (startActivityInfo.taskAffinity == null){
                 mHasTaskAffinity = false;
                 mTaskId = parameters.getActivity().getTaskId();
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/InteractiveTokenCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/InteractiveTokenCommand.java
@@ -70,7 +70,7 @@ public class InteractiveTokenCommand extends TokenCommand {
         try {
             final ComponentName componentName = parameters.getActivity().getComponentName();
             final ActivityInfo startActivityInfo = componentName != null ? packageManager.getActivityInfo(componentName, 0) : null;
-            if (startActivityInfo.taskAffinity == null){
+            if (startActivityInfo == null || startActivityInfo.taskAffinity == null){
                 mHasTaskAffinity = false;
                 mTaskId = parameters.getActivity().getTaskId();
             }


### PR DESCRIPTION
This began by debugging the submodule update in https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1355/ 

It looks like we can end up with null ComponentNames when using Robolectric, that we're passing into the Shadow package manager and it's failing on line 167.  I *think* the best way to deal with this is just to be defensive in this case and treat it as if it had no affinity.

Not all the tests pass locally for me, but with this change, *this* failure does not happen.

