### PR TITLE
Restore the ability of our thread pools to carry names.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -91,12 +91,12 @@ import static com.microsoft.identity.common.internal.eststelemetry.EstsTelemetry
 public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
-    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
+    public static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
     private static final int INTERACTIVE_REQUEST_THREAD_POOL_SIZE = 1;
     //TODO:1315931 - Refactor the threadpools to not be unbounded for both silent and interactive requests.
-    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedFixedPoolExecutor(10, "interactive");
-    private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedSingleThreadExecutor("silent");
-    );
+    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedFixedPoolExecutor(INTERACTIVE_REQUEST_THREAD_POOL_SIZE, "interactive");
+    private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedFixedPoolExecutor(SILENT_REQUEST_THREAD_POOL_SIZE, "silent");
+
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/CommandDispatcher.java
@@ -94,11 +94,8 @@ public class CommandDispatcher {
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
     private static final int INTERACTIVE_REQUEST_THREAD_POOL_SIZE = 1;
     //TODO:1315931 - Refactor the threadpools to not be unbounded for both silent and interactive requests.
-    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedThreadPoolExecutor(
-            1, INTERACTIVE_REQUEST_THREAD_POOL_SIZE, -1, 0, TimeUnit.MINUTES, "interactive"
-    );
-    private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedThreadPoolExecutor(
-            1, SILENT_REQUEST_THREAD_POOL_SIZE, -1, 1, TimeUnit.MINUTES, "silent"
+    private static final ExecutorService sInteractiveExecutor = ThreadUtils.getNamedFixedPoolExecutor(10, "interactive");
+    private static final ExecutorService sSilentExecutor = ThreadUtils.getNamedSingleThreadExecutor("silent");
     );
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -155,7 +155,7 @@ class DevicePopManager implements IDevicePopManager {
     /**
      * A background worker to service async tasks.
      */
-    private static final ExecutorService sThreadExecutor = ThreadUtils.getNamedThreadPoolExecutor(1, 5, 5, 1, TimeUnit.MINUTES, "pop-manager");
+    private static final ExecutorService sThreadExecutor = ThreadUtils.getNamedFixedPoolExecutor(5,"pop-manager");
 
     /**
      * Properties used by the self-signed certificate.

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -72,35 +72,6 @@ public class ThreadUtils {
     public static ExecutorService getNamedSingleThreadExecutor(final String poolName) {
         return Executors.newSingleThreadExecutor(getNamedThreadFactory(poolName, System.getSecurityManager()));
     }
-    /**
-     * Construct a thread pool with specified name and optionally bounded size.
-     *
-     * @param corePool      The smallest number of threads to keep alive in the pool.
-     * @param maxPool       The maximum number of threads to allow in the thread pool, after which RejectedExecutionException will occur.
-     * @param queueSize     The number of items to keep in the queue.  If this is < 0, the queue is unbounded.
-     * @param keepAliveTime The amount of time to keep excess (greater than corePool size) threads alive before terminating them.
-     * @param keepAliveUnit The time unit on that time.
-     * @param poolName      The name of the thread pool in use.
-     * @return An executor service with the specified properties.
-     */
-    public static ExecutorService getNamedThreadPoolExecutor(final int corePool, final int maxPool,
-                                                             final int queueSize, final long keepAliveTime,
-                                                             @NonNull final TimeUnit keepAliveUnit,
-                                                             @NonNull final String poolName) {
-        if (queueSize > 0) {
-            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
-                                          new ArrayBlockingQueue<Runnable>(queueSize),
-                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
-        } else if (queueSize == 0) {
-            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
-                                          new SynchronousQueue<Runnable>(),
-                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
-        } else { // (queueSize < 0)
-            return new ThreadPoolExecutor(corePool, maxPool, keepAliveTime, keepAliveUnit,
-                                          new LinkedBlockingQueue<Runnable>(),
-                                          getNamedThreadFactory(poolName, System.getSecurityManager()));
-        }
-    }
 
     //Nice thought, but if you're using executors, you're using ThreadGroup whether you want to or not.
     @SuppressWarnings("PMD.AvoidThreadGroup")

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ThreadUtils.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.logging.Logger;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -60,6 +61,17 @@ public class ThreadUtils {
         }
     }
 
+    public static ExecutorService getNamedFixedPoolExecutor(final int poolSize, final String poolName) {
+        return Executors.newFixedThreadPool(poolSize, getNamedThreadFactory(poolName, System.getSecurityManager()));
+    }
+
+    public static ExecutorService getNamedCachedPoolExecutor(final String poolName) {
+        return Executors.newCachedThreadPool(getNamedThreadFactory(poolName, System.getSecurityManager()));
+    }
+
+    public static ExecutorService getNamedSingleThreadExecutor(final String poolName) {
+        return Executors.newSingleThreadExecutor(getNamedThreadFactory(poolName, System.getSecurityManager()));
+    }
     /**
      * Construct a thread pool with specified name and optionally bounded size.
      *

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class ThreadUtilsTests {
     @Test
     public void basicPoolTest() throws Exception {
-        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
+        final ExecutorService s = ThreadUtils.getNamedFixedPoolExecutor(10, "testPool");
         final Future<String> result = s.submit(new Callable<String>() {
             @Override
             public String call() {
@@ -48,7 +48,22 @@ public class ThreadUtilsTests {
 
     @Test
     public void capacityOneTest() throws Exception {
-        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 1, 5, TimeUnit.SECONDS, "testPool");
+        final ExecutorService s = ThreadUtils.getNamedFixedPoolExecutor(1, "testPool");
+        final Future<?> result = s.submit(hangThread());
+        final Future<?> result2 = s.submit(hangThread());
+        s.submit(new Runnable() {
+            @Override
+            public void run() {
+             }
+        });
+        Assert.assertTrue("Execution should have been rejected", caught);
+        result.cancel(true);
+        result2.cancel(true);
+        s.shutdownNow();
+    }
+    @Test
+    public void capacitySingleTest() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedSingleThreadExecutor("testPool");
         final Future<?> result = s.submit(hangThread());
         final Future<?> result2 = s.submit(hangThread());
         boolean caught = false;

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -22,11 +22,15 @@ import com.microsoft.identity.common.internal.util.ThreadUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,6 +47,24 @@ public class ThreadUtilsTests {
             }
         });
         Assert.assertTrue(result.get().startsWith("testPool"));
+        s.shutdownNow();
+    }
+
+    @Test
+    public void exceptionPropagationTest() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 10, -1, 5, TimeUnit.SECONDS, "testPool");
+        final Future<String> result = s.submit(new Callable<String>() {
+            @Override
+            public String call() {
+                throw new RuntimeException("Boom!");
+            }
+        });
+        try {
+            result.get();
+            throw new AssertionError("Should have gotten an exception here");
+        } catch (ExecutionException e) {
+            Assert.assertEquals("Boom!", e.getCause().getMessage());
+        }
         s.shutdownNow();
     }
 
@@ -82,6 +104,213 @@ public class ThreadUtilsTests {
         result2.cancel(true);
         s.shutdownNow();
     }
+
+    @Test
+    public void capacityFiveUnboundedLooped() throws Exception {
+        for (int i = 0; i < 10000; i++) {
+            capacityFiveTestUnbounded();
+        }
+    }
+
+    @Test
+    public void capacityFiveTestUnbounded() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, -1, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+
+        for (int i = 0; i < 10; i++) {
+            CountDownLatch newLatch = new CountDownLatch(1);
+            CountDownLatch newGoLatch = new CountDownLatch(1);
+            CountDownLatch newStopLatch = new CountDownLatch(1);
+            for (int j = 0; j < 1000; j++) {
+                s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+            }
+            Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+            newGoLatch.countDown();
+            Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        }
+
+        s.shutdownNow();
+    }
+
+    @Test
+    public void capacityFiveTestUnboundedExceptionsAndCancellations() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, -1, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+
+        for (int i = 0; i < 10; i++) {
+            CountDownLatch newLatch = new CountDownLatch(1);
+            CountDownLatch newGoLatch = new CountDownLatch(1);
+            CountDownLatch newStopLatch = new CountDownLatch(1);
+            List<Future> futures = new ArrayList<>();
+            for (int j = 0; j < 1000; j++) {
+                if (j%3 == 0) {
+                    s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+                } else if (j%3 == 1) {
+                    s.submit(exceptionTaskLatched(newLatch, newGoLatch, newStopLatch));
+                } else {
+                    Future f = s.submit(hangThread());
+                    futures.add(f);
+                }
+            }
+            Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+            for (Future f: futures) {
+                f.cancel(true);
+            }
+            newGoLatch.countDown();
+            Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        }
+
+        s.shutdownNow();
+    }
+
+    @Test
+    public void capacityFiveTestUnboundedExceptions() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, -1, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+
+        for (int i = 0; i < 10; i++) {
+            CountDownLatch newLatch = new CountDownLatch(1);
+            CountDownLatch newGoLatch = new CountDownLatch(1);
+            CountDownLatch newStopLatch = new CountDownLatch(1);
+            for (int j = 0; j < 1000; j++) {
+                if (j%2 == 0) {
+                    s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+                } else {
+                    s.submit(exceptionTaskLatched(newLatch, newGoLatch, newStopLatch));
+                }
+            }
+            Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+            newGoLatch.countDown();
+            Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        }
+
+        s.shutdownNow();
+    }
+
+    @Test
+    public void capacityFiveTest() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, 0, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        boolean caught = false;
+        try {
+            s.submit(new Runnable() {
+                @Override
+                public void run() {
+
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            caught = true;
+        }
+        Assert.assertTrue("Execution should have been rejected", caught);
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+        ((ThreadPoolExecutor)s).purge();
+        int k = 0;
+        // As far as I can tell, there's no reliable method to wait on this.
+        // This is probably a good reason not to do this thing.
+        while (((ThreadPoolExecutor)s).getActiveCount() > 0 && k < 10) {
+            k++;
+            Thread.sleep(0, 50);
+        }
+        Assert.assertEquals(0, ((ThreadPoolExecutor)s).getActiveCount());
+        Assert.assertEquals(0, ((ThreadPoolExecutor)s).getQueue().size());
+        CountDownLatch newLatch = new CountDownLatch(1);
+        CountDownLatch newGoLatch = new CountDownLatch(1);
+        CountDownLatch newStopLatch = new CountDownLatch(1);
+        s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+        Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+        newGoLatch.countDown();
+        Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        ((ThreadPoolExecutor)s).purge();
+        s.shutdownNow();
+    }
+
+    @Test
+    public void capacityFiveTestExceptions() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, 0, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(exceptionTaskLatched(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(exceptionTaskLatched(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        boolean caught = false;
+        try {
+            s.submit(new Runnable() {
+                @Override
+                public void run() {
+
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            caught = true;
+        }
+        Assert.assertTrue("Execution should have been rejected", caught);
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+        ((ThreadPoolExecutor)s).purge();
+        int k = 0;
+        // As far as I can tell, there's no reliable method to wait on this.
+        // This is probably a good reason not to do this thing.
+        while (((ThreadPoolExecutor)s).getActiveCount() > 0 && k < 10) {
+            k++;
+            Thread.sleep(0, 100);
+        }
+        Assert.assertEquals(0, ((ThreadPoolExecutor)s).getActiveCount());
+        Assert.assertEquals(0, ((ThreadPoolExecutor)s).getQueue().size());
+        CountDownLatch newLatch = new CountDownLatch(1);
+        CountDownLatch newGoLatch = new CountDownLatch(1);
+        CountDownLatch newStopLatch = new CountDownLatch(1);
+        s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+        Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+        newGoLatch.countDown();
+        Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        ((ThreadPoolExecutor)s).purge();
+        s.shutdownNow();
+    }
+
     @Test
     public void capacityZeroTest() throws Exception {
         final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 1, 0, 5, TimeUnit.SECONDS, "testPool");
@@ -101,7 +330,37 @@ public class ThreadUtilsTests {
         result.cancel(true);
         s.shutdownNow();
     }
+    private Runnable exceptionTaskLatched(CountDownLatch latch, CountDownLatch goLatch, CountDownLatch stopLatch) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+                try {
+                    goLatch.await();
+                    throw new RuntimeException("BOOM!");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stopLatch.countDown();
+                }
+            }
+        };
+    }
 
+    private Runnable hangThreadLatch(CountDownLatch latch, CountDownLatch goLatch, CountDownLatch stopLatch) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+                try {
+                    goLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                stopLatch.countDown();
+            }
+        };
+    }
     private Runnable hangThread() {
         return new Runnable() {
             @Override

--- a/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/unit/ThreadUtilsTests.java
@@ -184,6 +184,49 @@ public class ThreadUtilsTests {
     }
 
     @Test
+    public void capacityFiveTestUnboundedExceptionsErrorsAndCancellations() throws Exception {
+        final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, -1, 5, TimeUnit.SECONDS, "testPool");
+        final CountDownLatch latch = new CountDownLatch(5);
+        final CountDownLatch goLatch = new CountDownLatch(1);
+        final CountDownLatch stopLatch = new CountDownLatch(5);
+        final Future<?> result = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result2 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result3 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result4 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+        final Future<?> result5 = s.submit(hangThreadLatch(latch, goLatch, stopLatch));
+
+        goLatch.countDown();
+        Assert.assertTrue(stopLatch.await(5, TimeUnit.MINUTES));
+
+        for (int i = 0; i < 100; i++) {
+            CountDownLatch newLatch = new CountDownLatch(1);
+            CountDownLatch newGoLatch = new CountDownLatch(1);
+            CountDownLatch newStopLatch = new CountDownLatch(1);
+            List<Future> futures = new ArrayList<>();
+            for (int j = 0; j < 1000; j++) {
+                if (j%4 == 0) {
+                    s.submit(hangThreadLatch(newLatch, newGoLatch, newStopLatch));
+                } else if (j%4 == 1) {
+                    s.submit(exceptionTaskLatched(newLatch, newGoLatch, newStopLatch));
+                } else if (j%4 == 2) {
+                    s.submit(errorTaskLatched(newLatch, newGoLatch, newStopLatch));
+                } else {
+                    Future f = s.submit(hangThread());
+                    futures.add(f);
+                }
+            }
+            Assert.assertTrue(newLatch.await(60, TimeUnit.SECONDS));
+            for (Future f: futures) {
+                f.cancel(true);
+            }
+            newGoLatch.countDown();
+            Assert.assertTrue(newStopLatch.await(60, TimeUnit.SECONDS));
+        }
+
+        s.shutdownNow();
+    }
+
+    @Test
     public void capacityFiveTestUnboundedExceptions() throws Exception {
         final ExecutorService s = ThreadUtils.getNamedThreadPoolExecutor(1, 5, -1, 5, TimeUnit.SECONDS, "testPool");
         final CountDownLatch latch = new CountDownLatch(5);
@@ -330,6 +373,23 @@ public class ThreadUtilsTests {
         result.cancel(true);
         s.shutdownNow();
     }
+    private Runnable errorTaskLatched(CountDownLatch latch, CountDownLatch goLatch, CountDownLatch stopLatch) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+                try {
+                    goLatch.await();
+                    throw new Error("KABOOM!");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stopLatch.countDown();
+                }
+            }
+        };
+    }
+
     private Runnable exceptionTaskLatched(CountDownLatch latch, CountDownLatch goLatch, CountDownLatch stopLatch) {
         return new Runnable() {
             @Override


### PR DESCRIPTION
This changes the semantics of the ThreadUtils class to mirror the Executors class, and adds testing at both
the command dispatcher and ThreadUtils classes to make certain that the number of threads desired can actually
be used.