### PR TITLE
Rename IKeyPairStorage to INameValueStorage

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/SharedPreferenceStringStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/SharedPreferenceStringStorage.java
@@ -26,16 +26,16 @@ import android.content.Context;
 
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
 /**
- * An implementation of {@link IKeyPairStorage} for storing String.
+ * An implementation of {@link INameValueStorage} for storing String.
  * Implemented with SharedPreference.
  */
-public class SharedPreferenceStringStorage implements IKeyPairStorage<String> {
+public class SharedPreferenceStringStorage implements INameValueStorage<String> {
 
     final ISharedPreferencesFileManager mSharedPrefs;
 
@@ -50,18 +50,18 @@ public class SharedPreferenceStringStorage implements IKeyPairStorage<String> {
     }
 
     @Override
-    public String get(@NonNull String key) {
-        return mSharedPrefs.getString(key);
+    public String get(@NonNull String name) {
+        return mSharedPrefs.getString(name);
     }
 
     @Override
-    public void put(@NonNull String key, @Nullable String value) {
-        mSharedPrefs.putString(key, value);
+    public void put(@NonNull String name, @Nullable String value) {
+        mSharedPrefs.putString(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        mSharedPrefs.remove(key);
+    public void remove(@NonNull String name) {
+        mSharedPrefs.remove(name);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/eststelemetry/EstsTelemetry.java
@@ -29,13 +29,10 @@ import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.SharedPreferenceStringStorage;
 import com.microsoft.identity.common.WarningType;
-import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
-import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.commands.BaseCommand;
 import com.microsoft.identity.common.internal.controllers.CommandResult;
 import com.microsoft.identity.common.java.eststelemetry.LastRequestTelemetryCache;
 import com.microsoft.identity.common.java.eststelemetry.RequestTelemetry;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.Map;

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryPropertiesCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryPropertiesCache.java
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.internal.telemetry;
 import android.content.Context;
 
 import com.microsoft.identity.common.SharedPreferenceStringStorage;
-import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
 import com.microsoft.identity.common.java.telemetry.TelemetryPropertiesCache;
 
 import lombok.NonNull;

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AbstractSharedPrefNameValueStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AbstractSharedPrefNameValueStorage.java
@@ -23,26 +23,25 @@
 package com.microsoft.identity.common.internal.util;
 
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 /**
- * Adapts {@link ISharedPreferencesFileManager} to {@link IKeyPairStorage<Long>}
+ * Adapts {@link ISharedPreferencesFileManager} to {@link INameValueStorage}
  * */
-public class SharedPrefLongKeyPairStorage extends AbstractSharedPrefKeyPairStorage<Long> {
-    public SharedPrefLongKeyPairStorage(ISharedPreferencesFileManager mManager) {
-        super(mManager);
+@AllArgsConstructor
+public abstract class AbstractSharedPrefNameValueStorage<T> implements INameValueStorage<T> {
+    protected ISharedPreferencesFileManager mManager;
+
+    @Override
+    public void remove(@NonNull String name) {
+        mManager.remove(name);
     }
 
     @Override
-    public Long get(@NonNull String key) {
-        return mManager.getLong(key);
-    }
-
-    @Override
-    public void put(@NonNull String key, Long value) {
-        mManager.putLong(key, value);
+    public void clear() {
+        mManager.clear();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -48,11 +48,11 @@ public class ClockSkewManager extends com.microsoft.identity.common.java.util.Cl
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public ClockSkewManager(@NonNull final ISharedPreferencesFileManager manager) {
-        super(new SharedPrefLongKeyPairStorage(manager));
+        super(new SharedPrefLongNameValueStorage(manager));
     }
 
     public ClockSkewManager(@NonNull final Context context) {
-        super(new SharedPrefLongKeyPairStorage(
+        super(new SharedPrefLongNameValueStorage(
                 SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         PreferencesMetadata.SKEW_PREFERENCES_FILENAME,

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefLongNameValueStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefLongNameValueStorage.java
@@ -23,25 +23,25 @@
 package com.microsoft.identity.common.internal.util;
 
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
-import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 /**
- * Adapts {@link ISharedPreferencesFileManager} to {@link IKeyPairStorage}
+ * Adapts {@link ISharedPreferencesFileManager} to {@link INameValueStorage <Long>}
  * */
-@AllArgsConstructor
-public abstract class AbstractSharedPrefKeyPairStorage<T> implements IKeyPairStorage<T> {
-    protected ISharedPreferencesFileManager mManager;
-
-    @Override
-    public void remove(@NonNull String key) {
-        mManager.remove(key);
+public class SharedPrefLongNameValueStorage extends AbstractSharedPrefNameValueStorage<Long> {
+    public SharedPrefLongNameValueStorage(ISharedPreferencesFileManager mManager) {
+        super(mManager);
     }
 
     @Override
-    public void clear() {
-        mManager.clear();
+    public Long get(@NonNull String name) {
+        return mManager.getLong(name);
+    }
+
+    @Override
+    public void put(@NonNull String name, Long value) {
+        mManager.putLong(name, value);
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/EstsTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/EstsTelemetry.java
@@ -26,7 +26,7 @@ import com.microsoft.identity.common.java.commands.ICommand;
 import com.microsoft.identity.common.java.commands.ICommandResult;
 import com.microsoft.identity.common.java.exception.IBaseException;
 import com.microsoft.identity.common.java.exception.IServiceException;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResultBase;
@@ -50,16 +50,16 @@ public class EstsTelemetry {
 
     private static volatile EstsTelemetry sEstsTelemetryInstance = null;
     private LastRequestTelemetryCache mLastRequestTelemetryCache;
-    private final IKeyPairStorage<CurrentRequestTelemetry> mTelemetryMap;
-    private final IKeyPairStorage<Set<FailedRequest>> mSentFailedRequests;
+    private final INameValueStorage<CurrentRequestTelemetry> mTelemetryMap;
+    private final INameValueStorage<Set<FailedRequest>> mSentFailedRequests;
 
     EstsTelemetry() {
         this(new TelemetryMap(), new SentFailedRequestsMap());
     }
 
     // Exposed for testing only.
-    EstsTelemetry(@NonNull final IKeyPairStorage<CurrentRequestTelemetry> telemetryMap,
-                  @NonNull final IKeyPairStorage<Set<FailedRequest>> sentFailedRequestsMap) {
+    EstsTelemetry(@NonNull final INameValueStorage<CurrentRequestTelemetry> telemetryMap,
+                  @NonNull final INameValueStorage<Set<FailedRequest>> sentFailedRequestsMap) {
         mTelemetryMap = telemetryMap;
         mSentFailedRequests = sentFailedRequestsMap;
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/LastRequestTelemetryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/LastRequestTelemetryCache.java
@@ -26,7 +26,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.Logger;
 
 import lombok.NonNull;
@@ -42,14 +42,14 @@ public class LastRequestTelemetryCache implements IRequestTelemetryCache<LastReq
     private static final Gson mGson = new Gson();
 
     // Storage for request telemetry data
-    private final IKeyPairStorage<String> mStorage;
+    private final INameValueStorage<String> mStorage;
 
     /**
      * Constructor of LastRequestTelemetryCache.
      *
      * @param keyPairStorage IKeyPairStorage
      */
-    public LastRequestTelemetryCache(@NonNull final IKeyPairStorage<String> keyPairStorage) {
+    public LastRequestTelemetryCache(@NonNull final INameValueStorage<String> keyPairStorage) {
         Logger.verbose(TAG, "Init: " + TAG);
         mStorage = keyPairStorage;
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/LastRequestTelemetryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/LastRequestTelemetryCache.java
@@ -47,7 +47,7 @@ public class LastRequestTelemetryCache implements IRequestTelemetryCache<LastReq
     /**
      * Constructor of LastRequestTelemetryCache.
      *
-     * @param keyPairStorage IKeyPairStorage
+     * @param keyPairStorage INameValueStorage
      */
     public LastRequestTelemetryCache(@NonNull final INameValueStorage<String> keyPairStorage) {
         Logger.verbose(TAG, "Init: " + TAG);

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SentFailedRequestsMap.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SentFailedRequestsMap.java
@@ -22,29 +22,29 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.eststelemetry;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.NonNull;
 
-public class SentFailedRequestsMap implements IKeyPairStorage<Set<FailedRequest>> {
+public class SentFailedRequestsMap implements INameValueStorage<Set<FailedRequest>> {
     private final ConcurrentHashMap<String, Set<FailedRequest>> sentFailedRequestsMap = new ConcurrentHashMap<>();
 
     @Override
-    public Set<FailedRequest> get(@NonNull String key) {
-        return sentFailedRequestsMap.get(key);
+    public Set<FailedRequest> get(@NonNull String name) {
+        return sentFailedRequestsMap.get(name);
     }
 
     @Override
-    public void put(@NonNull String key, Set<FailedRequest> value) {
-        sentFailedRequestsMap.put(key, value);
+    public void put(@NonNull String name, Set<FailedRequest> value) {
+        sentFailedRequestsMap.put(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        sentFailedRequestsMap.remove(key);
+    public void remove(@NonNull String name) {
+        sentFailedRequestsMap.remove(name);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryMap.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryMap.java
@@ -22,29 +22,29 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.eststelemetry;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.NonNull;
 
-public class TelemetryMap implements IKeyPairStorage<CurrentRequestTelemetry>{
+public class TelemetryMap implements INameValueStorage<CurrentRequestTelemetry> {
 
     private final ConcurrentHashMap<String, CurrentRequestTelemetry> telemetryMap = new ConcurrentHashMap<>();
 
     @Override
-    public CurrentRequestTelemetry get(@NonNull String key) {
-        return telemetryMap.get(key);
+    public CurrentRequestTelemetry get(@NonNull String name) {
+        return telemetryMap.get(name);
     }
 
     @Override
-    public void put(@NonNull String key, CurrentRequestTelemetry value) {
-        telemetryMap.put(key, value);
+    public void put(@NonNull String name, CurrentRequestTelemetry value) {
+        telemetryMap.put(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        telemetryMap.remove(key);
+    public void remove(@NonNull String name) {
+        telemetryMap.remove(name);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/INameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/INameValueStorage.java
@@ -26,30 +26,30 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
 /**
- * An interface for a KeyPair storage.
+ * An interface for a NameValue storage.
  * */
-public interface IKeyPairStorage<T> {
+public interface INameValueStorage<T> {
     /**
      * Gets a value from the storage.
      *
-     * @param key A key associated to the value.
+     * @param name A name associated to the value.
      */
-    T get(@NonNull String key);
+    T get(@NonNull String name);
 
     /**
      * Puts a value into the storage.
      *
-     * @param key A key associated to the value.
+     * @param name A name associated to the value.
      * @param value value to be persisted.
      */
-    void put(@NonNull String key, @Nullable T value);
+    void put(@NonNull String name, @Nullable T value);
 
     /**
      * Removes a value from the storage.
      *
-     * @param key A key associated to the value.
+     * @param name A name associated to the value.
      */
-    void remove(@NonNull String key);
+    void remove(@NonNull String name);
 
     /**
      * Clear all data from the storage.

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryPropertiesCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryPropertiesCache.java
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.telemetry;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.util.StringUtil;
 import lombok.NonNull;
 
@@ -40,9 +40,9 @@ public class TelemetryPropertiesCache {
     private static final String DEVICE_ID_GUID = "device_id_guid";
     // endregion
 
-    private final IKeyPairStorage<String> mStorage;
+    private final INameValueStorage<String> mStorage;
 
-    public TelemetryPropertiesCache(@NonNull final IKeyPairStorage<String> storage) {
+    public TelemetryPropertiesCache(@NonNull final INameValueStorage<String> storage) {
         mStorage = storage;
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ClockSkewManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ClockSkewManager.java
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.util;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -35,9 +35,9 @@ public class ClockSkewManager implements IClockSkewManager {
         private static final String KEY_SKEW = "skew";
     }
 
-    private final IKeyPairStorage<Long> mClockSkewStorage;
+    private final INameValueStorage<Long> mClockSkewStorage;
 
-    public ClockSkewManager(@NonNull final IKeyPairStorage<Long> storage) {
+    public ClockSkewManager(@NonNull final INameValueStorage<Long> storage) {
         mClockSkewStorage = storage;
     }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/InMemoryStorage.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/InMemoryStorage.java
@@ -22,13 +22,13 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.HashMap;
 
 import lombok.NonNull;
 
-public class InMemoryStorage<T> implements IKeyPairStorage<T> {
+public class InMemoryStorage<T> implements INameValueStorage<T> {
 
     final HashMap<String, T> mMap = new HashMap<>();
 
@@ -37,18 +37,18 @@ public class InMemoryStorage<T> implements IKeyPairStorage<T> {
     }
 
     @Override
-    public T get(final String key) {
-        return mMap.get(key);
+    public T get(final String name) {
+        return mMap.get(name);
     }
 
     @Override
-    public void put(final String key, final T value) {
-        mMap.put(key, value);
+    public void put(final String name, final T value) {
+        mMap.put(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        mMap.remove(key);
+    public void remove(@NonNull String name) {
+        mMap.remove(name);
     }
 
     @Override

--- a/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/InMemorySentFailedRequestsMap.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/InMemorySentFailedRequestsMap.java
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.eststelemetry;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,23 +30,23 @@ import java.util.concurrent.ConcurrentMap;
 
 import lombok.NonNull;
 
-class InMemorySentFailedRequestsMap implements IKeyPairStorage<Set<FailedRequest>> {
+class InMemorySentFailedRequestsMap implements INameValueStorage<Set<FailedRequest>> {
 
     final ConcurrentMap<String, Set<FailedRequest>> mMap = new ConcurrentHashMap<>();
 
     @Override
-    public Set<FailedRequest> get(final String key) {
-        return mMap.get(key);
+    public Set<FailedRequest> get(final String name) {
+        return mMap.get(name);
     }
 
     @Override
-    public void put(final String key, final Set<FailedRequest> value) {
-        mMap.put(key, value);
+    public void put(final String name, final Set<FailedRequest> value) {
+        mMap.put(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        mMap.remove(key);
+    public void remove(@NonNull String name) {
+        mMap.remove(name);
     }
 
     @Override

--- a/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/InMemoryTelemetryMap.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/InMemoryTelemetryMap.java
@@ -22,30 +22,30 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.eststelemetry;
 
-import com.microsoft.identity.common.java.interfaces.IKeyPairStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import lombok.NonNull;
 
-class InMemoryTelemetryMap implements IKeyPairStorage<CurrentRequestTelemetry> {
+class InMemoryTelemetryMap implements INameValueStorage<CurrentRequestTelemetry> {
 
     final ConcurrentMap<String, CurrentRequestTelemetry> mMap = new ConcurrentHashMap<>();
 
     @Override
-    public CurrentRequestTelemetry get(final String key) {
-        return mMap.get(key);
+    public CurrentRequestTelemetry get(final String name) {
+        return mMap.get(name);
     }
 
     @Override
-    public void put(final String key, final CurrentRequestTelemetry value) {
-        mMap.put(key, value);
+    public void put(final String name, final CurrentRequestTelemetry value) {
+        mMap.put(name, value);
     }
 
     @Override
-    public void remove(@NonNull String key) {
-        mMap.remove(key);
+    public void remove(@NonNull String name) {
+        mMap.remove(name);
     }
 
     @Override


### PR DESCRIPTION
This is per a recent feedback provided from @shoatman during one of the standup meetings.

This is a simple PR...just renaming a file and fixing imports per that change