### PR TITLE
Just consume the latest common4j

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -148,7 +148,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:0.0.5") {
+    distApi("com.microsoft.identity:common4j:0.0.+") {
         transitive = false
     }
 


### PR DESCRIPTION
Going forward probably makes sense to create two separate flavors here: `latest` and `dist`

latest - consumes latest build
dist - consumes hard coded version in Maven Central