### PR TITLE
Restore slice and DC special handling to broker

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -145,11 +145,11 @@ dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 
     localApi(project(":common4j")) {
-        transitive = false
+        transitive = true
     }
 
     distApi("com.microsoft.identity:common4j:0.0.+") {
-        transitive = false
+        transitive = true
     }
 
     implementation (group: 'com.microsoft.device.display', name: 'display-mask', version: '0.3.0')

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AccountsInOneOrganization.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AccountsInOneOrganization.java
@@ -22,6 +22,14 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authorities;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AccountsInOneOrganization extends AzureActiveDirectoryAudience {
 
     public AccountsInOneOrganization() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AllAccounts.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AllAccounts.java
@@ -24,16 +24,23 @@ package com.microsoft.identity.common.internal.authorities;
 
 import androidx.annotation.NonNull;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class AllAccounts extends AzureActiveDirectoryAudience {
 
     public static final String ALL_ACCOUNTS_TENANT_ID = "common";
 
     public AllAccounts() {
-        this.setTenantId(ALL_ACCOUNTS_TENANT_ID);
+        super.setTenantId(ALL_ACCOUNTS_TENANT_ID);
     }
 
     public AllAccounts(@NonNull final String cloudUrl) {
-        this.setCloudUrl(cloudUrl);
-        this.setTenantId(ALL_ACCOUNTS_TENANT_ID);
+        super.setCloudUrl(cloudUrl);
+        super.setTenantId(ALL_ACCOUNTS_TENANT_ID);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AnyOrganizationalAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AnyOrganizationalAccount.java
@@ -22,6 +22,15 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authorities;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Accessors(prefix = "m")
 public class AnyOrganizationalAccount extends AzureActiveDirectoryAudience {
 
     public AnyOrganizationalAccount() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AnyPersonalAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AnyPersonalAccount.java
@@ -22,6 +22,11 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authorities;
 
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 public class AnyPersonalAccount extends AzureActiveDirectoryAudience {
 
     public static final String ANY_PERSONAL_ACCOUNT_TENANT_ID = "consumers";

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -57,7 +57,6 @@ import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @Accessors(prefix = "m")
-@EqualsAndHashCode
 @ToString
 public abstract class Authority {
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -250,6 +250,10 @@ public abstract class Authority {
     // This method *must* be regenerated if the class' structural definition changes through the
     // addition/subtraction of fields.
     @SuppressWarnings("PMD")
+    /**
+     * This implementation of {@link equals} does not take into account particular fields.
+     * The <strong>only</strong> fields considered here are authority type and authority url.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -267,6 +271,10 @@ public abstract class Authority {
     // This method *must* be regenerated if the class' structural definition changes through the
     // addition/subtraction of fields.
     @SuppressWarnings("PMD")
+    /**
+     * This implementation of {@link hashCode} does not take into account particular fields.
+     * The <strong>only</strong> fields considered here are authority type and authority url.
+     */
     @Override
     public int hashCode() {
         int result = ((mAuthorityTypeString == null) ? "0" : mAuthorityTypeString).hashCode();

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -36,15 +36,29 @@ import com.microsoft.identity.common.internal.providers.microsoft.azureactivedir
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2StrategyParameters;
+import com.microsoft.identity.common.internal.util.ObjectUtils;
+import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Accessors(prefix = "m")
+@EqualsAndHashCode
+@ToString
 public abstract class Authority {
 
     private static final String TAG = Authority.class.getSimpleName();
@@ -94,7 +108,7 @@ public abstract class Authority {
 
     public Authority() {
         // setting slice directly here in constructor if slice provided as command line param
-        if (!TextUtils.isEmpty(BuildConfig.SLICE) || !TextUtils.isEmpty(BuildConfig.DC)) {
+        if (!StringUtil.isEmpty(BuildConfig.SLICE) || !StringUtil.isEmpty(BuildConfig.DC)) {
             com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice slice = new AzureActiveDirectorySlice();
             slice.setSlice(BuildConfig.SLICE);
             slice.setDataCenter(BuildConfig.DC);
@@ -240,10 +254,11 @@ public abstract class Authority {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Authority)) return false;
+        if (o == null) return false;
 
         Authority authority = (Authority) o;
 
-        if (!mAuthorityTypeString.equals(authority.mAuthorityTypeString)) return false;
+        if (!ObjectUtils.equals(mAuthorityTypeString, authority.mAuthorityTypeString)) return false;
         return getAuthorityURL().equals(authority.getAuthorityURL());
     }
     //CHECKSTYLE:ON
@@ -255,7 +270,7 @@ public abstract class Authority {
     @SuppressWarnings("PMD")
     @Override
     public int hashCode() {
-        int result = mAuthorityTypeString.hashCode();
+        int result = ((mAuthorityTypeString == null) ? "0" : mAuthorityTypeString).hashCode();
         result = 31 * result + getAuthorityURL().hashCode();
         return result;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/Authority.java
@@ -254,7 +254,6 @@ public abstract class Authority {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Authority)) return false;
-        if (o == null) return false;
 
         Authority authority = (Authority) o;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.logging.Logger;
 import java.util.List;
 import java.util.Locale;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -51,6 +52,7 @@ import static com.microsoft.identity.common.internal.authorities.AllAccounts.ALL
 import static com.microsoft.identity.common.internal.authorities.AnyPersonalAccount.ANY_PERSONAL_ACCOUNT_TENANT_ID;
 
 @SuperBuilder
+@SuppressFBWarnings(value = "RCN", justification = "Lombok-generated code creates redundant checks")
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
@@ -39,9 +39,23 @@ import com.microsoft.identity.common.logging.Logger;
 import java.util.List;
 import java.util.Locale;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
 import static com.microsoft.identity.common.internal.authorities.AllAccounts.ALL_ACCOUNTS_TENANT_ID;
 import static com.microsoft.identity.common.internal.authorities.AnyPersonalAccount.ANY_PERSONAL_ACCOUNT_TENANT_ID;
 
+@SuperBuilder
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(prefix = "m")
+@ToString(callSuper = true)
 public abstract class AzureActiveDirectoryAudience {
 
     private static final String TAG = AzureActiveDirectoryAudience.class.getSimpleName();
@@ -157,7 +171,7 @@ public abstract class AzureActiveDirectoryAudience {
     }
 
     public static AzureActiveDirectoryAudience getAzureActiveDirectoryAudience(final String cloudUrl,
-                                                                               final String tenantId) {
+                                                                               final @NonNull String tenantId) {
         final String methodName = ":getAzureActiveDirectoryAudience";
         AzureActiveDirectoryAudience audience = null;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAudience.java
@@ -173,7 +173,7 @@ public abstract class AzureActiveDirectoryAudience {
     }
 
     public static AzureActiveDirectoryAudience getAzureActiveDirectoryAudience(final String cloudUrl,
-                                                                               final @NonNull String tenantId) {
+                                                                               final String tenantId) {
         final String methodName = ":getAzureActiveDirectoryAudience";
         AzureActiveDirectoryAudience audience = null;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectorySlice.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectorySlice.java
@@ -25,11 +25,13 @@ package com.microsoft.identity.common.internal.authorities;
 import com.google.gson.annotations.SerializedName;
 
 public class AzureActiveDirectorySlice {
+    public static final String SLICE = "slice";
+    public static final String DC = "dc";
 
-    @SerializedName("slice")
+    @SerializedName(SLICE)
     private String mSlice;
 
-    @SerializedName("dc")
+    @SerializedName(DC)
     private String mDataCenter;
 
     public String getSlice() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/UnknownAudience.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/UnknownAudience.java
@@ -22,5 +22,10 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authorities;
 
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 public class UnknownAudience extends AzureActiveDirectoryAudience {
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/BearerAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/BearerAuthenticationSchemeInternal.java
@@ -24,14 +24,18 @@ package com.microsoft.identity.common.internal.authscheme;
 
 import androidx.annotation.NonNull;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
 
 /**
  * Internal representation of a Bearer Auth Scheme.
  */
 @Getter
+@EqualsAndHashCode(callSuper = true)
 @Accessors(prefix = "m")
+@SuperBuilder
 public class BearerAuthenticationSchemeInternal
         extends TokenAuthenticationScheme
         implements ITokenAuthenticationSchemeInternal {

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -46,6 +46,8 @@ public class BrokerRequest implements Serializable {
     private static final long serialVersionUID = -543392127065130474L;
 
     private class SerializedNames {
+        static final String DC = "data_center";
+        static final String SLICE = "slice";
         final static String EXTRA_OPTIONS = "extra_options";
         final static String AUTHORITY = "authority";
         final static String SCOPE = "scopes";

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -27,11 +27,18 @@ import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
 /**
  * This class contains information about a specific Azure Active Directory Cloud.  Azure Active Directory
  * as a service is available in multiple clouds.  World wide is the default; however their are sovereign clouds
  * available for Germany, China, etc....
  */
+@SuperBuilder
+@EqualsAndHashCode
+@Accessors(prefix = "m")
 public class AzureActiveDirectoryCloud {
 
     @SerializedName("preferred_network")

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectorySlice.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectorySlice.java
@@ -2,6 +2,19 @@ package com.microsoft.identity.common.internal.providers.microsoft.azureactivedi
 
 import com.google.gson.annotations.SerializedName;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@EqualsAndHashCode
+@Accessors(prefix = "m")
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class AzureActiveDirectorySlice {
 
     public final static String SLICE_PARAMETER = "slice";

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -74,6 +74,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
@@ -218,11 +220,12 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         final BrokerRequest brokerRequest = brokerRequestFromBundle(intent.getExtras());
 
-        return BrokerInteactiveParametersFromBrokerRequest(callingActivity, intent.getIntExtra(CALLER_INFO_UID, 0),
+        return brokerInteactiveParametersFromBrokerRequest(callingActivity, intent.getIntExtra(CALLER_INFO_UID, 0),
                 intent.getStringExtra(NEGOTIATED_BP_VERSION_KEY), brokerRequest);
     }
 
-    public BrokerInteractiveTokenCommandParameters BrokerInteactiveParametersFromBrokerRequest(@NonNull Activity callingActivity, int callingAppUid, String negotiatedBrokerProtocolVersion, BrokerRequest brokerRequest) {
+    @SuppressFBWarnings(value = "RCN", justification = "The SDK type may actually be null")
+    public BrokerInteractiveTokenCommandParameters brokerInteactiveParametersFromBrokerRequest(@NonNull Activity callingActivity, int callingAppUid, String negotiatedBrokerProtocolVersion, BrokerRequest brokerRequest) {
         if (brokerRequest == null) {
             Logger.error(TAG, "Broker Result is null, returning empty parameters, " +
                     "validation is expected to fail", null

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -235,7 +235,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         List<Pair<String, String>> extraQP = QueryParamsAdapter._fromJson(brokerRequest.getExtraQueryStringParameter());
         List<Pair<String, String>> extraOptions = QueryParamsAdapter._fromJson(brokerRequest.getExtraOptions());
-        ;
+        List<Pair<String, String>> extraQPCopy = new ArrayList<>(extraQP);
 
         final AzureActiveDirectoryAuthority authority = AdalBrokerRequestAdapter.getRequestAuthorityWithExtraQP(
                 brokerRequest.getAuthority(),
@@ -267,7 +267,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .applicationVersion(brokerRequest.getApplicationVersion())
                 .callerPackageName(brokerRequest.getApplicationName())
                 .callerAppVersion(brokerRequest.getApplicationVersion())
-                .extraQueryStringParameters(extraQP)
+                .extraQueryStringParameters((brokerRequest.getExtraQueryStringParameter() == null ||
+                        (extraQPCopy.size() > 0 && extraQP.size() == 0) ? null : extraQP))
                 .authority(authority)
                 .extraOptions(extraOptions)
                 .scopes(getScopesAsSet(brokerRequest.getScope()))

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -124,7 +124,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
             }
         }
 
-        final String extraQueryStringParameter = (extraStringQueryParameters.size() > 0) ?
+        final String extraQueryStringParameter = (extraQueryStringParameters.size() > 0) ?
                 QueryParamsAdapter._toJson(extraQueryStringParameters)
                 : null;
         final String extraOptions = parameters.getExtraOptions() != null ?

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -124,7 +124,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
             }
         }
 
-        final String extraQueryStringParameter = (queryParams != null || sliceData != null) ?
+        final String extraQueryStringParameter = (extraStringQueryParameters.size() > 0) ?
                 QueryParamsAdapter._toJson(extraQueryStringParameters)
                 : null;
         final String extraOptions = parameters.getExtraOptions() != null ?

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserDescriptor.java
@@ -32,6 +32,15 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Set;
 
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Builder
+@EqualsAndHashCode
+@Accessors(prefix = "m")
+@Getter
 public class BrowserDescriptor implements Serializable {
     private static final long serialVersionUID = 3745812401643512530L;
     @SerializedName("browser_package_name")

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/QueryParamsAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/QueryParamsAdapter.java
@@ -85,7 +85,7 @@ public class QueryParamsAdapter extends TypeAdapter<List<Pair<String, String>>> 
     }
 
     public static List<Pair<String, String>> _fromJson(final String jsonString) {
-        if (TextUtils.isEmpty(jsonString)) {
+        if (StringUtil.isEmpty(jsonString)) {
             return new ArrayList<>();
         }
         final Type listType = new TypeToken<List<Pair<String, String>>>(){}.getType();

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
@@ -49,8 +49,16 @@ public final class StringUtil {
      * @param message String
      * @return true if the string object is null or the string is empty.
      */
-    public static boolean isEmpty(final String message) {
-        return message == null || message.trim().length() == 0; //NOPMD  Suppressing PMD warning for new String creation on trim()"
+    public static boolean isEmpty(final CharSequence message) {
+        if (message == null) {
+            return true;
+        }
+        for (int i = 0; i < message.length(); i++) {
+            if (!Character.isWhitespace(message.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/unit/MockAccountRecord.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/MockAccountRecord.java
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.unit;
+
+import com.microsoft.identity.common.internal.dto.IAccountRecord;
+
+/**
+ * A completely empty IAccountRecord.
+ */
+public class MockAccountRecord implements IAccountRecord {
+    @Override
+    public String getHomeAccountId() {
+        return null;
+    }
+
+    @Override
+    public String getEnvironment() {
+        return null;
+    }
+
+    @Override
+    public String getRealm() {
+        return null;
+    }
+
+    @Override
+    public String getLocalAccountId() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getAuthorityType() {
+        return null;
+    }
+
+    @Override
+    public String getAlternativeAccountId() {
+        return null;
+    }
+
+    @Override
+    public String getFirstName() {
+        return null;
+    }
+
+    @Override
+    public String getFamilyName() {
+        return null;
+    }
+
+    @Override
+    public String getMiddleName() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getAvatarUrl() {
+        return null;
+    }
+
+    @Override
+    public String getClientInfo() {
+        return null;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/MockContext.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/MockContext.java
@@ -1,0 +1,587 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.unit;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.IntentSender;
+import android.content.ServiceConnection;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.database.DatabaseErrorHandler;
+import android.database.sqlite.SQLiteDatabase;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
+import android.view.Display;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A campletely empty Context class.
+ */
+public class MockContext extends Context {
+    @Override
+    public AssetManager getAssets() {
+        return null;
+    }
+
+    @Override
+    public Resources getResources() {
+        return null;
+    }
+
+    @Override
+    public PackageManager getPackageManager() {
+        return null;
+    }
+
+    @Override
+    public ContentResolver getContentResolver() {
+        return null;
+    }
+
+    @Override
+    public Looper getMainLooper() {
+        return null;
+    }
+
+    @Override
+    public Context getApplicationContext() {
+        return null;
+    }
+
+    @Override
+    public void setTheme(int resid) {
+
+    }
+
+    @Override
+    public Resources.Theme getTheme() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public String getPackageName() {
+        return null;
+    }
+
+    @Override
+    public ApplicationInfo getApplicationInfo() {
+        return null;
+    }
+
+    @Override
+    public String getPackageResourcePath() {
+        return null;
+    }
+
+    @Override
+    public String getPackageCodePath() {
+        return null;
+    }
+
+    @Override
+    public SharedPreferences getSharedPreferences(String name, int mode) {
+        return null;
+    }
+
+    @Override
+    public boolean moveSharedPreferencesFrom(Context sourceContext, String name) {
+        return false;
+    }
+
+    @Override
+    public boolean deleteSharedPreferences(String name) {
+        return false;
+    }
+
+    @Override
+    public FileInputStream openFileInput(String name) throws FileNotFoundException {
+        return null;
+    }
+
+    @Override
+    public FileOutputStream openFileOutput(String name, int mode) throws FileNotFoundException {
+        return null;
+    }
+
+    @Override
+    public boolean deleteFile(String name) {
+        return false;
+    }
+
+    @Override
+    public File getFileStreamPath(String name) {
+        return null;
+    }
+
+    @Override
+    public File getDataDir() {
+        return null;
+    }
+
+    @Override
+    public File getFilesDir() {
+        return null;
+    }
+
+    @Override
+    public File getNoBackupFilesDir() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public File getExternalFilesDir(@Nullable String type) {
+        return null;
+    }
+
+    @Override
+    public File[] getExternalFilesDirs(String type) {
+        return new File[0];
+    }
+
+    @Override
+    public File getObbDir() {
+        return null;
+    }
+
+    @Override
+    public File[] getObbDirs() {
+        return new File[0];
+    }
+
+    @Override
+    public File getCacheDir() {
+        return null;
+    }
+
+    @Override
+    public File getCodeCacheDir() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public File getExternalCacheDir() {
+        return null;
+    }
+
+    @Override
+    public File[] getExternalCacheDirs() {
+        return new File[0];
+    }
+
+    @Override
+    public File[] getExternalMediaDirs() {
+        return new File[0];
+    }
+
+    @Override
+    public String[] fileList() {
+        return new String[0];
+    }
+
+    @Override
+    public File getDir(String name, int mode) {
+        return null;
+    }
+
+    @Override
+    public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory) {
+        return null;
+    }
+
+    @Override
+    public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory, @Nullable DatabaseErrorHandler errorHandler) {
+        return null;
+    }
+
+    @Override
+    public boolean moveDatabaseFrom(Context sourceContext, String name) {
+        return false;
+    }
+
+    @Override
+    public boolean deleteDatabase(String name) {
+        return false;
+    }
+
+    @Override
+    public File getDatabasePath(String name) {
+        return null;
+    }
+
+    @Override
+    public String[] databaseList() {
+        return new String[0];
+    }
+
+    @Override
+    public Drawable getWallpaper() {
+        return null;
+    }
+
+    @Override
+    public Drawable peekWallpaper() {
+        return null;
+    }
+
+    @Override
+    public int getWallpaperDesiredMinimumWidth() {
+        return 0;
+    }
+
+    @Override
+    public int getWallpaperDesiredMinimumHeight() {
+        return 0;
+    }
+
+    @Override
+    public void setWallpaper(Bitmap bitmap) throws IOException {
+
+    }
+
+    @Override
+    public void setWallpaper(InputStream data) throws IOException {
+
+    }
+
+    @Override
+    public void clearWallpaper() throws IOException {
+
+    }
+
+    @Override
+    public void startActivity(Intent intent) {
+
+    }
+
+    @Override
+    public void startActivity(Intent intent, @Nullable Bundle options) {
+
+    }
+
+    @Override
+    public void startActivities(Intent[] intents) {
+
+    }
+
+    @Override
+    public void startActivities(Intent[] intents, Bundle options) {
+
+    }
+
+    @Override
+    public void startIntentSender(IntentSender intent, @Nullable Intent fillInIntent, int flagsMask, int flagsValues, int extraFlags) throws IntentSender.SendIntentException {
+
+    }
+
+    @Override
+    public void startIntentSender(IntentSender intent, @Nullable Intent fillInIntent, int flagsMask, int flagsValues, int extraFlags, @Nullable Bundle options) throws IntentSender.SendIntentException {
+
+    }
+
+    @Override
+    public void sendBroadcast(Intent intent) {
+
+    }
+
+    @Override
+    public void sendBroadcast(Intent intent, @Nullable String receiverPermission) {
+
+    }
+
+    @Override
+    public void sendOrderedBroadcast(Intent intent, @Nullable String receiverPermission) {
+
+    }
+
+    @Override
+    public void sendOrderedBroadcast(@NonNull Intent intent, @Nullable String receiverPermission, @Nullable BroadcastReceiver resultReceiver, @Nullable Handler scheduler, int initialCode, @Nullable String initialData, @Nullable Bundle initialExtras) {
+
+    }
+
+    @Override
+    public void sendBroadcastAsUser(Intent intent, UserHandle user) {
+
+    }
+
+    @Override
+    public void sendBroadcastAsUser(Intent intent, UserHandle user, @Nullable String receiverPermission) {
+
+    }
+
+    @Override
+    public void sendOrderedBroadcastAsUser(Intent intent, UserHandle user, @Nullable String receiverPermission, BroadcastReceiver resultReceiver, @Nullable Handler scheduler, int initialCode, @Nullable String initialData, @Nullable Bundle initialExtras) {
+
+    }
+
+    @Override
+    public void sendStickyBroadcast(Intent intent) {
+
+    }
+
+    @Override
+    public void sendStickyOrderedBroadcast(Intent intent, BroadcastReceiver resultReceiver, @Nullable Handler scheduler, int initialCode, @Nullable String initialData, @Nullable Bundle initialExtras) {
+
+    }
+
+    @Override
+    public void removeStickyBroadcast(Intent intent) {
+
+    }
+
+    @Override
+    public void sendStickyBroadcastAsUser(Intent intent, UserHandle user) {
+
+    }
+
+    @Override
+    public void sendStickyOrderedBroadcastAsUser(Intent intent, UserHandle user, BroadcastReceiver resultReceiver, @Nullable Handler scheduler, int initialCode, @Nullable String initialData, @Nullable Bundle initialExtras) {
+
+    }
+
+    @Override
+    public void removeStickyBroadcastAsUser(Intent intent, UserHandle user) {
+
+    }
+
+    @Nullable
+    @Override
+    public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter, int flags) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, @Nullable String broadcastPermission, @Nullable Handler scheduler) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter, @Nullable String broadcastPermission, @Nullable Handler scheduler, int flags) {
+        return null;
+    }
+
+    @Override
+    public void unregisterReceiver(BroadcastReceiver receiver) {
+
+    }
+
+    @Nullable
+    @Override
+    public ComponentName startService(Intent service) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ComponentName startForegroundService(Intent service) {
+        return null;
+    }
+
+    @Override
+    public boolean stopService(Intent service) {
+        return false;
+    }
+
+    @Override
+    public boolean bindService(Intent service, @NonNull ServiceConnection conn, int flags) {
+        return false;
+    }
+
+    @Override
+    public void unbindService(@NonNull ServiceConnection conn) {
+
+    }
+
+    @Override
+    public boolean startInstrumentation(@NonNull ComponentName className, @Nullable String profileFile, @Nullable Bundle arguments) {
+        return false;
+    }
+
+    @Override
+    public Object getSystemService(@NonNull String name) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getSystemServiceName(@NonNull Class<?> serviceClass) {
+        return null;
+    }
+
+    @Override
+    public int checkPermission(@NonNull String permission, int pid, int uid) {
+        return 0;
+    }
+
+    @Override
+    public int checkCallingPermission(@NonNull String permission) {
+        return 0;
+    }
+
+    @Override
+    public int checkCallingOrSelfPermission(@NonNull String permission) {
+        return 0;
+    }
+
+    @Override
+    public int checkSelfPermission(@NonNull String permission) {
+        return 0;
+    }
+
+    @Override
+    public void enforcePermission(@NonNull String permission, int pid, int uid, @Nullable String message) {
+
+    }
+
+    @Override
+    public void enforceCallingPermission(@NonNull String permission, @Nullable String message) {
+
+    }
+
+    @Override
+    public void enforceCallingOrSelfPermission(@NonNull String permission, @Nullable String message) {
+
+    }
+
+    @Override
+    public void grantUriPermission(String toPackage, Uri uri, int modeFlags) {
+
+    }
+
+    @Override
+    public void revokeUriPermission(Uri uri, int modeFlags) {
+
+    }
+
+    @Override
+    public void revokeUriPermission(String toPackage, Uri uri, int modeFlags) {
+
+    }
+
+    @Override
+    public int checkUriPermission(Uri uri, int pid, int uid, int modeFlags) {
+        return 0;
+    }
+
+    @Override
+    public int checkCallingUriPermission(Uri uri, int modeFlags) {
+        return 0;
+    }
+
+    @Override
+    public int checkCallingOrSelfUriPermission(Uri uri, int modeFlags) {
+        return 0;
+    }
+
+    @Override
+    public int checkUriPermission(@Nullable Uri uri, @Nullable String readPermission, @Nullable String writePermission, int pid, int uid, int modeFlags) {
+        return 0;
+    }
+
+    @Override
+    public void enforceUriPermission(Uri uri, int pid, int uid, int modeFlags, String message) {
+
+    }
+
+    @Override
+    public void enforceCallingUriPermission(Uri uri, int modeFlags, String message) {
+
+    }
+
+    @Override
+    public void enforceCallingOrSelfUriPermission(Uri uri, int modeFlags, String message) {
+
+    }
+
+    @Override
+    public void enforceUriPermission(@Nullable Uri uri, @Nullable String readPermission, @Nullable String writePermission, int pid, int uid, int modeFlags, @Nullable String message) {
+
+    }
+
+    @Override
+    public Context createPackageContext(String packageName, int flags) throws PackageManager.NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public Context createContextForSplit(String splitName) throws PackageManager.NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public Context createConfigurationContext(@NonNull Configuration overrideConfiguration) {
+        return null;
+    }
+
+    @Override
+    public Context createDisplayContext(@NonNull Display display) {
+        return null;
+    }
+
+    @Override
+    public Context createDeviceProtectedStorageContext() {
+        return null;
+    }
+
+    @Override
+    public boolean isDeviceProtectedStorage() {
+        return false;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/MockOauth2TokenCache.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/MockOauth2TokenCache.java
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.unit;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
+import com.microsoft.identity.common.internal.dto.IdTokenRecord;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
+import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
+
+import java.util.List;
+import java.util.Set;
+
+public class MockOauth2TokenCache extends OAuth2TokenCache<OAuth2Strategy, AuthorizationRequest, TokenResponse> {
+    public MockOauth2TokenCache() {
+        super(new MockContext());
+    }
+
+    @Override
+    public ICacheRecord save(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
+        return null;
+    }
+
+    @Override
+    public List<ICacheRecord> saveAndLoadAggregatedAccountData(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
+        return null;
+    }
+
+    @Override
+    public ICacheRecord save(AccountRecord accountRecord, IdTokenRecord idTokenRecord) {
+        return null;
+    }
+
+    @Override
+    public ICacheRecord load(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authScheme) {
+        return null;
+    }
+
+    @Override
+    public List<ICacheRecord> loadWithAggregatedAccountData(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authenticationScheme) {
+        return null;
+    }
+
+    @Override
+    public boolean removeCredential(Credential credential) {
+        return false;
+    }
+
+    @Override
+    public AccountRecord getAccount(String environment, String clientId, String homeAccountId, String realm) {
+        return null;
+    }
+
+    @Override
+    public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId, String homeAccountId) {
+        return null;
+    }
+
+    @Override
+    public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
+        return null;
+    }
+
+    @Override
+    public ICacheRecord getAccountWithAggregatedAccountDataByLocalAccountId(String environment, String clientId, String localAccountId) {
+        return null;
+    }
+
+    @Override
+    public List<AccountRecord> getAccounts(String environment, String clientId) {
+        return null;
+    }
+
+    @Override
+    public List<AccountRecord> getAllTenantAccountsForAccountByClientId(String clientId, AccountRecord accountRecord) {
+        return null;
+    }
+
+    @Override
+    public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId) {
+        return null;
+    }
+
+    @Override
+    public List<IdTokenRecord> getIdTokensForAccountRecord(String clientId, AccountRecord accountRecord) {
+        return null;
+    }
+
+    @Override
+    public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm) {
+        return null;
+    }
+
+    @Override
+    public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm, CredentialType... typesToRemove) {
+        return null;
+    }
+
+    @Override
+    public void clearAll() {
+
+    }
+
+    @Override
+    protected Set<String> getAllClientIds() {
+        return null;
+    }
+
+    @Override
+    public AccountRecord getAccountByHomeAccountId(@Nullable String environment, @NonNull String clientId, @NonNull String homeAccountId) {
+        return null;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -449,19 +449,19 @@ public class MsalBrokerRequestAdapterTest {
         Assert.assertEquals(testScopes, out.getScopes());
         Assert.assertEquals(null, out.getFragment());
         Assert.assertEquals(sdkType, out.getSdkType());
-        final List<Pair<String, String>> slices = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
+        final List<Pair<String, String>> slices = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.<Pair<String,String>>emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
             public boolean test(Pair<String, String> p1) {
                 return "slice".equals(p1.first);
             }
-        }).collect(Collectors.toList());
+        }).collect(Collectors.<Pair<String,String>>toList());
         if (!slices.isEmpty()) {
 
         }
-        final List<Pair<String, String>> dcs = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
+        final List<Pair<String, String>> dcs = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.<Pair<String,String>>emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
             public boolean test(Pair<String, String> p1) {
                 return "dc".equals(p1.first);
             }
-        }).collect(Collectors.toList());
+        }).collect(Collectors.<Pair<String,String>>toList());
         if (!dcs.isEmpty()) {
 
         }

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -4,34 +4,23 @@ import android.app.Activity;
 import android.content.Context;
 import android.util.Pair;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
+import com.microsoft.identity.common.internal.authscheme.ITokenAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
-import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
-import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.commands.parameters.BrokerInteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
-import com.microsoft.identity.common.internal.dto.AccountRecord;
-import com.microsoft.identity.common.internal.dto.Credential;
-import com.microsoft.identity.common.internal.dto.CredentialType;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
-import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
-import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
-import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
-import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
 import com.microsoft.identity.common.internal.request.SdkType;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
@@ -41,18 +30,21 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(ParameterizedRobolectricTestRunner.class)
 public class MsalBrokerRequestAdapterTest {
 
     public static final String TEST_APPLICATION_NAME = "application";
@@ -67,75 +59,26 @@ public class MsalBrokerRequestAdapterTest {
     public static final String TEST_CLOUD_URL = "https://login.fabrikam.com";
     public static final AzureActiveDirectoryAudience TEST_AUDIENCE = AccountsInOneOrganization.builder().tenantId(TEST_TENANT_ID).cloudUrl(TEST_CLOUD_URL)
             .build();
-    public static final AzureActiveDirectorySlice TEST_SLICE = AzureActiveDirectorySlice.builder().slice("aSlice").dataCenter("dataCenter").build();
+    public static final AzureActiveDirectorySlice TEST_SLICE_WITH_SLICE_DC = AzureActiveDirectorySlice.builder()
+            .slice("aSlice")
+            .dataCenter("dataCenter")
+            .build();
+    public static final AzureActiveDirectorySlice TEST_SLICE_WITH_SLICE = AzureActiveDirectorySlice.builder()
+            .slice("aSlice")
+            .build();
+    public static final AzureActiveDirectorySlice TEST_SLICE_WITH_DC = AzureActiveDirectorySlice.builder()
+            .dataCenter("dataCenter")
+            .build();
+    public static final AzureActiveDirectorySlice TEST_SLICE_WITH_NOTHING = AzureActiveDirectorySlice.builder()
+            .build();
+
+    private final List<AzureActiveDirectorySlice> slices = Arrays.asList(TEST_SLICE_WITH_DC,
+            TEST_SLICE_WITH_SLICE, TEST_SLICE_WITH_SLICE_DC, TEST_SLICE_WITH_NOTHING, null);
+
     public static Context mockContext = Mockito.mock(Context.class);
 
-    public static final IAccountRecord TEST_ACCOUNT_RECORD = new IAccountRecord() {
-        @Override
-        public String getHomeAccountId() {
-            return null;
-        }
+    public static final IAccountRecord TEST_ACCOUNT_RECORD = Mockito.mock(IAccountRecord.class);
 
-        @Override
-        public String getEnvironment() {
-            return null;
-        }
-
-        @Override
-        public String getRealm() {
-            return null;
-        }
-
-        @Override
-        public String getLocalAccountId() {
-            return null;
-        }
-
-        @Override
-        public String getUsername() {
-            return null;
-        }
-
-        @Override
-        public String getAuthorityType() {
-            return null;
-        }
-
-        @Override
-        public String getAlternativeAccountId() {
-            return null;
-        }
-
-        @Override
-        public String getFirstName() {
-            return null;
-        }
-
-        @Override
-        public String getFamilyName() {
-            return null;
-        }
-
-        @Override
-        public String getMiddleName() {
-            return null;
-        }
-
-        @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public String getAvatarUrl() {
-            return null;
-        }
-
-        @Override
-        public String getClientInfo() {
-            return null;
-        }
-    };
     public static final List<BrowserDescriptor> TEST_BROWSER_SAFE_LIST = Arrays.asList(
             BrowserDescriptor.builder()
                     .packageName("aBrowser")
@@ -143,109 +86,16 @@ public class MsalBrokerRequestAdapterTest {
                     .versionLowerBound("1")
                     .versionUpperBound("2")
                     .build());
+
     public static final String TEST_CLAIMS_JSON = "{ \"claims\": \"something\"";
     public static final String TEST_CLIENT_ID = "aClientId";
     public static final String TEST_CORRELATION_ID = "aCorrelationId";
     public static final List<Pair<String, String>> TEST_EXTRA_OPTIONS = Arrays.asList(new Pair<String, String>("one", "two"));
     public static final List<Pair<String, String>> TEST_EXTRA_QUERY_STRING_PARAMETERS = Arrays.asList(new Pair<String, String>("QPone", "QPtwo"));
+    public static final List<Pair<String, String>> TEST_EXTRA_QUERY_STRING_PARAMETERS_SLICE = Arrays.asList(new Pair<String, String>("QPone", "QPtwo"), new Pair<>("slice", "aDifferentSlice"));
     public static final List<String> TEST_EXTRA_SCOPE = Arrays.asList("extraScope");
     public static final String TEST_LOGIN_HINT = "aLoginHint";
-    public static final OAuth2TokenCache TEST_OAUTH_2_TOKEN_CACHE = new OAuth2TokenCache<OAuth2Strategy, AuthorizationRequest, TokenResponse>(mockContext) {
-        @Override
-        public ICacheRecord save(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
-            return null;
-        }
-
-        @Override
-        public List<ICacheRecord> saveAndLoadAggregatedAccountData(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
-            return null;
-        }
-
-        @Override
-        public ICacheRecord save(AccountRecord accountRecord, IdTokenRecord idTokenRecord) {
-            return null;
-        }
-
-        @Override
-        public ICacheRecord load(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authScheme) {
-            return null;
-        }
-
-        @Override
-        public List<ICacheRecord> loadWithAggregatedAccountData(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authenticationScheme) {
-            return null;
-        }
-
-        @Override
-        public boolean removeCredential(Credential credential) {
-            return false;
-        }
-
-        @Override
-        public AccountRecord getAccount(String environment, String clientId, String homeAccountId, String realm) {
-            return null;
-        }
-
-        @Override
-        public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId, String homeAccountId) {
-            return null;
-        }
-
-        @Override
-        public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
-            return null;
-        }
-
-        @Override
-        public ICacheRecord getAccountWithAggregatedAccountDataByLocalAccountId(String environment, String clientId, String localAccountId) {
-            return null;
-        }
-
-        @Override
-        public List<AccountRecord> getAccounts(String environment, String clientId) {
-            return null;
-        }
-
-        @Override
-        public List<AccountRecord> getAllTenantAccountsForAccountByClientId(String clientId, AccountRecord accountRecord) {
-            return null;
-        }
-
-        @Override
-        public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId) {
-            return null;
-        }
-
-        @Override
-        public List<IdTokenRecord> getIdTokensForAccountRecord(String clientId, AccountRecord accountRecord) {
-            return null;
-        }
-
-        @Override
-        public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm) {
-            return null;
-        }
-
-        @Override
-        public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm, CredentialType... typesToRemove) {
-            return null;
-        }
-
-        @Override
-        public void clearAll() {
-
-        }
-
-        @Override
-        protected Set<String> getAllClientIds() {
-            return null;
-        }
-
-        @Override
-        public AccountRecord getAccountByHomeAccountId(@Nullable String environment, @NonNull String clientId, @NonNull String homeAccountId) {
-            return null;
-        }
-    };
+    public static final OAuth2TokenCache TEST_OAUTH_2_TOKEN_CACHE = Mockito.mock(OAuth2TokenCache.class);
     public static final String TEST_REDIRECT_URI = "aRedirectUri";
     public static final HashMap<String, String> TEST_REQUEST_HEADERS = new HashMap<>(Collections.singletonMap("aHeader", "aValue"));
     public static final String REQUIRED_BROKER_PROTOCOL_VERSION = "3.0";
@@ -259,82 +109,362 @@ public class MsalBrokerRequestAdapterTest {
             .preferredCacheHostName(CACHE_HOST_NAME)
             .preferredNetworkHostName(NETWORK_HOST_NAME)
             .build();
-    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY = AzureActiveDirectoryAuthority.builder()
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITH_SLICE_DC = AzureActiveDirectoryAuthority.builder()
             .audience(TEST_AUDIENCE)
-            .slice(TEST_SLICE)
+            .slice(TEST_SLICE_WITH_SLICE)
             .authorityTypeString(TEST_AUTHORITY_TYPE)
             .azureActiveDirectoryCloud(TEST_CLOUD)
             .authorityUrl("https://an.authority.url/")
             .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITH_SLICE = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(TEST_SLICE_WITH_SLICE)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITH_DC = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(TEST_SLICE_WITH_DC)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITH_NONE_SLICE = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(TEST_SLICE_WITH_NOTHING)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITH_NULL_SLICE = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(null)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY_WITHOUT_SLICE = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(null)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+    public static final Fragment TEST_FRAGMENT = new Fragment();
+
+        MsalBrokerRequestAdapter adapter = new MsalBrokerRequestAdapter();
+        boolean forceRefresh = true;
+        boolean handleNullTaskAffinity = true;
+        boolean isSharedDevice = true;
+        boolean isWebViewZoomControlsEnabled = true;
+        boolean isWebViewZoomEnabled = true;
+        boolean powerOptCheckEnabled = true;
+        OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter.LOGIN;
+        SdkType sdkType = SdkType.ADAL;
+        Authority testAuthority = TEST_AUTHORITY_WITH_SLICE;
+        String testApplicationName = TEST_APPLICATION_NAME;
+        String testApplicationVersion = TEST_APPLICATION_VERSION;
+        AbstractAuthenticationScheme authenticationScheme = BearerAuthenticationSchemeInternal.builder().build();
+        AuthorizationAgent authorizationAgent = AuthorizationAgent.BROWSER;
+        boolean brokerBrowserSupportEnabled = false;
+        List<BrowserDescriptor> testBrowserSafeList = TEST_BROWSER_SAFE_LIST;
+        IAccountRecord testAccountRecord = TEST_ACCOUNT_RECORD;
+        String testClaimsJson = TEST_CLAIMS_JSON;
+        String testClientId = TEST_CLIENT_ID;
+        String testCorrelationId = TEST_CORRELATION_ID;
+        List<Pair<String, String>> testExtraOptions = TEST_EXTRA_OPTIONS;
+        List<Pair<String, String>> testExtraQueryStringParameters = TEST_EXTRA_QUERY_STRING_PARAMETERS;
+        List<String> testExtraScope = TEST_EXTRA_SCOPE;
+        Fragment testFragment = TEST_FRAGMENT;
+        String testLoginHint = TEST_LOGIN_HINT;
+        OAuth2TokenCache testOauth2TokenCache = TEST_OAUTH_2_TOKEN_CACHE;
+        String testRedirectUri = TEST_REDIRECT_URI;
+        HashMap<String, String> testRequestHeaders = TEST_REQUEST_HEADERS;
+        String requiredBrokerProtocolVersion = REQUIRED_BROKER_PROTOCOL_VERSION;
+        String sdkVersion = SDK_VERSION;
+
+    @ParameterizedRobolectricTestRunner.Parameters
+    public static Collection arguments() {
+        return Arrays.asList(new Object[][] {
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.CONSENT, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.SELECT_ACCOUNT, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.SELECT_ACCOUNT, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, null,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.SELECT_ACCOUNT, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, null, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.SELECT_ACCOUNT, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, null, null,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.SELECT_ACCOUNT, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, null, null,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { false, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, false, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, false, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, false, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, false, true, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, false, OpenIdConnectPromptParameter.LOGIN, SdkType.ADAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITH_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITH_SLICE,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITH_SLICE_DC,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITH_NONE_SLICE,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITHOUT_SLICE,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITH_NULL_SLICE,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+                { true, true, true, true, true, true, OpenIdConnectPromptParameter.LOGIN, SdkType.MSAL, TEST_AUTHORITY_WITHOUT_SLICE,
+                        TEST_APPLICATION_NAME, TEST_APPLICATION_VERSION, BearerAuthenticationSchemeInternal.builder().build(),
+                        AuthorizationAgent.BROWSER,
+                        true, TEST_BROWSER_SAFE_LIST, TEST_ACCOUNT_RECORD, TEST_CLAIMS_JSON, TEST_CLIENT_ID,
+                        TEST_CORRELATION_ID, TEST_EXTRA_OPTIONS, TEST_EXTRA_QUERY_STRING_PARAMETERS_SLICE,
+                        TEST_EXTRA_SCOPE, TEST_FRAGMENT, TEST_LOGIN_HINT,
+                        TEST_OAUTH_2_TOKEN_CACHE, TEST_REDIRECT_URI, TEST_REQUEST_HEADERS, "3.0", "anSdkVersion",
+                        TEST_SCOPES },
+
+        });
+    }
+
+    public MsalBrokerRequestAdapterTest(boolean forceRefresh, boolean handleNullTaskAffinity, boolean isSharedDevice,
+                                        boolean isWebViewZoomControlsEnabled, boolean isWebViewZoomEnabled,
+                                        boolean powerOptCheckEnabled, OpenIdConnectPromptParameter promptParameter,
+                                        SdkType sdkType, Authority testAuthority, String testApplicationName,
+                                        String testApplicationVersion,
+                                        AbstractAuthenticationScheme authenticationScheme,
+                                        AuthorizationAgent authorizationAgent, boolean brokerBrowserSupportEnabled,
+                                        List<BrowserDescriptor> testBrowserSafeList,
+                                        IAccountRecord testAccountRecord, String testClaimsJson, String testClientId,
+                                        String testCorrelationId, List<Pair<String, String>> testExtraOptions,
+                                        List<Pair<String, String>> testExtraQueryStringParameters,
+                                        List<String> testExtraScope, Fragment testFragment, String testLoginHint,
+                                        OAuth2TokenCache testOauth2TokenCache, String testRedirectUri,
+                                        HashMap<String, String> testRequestHeaders, String requiredBrokerProtocolVersion,
+                                        String sdkVersion, Set<String> testScopes) {
+        this.forceRefresh = forceRefresh;
+        this.handleNullTaskAffinity = handleNullTaskAffinity;
+        this.isSharedDevice = isSharedDevice;
+        this.isWebViewZoomControlsEnabled = isWebViewZoomControlsEnabled;
+        this.isWebViewZoomEnabled = isWebViewZoomEnabled;
+        this.powerOptCheckEnabled = powerOptCheckEnabled;
+        this.promptParameter = promptParameter;
+        this.sdkType = sdkType;
+        this.testAuthority = testAuthority;
+        this.testApplicationName = testApplicationName;
+        this.testApplicationVersion = testApplicationVersion;
+        this.authenticationScheme = authenticationScheme;
+        this.authorizationAgent = authorizationAgent;
+        this.brokerBrowserSupportEnabled = brokerBrowserSupportEnabled;
+        this.testBrowserSafeList = testBrowserSafeList;
+        this.testAccountRecord = testAccountRecord;
+        this.testClaimsJson = testClaimsJson;
+        this.testClientId = testClientId;
+        this.testCorrelationId = testCorrelationId;
+        this.testExtraOptions = testExtraOptions;
+        this.testExtraQueryStringParameters = testExtraQueryStringParameters;
+        this.testExtraScope = testExtraScope;
+        this.testFragment = testFragment;
+        this.testLoginHint = testLoginHint;
+        this.testOauth2TokenCache = testOauth2TokenCache;
+        this.testRedirectUri = testRedirectUri;
+        this.testRequestHeaders = testRequestHeaders;
+        this.requiredBrokerProtocolVersion = requiredBrokerProtocolVersion;
+        this.sdkVersion = sdkVersion;
+        this.testScopes = testScopes;
+    }
+
+    Set<String> testScopes = TEST_SCOPES;
 
     @Test
     public void testRequestGeneration() {
-        final MsalBrokerRequestAdapter adapter = new MsalBrokerRequestAdapter();
-        final boolean forceRefresh = true;
-        final Fragment TEST_FRAGMENT = new Fragment();
-        final boolean handleNullTaskAffinity = true;
-        final boolean isSharedDevice = true;
-        final boolean isWebViewZoomControlsEnabled = true;
-        final boolean isWebViewZoomEnabled = true;
-        final boolean powerOptCheckEnabled = true;
-        final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter.LOGIN;
-        final SdkType sdkType = SdkType.ADAL;
+        parameterizedTransmissionTest(forceRefresh, handleNullTaskAffinity, isSharedDevice, isWebViewZoomControlsEnabled, isWebViewZoomEnabled, powerOptCheckEnabled, promptParameter, sdkType, testAuthority, testApplicationName, testApplicationVersion, authenticationScheme, authorizationAgent, brokerBrowserSupportEnabled, testBrowserSafeList, testAccountRecord, testClaimsJson, testClientId, testCorrelationId, testExtraOptions, testExtraQueryStringParameters, testExtraScope, testFragment, testLoginHint, testOauth2TokenCache, testRedirectUri, testRequestHeaders, requiredBrokerProtocolVersion, sdkVersion, testScopes);
+    }
+
+    private void parameterizedTransmissionTest(boolean forceRefresh, boolean handleNullTaskAffinity, boolean isSharedDevice, boolean isWebViewZoomControlsEnabled, boolean isWebViewZoomEnabled, boolean powerOptCheckEnabled, OpenIdConnectPromptParameter promptParameter, SdkType sdkType, Authority testAuthority, String testApplicationName, String testApplicationVersion, AbstractAuthenticationScheme authenticationScheme, AuthorizationAgent authorizationAgent, boolean brokerBrowserSupportEnabled, List<BrowserDescriptor> testBrowserSafeList, IAccountRecord testAccountRecord, String testClaimsJson, String testClientId, String testCorrelationId, List<Pair<String, String>> testExtraOptions, List<Pair<String, String>> testExtraQueryStringParameters, List<String> testExtraScope, Fragment testFragment, String testLoginHint, OAuth2TokenCache testOauth2TokenCache, String testRedirectUri, HashMap<String, String> testRequestHeaders, String requiredBrokerProtocolVersion, String sdkVersion, Set<String> testScopes) {
+        MsalBrokerRequestAdapter adapter = new MsalBrokerRequestAdapter();
         InteractiveTokenCommandParameters params = InteractiveTokenCommandParameters.builder()
-                .authority(TEST_AUTHORITY)
+                .authority(testAuthority)
                 .activity(new Activity())
-                .applicationName(TEST_APPLICATION_NAME)
-                .applicationVersion(TEST_APPLICATION_VERSION)
-                .authenticationScheme(BearerAuthenticationSchemeInternal.builder().build())
-                .authorizationAgent(AuthorizationAgent.BROWSER)
-                .brokerBrowserSupportEnabled(false)
-                .browserSafeList(TEST_BROWSER_SAFE_LIST)
-                .account(TEST_ACCOUNT_RECORD)
-                .claimsRequestJson(TEST_CLAIMS_JSON)
-                .clientId(TEST_CLIENT_ID)
-                .correlationId(TEST_CORRELATION_ID)
-                .extraOptions(TEST_EXTRA_OPTIONS)
-                .extraQueryStringParameters(TEST_EXTRA_QUERY_STRING_PARAMETERS)
-                .extraScopesToConsent(TEST_EXTRA_SCOPE)
+                .applicationName(testApplicationName)
+                .applicationVersion(testApplicationVersion)
+                .authenticationScheme(authenticationScheme)
+                .authorizationAgent(authorizationAgent)
+                .brokerBrowserSupportEnabled(brokerBrowserSupportEnabled)
+                .browserSafeList(testBrowserSafeList)
+                .account(testAccountRecord)
+                .claimsRequestJson(testClaimsJson)
+                .clientId(testClientId)
+                .correlationId(testCorrelationId)
+                .extraOptions(testExtraOptions)
+                .extraQueryStringParameters(testExtraQueryStringParameters)
+                .extraScopesToConsent(testExtraScope)
                 .forceRefresh(forceRefresh)
-                .fragment(TEST_FRAGMENT)
+                .fragment(testFragment)
                 .handleNullTaskAffinity(handleNullTaskAffinity)
                 .isSharedDevice(isSharedDevice)
                 .isWebViewZoomControlsEnabled(isWebViewZoomControlsEnabled)
                 .isWebViewZoomEnabled(isWebViewZoomEnabled)
-                .loginHint(TEST_LOGIN_HINT)
-                .oAuth2TokenCache(TEST_OAUTH_2_TOKEN_CACHE)
+                .loginHint(testLoginHint)
+                .oAuth2TokenCache(testOauth2TokenCache)
                 .powerOptCheckEnabled(powerOptCheckEnabled)
                 .prompt(promptParameter)
-                .redirectUri(TEST_REDIRECT_URI)
-                .requestHeaders(TEST_REQUEST_HEADERS)
-                .requiredBrokerProtocolVersion(REQUIRED_BROKER_PROTOCOL_VERSION)
+                .redirectUri(testRedirectUri)
+                .requestHeaders(testRequestHeaders)
+                .requiredBrokerProtocolVersion(requiredBrokerProtocolVersion)
                 .sdkType(sdkType)
-                .sdkVersion(SDK_VERSION)
-                .scopes(TEST_SCOPES)
+                .sdkVersion(sdkVersion)
+                .scopes(testScopes)
                 .build();
         BrokerRequest brokerRequest = adapter.brokerRequestFromAcquireTokenParameters(params);
         Activity mockActivity = Mockito.mock(Activity.class);
         BrokerInteractiveTokenCommandParameters out = adapter.brokerInteactiveParametersFromBrokerRequest(mockActivity, 0, "3.0",
                 brokerRequest);
-        Assert.assertEquals(TEST_SCOPES, out.getScopes());
+        Assert.assertEquals(testScopes, out.getScopes());
         Assert.assertEquals(null, out.getFragment());
-        Assert.assertEquals(TEST_AUTHORITY, out.getAuthority());
+        Assert.assertEquals(testAuthority, out.getAuthority());
         Assert.assertEquals(sdkType, out.getSdkType());
-        Assert.assertEquals(SDK_VERSION, out.getSdkVersion());
-        Assert.assertEquals(TEST_APPLICATION_NAME, out.getApplicationName());
-        Assert.assertEquals(TEST_APPLICATION_VERSION, out.getApplicationVersion());
-        Assert.assertEquals(TEST_EXTRA_OPTIONS, out.getExtraOptions());
+        Assert.assertEquals(sdkVersion, out.getSdkVersion());
+        Assert.assertEquals(testApplicationName, out.getApplicationName());
+        Assert.assertEquals(testApplicationVersion, out.getApplicationVersion());
+        Assert.assertEquals(testExtraOptions == null ? Collections.emptyList() : testExtraOptions, out.getExtraOptions());
         Assert.assertEquals(null, out.getBrowserSafeList());
-        Assert.assertEquals(TEST_CLAIMS_JSON, out.getClaimsRequestJson());
-        Assert.assertEquals(TEST_CLIENT_ID, out.getClientId());
-        Assert.assertEquals(TEST_CORRELATION_ID, out.getCorrelationId());
-        Assert.assertEquals(TEST_LOGIN_HINT, out.getLoginHint());
+        Assert.assertEquals(testClaimsJson, out.getClaimsRequestJson());
+        Assert.assertEquals(testClientId, out.getClientId());
+        Assert.assertEquals(testCorrelationId, out.getCorrelationId());
+        Assert.assertEquals(testLoginHint, out.getLoginHint());
         Assert.assertEquals(null, out.getAccount());
     }
 
+    /*
     @Test
     public void authorityFromUrlTest() {
         AzureActiveDirectoryAuthority a = (AzureActiveDirectoryAuthority) Authority.getAuthorityFromAuthorityUrl("https://login.fabrikam.com/aTenantId");
         Assert.assertEquals("https://login.fabrikam.com/aTenantId", a.getAuthorityURL().toString());
     }
+    */
 }

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -13,6 +13,7 @@ import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAu
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.commands.parameters.BrokerInteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
@@ -43,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
@@ -447,13 +449,19 @@ public class MsalBrokerRequestAdapterTest {
         Assert.assertEquals(testScopes, out.getScopes());
         Assert.assertEquals(null, out.getFragment());
         Assert.assertEquals(sdkType, out.getSdkType());
-        final List<Pair<String, String>> slices = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(p -> "slice".equals(p.first))
-                .collect(Collectors.toList());
+        final List<Pair<String, String>> slices = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
+            public boolean test(Pair<String, String> p1) {
+                return "slice".equals(p1.first);
+            }
+        }).collect(Collectors.toList());
         if (!slices.isEmpty()) {
 
         }
-        final List<Pair<String, String>> dcs = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(p -> "dc".equals(p.first))
-                .collect(Collectors.toList());
+        final List<Pair<String, String>> dcs = Optional.ofNullable(testExtraQueryStringParametersCopy).orElse(Collections.emptyList()).stream().filter(new Predicate<Pair<String, String>>() {
+            public boolean test(Pair<String, String> p1) {
+                return "dc".equals(p1.first);
+            }
+        }).collect(Collectors.toList());
         if (!dcs.isEmpty()) {
 
         }

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -1,7 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.unit.internal.request;
 
 import android.app.Activity;
-import android.content.Context;
 import android.util.Pair;
 
 import androidx.fragment.app.Fragment;
@@ -13,7 +34,6 @@ import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAu
 import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
-import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.commands.parameters.BrokerInteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.dto.IAccountRecord;
@@ -26,15 +46,17 @@ import com.microsoft.identity.common.internal.request.SdkType;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 import com.microsoft.identity.common.internal.util.StringUtil;
+import com.microsoft.identity.common.unit.MockAccountRecord;
+import com.microsoft.identity.common.unit.MockOauth2TokenCache;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.Robolectric;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,7 +93,8 @@ public class MsalBrokerRequestAdapterTest {
             .build();
     public static final AzureActiveDirectorySlice TEST_SLICE_WITH_NOTHING = AzureActiveDirectorySlice.builder()
             .build();
-    public static final IAccountRecord TEST_ACCOUNT_RECORD = Mockito.mock(IAccountRecord.class);
+    public static final IAccountRecord TEST_ACCOUNT_RECORD = new MockAccountRecord();
+
     public static final List<BrowserDescriptor> TEST_BROWSER_SAFE_LIST = Arrays.asList(
             BrowserDescriptor.builder()
                     .packageName("aBrowser")
@@ -87,7 +110,7 @@ public class MsalBrokerRequestAdapterTest {
     public static final List<Pair<String, String>> TEST_EXTRA_QUERY_STRING_PARAMETERS_SLICE = Arrays.asList(new Pair<String, String>("QPone", "QPtwo"), new Pair<>("slice", "aDifferentSlice"));
     public static final List<String> TEST_EXTRA_SCOPE = Arrays.asList("extraScope");
     public static final String TEST_LOGIN_HINT = "aLoginHint";
-    public static final OAuth2TokenCache TEST_OAUTH_2_TOKEN_CACHE = Mockito.mock(OAuth2TokenCache.class);
+    public static final OAuth2TokenCache TEST_OAUTH_2_TOKEN_CACHE = new MockOauth2TokenCache();
     public static final String TEST_REDIRECT_URI = "aRedirectUri";
     public static final HashMap<String, String> TEST_REQUEST_HEADERS = new HashMap<>(Collections.singletonMap("aHeader", "aValue"));
     public static final String REQUIRED_BROKER_PROTOCOL_VERSION = "3.0";
@@ -143,7 +166,6 @@ public class MsalBrokerRequestAdapterTest {
             .authorityUrl("https://an.authority.url/")
             .build();
     public static final Fragment TEST_FRAGMENT = new Fragment();
-    public static Context mockContext = Mockito.mock(Context.class);
     private final List<AzureActiveDirectorySlice> slices = Arrays.asList(TEST_SLICE_WITH_DC,
             TEST_SLICE_WITH_SLICE, TEST_SLICE_WITH_SLICE_DC, TEST_SLICE_WITH_NOTHING, null);
     @Rule
@@ -443,7 +465,7 @@ public class MsalBrokerRequestAdapterTest {
                 .scopes(testScopes)
                 .build();
         BrokerRequest brokerRequest = adapter.brokerRequestFromAcquireTokenParameters(params);
-        Activity mockActivity = Mockito.mock(Activity.class);
+        Activity mockActivity = Robolectric.buildActivity(Activity.class).get();
         BrokerInteractiveTokenCommandParameters out = adapter.brokerInteactiveParametersFromBrokerRequest(mockActivity, 0, "3.0",
                 brokerRequest);
         Assert.assertEquals(testScopes, out.getScopes());
@@ -497,4 +519,5 @@ public class MsalBrokerRequestAdapterTest {
         Assert.assertEquals(testLoginHint, out.getLoginHint());
         Assert.assertEquals(null, out.getAccount());
     }
+
 }

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -1,0 +1,344 @@
+package com.microsoft.identity.common.unit.internal.request;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.Pair;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
+import com.microsoft.identity.common.internal.authorities.AllAccounts;
+import com.microsoft.identity.common.internal.authorities.AnyOrganizationalAccount;
+import com.microsoft.identity.common.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
+import com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.internal.authscheme.BearerAuthenticationSchemeInternal;
+import com.microsoft.identity.common.internal.broker.BrokerRequest;
+import com.microsoft.identity.common.internal.cache.AccountDeletionRecord;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.commands.parameters.BrokerInteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.dto.Credential;
+import com.microsoft.identity.common.internal.dto.CredentialType;
+import com.microsoft.identity.common.internal.dto.IAccountRecord;
+import com.microsoft.identity.common.internal.dto.IdTokenRecord;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
+import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
+import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
+import com.microsoft.identity.common.internal.providers.oauth2.TokenResponse;
+import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
+import com.microsoft.identity.common.internal.request.SdkType;
+import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
+import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoTestRule;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+@RunWith(RobolectricTestRunner.class)
+public class MsalBrokerRequestAdapterTest {
+
+    public static final String TEST_APPLICATION_NAME = "application";
+    public static final String TEST_APPLICATION_VERSION = "version";
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    public static final boolean CLOUD_IS_VALIDATES = true;
+    public static final String CACHE_HOST_NAME = "cacheHostName";
+    public static final String NETWORK_HOST_NAME = "networkHostName";
+    public static final String TEST_TENANT_ID = "aTenantId";
+    public static final String TEST_CLOUD_URL = "https://login.fabrikam.com";
+    public static final AzureActiveDirectoryAudience TEST_AUDIENCE = AccountsInOneOrganization.builder().tenantId(TEST_TENANT_ID).cloudUrl(TEST_CLOUD_URL)
+            .build();
+    public static final AzureActiveDirectorySlice TEST_SLICE = AzureActiveDirectorySlice.builder().slice("aSlice").dataCenter("dataCenter").build();
+    public static Context mockContext = Mockito.mock(Context.class);
+
+    public static final IAccountRecord TEST_ACCOUNT_RECORD = new IAccountRecord() {
+        @Override
+        public String getHomeAccountId() {
+            return null;
+        }
+
+        @Override
+        public String getEnvironment() {
+            return null;
+        }
+
+        @Override
+        public String getRealm() {
+            return null;
+        }
+
+        @Override
+        public String getLocalAccountId() {
+            return null;
+        }
+
+        @Override
+        public String getUsername() {
+            return null;
+        }
+
+        @Override
+        public String getAuthorityType() {
+            return null;
+        }
+
+        @Override
+        public String getAlternativeAccountId() {
+            return null;
+        }
+
+        @Override
+        public String getFirstName() {
+            return null;
+        }
+
+        @Override
+        public String getFamilyName() {
+            return null;
+        }
+
+        @Override
+        public String getMiddleName() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getAvatarUrl() {
+            return null;
+        }
+
+        @Override
+        public String getClientInfo() {
+            return null;
+        }
+    };
+    public static final List<BrowserDescriptor> TEST_BROWSER_SAFE_LIST = Arrays.asList(
+            BrowserDescriptor.builder()
+                    .packageName("aBrowser")
+                    .signatureHashes(Collections.singleton("browserHash"))
+                    .versionLowerBound("1")
+                    .versionUpperBound("2")
+                    .build());
+    public static final String TEST_CLAIMS_JSON = "{ \"claims\": \"something\"";
+    public static final String TEST_CLIENT_ID = "aClientId";
+    public static final String TEST_CORRELATION_ID = "aCorrelationId";
+    public static final List<Pair<String, String>> TEST_EXTRA_OPTIONS = Arrays.asList(new Pair<String, String>("one", "two"));
+    public static final List<Pair<String, String>> TEST_EXTRA_QUERY_STRING_PARAMETERS = Arrays.asList(new Pair<String, String>("QPone", "QPtwo"));
+    public static final List<String> TEST_EXTRA_SCOPE = Arrays.asList("extraScope");
+    public static final String TEST_LOGIN_HINT = "aLoginHint";
+    public static final OAuth2TokenCache TEST_OAUTH_2_TOKEN_CACHE = new OAuth2TokenCache<OAuth2Strategy, AuthorizationRequest, TokenResponse>(mockContext) {
+        @Override
+        public ICacheRecord save(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
+            return null;
+        }
+
+        @Override
+        public List<ICacheRecord> saveAndLoadAggregatedAccountData(OAuth2Strategy oAuth2Strategy, AuthorizationRequest request, TokenResponse response) throws ClientException {
+            return null;
+        }
+
+        @Override
+        public ICacheRecord save(AccountRecord accountRecord, IdTokenRecord idTokenRecord) {
+            return null;
+        }
+
+        @Override
+        public ICacheRecord load(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authScheme) {
+            return null;
+        }
+
+        @Override
+        public List<ICacheRecord> loadWithAggregatedAccountData(String clientId, String target, AccountRecord account, AbstractAuthenticationScheme authenticationScheme) {
+            return null;
+        }
+
+        @Override
+        public boolean removeCredential(Credential credential) {
+            return false;
+        }
+
+        @Override
+        public AccountRecord getAccount(String environment, String clientId, String homeAccountId, String realm) {
+            return null;
+        }
+
+        @Override
+        public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId, String homeAccountId) {
+            return null;
+        }
+
+        @Override
+        public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
+            return null;
+        }
+
+        @Override
+        public ICacheRecord getAccountWithAggregatedAccountDataByLocalAccountId(String environment, String clientId, String localAccountId) {
+            return null;
+        }
+
+        @Override
+        public List<AccountRecord> getAccounts(String environment, String clientId) {
+            return null;
+        }
+
+        @Override
+        public List<AccountRecord> getAllTenantAccountsForAccountByClientId(String clientId, AccountRecord accountRecord) {
+            return null;
+        }
+
+        @Override
+        public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId) {
+            return null;
+        }
+
+        @Override
+        public List<IdTokenRecord> getIdTokensForAccountRecord(String clientId, AccountRecord accountRecord) {
+            return null;
+        }
+
+        @Override
+        public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm) {
+            return null;
+        }
+
+        @Override
+        public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm, CredentialType... typesToRemove) {
+            return null;
+        }
+
+        @Override
+        public void clearAll() {
+
+        }
+
+        @Override
+        protected Set<String> getAllClientIds() {
+            return null;
+        }
+
+        @Override
+        public AccountRecord getAccountByHomeAccountId(@Nullable String environment, @NonNull String clientId, @NonNull String homeAccountId) {
+            return null;
+        }
+    };
+    public static final String TEST_REDIRECT_URI = "aRedirectUri";
+    public static final HashMap<String, String> TEST_REQUEST_HEADERS = new HashMap<>(Collections.singletonMap("aHeader", "aValue"));
+    public static final String REQUIRED_BROKER_PROTOCOL_VERSION = "3.0";
+    public static final String SDK_VERSION = "sdkVersion";
+    public static final Set<String> TEST_SCOPES = Collections.singleton("aScope");
+    public static final List<String> CLOUD_ALIASES = Arrays.asList("common");
+    public static final String TEST_AUTHORITY_TYPE = "AAD";
+    public static final AzureActiveDirectoryCloud TEST_CLOUD = AzureActiveDirectoryCloud.builder()
+            .cloudHostAliases(CLOUD_ALIASES)
+            .isValidated(CLOUD_IS_VALIDATES)
+            .preferredCacheHostName(CACHE_HOST_NAME)
+            .preferredNetworkHostName(NETWORK_HOST_NAME)
+            .build();
+    public static final AzureActiveDirectoryAuthority TEST_AUTHORITY = AzureActiveDirectoryAuthority.builder()
+            .audience(TEST_AUDIENCE)
+            .slice(TEST_SLICE)
+            .authorityTypeString(TEST_AUTHORITY_TYPE)
+            .azureActiveDirectoryCloud(TEST_CLOUD)
+            .authorityUrl("https://an.authority.url/")
+            .build();
+
+    @Test
+    public void testRequestGeneration() {
+        final MsalBrokerRequestAdapter adapter = new MsalBrokerRequestAdapter();
+        final boolean forceRefresh = true;
+        final Fragment TEST_FRAGMENT = new Fragment();
+        final boolean handleNullTaskAffinity = true;
+        final boolean isSharedDevice = true;
+        final boolean isWebViewZoomControlsEnabled = true;
+        final boolean isWebViewZoomEnabled = true;
+        final boolean powerOptCheckEnabled = true;
+        final OpenIdConnectPromptParameter promptParameter = OpenIdConnectPromptParameter.LOGIN;
+        final SdkType sdkType = SdkType.ADAL;
+        InteractiveTokenCommandParameters params = InteractiveTokenCommandParameters.builder()
+                .authority(TEST_AUTHORITY)
+                .activity(new Activity())
+                .applicationName(TEST_APPLICATION_NAME)
+                .applicationVersion(TEST_APPLICATION_VERSION)
+                .authenticationScheme(BearerAuthenticationSchemeInternal.builder().build())
+                .authorizationAgent(AuthorizationAgent.BROWSER)
+                .brokerBrowserSupportEnabled(false)
+                .browserSafeList(TEST_BROWSER_SAFE_LIST)
+                .account(TEST_ACCOUNT_RECORD)
+                .claimsRequestJson(TEST_CLAIMS_JSON)
+                .clientId(TEST_CLIENT_ID)
+                .correlationId(TEST_CORRELATION_ID)
+                .extraOptions(TEST_EXTRA_OPTIONS)
+                .extraQueryStringParameters(TEST_EXTRA_QUERY_STRING_PARAMETERS)
+                .extraScopesToConsent(TEST_EXTRA_SCOPE)
+                .forceRefresh(forceRefresh)
+                .fragment(TEST_FRAGMENT)
+                .handleNullTaskAffinity(handleNullTaskAffinity)
+                .isSharedDevice(isSharedDevice)
+                .isWebViewZoomControlsEnabled(isWebViewZoomControlsEnabled)
+                .isWebViewZoomEnabled(isWebViewZoomEnabled)
+                .loginHint(TEST_LOGIN_HINT)
+                .oAuth2TokenCache(TEST_OAUTH_2_TOKEN_CACHE)
+                .powerOptCheckEnabled(powerOptCheckEnabled)
+                .prompt(promptParameter)
+                .redirectUri(TEST_REDIRECT_URI)
+                .requestHeaders(TEST_REQUEST_HEADERS)
+                .requiredBrokerProtocolVersion(REQUIRED_BROKER_PROTOCOL_VERSION)
+                .sdkType(sdkType)
+                .sdkVersion(SDK_VERSION)
+                .scopes(TEST_SCOPES)
+                .build();
+        BrokerRequest brokerRequest = adapter.brokerRequestFromAcquireTokenParameters(params);
+        Activity mockActivity = Mockito.mock(Activity.class);
+        BrokerInteractiveTokenCommandParameters out = adapter.BrokerInteactiveParametersFromBrokerRequest(mockActivity, 0, "3.0",
+                brokerRequest);
+        Assert.assertEquals(TEST_SCOPES, out.getScopes());
+        Assert.assertEquals(null, out.getFragment());
+        Assert.assertEquals(TEST_AUTHORITY, out.getAuthority());
+        Assert.assertEquals(sdkType, out.getSdkType());
+        Assert.assertEquals(SDK_VERSION, out.getSdkVersion());
+        Assert.assertEquals(TEST_APPLICATION_NAME, out.getApplicationName());
+        Assert.assertEquals(TEST_APPLICATION_VERSION, out.getApplicationVersion());
+        Assert.assertEquals(TEST_EXTRA_OPTIONS, out.getExtraOptions());
+        Assert.assertEquals(null, out.getBrowserSafeList());
+        Assert.assertEquals(TEST_CLAIMS_JSON, out.getClaimsRequestJson());
+        Assert.assertEquals(TEST_CLIENT_ID, out.getClientId());
+        Assert.assertEquals(TEST_CORRELATION_ID, out.getCorrelationId());
+        Assert.assertEquals(TEST_LOGIN_HINT, out.getLoginHint());
+        Assert.assertEquals(null, out.getAccount());
+    }
+
+    @Test
+    public void authorityFromUrlTest() {
+        AzureActiveDirectoryAuthority a = (AzureActiveDirectoryAuthority) Authority.getAuthorityFromAuthorityUrl("https://login.fabrikam.com/aTenantId");
+        Assert.assertEquals("https://login.fabrikam.com/aTenantId", a.getAuthorityURL().toString());
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/internal/request/MsalBrokerRequestAdapterTest.java
@@ -10,8 +10,6 @@ import androidx.fragment.app.Fragment;
 
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
-import com.microsoft.identity.common.internal.authorities.AllAccounts;
-import com.microsoft.identity.common.internal.authorities.AnyOrganizationalAccount;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
@@ -45,9 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
-import org.mockito.junit.MockitoTestRule;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Arrays;
@@ -318,7 +314,7 @@ public class MsalBrokerRequestAdapterTest {
                 .build();
         BrokerRequest brokerRequest = adapter.brokerRequestFromAcquireTokenParameters(params);
         Activity mockActivity = Mockito.mock(Activity.class);
-        BrokerInteractiveTokenCommandParameters out = adapter.BrokerInteactiveParametersFromBrokerRequest(mockActivity, 0, "3.0",
+        BrokerInteractiveTokenCommandParameters out = adapter.brokerInteactiveParametersFromBrokerRequest(mockActivity, 0, "3.0",
                 brokerRequest);
         Assert.assertEquals(TEST_SCOPES, out.getScopes());
         Assert.assertEquals(null, out.getFragment());


### PR DESCRIPTION
We used to have slice and dc parameters propagate through the broker.  We stopped that, which is confusing.  Users can completely bypass this modeled method, by putting them in the extraQueryParamters which is used as a bag to transmit them across to the broker anyway.