### PR TITLE
Bring latest patch version of common4j in sync with common

### DIFF
--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 00:41:12 UTC 2021
 versionName=0.0.5
 versionCode=1
-latestPatchVersion=221
+latestPatchVersion=222

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue May 11 23:25:47 UTC 2021
 versionName=0.0.5
 versionCode=1
-latestPatchVersion=215
+latestPatchVersion=221


### PR DESCRIPTION
These numbers are incremented automatically via: https://dev.azure.com/IdentityDivision/IDDP/_build?definitionId=1183&_a=summary

But we had to start somewhere for common4j and we started with same version as common was it....but I was too slow to keep up with it as other merges were happening in dev. Once this goes in, we shouldn't have to worry about it again.

The other option is that we don't care whether these are in sync or not.