### PR TITLE
Fixing Redirect Uri for Authenticator App, when migrating to MSAL

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
@@ -140,13 +140,6 @@ public class PackageHelper {
     public static String getBrokerRedirectUrl(final String packageName, final String signatureDigest) {
         if (!StringExtensions.isNullOrBlank(packageName)
                 && !StringExtensions.isNullOrBlank(signatureDigest)) {
-            // If the caller is the Authenticator, then use the broker redirect URI.
-            if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
-                    && (signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash)
-                    || signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash))) {
-                return AuthenticationConstants.Broker.BROKER_REDIRECT_URI;
-            }
-
             try {
                 return String.format("%s://%s/%s", AuthenticationConstants.Broker.REDIRECT_PREFIX,
                         URLEncoder.encode(packageName, AuthenticationConstants.ENCODING_UTF8),


### PR DESCRIPTION
Address the following issue :
Broker redirect uri is invalid. Expected: urn:ietf:wg:oauth:2.0:oob Actual: msauth://.......

A test build was provided to the Authenticator app with this change and it all looks good,
we got a confirmation from the Authenticator team.