### PR TITLE
Introduce a more human readable way to specify in tests whether password prompt is expected or not

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add helper for Automation Tests to account for passwordPageExpected (#1449)
 - [MAJOR] Migrate Exceptions from common to common4j (#1442)
 - [PATCH] Fixing removeAccount method for msal cpp when the realm is empty (#1422)
 - [MINOR] Migrate Requests/Responses (#1424)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 V.Next
 ----------
-- [MINOR] Add helper for Automation Tests to account for passwordPageExpected (#1449)
 - [MAJOR] Migrate Exceptions from common to common4j (#1442)
 - [PATCH] Fixing removeAccount method for msal cpp when the realm is empty (#1422)
 - [MINOR] Migrate Requests/Responses (#1424)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -93,6 +93,12 @@ public class PromptHandlerParameters {
     private final boolean consentPageExpected;
 
     /**
+     * Denotes whether or not the password page is expected to appear during an interactive token
+     * request.
+     */
+    private final boolean passwordPageExpected;
+
+    /**
      * Denotes whether or not the speed bump page is expected to appear during an interactive token
      * request.
      */

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptParameter.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptParameter.java
@@ -28,5 +28,6 @@ package com.microsoft.identity.client.ui.automation.interaction;
 public enum PromptParameter {
     SELECT_ACCOUNT,
     LOGIN,
-    CONSENT
+    CONSENT,
+    WHEN_REQUIRED
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -76,6 +76,20 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
             loginComponentHandler.handleEmailField(username);
         }
 
+        if (parameters.getPrompt() == PromptParameter.WHEN_REQUIRED ) {
+            if (parameters.isConsentPageExpected()) {
+                final UiResponse consentPageResponse = parameters.getConsentPageResponse();
+                if (consentPageResponse == UiResponse.ACCEPT) {
+                    loginComponentHandler.acceptConsent();
+                } else {
+                    loginComponentHandler.declineConsent();
+                }
+            }
+            if(parameters.isPasswordPageExpected()) {
+                loginComponentHandler.handlePasswordField(password);
+            }
+        }
+
         if (parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
             loginComponentHandler.handlePasswordField(password);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -76,21 +76,7 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
             loginComponentHandler.handleEmailField(username);
         }
 
-        if (parameters.getPrompt() == PromptParameter.WHEN_REQUIRED ) {
-            if (parameters.isConsentPageExpected()) {
-                final UiResponse consentPageResponse = parameters.getConsentPageResponse();
-                if (consentPageResponse == UiResponse.ACCEPT) {
-                    loginComponentHandler.acceptConsent();
-                } else {
-                    loginComponentHandler.declineConsent();
-                }
-            }
-            if(parameters.isPasswordPageExpected()) {
-                loginComponentHandler.handlePasswordField(password);
-            }
-        }
-
-        if (parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
+        if (parameters.isPasswordPageExpected() || parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
             loginComponentHandler.handlePasswordField(password);
         }
 


### PR DESCRIPTION
Adding logic to account for passwordPage for Automation Tests. Associates to [this](https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1452/commits) PR in MSAL. 

We used to kind of sort of re-use the prompt parameter for this purpose...however, better to have a dedicated field for this purpose that says:

`passwordPageExpected(true/false)`