### PR TITLE
[Major | API Breaking] SSOStateSerializer Moving Out of Internal Package

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ V.Next
 - [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)
 - [PATCH] Avoid needless BAM-cache lookups for non-foci apps when doing cache discovery (#1427)
 - [PATCH] Avoid multiple reads of BAM-Cache when inserting new data (#1429)
-- [MAJOR] Relocate SSOStatesSerializer out of internal namespace (#1448)
+- [MAJOR] Relocate SSOStatesSerializer out of internal namespace (integration steps available at aka.ms/AAd2vt8) (#1448)
 
 Version 3.4.3
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ V.Next
 - [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)
 - [PATCH] Avoid needless BAM-cache lookups for non-foci apps when doing cache discovery (#1427)
 - [PATCH] Avoid multiple reads of BAM-Cache when inserting new data (#1429)
+- [MAJOR] Relocate SSOStatesSerializer out of internal namespace
 
 Version 3.4.3
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,7 +29,7 @@ V.Next
 - [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)
 - [PATCH] Avoid needless BAM-cache lookups for non-foci apps when doing cache discovery (#1427)
 - [PATCH] Avoid multiple reads of BAM-Cache when inserting new data (#1429)
-- [MAJOR] Relocate SSOStatesSerializer out of internal namespace
+- [MAJOR] Relocate SSOStatesSerializer out of internal namespace (#1448)
 
 Version 3.4.3
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/TokenShareUtility.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/TokenShareUtility.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.WarningType;
+import com.microsoft.identity.common.adal.tokensharing.SSOStateSerializer;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ServiceException;

--- a/common/src/main/java/com/microsoft/identity/common/adal/tokensharing/SSOStateSerializer.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/tokensharing/SSOStateSerializer.java
@@ -21,12 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package com.microsoft.identity.common.adal.internal.tokensharing;
+package com.microsoft.identity.common.adal.tokensharing;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.adal.internal.tokensharing.TokenCacheItemSerializationAdapater;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.ADALTokenCacheItem;
 
@@ -41,7 +42,7 @@ import java.util.List;
  * deserialization details. It provides a serializer to serialize the
  * TokenCacheItem and a deserializer to return the TokenCacheItem.
  */
-final class SSOStateSerializer {
+public final class SSOStateSerializer {
     /**
      * The version number of {@link SSOStateSerializer }.
      */
@@ -146,7 +147,7 @@ final class SSOStateSerializer {
      * @param item ADALTokenCacheItem to convert to serialized json
      * @return String
      */
-    static String serialize(final ADALTokenCacheItem item) {
+    public static String serialize(final ADALTokenCacheItem item) {
         SSOStateSerializer ssoStateSerializer = new SSOStateSerializer(item);
         return ssoStateSerializer.internalSerialize();
     }
@@ -161,7 +162,7 @@ final class SSOStateSerializer {
      * @return ADALTokenCacheItem
      * @throws ClientException
      */
-    static ADALTokenCacheItem deserialize(final String serializedBlob) throws ClientException {
+    public static ADALTokenCacheItem deserialize(final String serializedBlob) throws ClientException {
         SSOStateSerializer ssoStateSerializer = new SSOStateSerializer();
         return ssoStateSerializer.internalDeserialize(serializedBlob);
     }


### PR DESCRIPTION
Impetus:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1333714?src=WorkItemMention&src-action=artifact_link

Summary:
- OneAuth is depending on this `internal` class to enable use of TSL/AccountDiscovery
- OneAuth ideally shouldn't have to 'drill into' this otherwise default visibility class, so moving out of `internal`
- This is API breaking for Android-Common, since OneAuth is known to have a dependency on this class
- This change _could_ be additive if we elected to duplicate the class and `@deprecate` the old one; I elected to move it and change the vis instead