### PR TITLE
spotbugs task change

### DIFF
--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -42,7 +42,6 @@ jobs:
   - template: ../templates/steps/spotbugs.yml
     parameters:
       project: common
-      spotbugsCommand: spotbugsDebug
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -6,9 +6,6 @@ parameters:
 - name: project
 - name: spotbugsCommand
   default: spotbugsLocalDebug
-  values:
-  - spotbugsLocalDebug
-  - spotbugsDebug
 - name: artifactName
   default: CodeAnalysisLogs
 


### PR DESCRIPTION
* The spotbugs task change 
* I get rid of the values of spotbugsCommand because it will be hard to maintain 

@shahzaibj recently added product flavors (local dist) to the common gradle so now the spotbug task changed
':common'. Candidates are: 'spotbugsDistDebug', 'spotbugsDistRelease', 'spotbugsLocalDebug', 'spotbugsLocalRelease'.
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/commit/90e5edd56c5bb909e928d9576e46e51ef478d7ca

