### PR TITLE
Do not report network errors an authority validation errors

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -46,9 +46,7 @@ import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.FinalizableResultFuture;
 import com.microsoft.identity.common.internal.result.GenerateShrResult;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -328,7 +326,7 @@ public class CommandDispatcherTest {
     public void testSubmitSilentWithTerminalException() {
         final String errorCode = "anError";
         final CountDownLatch testLatch = new CountDownLatch(1);
-        CommandDispatcher.submitSilent(new IErrorExceptionCommand(getEmptyTestParams(),
+        CommandDispatcher.submitSilent(new CommandThrowingIErrorInformationException(getEmptyTestParams(),
                 new CommandCallback<String, Exception>() {
                     @Override
                     public void onCancel() {
@@ -506,11 +504,11 @@ public class CommandDispatcherTest {
         }
     }
 
-    static class IErrorExceptionCommand extends BaseCommand<String> {
+    static class CommandThrowingIErrorInformationException extends BaseCommand<String> {
         final String mErrorCode;
 
-        public IErrorExceptionCommand(@NonNull final CommandParameters parameters,
-                                @NonNull final CommandCallback callback, String errorCode) {
+        public CommandThrowingIErrorInformationException(@NonNull final CommandParameters parameters,
+                                                         @NonNull final CommandCallback callback, String errorCode) {
             super(parameters, getTestController(), callback, "test_id");
             mErrorCode = errorCode;
         }

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -27,6 +27,8 @@ import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.TerminalException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.commands.BaseCommand;
 import com.microsoft.identity.common.internal.commands.CommandCallback;
@@ -322,6 +324,32 @@ public class CommandDispatcherTest {
                 }));
     }
 
+    @Test
+    public void testSubmitSilentWithTerminalException() {
+        final String errorCode = "anError";
+        final CountDownLatch testLatch = new CountDownLatch(1);
+        CommandDispatcher.submitSilent(new IErrorExceptionCommand(getEmptyTestParams(),
+                new CommandCallback<String, Exception>() {
+                    @Override
+                    public void onCancel() {
+                        testLatch.countDown();
+                        Assert.fail();
+                    }
+
+                    @Override
+                    public void onError(Exception error) {
+                        Assert.assertEquals(ClientException.class, error.getClass());
+                        Assert.assertEquals(errorCode, ((ClientException) error).getErrorCode());
+                        testLatch.countDown();
+                    }
+
+                    @Override
+                    public void onTaskCompleted(String s) {
+                        testLatch.countDown();
+                        Assert.fail();
+                    }
+                }, errorCode));
+    }
     /**
      * This test takes a while to run.  But it should always work.  Just put it here in order
      * to save anyone else from having to write it.  Effectively all of these results are non
@@ -470,6 +498,26 @@ public class CommandDispatcherTest {
         @Override
         public String execute() {
             throw new RuntimeException("An unexpected exception!");
+        }
+
+        @Override
+        public boolean isEligibleForEstsTelemetry() {
+            return false;
+        }
+    }
+
+    static class IErrorExceptionCommand extends BaseCommand<String> {
+        final String mErrorCode;
+
+        public IErrorExceptionCommand(@NonNull final CommandParameters parameters,
+                                @NonNull final CommandCallback callback, String errorCode) {
+            super(parameters, getTestController(), callback, "test_id");
+            mErrorCode = errorCode;
+        }
+
+        @Override
+        public String execute() {
+            throw new TerminalException("An unexpected exception!", new Exception("Exception"), mErrorCode);
         }
 
         @Override

--- a/common/src/main/java/com/microsoft/identity/common/exception/BaseException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BaseException.java
@@ -26,8 +26,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.providers.oauth2.IErrorResponse;
 
-public class BaseException extends Exception {
+public class BaseException extends Exception implements IErrorInformation {
 
     public static final String sName =  BaseException.class.getName();
     private static final long serialVersionUID = -5166242728507796770L;

--- a/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.exception;
 
 import javax.annotation.Nullable;
@@ -10,7 +32,7 @@ import javax.annotation.Nullable;
  */
 public interface IErrorInformation {
     /**
-     * Get the error code associated with this operation.  May be null.
+     * Get the error code associated with this operation.  May not be null.
      * @return the associated error code.
      */
     @Nullable

--- a/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
@@ -1,0 +1,18 @@
+package com.microsoft.identity.common.exception;
+
+import javax.annotation.Nullable;
+
+/**
+ * An interface that indicates that there is structured data that can be exctracted from the
+ * containing class.  Specifically, this indicates the presence of a string that represents
+ * the error code to return to the user.  This interface is specifically written with descendants
+ * of (@link Throwable} in mind.
+ */
+public interface IErrorInformation {
+    /**
+     * Get the error code associated with this operation.  May be null.
+     * @return the associated error code.
+     */
+    @Nullable
+    String getErrorCode();
+}

--- a/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/IErrorInformation.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.exception;
 
 import javax.annotation.Nullable;
 
+import lombok.NonNull;
+
 /**
  * An interface that indicates that there is structured data that can be exctracted from the
  * containing class.  Specifically, this indicates the presence of a string that represents
@@ -35,6 +37,6 @@ public interface IErrorInformation {
      * Get the error code associated with this operation.  May not be null.
      * @return the associated error code.
      */
-    @Nullable
+    @NonNull
     String getErrorCode();
 }

--- a/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
@@ -38,7 +38,7 @@ import lombok.experimental.Accessors;
 @Accessors(prefix = "m")
 public class TerminalException extends RuntimeException implements IErrorInformation {
 
-    final String mErrorCode;
+    private final String mErrorCode;
     /**
      * Construct a TerminalException with a message and cause.
      * @param message the exception message.
@@ -47,7 +47,7 @@ public class TerminalException extends RuntimeException implements IErrorInforma
      */
     public TerminalException(final @Nullable String message,
                              final @NonNull Throwable cause,
-                             final @Nullable String errorCode) {
+                             final @NonNull String errorCode) {
         super(message, cause);
         this.mErrorCode = errorCode;
     }
@@ -55,10 +55,10 @@ public class TerminalException extends RuntimeException implements IErrorInforma
     /**
      * Construct a TerminalException with a cause.
      * @param cause the causing exception.  Should not be null.
-     * @param errorCode the error code.  May be null.  This should be an error string from {@link ClientException}.
+     * @param errorCode the error code.  May not be null.  This should be an error string from {@link ClientException}.
      */
     public TerminalException(final @NonNull Throwable cause,
-                             final @Nullable String errorCode) {
+                             final @NonNull String errorCode) {
         super(cause);
         this.mErrorCode = errorCode;
     }

--- a/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
@@ -1,0 +1,46 @@
+package com.microsoft.identity.common.exception;
+
+import javax.annotation.Nullable;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * A RuntimeException derivative indicating that the command cannot continue.  This is largely
+ * written to be thrown in situations where there is not clear path to handling the error except
+ * to abort whatever command is in progress and return an error to the user, short circuiting
+ * whatever other error handling may be present in the code.
+ */
+@Getter
+public class TerminalException extends RuntimeException implements IErrorInformation {
+
+    final String mErrorCode;
+    /**
+     * Construct a TerminalException with a message and cause.
+     * @param message the exception message.
+     * @param cause the causing exception.  Should not be null.
+     * @param errorCode the error code.  May be null.  This should be an error string from {@link ClientException}.
+     */
+    public TerminalException(final @Nullable String message,
+                             final @NonNull Throwable cause,
+                             final @Nullable String errorCode) {
+        super(message, cause);
+        this.mErrorCode = errorCode;
+    }
+
+    /**
+     * Construct a TerminalException with a cause.
+     * @param cause the causing exception.  Should not be null.
+     * @param errorCode the error code.  May be null.  This should be an error string from {@link ClientException}.
+     */
+    public TerminalException(final @NonNull Throwable cause,
+                             final @Nullable String errorCode) {
+        super(cause);
+        this.mErrorCode = errorCode;
+    }
+
+    @Override
+    public @Nullable String getErrorCode() {
+        return null;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
@@ -1,9 +1,32 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.exception;
 
 import javax.annotation.Nullable;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.experimental.Accessors;
 
 /**
  * A RuntimeException derivative indicating that the command cannot continue.  This is largely
@@ -12,6 +35,7 @@ import lombok.NonNull;
  * whatever other error handling may be present in the code.
  */
 @Getter
+@Accessors(prefix = "m")
 public class TerminalException extends RuntimeException implements IErrorInformation {
 
     final String mErrorCode;
@@ -37,10 +61,5 @@ public class TerminalException extends RuntimeException implements IErrorInforma
                              final @Nullable String errorCode) {
         super(cause);
         this.mErrorCode = errorCode;
-    }
-
-    @Override
-    public @Nullable String getErrorCode() {
-        return null;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
+++ b/common/src/main/java/com/microsoft/identity/common/exception/TerminalException.java
@@ -43,7 +43,7 @@ public class TerminalException extends RuntimeException implements IErrorInforma
      * Construct a TerminalException with a message and cause.
      * @param message the exception message.
      * @param cause the causing exception.  Should not be null.
-     * @param errorCode the error code.  May be null.  This should be an error string from {@link ClientException}.
+     * @param errorCode the error code.  May not be null.  This should be an error string from {@link ClientException}.
      */
     public TerminalException(final @Nullable String message,
                              final @NonNull Throwable cause,

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/SilentTokenCommandParameters.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/parameters/SilentTokenCommandParameters.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.commands.parameters;
 
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.TerminalException;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryB2CAuthority;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -54,14 +53,12 @@ public class SilentTokenCommandParameters extends TokenCommandParameters {
             Logger.warn(TAG, "The account set on silent operation parameters is NULL.");
             // if the authority is B2C, then we do not need check if matches with the account enviroment
             // as B2C only exists in one cloud and can use custom domains
-        } else {
-            if (!isAuthorityB2C() && !authorityMatchesAccountEnvironment()) {
-                throw new ArgumentException(
-                        ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
-                        ArgumentException.AUTHORITY_ARGUMENT_NAME,
-                        "Authority passed to silent parameters does not match with the cloud associated to the account."
-                );
-            }
+        } else if (!isAuthorityB2C() && !authorityMatchesAccountEnvironment()) {
+            throw new ArgumentException(
+                    ArgumentException.ACQUIRE_TOKEN_SILENT_OPERATION_NAME,
+                    ArgumentException.AUTHORITY_ARGUMENT_NAME,
+                    "Authority passed to silent parameters does not match with the cloud associated to the account."
+            );
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.DeviceRegistrationRequiredException;
+import com.microsoft.identity.common.exception.TerminalException;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.exception.UiRequiredException;
 import com.microsoft.identity.common.exception.UserCancelException;
@@ -244,6 +245,16 @@ public class ExceptionAdapter {
         Throwable e = exception;
         if (exception instanceof ExecutionException){
             e = exception.getCause();
+        }
+
+        if (e instanceof TerminalException) {
+            String errorCode = ((TerminalException) e).getErrorCode();
+            e = e.getCause();
+            return new ClientException(
+                    errorCode,
+                    "An unhandled exception occurred with message: " + e.getMessage(),
+                    e
+            );
         }
 
         if (e instanceof IOException) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/ExceptionAdapter.java
@@ -248,7 +248,7 @@ public class ExceptionAdapter {
         }
 
         if (e instanceof TerminalException) {
-            String errorCode = ((TerminalException) e).getErrorCode();
+            final String errorCode = ((TerminalException) e).getErrorCode();
             e = e.getCause();
             return new ClientException(
                     errorCode,


### PR DESCRIPTION
In this ICM:https://portal.microsofticm.com/imp/v3/incidents/details/243581504/home we observe that a failure to contact the network for authority validation will result in a rejection stating that an attempt to make a cross-cloud call was made and rejected.

What we're doing here is clarifying the error. Rather than throwing an ArgumentException though, it was suggested that a RuntimeException would be less invasive, but that would lead to UNKNOWN_ERROR results.  Since at the point that we throw the exception we know what the error code should be, we create an instance of RuntimeException that has this additional information so that it can be properly reported to the caller and in the logs.

Tests were added to verify that the correct handling is happening for the new TerminalException class in the CommandDispatcher.

<strike>This is not intended to merge directly into the release/3.4.4-RC1 branch, but into the next release branch cut after the merge back to master.  Since it doesn't yet exist, this should be equivalent.</strike>
This targets release/3.4.5