### PR TITLE
remove ref:master and update version

### DIFF
--- a/azure-pipelines/maven-release/common.yml
+++ b/azure-pipelines/maven-release/common.yml
@@ -14,7 +14,6 @@ resources:
   repositories:
   - repository: self
     type: git
-    ref: master
 
 jobs:
 - template: ../templates/steps/maven-release/maven-release-jobs.yml

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.4.4-RC1
+versionName=3.4.4-RC2
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
- Removed ref:master from the maven releases pipeline.  As this will always build and deploy master rather than the current branch.  You don't need to worry about accidentally running this pipeline.  As it results in a staged release in sonatype rather than immediately and automatically going to prod maven
- Updated version number for next release