### PR TITLE
Undo changes that breaks MSAL CPP

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/net/AbstractHttpClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/AbstractHttpClient.java
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.net;
+
+import lombok.NonNull;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * Deprecated
+ *
+ * Kept for backcompat purpose. Will be remove in the next major release.
+ * @see com.microsoft.identity.common.java.net.AbstractHttpClient
+ * */
+public abstract class AbstractHttpClient implements HttpClient {
+
+    @Override
+    public HttpResponse method(@NonNull String httpMethod, @NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.validateAndNormalizeMethod(httpMethod), requestUrl, requestHeaders, requestContent);
+    }
+
+    @Override
+    public abstract HttpResponse method(@NonNull HttpMethod httpMethod, @NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException;
+
+    @Override
+    public HttpResponse put(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
+        return method(HttpMethod.PUT, requestUrl, requestHeaders, requestContent);
+    }
+
+    @Override
+    public HttpResponse patch(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
+        return method(HttpMethod.PATCH, requestUrl, requestHeaders, requestContent);
+    }
+
+    @Override
+    public HttpResponse options(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.OPTIONS, requestUrl, requestHeaders, null);
+    }
+
+    @Override
+    public HttpResponse post(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
+        return method(HttpMethod.POST, requestUrl, requestHeaders, requestContent);
+    }
+
+    @Override
+    public HttpResponse delete(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
+        return method(HttpMethod.DELETE, requestUrl, requestHeaders, requestContent);
+    }
+
+    @Override
+    public HttpResponse get(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.GET, requestUrl, requestHeaders, null);
+    }
+
+    @Override
+    public HttpResponse head(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.HEAD, requestUrl, requestHeaders, null);
+    }
+
+    @Override
+    public HttpResponse trace(@NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.TRACE, requestUrl, requestHeaders, null);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/HttpClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/HttpClient.java
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.net;
+
+import com.microsoft.identity.common.java.util.StringUtil;
+import lombok.NonNull;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Deprecated
+ *
+ * Kept for backcompat purpose. Will be remove in the next major release.
+ * @see com.microsoft.identity.common.java.net.HttpClient
+ * */
+public interface HttpClient {
+    /**
+     * Execute an arbitrary method by name.  This will fail with an IllegalArgumentException unless
+     * httpMethod is one of { PUT, GET, HEAD, POST, PATCH, DELETE, OPTIONS, or TRACE }.
+     * @param httpMethod the string of the http method to use.  Must be one of { PUT, GET,
+     *                   HEAD, POST, PATCH, DELETE, OPTIONS, or TRACE }, case insensitive.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse method(@NonNull String httpMethod,
+                        @NonNull URL requestUrl,
+                        @NonNull Map<String, String> requestHeaders,
+                        byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an arbitrary method.
+     * @param httpMethod the HttpMethod to use for the call.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse method(@NonNull HttpMethod httpMethod,
+                        @NonNull URL requestUrl,
+                        @NonNull Map<String, String> requestHeaders,
+                        byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an HTTP PUT request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse put(@NonNull URL requestUrl,
+                     @NonNull Map<String, String> requestHeaders,
+                     byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an HTTP PATCH request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse patch(@NonNull URL requestUrl,
+                       @NonNull Map<String, String> requestHeaders,
+                       byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an HTTP OPTIONS request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse options(@NonNull URL requestUrl,
+                         @NonNull Map<String, String> requestHeaders) throws IOException;
+
+    /**
+     * Execute an HTTP POST request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse post(@NonNull URL requestUrl,
+                      @NonNull Map<String, String> requestHeaders,
+                      byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an HTTP PATCH request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @param requestContent the body content of the request, if applicable.  May be null.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse delete(@NonNull URL requestUrl,
+                        @NonNull Map<String, String> requestHeaders,
+                        byte[] requestContent) throws IOException;
+
+    /**
+     * Execute an HTTP GET request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse get(@NonNull URL requestUrl,
+                     @NonNull Map<String, String> requestHeaders) throws IOException;
+
+    /**
+     * Execute an HTTP HEAD request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse head(@NonNull URL requestUrl,
+                      @NonNull Map<String, String> requestHeaders) throws IOException;
+
+    /**
+     * Execute an HTTP TRACE request.
+     * @param requestUrl the URL of the resource to operate on.
+     * @param requestHeaders the headers for the request.
+     * @return an HttpResponse with the result of the call.
+     * @throws IOException if there was a communication problem.
+     */
+    HttpResponse trace(@NonNull URL requestUrl,
+                       @NonNull Map<String, String> requestHeaders) throws IOException;
+
+    /**
+     * An enumeration of the HTTP verbs supported by this client interface.
+     */
+    enum HttpMethod {
+        GET,
+        HEAD,
+        PUT,
+        POST,
+        OPTIONS,
+        PATCH,
+        DELETE,
+        TRACE;
+
+        private static final Map<String, HttpClient.HttpMethod> validMethods;
+
+        static {
+            validMethods = new LinkedHashMap<>(HttpMethod.values().length);
+            for (HttpMethod method: HttpMethod.values()) {
+                validMethods.put(method.name(), method);
+            }
+        }
+
+        public static HttpMethod validateAndNormalizeMethod(@NonNull final String httpMethod) {
+            if (StringUtil.isNullOrEmpty(httpMethod)) {
+                throw new IllegalArgumentException("HTTP method cannot be null or blank");
+            }
+
+            HttpMethod method = validMethods.get(httpMethod);
+            if (method != null) {
+                return method;
+            }
+            throw new IllegalArgumentException("Unknown or unsupported HTTP method: " + httpMethod);
+        }
+
+        public com.microsoft.identity.common.java.net.HttpClient.HttpMethod adapt(){
+            switch (this){
+                case GET:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.GET;
+                case HEAD:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.HEAD;
+                case PUT:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.PUT;
+                case POST:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.POST;
+                case OPTIONS:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.OPTIONS;
+                case PATCH:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.PATCH;
+                case DELETE:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.DELETE;
+                case TRACE:
+                    return com.microsoft.identity.common.java.net.HttpClient.HttpMethod.TRACE;
+            }
+
+            throw new IllegalStateException("Unexpected value");
+        }
+    }
+}
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClient.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.net;
 
 import androidx.annotation.Nullable;
 
-import com.microsoft.identity.common.java.net.AbstractHttpClient;
 import com.microsoft.identity.common.java.net.IRetryPolicy;
 
 import java.io.IOException;
@@ -42,6 +41,8 @@ import static com.microsoft.identity.common.java.net.UrlConnectionHttpClient.DEF
 /**
  * Deprecated
  * <p>
+ * Kept for backcompat purpose. Will be remove in the next major release.
+ *
  * Currently served as an adapter of {@link com.microsoft.identity.common.java.net.UrlConnectionHttpClient}
  */
 public class UrlConnectionHttpClient extends AbstractHttpClient {
@@ -162,7 +163,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
 
     @Override
     public HttpResponse method(@NonNull HttpMethod httpMethod, @NonNull URL requestUrl, @NonNull Map<String, String> requestHeaders, byte[] requestContent) throws IOException {
-        return new HttpResponse(sAdaptedObject.method(httpMethod, requestUrl, requestHeaders, requestContent));
+        return new HttpResponse(sAdaptedObject.method(httpMethod.adapt(), requestUrl, requestHeaders, requestContent));
     }
 
     @Override


### PR DESCRIPTION
bring back these classes. Apparently internal classes are not so internal after all 😆 
 
We'll remove them (and introduce breaking changes) when we're ready to do a major release.

(Disclaimer: this is only making sure that it doesn't break MSALCPP, not OneAuth, since I can't get the latter set up on my machine yet)