### PR TITLE
Disregard pageload errors for non-primary-frame

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.Next
 - [PATCH] Add common-java. Migrate Logger. (#1300)
 - [PATCH] Perf: Avoid repeated calls to getCredentials() when loading from cache (#1334)
 - [PATCH] Rev Nimbus version: 8.2 -> 9.9 (#1346)
+- [PATCH] Disregard pageload errors for the non-primary frame during interactive auth (#1357)
 
 Version 3.4.2
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -145,7 +145,15 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     public void onReceivedError(@NonNull final WebView view,
                                 @NonNull final WebResourceRequest request,
                                 @NonNull final WebResourceError error) {
-        sendErrorToCallback(view, error.getErrorCode(), error.getDescription().toString());
+        final String methodName = "onReceivedError (23)";
+        final boolean isForMainFrame = request.isForMainFrame();
+
+        Logger.warn(TAG + methodName, "WebResourceError - isForMainFrame? " + isForMainFrame);
+        Logger.warnPII(TAG + methodName, "Failing url: " + request.getUrl());
+
+        if (request.isForMainFrame()) {
+            sendErrorToCallback(view, error.getErrorCode(), error.getDescription().toString());
+        }
     }
 
     private void sendErrorToCallback(@NonNull final WebView view,


### PR DESCRIPTION
Impetus
- https://portal.microsofticm.com/imp/v3/incidents/details/239658713/home

Summary:
Suppose an ADFS sign-in page is customized to include an iframe of custom content; page load errors inside of that frame should not prevent a user from being able to sign-in. [This change drops events from the "non-primary frame".](https://stackoverflow.com/questions/44068123/how-to-detect-errors-only-from-the-main-page-in-new-onreceivederror-from-webview)

This change needed only on the API 23 overload, as the default behavior prior to this override was to drop these events.

Testing:
Manual testing against a real-life ADFS instance with this problem. See above linked IcM.