### PR TITLE
Just rolling back the edge-triggered connection changes, in case.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -69,8 +69,10 @@ public class DefaultConnectionService implements IConnectionService {
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
 
-        return activeNetwork != null &&
-                        activeNetwork.isConnectedOrConnecting();
+        @SuppressWarnings("deprecation")
+        final boolean isConnectionAvailable = activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+        Telemetry.emit((BaseEvent) new BaseEvent().put(TelemetryEventStrings.Key.NETWORK_CONNECTION, String.valueOf(isConnectionAvailable)));
+        return isConnectionAvailable;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -49,12 +49,6 @@ import com.microsoft.identity.common.internal.telemetry.events.BaseEvent;
 public class DefaultConnectionService implements IConnectionService {
 
     private final Context mConnectionContext;
-    private static boolean connectionAvailable = false;
-    // We need a single instance of the NetworkCallback to prevent multiple callbacks from being
-    // registered for each instance of DefaultConnectionService.
-    private static ConnectivityManager.NetworkCallback networkCallback;
-
-    private static final Object lock = new Object();
 
     /**
      * Constructor of DefaultConnectionService.
@@ -63,65 +57,6 @@ public class DefaultConnectionService implements IConnectionService {
      */
     public DefaultConnectionService(Context ctx) {
         mConnectionContext = ctx;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            registerNetworkCallback();
-        }
-    }
-
-    /**
-     * Registers a new network callback
-     */
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    public void registerNetworkCallback() {
-        synchronized (lock) {
-            if (null == networkCallback) {
-                try {
-                    final ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
-                            .getSystemService(Context.CONNECTIVITY_SERVICE);
-                    final NetworkRequest.Builder builder = new NetworkRequest.Builder()
-                            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
-
-                    NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
-                    // Initialize the connectionAvailable to the active network info, before the callback is registered.
-                    DefaultConnectionService.connectionAvailable =
-                            null != activeNetwork &&
-                                    activeNetwork.isConnectedOrConnecting();
-
-                    connectivityManager.registerNetworkCallback(
-                            builder.build(),
-                            networkCallback = new ConnectivityManager.NetworkCallback() {
-                                @Override
-                                public void onAvailable(@NonNull Network network) {
-                                    DefaultConnectionService.connectionAvailable = true;
-                                }
-
-                                @Override
-                                public void onLost(@NonNull Network network) {
-                                    DefaultConnectionService.connectionAvailable = false;
-                                }
-                            });
-                } catch (Exception e) {
-                    // The connection callback registration failed
-                    DefaultConnectionService.connectionAvailable = false;
-                }
-            }
-        }
-    }
-
-    /**
-     * De-registers the existing network callback.
-     */
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    public void unregisterNetworkCallback() {
-        synchronized (lock) {
-            if (networkCallback != null) {
-                final ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
-                        .getSystemService(Context.CONNECTIVITY_SERVICE);
-
-                connectivityManager.unregisterNetworkCallback(networkCallback);
-                networkCallback = null;
-            }
-        }
     }
 
     /**
@@ -130,22 +65,12 @@ public class DefaultConnectionService implements IConnectionService {
      * @return True if network connection available, false otherwise.
      */
     public boolean isConnectionAvailable() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
-                    .getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
 
-            NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
-
-            DefaultConnectionService.connectionAvailable =
-                    activeNetwork != null &&
-                            activeNetwork.isConnectedOrConnecting();
-        }
-        Telemetry.emit((BaseEvent) new BaseEvent().put(
-                TelemetryEventStrings.Key.NETWORK_CONNECTION,
-                String.valueOf(DefaultConnectionService.connectionAvailable)
-        ));
-
-        return DefaultConnectionService.connectionAvailable;
+        return activeNetwork != null &&
+                        activeNetwork.isConnectedOrConnecting();
     }
 
     /**


### PR DESCRIPTION
In testing this out, I took an emulator running android 30 and S, and running the MSAL test app, worked through various acquire token flows while enabling or disabling the network.  No abnormal behavior was observed
