### PR TITLE
Fixing the Authenticator RedirectURI in broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
@@ -140,13 +140,6 @@ public class PackageHelper {
     public static String getBrokerRedirectUrl(final String packageName, final String signatureDigest) {
         if (!StringExtensions.isNullOrBlank(packageName)
                 && !StringExtensions.isNullOrBlank(signatureDigest)) {
-            // If the caller is the Authenticator, then use the broker redirect URI.
-            if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
-                    && (signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash)
-                    || signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash))) {
-                return AuthenticationConstants.Broker.BROKER_REDIRECT_URI;
-            }
-
             try {
                 return String.format("%s://%s/%s", AuthenticationConstants.Broker.REDIRECT_PREFIX,
                         URLEncoder.encode(packageName, AuthenticationConstants.ENCODING_UTF8),

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.4.3
+versionName=3.4.4-RC1
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
Address the issue :
Broker redirect uri is invalid. Expected: urn:ietf:wg:oauth:2.0:oob Actual: msauth://.......