### PR TITLE
Update 3.4.4-RC1 changelog to include CommandDispatcher fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 3.4.4
 - [PATCH] Only hit cache once when loading x-tenant idtokens (#1385)
 - [PATCH] Disregard pageload errors for the non-primary frame during interactive auth (#1357)
 - [PATCH] Avoid unnecessary BAM-cache reload (#1439, cherry-picked from #1426)
+- [PATCH] Concurrency fix: revert thread pool construction changes in CommandDispatcher (#1434)
 
 Version 3.4.3
 ----------


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1434 did not update the changelog