### PR TITLE
[PoP] Cherry-Pick Changes from #1346 to release/3.4.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.4.4
+----------
+- [PATCH] Rev Nimbus version: 8.2 -> 9.9 (#1346)
+
 Version 3.4.3
 ----------
 - [PATCH] Revert connection detection change, disable throttling cache (#1351, #1353)

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -81,7 +81,9 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -807,8 +809,8 @@ class DevicePopManager implements IDevicePopManager {
         final String errCode;
 
         try {
-            final net.minidev.json.JSONObject jwkJson = getDevicePopJwkMinifiedJson();
-            return jwkJson.getAsString(SignedHttpRequestJwtClaims.JWK);
+            final Map<String, Object> jwkMap = getDevicePopJwkMinifiedJson();
+            return jwkMap.get(SignedHttpRequestJwtClaims.JWK).toString();
         } catch (final UnrecoverableEntryException e) {
             exception = e;
             errCode = INVALID_PROTECTION_PARAMS;
@@ -1444,15 +1446,15 @@ class DevicePopManager implements IDevicePopManager {
      * @throws NoSuchAlgorithmException    If the KeyStore is unable to use the designated alg.
      * @throws KeyStoreException           If the KeyStore experiences an error during read.
      */
-    private net.minidev.json.JSONObject getDevicePopJwkMinifiedJson()
+    private Map<String, Object> getDevicePopJwkMinifiedJson()
             throws UnrecoverableEntryException, NoSuchAlgorithmException, KeyStoreException {
         final KeyStore.PrivateKeyEntry keyEntry = mKeyManager.getEntry();
         final KeyPair rsaKeyPair = getKeyPairForEntry(keyEntry);
         final RSAKey rsaKey = getRsaKeyForKeyPair(rsaKeyPair);
         final RSAKey publicRsaKey = rsaKey.toPublicJWK();
-        final net.minidev.json.JSONObject jwkContents = publicRsaKey.toJSONObject();
-        final net.minidev.json.JSONObject wrappedJwk = new net.minidev.json.JSONObject();
-        wrappedJwk.appendField(SignedHttpRequestJwtClaims.JWK, jwkContents);
+        final Map<String, Object> jwkContents = publicRsaKey.toJSONObject();
+        final Map<String, Object> wrappedJwk = new HashMap<>();
+        wrappedJwk.put(SignedHttpRequestJwtClaims.JWK, jwkContents);
 
         return wrappedJwk;
     }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -35,7 +35,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "8.2"
+    nimbusVersion = "9.9"
     powerMockVersion = "1.6.6"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
Brings changes from #1346 

Per [this bug](), AuthApp shipped a ProGuard rule that override our 8,2 dependency version of Nimbus with API-incompatible 9,9

This change brings the versions used by AuthApp & Common into alignment