### PR TITLE
Add common dimension strategy for uiautomationutilities

### DIFF
--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -71,6 +71,13 @@ android {
         buildConfigField("String", "INSTALL_SOURCE_PLAY_STORE", "\"$installSourcePlayStore\"")
         buildConfigField("String", "INSTALL_SOURCE_LOCAL_APK", "\"$installSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
+
+        // Specifies a sorted list of flavors that the plugin should try to use from
+        // a given dimension. The following tells the plugin that, when encountering
+        // a dependency that includes a "main" dimension, it should select the
+        // "local" flavor. You can include additional flavor names to provide a
+        // sorted list of fallbacks for the dimension.
+        missingDimensionStrategy 'main', 'local'
     }
 
     buildTypes {


### PR DESCRIPTION
This is to fix the broken build of ui automation utilties: https://dev.azure.com/IdentityDivision/IDDP/_build/results?buildId=774290&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=16f964a0-1e38-57f7-e961-778a6c83ce9d&l=88

Caused by: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1338

This is because `common` now has flavors (local vs dist to determine how to use `common4j`), however, `uiautomationutilties` doesn't have any flavor for the `main` dimension so it needs a strategy to resolve flavor of common

Related reading: https://developer.android.com/studio/build/dependencies#resolve_matching_errors