### PR TITLE
UiAutomation: Handle StaySignedin page

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -111,7 +111,8 @@ public class PromptHandlerParameters {
     private final boolean enrollPageExpected;
 
     /**
-     * Denotes whether or not the Stay signed in page is expected to appear during an interactive token
+     * Denotes whether or not the Stay signed in page is expected to appear during an interactive
+     * token request
      */
     private final boolean staySignedInPageExpected;
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -111,6 +111,11 @@ public class PromptHandlerParameters {
     private final boolean enrollPageExpected;
 
     /**
+     * Denotes whether or not the Stay signed in page is expected to appear during an interactive token
+     */
+    private final boolean staySignedInPageExpected;
+
+    /**
      * Denotes the way in which we want to respond to the enroll page for this request.
      */
     @Builder.Default
@@ -127,4 +132,7 @@ public class PromptHandlerParameters {
      */
     @Builder.Default
     private final UiResponse speedBumpResponse = UiResponse.ACCEPT;
+
+    @Builder.Default
+    private final UiResponse staySignedInResponse = UiResponse.ACCEPT;
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -160,7 +160,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     }
 
     @Override
-    public void handleStaySignedIn(UiResponse staySignedInResponse) {
+    public void handleStaySignedIn(final UiResponse staySignedInResponse) {
         final UiObject staySignedInView = UiAutomatorUtils.obtainUiObjectWithText("Stay signed in?");
 
         if (!staySignedInView.waitForExists(FIND_UI_ELEMENT_TIMEOUT)) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -29,6 +29,7 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
+import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
@@ -156,5 +157,20 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         Assert.assertTrue("Register page appears.", registerBtn.exists());
 
         handleNextButton();
+    }
+
+    @Override
+    public void handleStaySignedIn(UiResponse staySignedInResponse) {
+        final UiObject staySignedInView = UiAutomatorUtils.obtainUiObjectWithText("Stay signed in?");
+
+        if (!staySignedInView.waitForExists(FIND_UI_ELEMENT_TIMEOUT)) {
+            fail("Stay signed in page did not show up");
+        }
+
+        if (staySignedInResponse == UiResponse.ACCEPT) {
+            handleNextButton();
+        } else {
+            handleBackButton();
+        }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
@@ -56,9 +56,9 @@ public interface IMicrosoftStsLoginComponentHandler extends IOAuth2LoginComponen
     void handleRegistration();
 
     /**
-     * Clicks yes or no on the "Stay signed in?" screen that gets shown after user signs in
+     * Clicks yes or no on the "Stay signed in?" screen that gets shown after user signs in.
      *
-     * @param staySignedInResponse denotes whether to accept or decline the staySignedIn prompt
+     * @param staySignedInResponse denotes whether to accept or decline the staySignedIn prompt.
      */
     void handleStaySignedIn(UiResponse staySignedInResponse);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client.ui.automation.interaction.microsoftsts;
 
 import com.microsoft.identity.client.ui.automation.interaction.IOAuth2LoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
 
 /**
  * A Login Component Handler for Microsoft STS.
@@ -53,4 +54,11 @@ public interface IMicrosoftStsLoginComponentHandler extends IOAuth2LoginComponen
      * Respond to the register page during an authorization request.
      */
     void handleRegistration();
+
+    /**
+     * Clicks yes or no on the "Stay signed in?" screen that gets shown after user signs in
+     *
+     * @param staySignedInResponse denotes whether to accept or decline the staySignedIn prompt
+     */
+    void handleStaySignedIn(UiResponse staySignedInResponse);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -26,7 +26,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.interaction.AbstractPromptHandler;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -92,6 +91,10 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
 
         final IMicrosoftStsLoginComponentHandler aadLoginComponentHandler =
                 (IMicrosoftStsLoginComponentHandler) loginComponentHandler;
+
+        if (parameters.isStaySignedInPageExpected()) {
+            aadLoginComponentHandler.handleStaySignedIn(parameters.getStaySignedInResponse());
+        }
 
         if (parameters.isSpeedBumpExpected()) {
             aadLoginComponentHandler.handleSpeedBump();


### PR DESCRIPTION
Adding logic to Accept/Decline the prompt in StaySignedIn Page
This logic is needed to automate test cases for cross cloud sign in 

Verifications:
Ran a local cross cloud UI tests with the changes and it was able to accept/decline the prompt in stay signed in page
![StaySignedIn](https://user-images.githubusercontent.com/75644120/119179797-38d4ef00-ba24-11eb-9527-2735b7605a99.png)
