### PR TITLE
Fix/Suppress SpotBugs issue

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -123,6 +123,8 @@ android {
 }
 
 dependencies {
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.3'
+
     //Java 8 - Desugaring - Enabled/Disabled via plugin
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/HttpRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/HttpRequest.java
@@ -33,11 +33,14 @@ import java.net.UnknownServiceException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This class is deprecated.
  *
  * @see com.microsoft.identity.common.java.net.HttpRequest
  */
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public final class HttpRequest extends com.microsoft.identity.common.java.net.HttpRequest {
 
     /**
@@ -286,13 +289,17 @@ public final class HttpRequest extends com.microsoft.identity.common.java.net.Ht
         Map<String, String> headerMap = requestHeaders;
         if (requestContentType != null) {
             headerMap = new LinkedHashMap<>(headerMap);
-            if (requestContentType != null) {
-                headerMap.put(HttpConstants.HeaderField.CONTENT_TYPE, requestContentType);
-            }
+            headerMap.put(HttpConstants.HeaderField.CONTENT_TYPE, requestContentType);
         }
+
         final com.microsoft.identity.common.java.net.HttpResponse response =
                 com.microsoft.identity.common.java.net.UrlConnectionHttpClient.getDefaultInstance().method(httpMethod, requestUrl, headerMap, requestContent);
-        if (response != null && com.microsoft.identity.common.java.net.UrlConnectionHttpClient.isRetryableError(response.getStatusCode())) {
+
+        if (response == null) {
+            return null;
+        }
+
+        if (com.microsoft.identity.common.java.net.UrlConnectionHttpClient.isRetryableError(response.getStatusCode())) {
             throw new UnknownServiceException("Retry failed again with 500/503/504");
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/HttpResponse.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/HttpResponse.java
@@ -28,11 +28,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Deprecated
  * <p>
  * Currently served as an adapter of {@link com.microsoft.identity.common.java.net.HttpResponse}
  */
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public final class HttpResponse extends com.microsoft.identity.common.java.net.HttpResponse {
     public HttpResponse(@NonNull final com.microsoft.identity.common.java.net.HttpResponse responseToBeAdapted) {
         super(responseToBeAdapted.getDate(),
@@ -44,7 +47,7 @@ public final class HttpResponse extends com.microsoft.identity.common.java.net.H
     public HttpResponse(final int statusCode,
                         final String responseBody,
                         final Map<String, List<String>> responseHeaders) {
-        super(null, statusCode, responseBody, responseHeaders);
+        super(statusCode, responseBody, responseHeaders);
     }
 
     public HttpResponse(final Date date,

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClient.java
@@ -44,6 +44,7 @@ import static com.microsoft.identity.common.java.net.UrlConnectionHttpClient.DEF
  * <p>
  * Currently served as an adapter of {@link com.microsoft.identity.common.java.net.UrlConnectionHttpClient}
  */
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class UrlConnectionHttpClient extends AbstractHttpClient {
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/java/util/ObjectMapper.java
+++ b/common/src/main/java/com/microsoft/identity/common/java/util/ObjectMapper.java
@@ -52,6 +52,8 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 
+import lombok.val;
+
 public final class ObjectMapper {
 
     /**
@@ -272,8 +274,9 @@ public final class ObjectMapper {
         TreeMap<String, String> fields = new Gson().fromJson(json, stringMap);
         if (object instanceof IHasExtraParameters) {
             final IHasExtraParameters params = (IHasExtraParameters) object;
-            if (params.getExtraParameters() != null) {
-                for (final Map.Entry<String, String> e : params.getExtraParameters()) {
+            val extraParams = params.getExtraParameters();
+            if (extraParams != null) {
+                for (final Map.Entry<String, String> e : extraParams) {
                     if (e.getKey() != null) {
                         fields.put(e.getKey(), e.getValue());
                     }

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -34,6 +34,8 @@ sourceSets {
 }
 
 dependencies {
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.3'
+
     implementation "net.jcip:jcip-annotations:1.0"
     implementation "com.google.code.gson:gson:2.8.5"
 

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -26,6 +26,12 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 public class AuthenticationConstants {
+
+    /**
+     * The Constant ENCODING_UTF8.
+     */
+    public static final String ENCODING_UTF8 = "UTF-8";
+
     /**
      * Represents the constants value for Active Directory.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpRequest.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.java.net;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,9 +43,12 @@ public class HttpRequest {
     @Accessors(prefix = "m")
     private final URL mRequestUrl;
 
-    @Getter
     @Accessors(prefix = "m")
     private final byte[] mRequestContent;
+
+    public byte[] getRequestContent() {
+        return Arrays.copyOf(mRequestContent, mRequestMethod.length());
+    }
 
     @Getter
     @Accessors(prefix = "m")
@@ -70,15 +74,15 @@ public class HttpRequest {
      * @param requestContentType Request content type.
      */
     public HttpRequest(@NonNull final URL requestUrl,
-                @NonNull final Map<String, String> requestHeaders,
-                @NonNull final String requestMethod,
-                final byte[] requestContent,
-                final String requestContentType) {
+                       @NonNull final Map<String, String> requestHeaders,
+                       @NonNull final String requestMethod,
+                       final byte[] requestContent,
+                       final String requestContentType) {
         mRequestUrl = requestUrl;
         mRequestHeaders.put(HOST, requestUrl.getAuthority());
         mRequestHeaders.putAll(requestHeaders);
         mRequestMethod = requestMethod;
-        mRequestContent = requestContent;
+        mRequestContent = requestContent != null ? Arrays.copyOf(requestContent, requestContent.length) : null;
         mRequestContentType = requestContentType;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
@@ -49,21 +49,21 @@ public class HttpResponse {
      */
     public HttpResponse(final int statusCode, final String responseBody,
                         final Map<String, List<String>> responseHeaders) {
-        this(null, statusCode, responseBody, responseHeaders);
+        this(new Date(), statusCode, responseBody, responseHeaders);
     }
 
     public HttpResponse(final Date date,
                         final int statusCode,
                         final String responseBody,
                         final Map<String, List<String>> headerFields) {
-        mDate = date;
+        mDate = new Date(date.getTime());
         mStatusCode = statusCode;
         mResponseBody = responseBody;
         mResponseHeaders = headerFields;
     }
 
     public Date getDate() {
-        return mDate;
+        return new Date(mDate.getTime());
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.net;
 
+import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.telemetry.Telemetry;
 import com.microsoft.identity.common.java.telemetry.events.HttpEndEvent;
@@ -50,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NonNull;
@@ -95,8 +97,9 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     @Builder.Default
     private final int streamBufferSize = DEFAULT_STREAM_BUFFER_SIZE;
 
-    private static transient AtomicReference<UrlConnectionHttpClient> defaultReference = new AtomicReference<>(null);
+    private static final transient AtomicReference<UrlConnectionHttpClient> defaultReference = new AtomicReference<>(null);
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public UrlConnectionHttpClient(@NonNull final UrlConnectionHttpClient client) {
         this(client.retryPolicy,
                 client.connectTimeoutMs,
@@ -235,7 +238,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
      */
     private String convertStreamToString(final InputStream inputStream) throws IOException {
         try {
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, AuthenticationConstants.ENCODING_UTF8));
             final char[] buffer = new char[streamBufferSize];
             final StringBuilder stringBuilder = new StringBuilder();
             int charsRead;
@@ -331,11 +334,11 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
         return urlConnection;
     }
 
-    private Integer getReadTimeoutMs() {
+    private int getReadTimeoutMs() {
         return readTimeoutMsSupplier == null ? readTimeoutMs : readTimeoutMsSupplier.get();
     }
 
-    private Integer getConnectTimeoutMs() {
+    private int getConnectTimeoutMs() {
         return connectTimeoutMsSupplier == null ? connectTimeoutMs : connectTimeoutMsSupplier.get();
     }
 


### PR DESCRIPTION
Suppress NM_SAME_SIMPLE_NAME_AS_SUPERCLASS. 
- This occurs when a child class and the super class has the same name, but belongs in a different packages.
- This is by design (to avoid breaking change - and I don't want to name the class in java with "Java" suffix either).

Suppress RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE
- This occurs with Lombok AllArgsConstructor.

The rest are fixed.
- Byte array and Date objects are returned as a copy.
- If date time is not provided, HttpResponse will use current Time (new Date()).
- InputStreamReader uses UTF-8. (Still can't use StandardCharsets.UTF_8) 
- Remove getReadTimeoutMs() and getConnectTimeoutMs() unnecessary boxing.
- Set params.getExtraParameters as a constant before iterating through it.
- Add null check for HttpRequest.sendWithMethod()'s response.