### PR TITLE
Add a method to IDeviceMetadata to get all metadata as a String

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ V.Next
 - [PATCH] Only hit cache once when loading x-tenant idtokens (#1385)
 - [PATCH] Avoid unnecessary BAM-cache reload (#1426)
 - [PATCH] Using singleton/LRU cached BAM-Cache implementation (#1420)
+- [MINOR] Add a method to IDeviceMetadata to get all metadata as a String (#1433)
 
 Version 3.4.3
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -24,12 +24,12 @@ package com.microsoft.identity.common.internal.platform;
 
 import android.os.Build;
 
-import com.microsoft.identity.common.java.platform.IDeviceMetadata;
+import com.microsoft.identity.common.java.platform.AbstractDeviceMetadata;
 
 /**
  * Provides device metadata in Android.
  **/
-public class AndroidDeviceMetadata implements IDeviceMetadata {
+public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     @Override
     public String getCpu() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDeviceMetadata.java
@@ -22,50 +22,19 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.platform;
 
-import lombok.NonNull;
-
 /**
- * An interface representing metadata of the device.
- * The implementation of its child varies from platform to platform.
+ * An abstract class to share some functionality between different implementations of
+ * {@link IDeviceMetadata} interface.
  */
-public interface IDeviceMetadata {
+public abstract class AbstractDeviceMetadata implements IDeviceMetadata {
 
-    /**
-     * Get the CPU name of this device.
-     *
-     * @return a String representing the CPU name
-     */
-    @NonNull
-    String getCpu();
+    private static final String SEPARATOR = ":";
 
-    /**
-     * Get the OS of this device. This would include the OS name and version.
-     *
-     * @return a String representing the OS information
-     */
-    @NonNull
-    String getOs();
-
-    /**
-     * Get the model name of this device.
-     *
-     * @return a String representing the device's model
-     */
-    @NonNull
-    String getDeviceModel();
-
-    /**
-     * Get the manufacturer of this device.
-     *
-     * @return a String representing this device's manufacturer
-     */
-    @NonNull
-    String getManufacturer();
-
-    /**
-     * Get all metadata about this device.
-     *
-     * @return a String containing all metadata about this device
-     */
-    String getAllMetadata();
+    @Override
+    public String getAllMetadata() {
+        return getDeviceModel() + SEPARATOR +
+                getManufacturer() + SEPARATOR +
+                getCpu() + SEPARATOR +
+                getOs();
+    }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
@@ -40,6 +40,8 @@ public class DeviceTest {
     final String NOT_SET = "NOT_SET";
     final String TEST_VERSION = "TEST_VERSION";
 
+    final static String METADATA_SEPARATOR = ":";
+
     @After
     public void tearDown() {
         Device.clearDeviceMetadata();
@@ -105,6 +107,16 @@ public class DeviceTest {
     public void testGetModel(){
         Device.setDeviceMetadata(new MockDeviceMetadata());
         Assert.assertEquals(MockDeviceMetadata.TEST_DEVICE_MODEL, Device.getModel());
+    }
+
+    @Test
+    public void testGetAllMetadata(){
+        final AbstractDeviceMetadata deviceMetadata = new MockDeviceMetadata();
+        final String expectedResult = MockDeviceMetadata.TEST_DEVICE_MODEL + METADATA_SEPARATOR +
+                MockDeviceMetadata.TEST_MANUFACTURER + METADATA_SEPARATOR +
+                MockDeviceMetadata.TEST_CPU + METADATA_SEPARATOR +
+                MockDeviceMetadata.TEST_OS;
+        Assert.assertEquals(expectedResult, deviceMetadata.getAllMetadata());
     }
 }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.platform;
 
-public class MockDeviceMetadata implements IDeviceMetadata {
+public class MockDeviceMetadata extends AbstractDeviceMetadata {
 
     public static final String TEST_CPU = "TestCPU";
     public static final String TEST_OS = "TestOS";


### PR DESCRIPTION
This per feedback provided from @AdamBJohnsonx here: https://github.com/AzureAD/ad-accounts-for-android/pull/1589#discussion_r658119608