### PR TITLE
Suppress warning based on nested NonNull. Add spotbugs to common4j PR.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.microsoft.identity.buildsystem' version '0.1.0'
+    id 'com.microsoft.identity.buildsystem' version '0.1.1'
     id 'com.android.library'
     id 'pmd'
     id 'checkstyle'

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -8,7 +8,7 @@
 
 plugins {
     id 'java-library'
-    id 'com.microsoft.identity.buildsystem' version '0.1.0'
+    id 'com.microsoft.identity.buildsystem' version '0.1.1'
     id 'maven-publish'
 }
 

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+<Match>
+  <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+</Match>
+</FindBugsFilter>


### PR DESCRIPTION
We're getting

```
RCN: Nullcheck of value previously dereferenced (RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE)

A value is checked here to see whether it is null, but this value can't be null because it was previously dereferenced and if it were null a null pointer exception would have occurred at the earlier dereference. Essentially, this code and the previous dereference disagree as to whether this value is allowed to be null. Either the check is redundant or the previous dereference is erroneous.
```

in spotbugs, because the same constructor argument has a NonNull check in both subclass and superclass (redundant).

----

Edit: Given that this error.... is not really useful and we're going to run into it often with Lombok, I'm going to suppress this project-wide.
