### PR TITLE
Fix for transient issues, Fix for the requests encountering device_network_not_available

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -515,8 +515,7 @@ public class CommandDispatcher {
      */
     private static boolean eligibleToCacheException(BaseException exception) {
         if (exception instanceof IntuneAppProtectionPolicyRequiredException
-                || (exception instanceof ClientException
-                && (ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE.equals(((ClientException)exception).getErrorCode())))) {
+                || ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE.equals(((ClientException)exception).getErrorCode())) {
             return false;
         }
         return true;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -40,6 +40,8 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.microsoft.identity.common.WarningType;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException;
 import com.microsoft.identity.common.exception.UserCancelException;
 import com.microsoft.identity.common.internal.commands.BaseCommand;
@@ -512,7 +514,9 @@ public class CommandDispatcher {
      * @return
      */
     private static boolean eligibleToCacheException(BaseException exception) {
-        if (exception instanceof IntuneAppProtectionPolicyRequiredException) {
+        if (exception instanceof IntuneAppProtectionPolicyRequiredException
+                || (exception instanceof ClientException
+                && (ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE.equals(((ClientException)exception).getErrorCode())))) {
             return false;
         }
         return true;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -514,6 +514,7 @@ public class CommandDispatcher {
      * @return
      */
     private static boolean eligibleToCacheException(BaseException exception) {
+        //TODO : ADO 1373343 Add the whole transient exception category.
         if (exception instanceof IntuneAppProtectionPolicyRequiredException
                 || ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE.equals(((ClientException)exception).getErrorCode())) {
             return false;


### PR DESCRIPTION
Created a new category TRANSIENT to help categorize the issues, which can help in not caching them if needed and taking the necessary steps to service these failures