### PR TITLE
Move vsts username and password to project level build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
@@ -31,8 +33,8 @@ allprojects {
             name "vsts-maven-adal-android"
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {
-                username "VSTS"
-                password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                username project.vstsUsername
+                password project.vstsPassword
             }
         }
         //Required for google published packages not published to maven central

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -355,16 +355,16 @@ afterEvaluate {
                 name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
-                    username project.vstsUsername
-                    password project.vstsPassword
+                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
+                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
                 }
             }
             maven {
                 name "vsts-maven-android"
                 url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
                 credentials {
-                    username project.vstsUsername
-                    password project.vstsPassword
+                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
+                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
                 }
             }
         }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,10 +33,6 @@ def unitTestType = "UnitTest"
 def androidTestType = "AndroidTest"
 def bothTestType = "BothTest"
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-
-
 android {
 
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
Address: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1402810

cc/ @AdamBJohnsonx 

The username and password needs to be declared in the top-level build.gradle file where the credentials to the ADAL Android repository are specified. For some reason this top level file was referencing constant names that look like they were meant for MSAL and they clearly weren't being supplied in the pipelines (pipelines were supplying a constant name for common - `ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN` as opposed to `ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN`) and this discrepancy was causing common to not be able to fetch `common4j` from internal maven and was causing build failures. So far this wasn't a problem because `common` never consumed anything from internal maven so we didn't notice this issue...but now that we are consuming something from internal maven (common4j) this problem has surfaced up.