### PR TITLE
disable default trigger

### DIFF
--- a/azure-pipelines/maven-release/common.yml
+++ b/azure-pipelines/maven-release/common.yml
@@ -6,6 +6,7 @@
 # Variable 'test_repo_branch' was defined in the Variables tab
 # Variable 'test_repo_dir' was defined in the Variables tab
 name: $(date:yyyyMMdd)$(rev:.r)
+trigger: none
 resources:
   repositories:
   - repository: self

--- a/azure-pipelines/testapps/Android-Complete AzureSample LocalDebug.yml
+++ b/azure-pipelines/testapps/Android-Complete AzureSample LocalDebug.yml
@@ -10,6 +10,7 @@
 # Variable 'test_repo_branch' was defined in the Variables tab
 # Variable 'test_repo_dir' was defined in the Variables tab
 # Cron Schedules have been converted using UTC Time Zone and may need to be updated for your location
+trigger: none
 schedules:
 - cron: 0 1 * * 1,2,3,4,5
   branches:

--- a/azure-pipelines/vsts-releases/common.yml
+++ b/azure-pipelines/vsts-releases/common.yml
@@ -7,6 +7,7 @@
 # Variable 'test_repo_branch' was defined in the Variables tab
 # Variable 'test_repo_dir' was defined in the Variables tab
 name: $(date:yyyyMMdd)$(rev:.r)
+trigger: none
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
YAML pipelines are configured by default with a CI trigger on all branches.
https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#ci-triggers

Disabling the CI trigger
https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#disabling-the-ci-trigger