### PR TITLE
Migrate Device, ObjectMapper, ClockSkewManager and IHasExtraParameters to common4j

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Migrate Device, ObjectMapper, ClockSkewManager and IHasExtraParameters to common4j (#1383)
 - [MINOR] Migrate eSTS Telemetry to common4j (#1372)
 - [PATCH] Fix/Suppress SpotBugs issue (#1367)
 - [MINOR] Migrate HTTP Layer to common java lib. (#1347)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -569,7 +569,7 @@ public final class AuthenticationConstants {
         /**
          * String of ADAL version.
          */
-        public static final String ADAL_ID_VERSION = "x-client-Ver";
+        public static final String ADAL_ID_VERSION = com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
 
         /**
          * String of ADAL id CPU.
@@ -1870,7 +1870,7 @@ public final class AuthenticationConstants {
         /**
          * The String representing the sdk version.
          */
-        public static final String VERSION = "x-client-Ver";
+        public static final String VERSION = com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
 
         /**
          * The String representing the MSAL SdkType.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1870,6 +1870,7 @@ public final class AuthenticationConstants {
         /**
          * The String representing the sdk version.
          */
+        @Deprecated
         public static final String VERSION = com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
 
         /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/AuthenticationSchemeFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/AuthenticationSchemeFactory.java
@@ -28,7 +28,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.logging.Logger;
 
 /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authscheme/PopAuthenticationSchemeInternal.java
@@ -28,7 +28,7 @@ import androidx.annotation.Nullable;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.platform.Device;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 
 import java.net.URL;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.internal.request.BrokerRequestType;
+import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
 
 import java.util.Map;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -286,7 +286,7 @@ public abstract class BaseController {
             ((MicrosoftTokenRequest) tokenRequest).setClientAppVersion(parameters.getApplicationVersion());
         }
 
-        if (tokenRequest instanceof IHasExtraParameters && parameters instanceof IHasExtraParameters) {
+        if (parameters instanceof IHasExtraParameters) {
             ((IHasExtraParameters) tokenRequest).setExtraParameters(((IHasExtraParameters)parameters).getExtraParameters());
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BaseController.java
@@ -47,7 +47,7 @@ import com.microsoft.identity.common.internal.commands.parameters.BrokerSilentTo
 import com.microsoft.identity.common.internal.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.DeviceCodeFlowCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.GenerateShrCommandParameters;
-import com.microsoft.identity.common.internal.commands.parameters.IHasExtraParameters;
+import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
 import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.RemoveAccountCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -68,7 +68,7 @@ import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
 import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
 import com.microsoft.identity.common.internal.ui.AuthorizationStrategyFactory;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.internal.util.ThreadUtils;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.logging.Logger;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -1,0 +1,36 @@
+package com.microsoft.identity.common.internal.platform;
+
+import android.os.Build;
+
+import com.microsoft.identity.common.java.platform.IDeviceMetadata;
+
+public class AndroidDeviceMetadata implements IDeviceMetadata {
+    @Override
+    public String getCpu() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            //CPU_ABI has been deprecated
+            return Build.CPU_ABI;
+        } else {
+            final String[] supportedABIs = Build.SUPPORTED_ABIS;
+            if (supportedABIs != null && supportedABIs.length > 0) {
+                return supportedABIs[0];
+            }
+        }
+        return "UNKNOWN";
+    }
+
+    @Override
+    public String getOs() {
+        return String.valueOf(Build.VERSION.SDK_INT);
+    }
+
+    @Override
+    public String getDeviceModel() {
+        return Build.MODEL;
+    }
+
+    @Override
+    public String getManufacturer() {
+        return Build.MANUFACTURER;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -1,9 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
 import android.os.Build;
 
 import com.microsoft.identity.common.java.platform.IDeviceMetadata;
 
+/**
+ * Provides device metadata in Android.
+ **/
 public class AndroidDeviceMetadata implements IDeviceMetadata {
     @Override
     public String getCpu() {
@@ -34,3 +59,4 @@ public class AndroidDeviceMetadata implements IDeviceMetadata {
         return Build.MANUFACTURER;
     }
 }
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
@@ -22,116 +22,28 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
-import android.os.Build;
-import android.text.TextUtils;
-
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.logging.DiagnosticContext;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Helper class to add additional platform specific query parameters or headers for the request sent to sts.
+ * A static class holding device data.
  */
-public final class Device {
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
+        justification = "This class kept its original name to avoid breaking change during the refactoring process." +
+                "Once the process is done, this class will be removed entirely. ")
+public final class Device extends com.microsoft.identity.common.java.platform.Device {
 
     private static IDevicePopManager sDevicePoPManager;
 
-    /**
-     * The String representing the sdk platform version.
-     */
-    public static final String PRODUCT_VERSION = "2.0.2";
-
-    /**
-     * Private constructor to prevent a help class from being initiated.
-     */
-    private Device() {
-    }
-
-    @SuppressWarnings("deprecation")
-    public static Map<String, String> getPlatformIdParameters() {
-        final Map<String, String> platformParameters = new HashMap<>();
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            //CPU_ABI has been deprecated
-            platformParameters.put(PlatformIdParameters.CPU_PLATFORM, Build.CPU_ABI);
-        } else {
-            final String[] supportedABIs = Build.SUPPORTED_ABIS;
-
-            if (supportedABIs != null && supportedABIs.length > 0) {
-                platformParameters.put(PlatformIdParameters.CPU_PLATFORM, supportedABIs[0]);
-            }
-        }
-
-        platformParameters.put(PlatformIdParameters.OS, String.valueOf(Build.VERSION.SDK_INT));
-        platformParameters.put(PlatformIdParameters.DEVICE_MODEL, Build.MODEL);
-
-        return Collections.unmodifiableMap(platformParameters);
-    }
-
-    public static String getProductVersion() {
-        final String version = DiagnosticContext.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION);
-        if (TextUtils.isEmpty(version)) {
-            return PRODUCT_VERSION;
-        } else {
-            return version;
-        }
-    }
-
-    public static final class PlatformIdParameters {
-        /**
-         * The String representing the CPU for the device.
-         */
-        public static final String CPU_PLATFORM = "x-client-CPU";
-
-        /**
-         * The String representing the device OS.
-         */
-        public static final String OS = "x-client-OS";
-
-        /**
-         * The String representing the device model.
-         */
-        public static final String DEVICE_MODEL = "x-client-DM";
-
-        /**
-         * String for the broker version.
-         */
-        public static final String BROKER_VERSION = "x-client-brkrver";
-    }
-
-    /**
-     * Gets the API level of the current runtime.
-     *
-     * @return The API level.
-     */
-    public static int getApiLevel() {
-        return Build.VERSION.SDK_INT;
-    }
-
-    /**
-     * Gets the manufacturer of the current device.
-     *
-     * @return The name of the device manufacturer.
-     */
-    public static String getManufacturer() {
-        return Build.MANUFACTURER;
-    }
-
-    /**
-     * Gets the model name/code of the current device.
-     *
-     * @return The device model name.
-     */
-    public static String getModel() {
-        return Build.MODEL;
+    // Note: this needs to be invoked at the beginning of an android flow.
+    static {
+        com.microsoft.identity.common.java.platform.Device.setDeviceMetadata(new AndroidDeviceMetadata());
     }
 
     public static synchronized IDevicePopManager getDevicePoPManagerInstance() throws ClientException {
@@ -139,7 +51,6 @@ public final class Device {
             if (null == sDevicePoPManager) {
                 sDevicePoPManager = new DevicePopManager();
             }
-
             return sDevicePoPManager;
         } catch (CertificateException
                 | NoSuchAlgorithmException

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/Device.java
@@ -41,7 +41,7 @@ public final class Device extends com.microsoft.identity.common.java.platform.De
 
     private static IDevicePopManager sDevicePoPManager;
 
-    // Note: this needs to be invoked at the beginning of an android flow.
+    // TODO: this needs to be invoked at the beginning of an android flow.
     static {
         com.microsoft.identity.common.java.platform.Device.setDeviceMetadata(new AndroidDeviceMetadata());
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePoPUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePoPUtils.java
@@ -29,7 +29,7 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.authscheme.IPoPAuthenticationSchemeParams;
 import com.microsoft.identity.common.internal.result.GenerateShrResult;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 
 import java.net.URL;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/MicrosoftTokenRequest.java
@@ -26,7 +26,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import com.microsoft.identity.common.internal.commands.parameters.IHasExtraParameters;
+import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 
 import java.util.UUID;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/OAuth2Strategy.java
@@ -52,7 +52,7 @@ import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.M
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.io.IOException;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/TokenRequest.java
@@ -26,7 +26,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import com.microsoft.identity.common.internal.commands.parameters.IHasExtraParameters;
+import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
 
 import java.util.Map;
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -60,7 +60,7 @@ import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 import com.microsoft.identity.common.internal.util.BrokerProtocolVersionUtil;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
+import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.internal.util.QueryParamsAdapter;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AbstractSharedPrefKeyPairStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AbstractSharedPrefKeyPairStorage.java
@@ -29,20 +29,19 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 /**
- * Adapts {@link ISharedPreferencesFileManager} to {@link IKeyPairStorage<Long>}
+ * Adapts {@link ISharedPreferencesFileManager} to {@link IKeyPairStorage}
  * */
-public class SharedPrefLongKeyPairStorage extends AbstractSharedPrefKeyPairStorage<Long> {
-    public SharedPrefLongKeyPairStorage(ISharedPreferencesFileManager mManager) {
-        super(mManager);
+@AllArgsConstructor
+public abstract class AbstractSharedPrefKeyPairStorage<T> implements IKeyPairStorage<T> {
+    protected ISharedPreferencesFileManager mManager;
+
+    @Override
+    public void remove(@NonNull String key) {
+        mManager.remove(key);
     }
 
     @Override
-    public Long get(@NonNull String key) {
-        return mManager.getLong(key);
-    }
-
-    @Override
-    public void put(@NonNull String key, Long value) {
-        mManager.putLong(key, value);
+    public void clear() {
+        mManager.clear();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -23,17 +23,12 @@
 package com.microsoft.identity.common.internal.util;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
-
-import java.util.Calendar;
-import java.util.Date;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -47,64 +42,23 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class ClockSkewManager extends com.microsoft.identity.common.java.util.ClockSkewManager {
 
     private static final class PreferencesMetadata {
-
         private static final String SKEW_PREFERENCES_FILENAME =
                 "com.microsoft.identity.client.clock_correction";
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public ClockSkewManager(@NonNull final ISharedPreferencesFileManager manager) {
-        super(new IKeyPairStorage<Long>() {
-            @Override
-            public Long get(@lombok.NonNull String key) {
-                return manager.getLong(key);
-            }
-
-            @Override
-            public void put(@lombok.NonNull String key, Long value) {
-                manager.putLong(key, value);
-            }
-
-            @Override
-            public void remove(@lombok.NonNull String key) {
-                manager.remove(key);
-            }
-
-            @Override
-            public void clear() {
-                manager.clear();
-            }
-        });
+        super(new SharedPrefLongKeyPairStorage(manager));
     }
 
     public ClockSkewManager(@NonNull final Context context) {
-        super(new IKeyPairStorage<Long>() {
-            final SharedPreferencesFileManager clockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
-                    context,
-                    PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
-                    -1,
-                    null
-            );
-
-            @Override
-            public Long get(@lombok.NonNull String key) {
-                return clockSkewPreferences.getLong(key);
-            }
-
-            @Override
-            public void put(@lombok.NonNull String key, Long value) {
-                clockSkewPreferences.putLong(key, value);
-            }
-
-            @Override
-            public void remove(@lombok.NonNull String key) {
-                clockSkewPreferences.remove(key);
-            }
-
-            @Override
-            public void clear() {
-                clockSkewPreferences.clear();
-            }
-        });
+        super(new SharedPrefLongKeyPairStorage(
+                SharedPreferencesFileManager.getSharedPreferences(
+                        context,
+                        PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
+                        -1,
+                        null
+                )
+        ));
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -23,71 +23,88 @@
 package com.microsoft.identity.common.internal.util;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
 
 import java.util.Calendar;
 import java.util.Date;
 
-public class ClockSkewManager implements IClockSkewManager {
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Deprecated
+ * Currently serving as an adapter of {@link com.microsoft.identity.common.java.util.ClockSkewManager}
+ */
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
+        justification = "This class kept its original name to avoid breaking change during the refactoring process." +
+                "Once the process is done, this class will be removed entirely. ")
+public class ClockSkewManager extends com.microsoft.identity.common.java.util.ClockSkewManager {
 
     private static final class PreferencesMetadata {
 
         private static final String SKEW_PREFERENCES_FILENAME =
                 "com.microsoft.identity.client.clock_correction";
-
-        private static final String KEY_SKEW = "skew";
     }
-
-    private ISharedPreferencesFileManager mClockSkewPreferences;
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public ClockSkewManager(@NonNull final ISharedPreferencesFileManager manager) {
-        mClockSkewPreferences = manager;
+        super(new IKeyPairStorage<Long>() {
+            @Override
+            public Long get(@lombok.NonNull String key) {
+                return manager.getLong(key);
+            }
+
+            @Override
+            public void put(@lombok.NonNull String key, Long value) {
+                manager.putLong(key, value);
+            }
+
+            @Override
+            public void remove(@lombok.NonNull String key) {
+                manager.remove(key);
+            }
+
+            @Override
+            public void clear() {
+                manager.clear();
+            }
+        });
     }
 
     public ClockSkewManager(@NonNull final Context context) {
-        mClockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
-                context,
-                PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
-                -1,
-                null
-        );
-    }
+        super(new IKeyPairStorage<Long>() {
+            final SharedPreferencesFileManager clockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
+                    context,
+                    PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
+                    -1,
+                    null
+            );
 
-    @Override
-    public void onTimestampReceived(long referenceTime) {
-        final long clientTime = getCurrentClientTime().getTime();
-        final long skewMillis = clientTime - referenceTime;
-        mClockSkewPreferences.putLong(PreferencesMetadata.KEY_SKEW, skewMillis);
-    }
+            @Override
+            public Long get(@lombok.NonNull String key) {
+                return clockSkewPreferences.getLong(key);
+            }
 
-    @Override
-    public long getSkewMillis() {
-        return mClockSkewPreferences.getLong(PreferencesMetadata.KEY_SKEW);
-    }
+            @Override
+            public void put(@lombok.NonNull String key, Long value) {
+                clockSkewPreferences.putLong(key, value);
+            }
 
-    @Override
-    public Date toClientTime(long referenceTime) {
-        return new Date(referenceTime + getSkewMillis());
-    }
+            @Override
+            public void remove(@lombok.NonNull String key) {
+                clockSkewPreferences.remove(key);
+            }
 
-    @Override
-    public Date toReferenceTime(long clientTime) {
-        return new Date(clientTime - getSkewMillis());
-    }
-
-    @Override
-    public Date getCurrentClientTime() {
-        return Calendar.getInstance().getTime();
-    }
-
-    @Override
-    public Date getAdjustedReferenceTime() {
-        return toReferenceTime(getCurrentClientTime().getTime());
+            @Override
+            public void clear() {
+                clockSkewPreferences.clear();
+            }
+        });
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefLongKeyPairStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefLongKeyPairStorage.java
@@ -20,33 +20,38 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.java.platform;
+package com.microsoft.identity.common.internal.util;
 
-public class MockDeviceMetadata implements IDeviceMetadata {
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
 
-    static final String TEST_CPU = "TestCPU";
-    static final String TEST_OS = "TestOS";
-    static final String TEST_DEVICE_MODEL = "TestDeviceModel";
-    static final String TEST_MANUFACTURER = "TestManufacturer";
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * Adapts {@link ISharedPreferencesFileManager} to {@link IKeyPairStorage<Long>}
+ * */
+@AllArgsConstructor
+public class SharedPrefLongKeyPairStorage implements IKeyPairStorage<Long> {
+    private ISharedPreferencesFileManager mManager;
 
     @Override
-    public String getCpu() {
-        return TEST_CPU;
+    public Long get(@NonNull String key) {
+        return mManager.getLong(key);
     }
 
     @Override
-    public String getOs() {
-        return TEST_OS;
+    public void put(@NonNull String key, Long value) {
+        mManager.putLong(key, value);
     }
 
     @Override
-    public String getDeviceModel() {
-        return TEST_DEVICE_MODEL;
+    public void remove(@NonNull String key) {
+        mManager.remove(key);
     }
 
     @Override
-    public String getManufacturer() {
-        return TEST_MANUFACTURER;
+    public void clear() {
+        mManager.clear();
     }
 }
-

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/parameters/GenerateShrCommandParametersTest.java
@@ -29,7 +29,6 @@ import com.microsoft.identity.common.internal.commands.CommandCallback;
 import com.microsoft.identity.common.internal.commands.GenerateShrCommand;
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
 import com.microsoft.identity.common.internal.util.UrlUtils;
 
 import org.junit.Assert;

--- a/common4j/changes.md
+++ b/common4j/changes.md
@@ -1,0 +1,4 @@
+### Common to Common4j migration.
+
+- If a class that you're consuming from package `com.microsoft.identity.common` is not found, look for one in `com.microsoft.identity.common.java`
+- The class *might* have a new, abstracted, interface. This document will keep track of what to do in order to consume those interfaces.

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -30,9 +30,14 @@ import lombok.NoArgsConstructor;
 public class AuthenticationConstants {
 
     /**
+     * The Constant UTF8.
+     */
+    public static final String ENCODING_UTF8_STRING = "UTF-8";
+
+    /**
      * The Constant ENCODING_UTF8.
      */
-    public static final Charset ENCODING_UTF8 = Charset.forName("UTF-8");
+    public static final Charset ENCODING_UTF8 = Charset.forName(ENCODING_UTF8_STRING);
 
     /**
      * Represents the constants value for Active Directory.
@@ -43,5 +48,15 @@ public class AuthenticationConstants {
          * String of client request id.
          */
         public static final String CLIENT_REQUEST_ID = "client-request-id";
+    }
+
+    /**
+     * Sdk platform and Sdk version fields.
+     */
+    public static final class SdkPlatformFields {
+        /**
+         * The String representing the sdk version.
+         */
+        public static final String VERSION = "x-client-Ver";
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IHasExtraParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IHasExtraParameters.java
@@ -20,9 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.internal.commands.parameters;
-
-import androidx.annotation.Nullable;
+package com.microsoft.identity.common.java.commands.parameters;
 
 import java.util.Map;
 
@@ -37,8 +35,8 @@ public interface IHasExtraParameters {
      * mutated by the caller, and attempts to do so <strong>may</strong>may throw
      * {@link UnsupportedOperationException} or result in undefined behavior.
      */
-    @Nullable Iterable<Map.Entry<String, String>> getExtraParameters();
-    
+    Iterable<Map.Entry<String, String>> getExtraParameters();
+
     /**
      * Set the {@link Iterable} of String, String extra parameters.
      * @param params a list of pairs of String, String parameters.  May be null.  There are no

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -1,0 +1,163 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.platform;
+
+import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
+import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.StringUtil;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import lombok.NonNull;
+
+/**
+ * Helper class to add additional platform specific query parameters or headers for the request sent to sts.
+ */
+public class Device {
+    private static final String TAG = Device.class.getSimpleName();
+
+    /**
+     * The String to be returned if the value is not set properly.
+     */
+    protected static final String NOT_SET = "NOT_SET";
+
+    private static IDeviceMetadata sDeviceMetadata;
+
+    private static final ReentrantReadWriteLock sLock = new ReentrantReadWriteLock();
+
+    public static void setDeviceMetadata(@NonNull final IDeviceMetadata deviceMetadata) {
+        sLock.writeLock().lock();
+        try {
+            sDeviceMetadata = deviceMetadata;
+        } finally {
+            sLock.writeLock().unlock();
+        }
+    }
+
+    // Visible for testing only.
+    static void clearDeviceMetadata(){
+        sLock.writeLock().lock();
+        try {
+            sDeviceMetadata = null;
+        } finally {
+            sLock.writeLock().unlock();
+        }
+    }
+
+    @NonNull
+    public static Map<String, String> getPlatformIdParameters() {
+        sLock.readLock().lock();
+        try {
+            final Map<String, String> platformParameters = new HashMap<>();
+
+            if (sDeviceMetadata != null) {
+                platformParameters.put(PlatformIdParameters.CPU_PLATFORM, sDeviceMetadata.getCpu());
+                platformParameters.put(PlatformIdParameters.OS, sDeviceMetadata.getOs());
+                platformParameters.put(PlatformIdParameters.DEVICE_MODEL, sDeviceMetadata.getDeviceModel());
+            } else {
+                platformParameters.put(PlatformIdParameters.CPU_PLATFORM, NOT_SET);
+                platformParameters.put(PlatformIdParameters.OS, NOT_SET);
+                platformParameters.put(PlatformIdParameters.DEVICE_MODEL, NOT_SET);
+            }
+
+            return Collections.unmodifiableMap(platformParameters);
+        } finally {
+            sLock.readLock().unlock();
+        }
+    }
+
+    @NonNull
+    public static String getProductVersion() {
+        final String methodName = ":getProductVersion";
+
+        final String version = DiagnosticContext.INSTANCE.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION);
+        if (StringUtil.isNullOrEmpty(version)) {
+            Logger.warn(TAG + methodName, "Product version is not set.");
+            return NOT_SET;
+        } else {
+            return version;
+        }
+    }
+
+    public static final class PlatformIdParameters {
+        /**
+         * The String representing the CPU for the device.
+         */
+        public static final String CPU_PLATFORM = "x-client-CPU";
+
+        /**
+         * The String representing the device OS.
+         */
+        public static final String OS = "x-client-OS";
+
+        /**
+         * The String representing the device model.
+         */
+        public static final String DEVICE_MODEL = "x-client-DM";
+
+        /**
+         * String for the broker version.
+         */
+        public static final String BROKER_VERSION = "x-client-brkrver";
+    }
+
+    /**
+     * Gets the manufacturer of the current device.
+     *
+     * @return The name of the device manufacturer.
+     */
+    @NonNull
+    public static String getManufacturer() {
+        sLock.readLock().lock();
+        try {
+            if (sDeviceMetadata != null) {
+                return sDeviceMetadata.getManufacturer();
+            }
+            return NOT_SET;
+        } finally {
+            sLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Gets the model name/code of the current device.
+     *
+     * @return The device model name.
+     */
+    @NonNull
+    public static String getModel() {
+        sLock.readLock().lock();
+        try {
+            if (sDeviceMetadata != null) {
+                return sDeviceMetadata.getDeviceModel();
+            }
+            return NOT_SET;
+        } finally {
+            sLock.readLock().unlock();
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -35,13 +35,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.NonNull;
 
 /**
- * Helper class to add additional platform specific query parameters or headers for the request sent to sts.
+ * Helper class to add additional platform specific query parameters or headers for the request sent to eSTS.
  */
 public class Device {
     private static final String TAG = Device.class.getSimpleName();
 
     /**
-     * The String to be returned if the value is not set properly.
+     * The String to be returned if the value is not set.
      */
     protected static final String NOT_SET = "NOT_SET";
 
@@ -144,7 +144,7 @@ public class Device {
     }
 
     /**
-     * Gets the model name/code of the current device.
+     * Gets the model name of the current device.
      *
      * @return The device model name.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
@@ -20,9 +20,24 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.internal.providers.oauth2;
+package com.microsoft.identity.common.java.platform;
 
-import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
+import lombok.NonNull;
 
-public interface ISuccessResponse extends IHasExtraParameters {
+/**
+ * An interface representing metadata of the device.
+ * The implementation of its child varies from platform to platform.
+ */
+public interface IDeviceMetadata {
+    @NonNull
+    String getCpu();
+
+    @NonNull
+    String getOs();
+
+    @NonNull
+    String getDeviceModel();
+
+    @NonNull
+    String getManufacturer();
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ClockSkewManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ClockSkewManager.java
@@ -1,0 +1,76 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.util;
+
+import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import lombok.NonNull;
+
+public class ClockSkewManager implements IClockSkewManager {
+
+    private static final class PreferencesMetadata {
+        private static final String KEY_SKEW = "skew";
+    }
+
+    private final IKeyPairStorage<Long> mClockSkewStorage;
+
+    public ClockSkewManager(@NonNull final IKeyPairStorage<Long> storage) {
+        mClockSkewStorage = storage;
+    }
+
+    @Override
+    public void onTimestampReceived(long referenceTime) {
+        final long clientTime = getCurrentClientTime().getTime();
+        final long skewMillis = clientTime - referenceTime;
+        mClockSkewStorage.put(PreferencesMetadata.KEY_SKEW, skewMillis);
+    }
+
+    @Override
+    public long getSkewMillis() {
+        return mClockSkewStorage.get(PreferencesMetadata.KEY_SKEW);
+    }
+
+    @Override
+    public Date toClientTime(long referenceTime) {
+        return new Date(referenceTime + getSkewMillis());
+    }
+
+    @Override
+    public Date toReferenceTime(long clientTime) {
+        return new Date(clientTime - getSkewMillis());
+    }
+
+    @Override
+    public Date getCurrentClientTime() {
+        return Calendar.getInstance().getTime();
+    }
+
+    @Override
+    public Date getAdjustedReferenceTime() {
+        return toReferenceTime(getCurrentClientTime().getTime());
+    }
+}
+

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IClockSkewManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IClockSkewManager.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.internal.util;
+package com.microsoft.identity.common.java.util;
 
 import java.util.Date;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ObjectMapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ObjectMapper.java
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.util;
 
-import androidx.annotation.NonNull;
+import lombok.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -32,11 +32,10 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
-import com.microsoft.identity.common.WarningType;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.internal.commands.parameters.IHasExtraParameters;
-import com.microsoft.identity.common.internal.util.StringUtil;
-import com.microsoft.identity.common.logging.Logger;
+import com.microsoft.identity.common.java.WarningType;
+import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.common.java.commands.parameters.IHasExtraParameters;
+import com.microsoft.identity.common.java.logging.Logger;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -72,7 +71,7 @@ public final class ObjectMapper {
      * track of the last seen name, and then when we get called to skip a value, if it will be a string, save it in a map.
      * This map is linked to preserve the order of the parameters for testing use.  At the end of this process, we
      * store the resulting Iterable in the object that can accept it.
-     * 
+     *
      * In order to do this, we're providing a completely fake reader object to a new json reader and then
      * delegating all of its operations away.
      */
@@ -104,6 +103,7 @@ public final class ObjectMapper {
                         };
                         final JsonReader jsonReader = new JsonReader(reader) {
                             String lastName = null;
+
                             public void beginArray() throws IOException {
                                 in.beginArray();
                             }
@@ -244,13 +244,14 @@ public final class ObjectMapper {
 
         final StringBuilder builder = new StringBuilder();
 
-        Iterator<TreeMap.Entry<String, String>> iterator = fields.entrySet().iterator();
+        Iterator<Map.Entry<String, String>> iterator = fields.entrySet().iterator();
 
+        //URLEncoder.encode doesn't support (String, Charset) in JDK 7,8
         while (iterator.hasNext()) {
-            TreeMap.Entry<String, String> entry = iterator.next();
-            builder.append(URLEncoder.encode(entry.getKey(), AuthenticationConstants.ENCODING_UTF8));
+            Map.Entry<String, String> entry = iterator.next();
+            builder.append(URLEncoder.encode(entry.getKey(), AuthenticationConstants.ENCODING_UTF8_STRING));
             builder.append('=');
-            builder.append(URLEncoder.encode(entry.getValue(), AuthenticationConstants.ENCODING_UTF8));
+            builder.append(URLEncoder.encode(entry.getValue(), AuthenticationConstants.ENCODING_UTF8_STRING));
 
             if (iterator.hasNext()) {
                 builder.append('&');
@@ -290,7 +291,7 @@ public final class ObjectMapper {
      * Method to serialize the object into a map.
      *
      * @param object Object
-     * @return Map<String,Object>
+     * @return Map<String, Object>
      */
     public static Map<String, Object> serializeObjectHashMap(final Object object) {
         String json = ObjectMapper.serializeObjectToJsonString(object);
@@ -312,7 +313,7 @@ public final class ObjectMapper {
     public static Map<String, String> deserializeQueryStringToMap(final String queryString) {
         final Map<String, String> decodedUrlMap = new HashMap<>();
 
-        if (StringUtil.isEmpty(queryString)) {
+        if (StringUtil.isNullOrEmpty(queryString)) {
             return decodedUrlMap;
         }
 
@@ -329,7 +330,7 @@ public final class ObjectMapper {
                 final String key = URLDecoder.decode(elements[0], ENCODING_SCHEME);
                 final String value = URLDecoder.decode(elements[1], ENCODING_SCHEME);
 
-                if (!StringUtil.isEmpty(key) && !StringUtil.isEmpty(value)) {
+                if (!StringUtil.isNullOrEmpty(key) && !StringUtil.isNullOrEmpty(value)) {
                     decodedUrlMap.put(key, value);
                 }
             } catch (final UnsupportedEncodingException e) {
@@ -340,3 +341,4 @@ public final class ObjectMapper {
         return decodedUrlMap;
     }
 }
+

--- a/common4j/src/test/com/microsoft/identity/common/java/InMemoryStorage.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/InMemoryStorage.java
@@ -28,21 +28,21 @@ import java.util.HashMap;
 
 import lombok.NonNull;
 
-public class InMemoryStorage implements IKeyPairStorage<String> {
+public class InMemoryStorage<T> implements IKeyPairStorage<T> {
 
-    final HashMap<String, String> mMap = new HashMap<>();
+    final HashMap<String, T> mMap = new HashMap<>();
 
     public int size(){
         return mMap.size();
     }
 
     @Override
-    public String get(final String key) {
+    public T get(final String key) {
         return mMap.get(key);
     }
 
     @Override
-    public void put(final String key, final String value) {
+    public void put(final String key, final T value) {
         mMap.put(key, value);
     }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
@@ -30,12 +30,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import lombok.val;
+import java.util.Map;
 
 /**
  * Tests for {@link com.microsoft.identity.common.java.platform.Device}.
  */
 public class DeviceTest {
+
+    final String NOT_SET = "NOT_SET";
+    final String TEST_VERSION = "TEST_VERSION";
 
     @After
     public void setUp() {
@@ -45,50 +48,50 @@ public class DeviceTest {
     @Test
     public void testGetDataWhenMetadataIsNotSet(){
         // Shouldn't crash.
-        val platformParameter = Device.getPlatformIdParameters();
+        final Map<String, String> platformParameter = Device.getPlatformIdParameters();
         Assert.assertEquals(3, platformParameter.size());
-        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
-        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
-        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.OS));
+        Assert.assertEquals(NOT_SET, platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
+        Assert.assertEquals(NOT_SET, platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
+        Assert.assertEquals(NOT_SET, platformParameter.get(Device.PlatformIdParameters.OS));
 
-        Assert.assertEquals("NOT_SET", Device.getManufacturer());
-        Assert.assertEquals("NOT_SET", Device.getModel());
-        Assert.assertEquals("NOT_SET", Device.getProductVersion());
+        Assert.assertEquals(NOT_SET, Device.getManufacturer());
+        Assert.assertEquals(NOT_SET, Device.getModel());
+        Assert.assertEquals(NOT_SET, Device.getProductVersion());
     }
 
     @Test
     public void testGetPlatformIdParameters(){
         Device.setDeviceMetadata(new MockDeviceMetadata());
 
-        val platformParameter = Device.getPlatformIdParameters();
+        final Map<String, String> platformParameter = Device.getPlatformIdParameters();
         Assert.assertEquals(3, platformParameter.size());
-        Assert.assertEquals(MockDeviceMetadata.testCPU, platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
-        Assert.assertEquals(MockDeviceMetadata.testDeviceModel, platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
-        Assert.assertEquals(MockDeviceMetadata.testOS, platformParameter.get(Device.PlatformIdParameters.OS));
+        Assert.assertEquals(MockDeviceMetadata.TEST_CPU, platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
+        Assert.assertEquals(MockDeviceMetadata.TEST_DEVICE_MODEL, platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
+        Assert.assertEquals(MockDeviceMetadata.TEST_OS, platformParameter.get(Device.PlatformIdParameters.OS));
     }
 
     @Test
     public void testGetProductVersion_DiagContextNotSet(){
-        Assert.assertEquals("NOT_SET", Device.getProductVersion());
+        Assert.assertEquals(NOT_SET, Device.getProductVersion());
     }
 
     @Test
     public void testGetProductVersion(){
-        DiagnosticContext.INSTANCE.getRequestContext().put(AuthenticationConstants.SdkPlatformFields.VERSION, "TestVersion");
-        Assert.assertEquals("TestVersion", Device.getProductVersion());
+        DiagnosticContext.INSTANCE.getRequestContext().put(AuthenticationConstants.SdkPlatformFields.VERSION, TEST_VERSION);
+        Assert.assertEquals(TEST_VERSION, Device.getProductVersion());
 
     }
     @Test
     public void testGetManufacturer(){
         Device.setDeviceMetadata(new MockDeviceMetadata());
-        Assert.assertEquals(MockDeviceMetadata.testManufacturer, Device.getManufacturer());
+        Assert.assertEquals(MockDeviceMetadata.TEST_MANUFACTURER, Device.getManufacturer());
     }
 
 
     @Test
     public void testGetModel(){
         Device.setDeviceMetadata(new MockDeviceMetadata());
-        Assert.assertEquals(MockDeviceMetadata.testDeviceModel, Device.getModel());
+        Assert.assertEquals(MockDeviceMetadata.TEST_DEVICE_MODEL, Device.getModel());
     }
 }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
@@ -1,0 +1,94 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.java.platform;
+
+import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import lombok.val;
+
+/**
+ * Tests for {@link com.microsoft.identity.common.java.platform.Device}.
+ */
+public class DeviceTest {
+
+    @After
+    public void setUp() {
+        Device.clearDeviceMetadata();
+    }
+
+    @Test
+    public void testGetDataWhenMetadataIsNotSet(){
+        // Shouldn't crash.
+        val platformParameter = Device.getPlatformIdParameters();
+        Assert.assertEquals(3, platformParameter.size());
+        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
+        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
+        Assert.assertEquals("NOT_SET", platformParameter.get(Device.PlatformIdParameters.OS));
+
+        Assert.assertEquals("NOT_SET", Device.getManufacturer());
+        Assert.assertEquals("NOT_SET", Device.getModel());
+        Assert.assertEquals("NOT_SET", Device.getProductVersion());
+    }
+
+    @Test
+    public void testGetPlatformIdParameters(){
+        Device.setDeviceMetadata(new MockDeviceMetadata());
+
+        val platformParameter = Device.getPlatformIdParameters();
+        Assert.assertEquals(3, platformParameter.size());
+        Assert.assertEquals(MockDeviceMetadata.testCPU, platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
+        Assert.assertEquals(MockDeviceMetadata.testDeviceModel, platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
+        Assert.assertEquals(MockDeviceMetadata.testOS, platformParameter.get(Device.PlatformIdParameters.OS));
+    }
+
+    @Test
+    public void testGetProductVersion_DiagContextNotSet(){
+        Assert.assertEquals("NOT_SET", Device.getProductVersion());
+    }
+
+    @Test
+    public void testGetProductVersion(){
+        DiagnosticContext.INSTANCE.getRequestContext().put(AuthenticationConstants.SdkPlatformFields.VERSION, "TestVersion");
+        Assert.assertEquals("TestVersion", Device.getProductVersion());
+
+    }
+    @Test
+    public void testGetManufacturer(){
+        Device.setDeviceMetadata(new MockDeviceMetadata());
+        Assert.assertEquals(MockDeviceMetadata.testManufacturer, Device.getManufacturer());
+    }
+
+
+    @Test
+    public void testGetModel(){
+        Device.setDeviceMetadata(new MockDeviceMetadata());
+        Assert.assertEquals(MockDeviceMetadata.testDeviceModel, Device.getModel());
+    }
+}
+

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
@@ -1,0 +1,30 @@
+package com.microsoft.identity.common.java.platform;
+
+public class MockDeviceMetadata implements IDeviceMetadata {
+
+    static final String testCPU = "TestCPU";
+    static final String testOS = "TestOS";
+    static final String testDeviceModel = "TestDeviceModel";
+    static final String testManufacturer = "TestManufacturer";
+
+    @Override
+    public String getCpu() {
+        return testCPU;
+    }
+
+    @Override
+    public String getOs() {
+        return testOS;
+    }
+
+    @Override
+    public String getDeviceModel() {
+        return testDeviceModel;
+    }
+
+    @Override
+    public String getManufacturer() {
+        return testManufacturer;
+    }
+}
+

--- a/common4j/src/test/com/microsoft/identity/common/java/util/ClockSkewManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/ClockSkewManagerTest.java
@@ -20,50 +20,25 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common;
 
-import android.content.Context;
+package com.microsoft.identity.common.java.util;
 
-import androidx.test.InstrumentationRegistry;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.microsoft.identity.common.java.InMemoryStorage;
 
-import com.microsoft.identity.common.internal.util.ClockSkewManager;
-import com.microsoft.identity.common.internal.util.IClockSkewManager;
-
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(JUnit4.class)
 public class ClockSkewManagerTest {
-
-    private Context context;
-    private IClockSkewManager clockSkewManager;
-
-    @Before
-    public void setUp() {
-        context = InstrumentationRegistry.getTargetContext();
-    }
-
-    @After
-    public void tearDown() {
-        // Reset the skew to 0
-        if (null != clockSkewManager) {
-            clockSkewManager.onTimestampReceived(0L);
-        }
-
-        // Reset the Context
-        context = null;
-    }
 
     @Test
     public void testOnTimestampReceived() {
-        clockSkewManager = new ClockSkewManager(context) {
+        final IClockSkewManager clockSkewManager = new ClockSkewManager(new InMemoryStorage<Long>()) {
             @Override
             public Date getCurrentClientTime() {
                 return new Date(12345);
@@ -77,7 +52,7 @@ public class ClockSkewManagerTest {
 
     @Test
     public void testOnTimestampReceived2() {
-        clockSkewManager = new ClockSkewManager(context) {
+        final IClockSkewManager clockSkewManager = new ClockSkewManager(new InMemoryStorage<Long>()) {
             @Override
             public Date getCurrentClientTime() {
                 return new Date(67890);
@@ -91,7 +66,7 @@ public class ClockSkewManagerTest {
 
     @Test
     public void testGetReferenceTime() {
-        clockSkewManager = new ClockSkewManager(context) {
+        final IClockSkewManager clockSkewManager = new ClockSkewManager(new InMemoryStorage<Long>()) {
             @Override
             public Date getCurrentClientTime() {
                 return new Date(67890);
@@ -108,7 +83,7 @@ public class ClockSkewManagerTest {
 
     @Test
     public void testToClientTime() {
-        clockSkewManager = new ClockSkewManager(context) {
+        final IClockSkewManager clockSkewManager = new ClockSkewManager(new InMemoryStorage<Long>()) {
             @Override
             public long getSkewMillis() {
                 return 42L;
@@ -120,7 +95,7 @@ public class ClockSkewManagerTest {
 
     @Test
     public void testToReferenceTime() {
-        clockSkewManager = new ClockSkewManager(context) {
+        final IClockSkewManager clockSkewManager = new ClockSkewManager(new InMemoryStorage<Long>()) {
             @Override
             public long getSkewMillis() {
                 return 42L;
@@ -130,3 +105,4 @@ public class ClockSkewManagerTest {
         assertEquals(67848L, clockSkewManager.toReferenceTime(67890).getTime());
     }
 }
+


### PR DESCRIPTION
- ObjectMapper and IHasExtraParameters are internally-used, so, no wrapper needed.
- We still need wrappers in Device and ClockSkewManager in android-common (for injecting android device metadata and a sharedpref storage)

NOTE: This introduces a breaking change in MSALCPP. As discussed, I'll make change in a separate branch and will merge in once we ship common.