### PR TITLE
Tests for DefaultConnectionService

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -25,14 +25,8 @@ package com.microsoft.identity.common.adal.internal.net;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.ConnectivityManager;
-import android.net.Network;
-import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
-import android.net.NetworkRequest;
 import android.os.Build;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.adal.internal.PowerManagerWrapper;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;

--- a/common/src/test/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapperShadow.java
+++ b/common/src/test/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapperShadow.java
@@ -31,16 +31,13 @@ import org.robolectric.annotation.Implements;
 @Implements(PowerManagerWrapper.class)
 public class PowerManagerWrapperShadow {
 
-    public static boolean deviceIdleMode = true;
-    public static boolean ignoringBatteryOptimizations = true;
-
     @Implementation
     public boolean isDeviceIdleMode(final Context connectionContext) {
-        return deviceIdleMode;
+        return true;
     }
 
     @Implementation
     public boolean isIgnoringBatteryOptimizations(final Context connectionContext) {
-        return ignoringBatteryOptimizations;
+        return false;
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapperShadow.java
+++ b/common/src/test/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapperShadow.java
@@ -1,0 +1,46 @@
+
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.adal.internal;
+
+import android.content.Context;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(PowerManagerWrapper.class)
+public class PowerManagerWrapperShadow {
+
+    public static boolean deviceIdleMode = true;
+    public static boolean ignoringBatteryOptimizations = true;
+
+    @Implementation
+    public boolean isDeviceIdleMode(final Context connectionContext) {
+        return deviceIdleMode;
+    }
+
+    @Implementation
+    public boolean isIgnoringBatteryOptimizations(final Context connectionContext) {
+        return ignoringBatteryOptimizations;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
@@ -57,26 +57,25 @@ public class DefaultConnectionServiceTest {
 
     @Test
     public void testConnectionWhenConnected() {
-        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+        final DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
 
         assertTrue(defaultConnectionService.isConnectionAvailable());
     }
 
     @Test
     public void testConnectionWhenNoActiveNetwork() {
-        ConnectivityManager connectivityManager = (ConnectivityManager) mContext
+        final ConnectivityManager connectivityManager = (ConnectivityManager) mContext
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 
         shadowOf(connectivityManager).setActiveNetworkInfo(null);
-        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+        final DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
 
         assertFalse(defaultConnectionService.isConnectionAvailable());
     }
 
     @Test
     public void testNetworkDisabledFromOptimizations() {
-        PowerManagerWrapperShadow.ignoringBatteryOptimizations = false;
-        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+        final DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
         ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
 
         assertTrue(defaultConnectionService.isNetworkDisabledFromOptimizations());
@@ -85,7 +84,7 @@ public class DefaultConnectionServiceTest {
     @Test
     public void testNetworkDisabledFromOptimizationsForAPIsBelow23() {
         ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.LOLLIPOP_MR1);
-        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+        final DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
 
         assertFalse(defaultConnectionService.isNetworkDisabledFromOptimizations());
     }

--- a/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
@@ -1,0 +1,92 @@
+
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.adal.internal.net;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.adal.internal.PowerManagerWrapperShadow;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {
+        PowerManagerWrapperShadow.class
+})
+public class DefaultConnectionServiceTest {
+
+    protected Context mContext;
+
+    @Before
+    public void setup() {
+        mContext = ApplicationProvider.getApplicationContext();
+    }
+
+    @Test
+    public void testConnectionWhenConnected() {
+        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+
+        assertTrue(defaultConnectionService.isConnectionAvailable());
+    }
+
+    @Test
+    public void testConnectionWhenNoActiveNetwork() {
+        ConnectivityManager connectivityManager = (ConnectivityManager) mContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        shadowOf(connectivityManager).setActiveNetworkInfo(null);
+        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+
+        assertFalse(defaultConnectionService.isConnectionAvailable());
+    }
+
+    @Test
+    public void testNetworkDisabledFromOptimizations() {
+        PowerManagerWrapperShadow.ignoringBatteryOptimizations = false;
+        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+        ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+
+        assertTrue(defaultConnectionService.isNetworkDisabledFromOptimizations());
+    }
+
+    @Test
+    public void testNetworkDisabledFromOptimizationsForAPIsBelow23() {
+        ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.LOLLIPOP_MR1);
+        DefaultConnectionService defaultConnectionService = new DefaultConnectionService(mContext);
+
+        assertFalse(defaultConnectionService.isNetworkDisabledFromOptimizations());
+    }
+}


### PR DESCRIPTION
## What does this PR do?
- Adds tests for the `DefaultConnectionService` class.

## Description of tasks to be completed.
- [x] Use robolectric to test the DefaultConnectionService

## How to test this PR?
- Run the test files that were created.

## Any addition comments.
N/A