### PR TITLE
Package validation support for nGMS agent

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.adal.internal;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -1060,6 +1061,23 @@ public final class AuthenticationConstants {
          * Broker Host app package name.
          */
         public static final String BROKER_HOST_APP_PACKAGE_NAME = "com.microsoft.identity.testuserapp";
+
+        /**
+         * Intune nGMS agent app package name.
+         */
+        public static final String INTUNE_NGMS_AGENT_APP_PACKAGE_NAME = "com.microsoft.intune.aospagent";
+
+        /**
+         * Signature info for Azure authenticator app that installs authenticator
+         * component.
+         */
+        public static final String INTUNE_NGMS_AGENT_APP_RELEASE_SIGNATURE = "1L4Z9FJCgn5c0VLhyAxC5O9LdlE=";
+
+        /**
+         * Signature info for Azure authenticator app that installs authenticator
+         * component.
+         */
+        public static final String INTUNE_NGMS_AGENT_APP_DEBUG_SIGNATURE = "placeholder,correct value inserted here";
 
         /**
          * Azure Authenticator app package name.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.java
@@ -40,6 +40,9 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_HOST_APP_SIGNATURE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.INTUNE_NGMS_AGENT_APP_DEBUG_SIGNATURE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.INTUNE_NGMS_AGENT_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.INTUNE_NGMS_AGENT_APP_RELEASE_SIGNATURE;
 
 /**
  * Represents packageName and SignatureHash of a broker app.
@@ -66,6 +69,16 @@ public class BrokerData {
             BROKER_HOST_APP_SIGNATURE
     );
 
+    public static final BrokerData INTUNE_NGMS_AGENT_DEBUG = new BrokerData(
+            INTUNE_NGMS_AGENT_APP_PACKAGE_NAME,
+            INTUNE_NGMS_AGENT_APP_DEBUG_SIGNATURE
+    );
+
+    public static final BrokerData INTUNE_NGMS_AGENT_PROD = new BrokerData(
+            INTUNE_NGMS_AGENT_APP_PACKAGE_NAME,
+            INTUNE_NGMS_AGENT_APP_RELEASE_SIGNATURE
+    );
+
     private static final Set<BrokerData> DEBUG_BROKERS = Collections.unmodifiableSet(new HashSet<BrokerData>() {{
         add(MICROSOFT_AUTHENTICATOR_DEBUG);
         add(BROKER_HOST);
@@ -79,6 +92,13 @@ public class BrokerData {
     private static final Set<BrokerData> ALL_BROKERS = Collections.unmodifiableSet(new HashSet<BrokerData>() {{
         addAll(DEBUG_BROKERS);
         addAll(PROD_BROKERS);
+    }});
+
+    // This set is specific to whitelist Intune nGMS agent to access Device Token WPJ API.
+    private static final Set<BrokerData> INTUNE_NGMS_AGENT_SPECIFIC = Collections.unmodifiableSet(new HashSet<BrokerData>() {{
+        add(INTUNE_NGMS_AGENT_DEBUG);
+        add(INTUNE_NGMS_AGENT_PROD);
+        add(BROKER_HOST);
     }});
 
     public final String packageName;
@@ -113,5 +133,9 @@ public class BrokerData {
 
     public static Set<BrokerData> getAllBrokers() {
         return ALL_BROKERS;
+    }
+
+    public static Set<BrokerData> getIntuneNgmsAgentSpecific() {
+        return INTUNE_NGMS_AGENT_SPECIFIC;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
@@ -32,6 +32,7 @@ import android.util.Base64;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.broker.PackageHelper;
@@ -71,31 +72,32 @@ public final class PackageUtils {
 
     /**
      * Find all the signatures for packages with a given name.
+     *
      * @param packageName the name of the package to find.
-     * @param context the android context to use to search.
+     * @param context     the android context to use to search.
      * @return the {@link List} of {@link X509Certificate} entries for packages with the given name;
      * @throws PackageManager.NameNotFoundException if the package was not in package manager.
-     * @throws ClientException if the package could not be found or had a bad certificate.
-     * @throws IOException if there was a storage read error.
-     * @throws GeneralSecurityException if there was a problem with accessing apis.
+     * @throws ClientException                      if the package could not be found or had a bad certificate.
+     * @throws IOException                          if there was a storage read error.
+     * @throws GeneralSecurityException             if there was a problem with accessing apis.
      */
     @SuppressLint("PackageManagerGetSignatures")
     @SuppressWarnings("deprecation")
     public static final List<X509Certificate> readCertDataForApp(final String packageName,
-                                                           final Context context)
+                                                                 final Context context)
             throws PackageManager.NameNotFoundException, ClientException, IOException,
             GeneralSecurityException {
 
         final PackageInfo packageInfo = PackageHelper.getPackageInfo(context.getPackageManager(), packageName);
         if (packageInfo == null) {
             throw new ClientException(ErrorStrings.APP_PACKAGE_NAME_NOT_FOUND,
-                    "No broker package existed.");
+                    "No such package existing : " + packageName);
         }
 
-        final Signature [] signatures = PackageHelper.getSignatures(packageInfo);
+        final Signature[] signatures = PackageHelper.getSignatures(packageInfo);
         if (signatures == null || signatures.length == 0) {
             throw new ClientException(BROKER_APP_VERIFICATION_FAILED,
-                    "No signature associated with the broker package.");
+                    "No signature associated with the package : " + packageName);
         }
 
         final List<X509Certificate> certificates = new ArrayList<>(signatures.length);
@@ -121,15 +123,16 @@ public final class PackageUtils {
     /**
      * Given a iterator of signature hashes, verify that one of them is present in the list
      * of certificates.
-     * @param certs A {@link List} of {@link X509Certificate} objects to examine
+     *
+     * @param certs       A {@link List} of {@link X509Certificate} objects to examine
      * @param validHashes an {@link Iterator<String>} of acceptable hashes.
      * @return a valid hash, if it is found.
-     * @throws NoSuchAlgorithmException if a certificate could not be examined.
+     * @throws NoSuchAlgorithmException     if a certificate could not be examined.
      * @throws CertificateEncodingException if a certificate was corrupt.
-     * @throws ClientException if no valid hash was found in the list.
+     * @throws ClientException              if no valid hash was found in the list.
      */
     public static final String verifySignatureHash(final @NonNull List<X509Certificate> certs,
-                                             final @NonNull Iterator<String> validHashes)
+                                                   final @NonNull Iterator<String> validHashes)
             throws NoSuchAlgorithmException,
             CertificateEncodingException, ClientException {
 
@@ -145,6 +148,7 @@ public final class PackageUtils {
             hashListStringBuilder.append(signatureHash);
             hashListStringBuilder.append(',');
 
+            //The next of the iterator should be overridden to get the signatureHash.
             while (validHashes.hasNext()) {
                 final String hash = validHashes.next();
                 if (!TextUtils.isEmpty(hash) && hash.equals(signatureHash)) {
@@ -158,9 +162,10 @@ public final class PackageUtils {
 
     /**
      * Validate a certificate chain.  This will search for a self
+     *
      * @param certificates a {@link List} of {@link X509Certificate} objects to validate.
      * @throws GeneralSecurityException if we aren't allowed to access certificates.
-     * @throws ClientException if any number other than 1 self signed certificate is found.
+     * @throws ClientException          if any number other than 1 self signed certificate is found.
      */
     public static final void verifyCertificateChain(final List<X509Certificate> certificates)
             throws GeneralSecurityException, ClientException {
@@ -180,6 +185,7 @@ public final class PackageUtils {
     /**
      * Find a self-signed certificate in the @{link List} of {@link X509Certificate}s.  This method
      * will throw an exception if there are less or more than preciselt one self-signed certificate.
+     *
      * @param certs a {link List} of certificates to examine.
      * @return the only self-signed {@link X509Certificate} in the {@link List}
      * @throws ClientException if any number other than 1 self signed certificate is found.
@@ -201,5 +207,32 @@ public final class PackageUtils {
         }
 
         return selfSignedCert;
+    }
+
+    public static String signatureVerificationAndThrow(final String packageName, final Context context,
+                                                       final Iterator<String> validPackageSignatures)
+            throws ClientException {
+        try {
+            // Read all the certificates associated with the package name. In higher version of
+            // android sdk, package manager will only returned the cert that is used to sign the
+            // APK. Even a cert is claimed to be issued by another certificates, sdk will return
+            // the signing cert. However, for the lower version of android, it will return all the
+            // certs in the chain. We need to verify that the cert chain is correctly chained up.
+            final List<X509Certificate> certs = readCertDataForApp(packageName, context);
+
+            final String signatureHash = PackageUtils.verifySignatureHash(certs, validPackageSignatures);
+
+            if (certs.size() > 1) {
+                PackageUtils.verifyCertificateChain(certs);
+            }
+
+            return signatureHash;
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new ClientException(ErrorStrings.APP_PACKAGE_NAME_NOT_FOUND, e.getMessage(), e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new ClientException(ErrorStrings.NO_SUCH_ALGORITHM, e.getMessage(), e);
+        } catch (final IOException | GeneralSecurityException e) {
+            throw new ClientException(ErrorStrings.BROKER_VERIFICATION_FAILED, e.getMessage(), e);
+        }
     }
 }


### PR DESCRIPTION
only let broker host and nGMS agent access the Device Token WPJ API.

Added an API in package util to have a general package validation