### PR TITLE
Small changes in the YAML for instrumented test template

### DIFF
--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -1,6 +1,9 @@
 # File: docker-tasks.yml
 
 steps:
+- task: PostBuildCleanup@3
+  condition: always()
+  displayName: 'Post build clean up'
 - checkout: self
   clean: true
   submodules: recursive
@@ -16,11 +19,11 @@ steps:
     docker run --privileged --cpus="3" --memory="12g" -v "$PWD":/home/gradle/ -w /home/gradle/ authclient.azurecr.io/samples/dbi-instrumented-api30 sh scripts/run-instrumented-tests.sh
   displayName: 'Build and test inside docker container'
 - task: PublishTestResults@2
+  condition: succeededOrFailed()
   inputs:
     testResultsFormat: 'JUnit'
     testResultsFiles: '**/TEST-*.xml'
     searchFolder: '$(System.DefaultWorkingDirectory)'
-    condition: succeededOrFailed()
     displayName: 'Publish Test Results'
 - script: |
     echo =============================================
@@ -45,6 +48,3 @@ steps:
     docker system df
   condition: always()
   displayName: 'Cleanup'
-- task: PostBuildCleanup@3
-  condition: always()
-  displayName: 'Post build clean up'


### PR DESCRIPTION
- I moved the "Post Build Cleanup" task to the top due to a suggestion in the [documentation](https://marketplace.visualstudio.com/items?itemName=mspremier.PostBuildCleanup)

> Adding the Task to a Build Definition
Simply add the Post Build Cleanup task (in task category Utility) to your build definition. Starting with v3.1.0, the task can be placed anywhere in your pipeline. Since post-job scripts are executed in reverse order of their corresponding task scripts, we recommend to put the Post Build Cleanup task as the first task in your pipeline. This ensures that every other post-job script is executed before we clean files from your build agent.


- The condition for PublishTestResults task was wrongly positioned so in case of an error the results were not published