### PR TITLE
Add new settings to control authorization behavior

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/InteractiveTokenCommandParameters.java
@@ -85,7 +85,7 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
         return handleNullTaskAffinity;
     }
 
-    public boolean authorziationInCurrentTask(){
+    public boolean authorizationInCurrentTask(){
         return authorizationInCurrentTask;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/InteractiveTokenCommandParameters.java
@@ -74,12 +74,19 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
     @Expose()
     private final boolean handleNullTaskAffinity;
 
+    @Expose()
+    private final boolean authorizationInCurrentTask;
+
     private final List<Pair<String, String>> extraQueryStringParameters;
 
     private final List<String> extraScopesToConsent;
 
     public boolean getHandleNullTaskAffinity(){
         return handleNullTaskAffinity;
+    }
+
+    public boolean authorziationInCurrentTask(){
+        return authorizationInCurrentTask;
     }
 
     public List<Pair<String, String>> getExtraQueryStringParameters() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -141,6 +141,8 @@ public class CommandDispatcher {
                     1, config.getMaxTheadPoolInteractive(), -1, 0, TimeUnit.MINUTES, "interactive"
             );
             sConfigured = true;
+        }else{
+            Logger.warn(TAG, "CommandDispatcher was already configured.");
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -135,7 +135,7 @@ public class CommandDispatcher {
         sExecutingCommandMap = newMap;
     }
 
-    public static void configureCommandDispatcher(CommandDispatcherConfiguration config){
+    public static synchronized void configureCommandDispatcher(CommandDispatcherConfiguration config){
         if(!sConfigured) {
             sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
                     1, config.getMaxTheadPoolInteractive(), -1, 0, TimeUnit.MINUTES, "interactive"

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -87,15 +87,18 @@ public class CommandDispatcher {
     private static final String TAG = CommandDispatcher.class.getSimpleName();
 
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
+
     private static final int INTERACTIVE_REQUEST_THREAD_POOL_SIZE = 1;
+
     //TODO:1315931 - Refactor the threadpools to not be unbounded for both silent and interactive requests.
-    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
+    private static ExecutorService sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
             1, INTERACTIVE_REQUEST_THREAD_POOL_SIZE, -1, 0, TimeUnit.MINUTES, "interactive"
     );
     private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedThreadPoolExecutor(
             1, SILENT_REQUEST_THREAD_POOL_SIZE, -1, 1, TimeUnit.MINUTES, "silent"
     );
     private static final Object sLock = new Object();
+    private static boolean sConfigured = false;
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();
 
@@ -130,6 +133,15 @@ public class CommandDispatcher {
             }
         }
         sExecutingCommandMap = newMap;
+    }
+
+    public static void configureCommandDispatcher(CommandDispatcherConfiguration config){
+        if(!sConfigured) {
+            sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
+                    1, config.getMaxTheadPoolInteractive(), -1, 0, TimeUnit.MINUTES, "interactive"
+            );
+            sConfigured = true;
+        }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcherConfiguration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcherConfiguration.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.internal.controllers;
 
 import com.google.gson.annotations.Expose;
@@ -10,6 +32,9 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @EqualsAndHashCode
 @SuperBuilder(toBuilder = true)
+/**
+ * Class for encapsulating command dispatcher configuration
+ */
 public class CommandDispatcherConfiguration {
 
     @Expose()

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcherConfiguration.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcherConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.identity.common.internal.controllers;
+
+import com.google.gson.annotations.Expose;
+import com.microsoft.identity.common.internal.request.SdkType;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
+public class CommandDispatcherConfiguration {
+
+    @Expose()
+    private int maxTheadPoolInteractive;
+
+}


### PR DESCRIPTION
- Added 2 new settings to MSAL Config: concurrent_authorization_requests (boolean), authorization_in_current_task (boolean)
- Added the first to InteractiveTokenParameters
- Used the second to modify the behavior of command dispatcher to allow the number of threads in the interactive thread pool to be increased via a new command dispatcher configuration class