### PR TITLE
Revert thread pool construction changes in command dispatcher

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -85,14 +85,8 @@ public class CommandDispatcher {
     private static final String TAG = CommandDispatcher.class.getSimpleName();
 
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
-    private static final int INTERACTIVE_REQUEST_THREAD_POOL_SIZE = 1;
-    //TODO:1315931 - Refactor the threadpools to not be unbounded for both silent and interactive requests.
-    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
-            1, INTERACTIVE_REQUEST_THREAD_POOL_SIZE, -1, 0, TimeUnit.MINUTES, "interactive"
-    );
-    private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedThreadPoolExecutor(
-            1, SILENT_REQUEST_THREAD_POOL_SIZE, -1, 1, TimeUnit.MINUTES, "silent"
-    );
+    private static final ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
+    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();


### PR DESCRIPTION
reverting back the changes made in: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/commit/cdb1dee78ec44c85909e23ce31a6e20a38f5f8f9

back to using newFixedThreadPool

The change made in that code review was twofold - to enable us to monitor the thread usage by naming threads in the executor, and to decrease resource usage by not starting threads before they were needed.  The first part of this worked precisely as desired, but the second caused an issue.  Because the ExecutorService starts threads only when the queue is full, setting the core size to less than the max pool size with an unbounded queue meant that the no threads were ever created beyond the initial core pool size.  This had the effect of serializing all the requests in the silent thread pool.

This change undoes that.