### PR TITLE
Small changes to Outlook sign and Teams sign in

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -57,7 +57,7 @@ public class OutlookApp extends App implements IFirstPartyApp {
                                 @NonNull final FirstPartyAppPromptHandlerParameters promptHandlerParameters) {
         Logger.i(TAG, "Adding First Account..");
         // Click start btn
-        UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/btn_add_account");
+        UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/btn_primary_button");
 
         // sign in with supplied username/password
         signIn(username, password, promptHandlerParameters);
@@ -76,8 +76,6 @@ public class OutlookApp extends App implements IFirstPartyApp {
         // click may be later
         UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/bottom_flow_navigation_start_button");
 
-        // Skip through account added optional UI
-        UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/product_tour_skip_btn");
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/TeamsApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/TeamsApp.java
@@ -63,7 +63,7 @@ public class TeamsApp extends App implements IFirstPartyApp {
                 Logger.i(TAG, "Adding First Account which is in TSL..");
                 // This case handles UI if our account (supplied username) is expected to be in TSL
                 final UiObject email = UiAutomatorUtils.obtainUiObjectWithResourceIdAndText(
-                        "com.microsoft.teams:id/email",
+                        "com.microsoft.teams:id/title",
                         username
                 );
 


### PR DESCRIPTION
- Updated id for add account button in Outlook
- Removed tour option as no longer part of Outlook first run experience
- Modified id for control for selecting existing account in Teams