### PR TITLE
SharedPrefsFileManager API fixes to 3.4.5 (and cherry-picks a changelog update from 3.4.4)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 VNext
 ----------
 
+Version 3.4.5
+----------
+- [PATCH] Fix for misconfigured ADALOAuth2TokenCache (#1444)
+
 Version 3.4.4
 ----------
 - [MINOR] Introduce support for authorization activities to be performed in the Android Task as the Activity that was provided for an interactive request.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ VNext
 
 Version 3.4.5
 ----------
-- [PATCH] Fix for misconfigured ADALOAuth2TokenCache (#1444)
+- [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)
 
 Version 3.4.4
 ----------
@@ -13,6 +13,7 @@ Version 3.4.4
 - [PATCH] Only hit cache once when loading x-tenant idtokens (#1385)
 - [PATCH] Disregard pageload errors for the non-primary frame during interactive auth (#1357)
 - [PATCH] Avoid unnecessary BAM-cache reload (#1439, cherry-picked from #1426)
+- [PATCH] Concurrency fix: revert thread pool construction changes in CommandDispatcher (#1434)
 
 Version 3.4.3
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -297,7 +297,6 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 getBrokerUidSequesteredFilename(appUid),
-                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
     }
@@ -306,7 +305,6 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
     }

--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -297,7 +297,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 getBrokerUidSequesteredFilename(appUid),
-                -1,
+                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
     }
@@ -306,7 +306,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         return SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                -1,
+                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
     }

--- a/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
@@ -123,7 +123,6 @@ public class DefaultSharedPrefsFileManagerReencrypterTest {
         mTestCacheFile = SharedPreferencesFileManager.getSharedPreferences(
                 mContext,
                 TEST_CACHE_FILENAME,
-                Context.MODE_PRIVATE,
                 null
         );
         mFileManagerReencrypter = new DefaultSharedPrefsFileManagerReencrypter();

--- a/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
@@ -123,7 +123,7 @@ public class DefaultSharedPrefsFileManagerReencrypterTest {
         mTestCacheFile = SharedPreferencesFileManager.getSharedPreferences(
                 mContext,
                 TEST_CACHE_FILENAME,
-                -1,
+                Context.MODE_PRIVATE,
                 null
         );
         mFileManagerReencrypter = new DefaultSharedPrefsFileManagerReencrypter();

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -260,7 +260,6 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 "test_prefs",
-                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -260,7 +260,7 @@ public class MsalOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 "test_prefs",
-                -1,
+                Context.MODE_PRIVATE,
                 new StorageHelper(context)
         );
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -100,7 +100,6 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
         mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 testContext,
                 sAccountCredentialSharedPreferences,
-                Context.MODE_PRIVATE,
                 new StorageHelper(testContext) // Use encrypted storage for tests...
         );
         mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -100,7 +100,7 @@ public class SharedPreferencesAccountCredentialCacheTest extends AndroidSecretKe
         mSharedPreferencesFileManager = SharedPreferencesFileManager.getSharedPreferences(
                 testContext,
                 sAccountCredentialSharedPreferences,
-                -1,
+                Context.MODE_PRIVATE,
                 new StorageHelper(testContext) // Use encrypted storage for tests...
         );
         mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -22,6 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
 import androidx.test.InstrumentationRegistry;
 
 import com.microsoft.identity.common.adal.internal.AndroidSecretKeyEnabledHelper;
@@ -40,12 +44,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-
-import android.content.Context;
 
 @RunWith(Parameterized.class)
 public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHelper {

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -61,13 +61,11 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
         return Arrays.asList(new ISharedPreferencesFileManager[]{
                 SharedPreferencesFileManager.getSharedPreferences(
                         InstrumentationRegistry.getTargetContext(),
-                        sTEST_SHARED_PREFS_NAME,
-                        Context.MODE_PRIVATE, null
+                        sTEST_SHARED_PREFS_NAME,null
                 ),
                 SharedPreferencesFileManager.getSharedPreferences(
                         InstrumentationRegistry.getTargetContext(),
                         sTEST_SHARED_PREFS_NAME,
-                        Context.MODE_PRIVATE,
                         new StorageHelper(InstrumentationRegistry.getTargetContext())
                 )
         });

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -45,6 +45,8 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
+import android.content.Context;
+
 @RunWith(Parameterized.class)
 public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHelper {
 
@@ -60,12 +62,12 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
                 SharedPreferencesFileManager.getSharedPreferences(
                         InstrumentationRegistry.getTargetContext(),
                         sTEST_SHARED_PREFS_NAME,
-                        -1, null
+                        Context.MODE_PRIVATE, null
                 ),
                 SharedPreferencesFileManager.getSharedPreferences(
                         InstrumentationRegistry.getTargetContext(),
                         sTEST_SHARED_PREFS_NAME,
-                        -1,
+                        Context.MODE_PRIVATE,
                         new StorageHelper(InstrumentationRegistry.getTargetContext())
                 )
         });

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -119,7 +119,7 @@ public class ADALOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         getContext(),
                         fileName,
-                        -1,
+                        Context.MODE_PRIVATE,
                         new StorageHelper(getContext())
                 );
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ADALOAuth2TokenCache.java
@@ -119,7 +119,6 @@ public class ADALOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         getContext(),
                         fileName,
-                        Context.MODE_PRIVATE,
                         new StorageHelper(getContext())
                 );
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -1607,7 +1607,6 @@ public class BrokerOAuth2TokenCache
                         context,
                         SharedPreferencesAccountCredentialCache
                                 .getBrokerUidSequesteredFilename(bindingProcessUid),
-                        Context.MODE_PRIVATE,
                         storageHelper
                 );
 
@@ -1625,7 +1624,6 @@ public class BrokerOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                        Context.MODE_PRIVATE,
                         storageHelper
                 );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/BrokerOAuth2TokenCache.java
@@ -1607,7 +1607,7 @@ public class BrokerOAuth2TokenCache
                         context,
                         SharedPreferencesAccountCredentialCache
                                 .getBrokerUidSequesteredFilename(bindingProcessUid),
-                        -1,
+                        Context.MODE_PRIVATE,
                         storageHelper
                 );
 
@@ -1625,7 +1625,7 @@ public class BrokerOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                        -1,
+                        Context.MODE_PRIVATE,
                         storageHelper
                 );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
@@ -77,7 +77,7 @@ public class HelloCache {
     public HelloCache(final @NonNull Context context,
                       final @NonNull String protocolName,
                       final @NonNull String targetAppPackageName) {
-        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME, -1, null);
+        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME, Context.MODE_PRIVATE, null);
         mContext = context;
         mProtocolName = protocolName;
         mTargetAppPackageName = targetAppPackageName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
@@ -77,7 +77,7 @@ public class HelloCache {
     public HelloCache(final @NonNull Context context,
                       final @NonNull String protocolName,
                       final @NonNull String targetAppPackageName) {
-        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME,null);
+        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME, null);
         mContext = context;
         mProtocolName = protocolName;
         mTargetAppPackageName = targetAppPackageName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/HelloCache.java
@@ -77,7 +77,7 @@ public class HelloCache {
     public HelloCache(final @NonNull Context context,
                       final @NonNull String protocolName,
                       final @NonNull String targetAppPackageName) {
-        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME, Context.MODE_PRIVATE, null);
+        mFileManager = SharedPreferencesFileManager.getSharedPreferences(context, SHARED_PREFERENCE_NAME,null);
         mContext = context;
         mProtocolName = protocolName;
         mTargetAppPackageName = targetAppPackageName;

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -143,7 +143,6 @@ public class MsalOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                        Context.MODE_PRIVATE,
                         storageHelper
                 );
         final IAccountCredentialCache accountCredentialCache =

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/MsalOAuth2TokenCache.java
@@ -143,7 +143,7 @@ public class MsalOAuth2TokenCache
                 SharedPreferencesFileManager.getSharedPreferences(
                         context,
                         DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
-                        -1,
+                        Context.MODE_PRIVATE,
                         storageHelper
                 );
         final IAccountCredentialCache accountCredentialCache =

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -79,7 +79,7 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
                                                                     final String name,
                                                                     final int operatingMode,
                                                                     final IStorageHelper storageHelper) {
-        String key = name + "/" + context.getPackageName() + "/" + operatingMode;
+        String key = name + "/" + context.getPackageName() + "/" + (operatingMode == -1 ? Context.MODE_PRIVATE : operatingMode);
         SharedPreferencesFileManager cachedFileManager = objectCache.get(key);
         if(cachedFileManager == null) {
             cachedFileManager = objectCache.putIfAbsent(key, new SharedPreferencesFileManager(context, name, operatingMode, storageHelper));
@@ -88,6 +88,20 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
             }
         }
         return cachedFileManager;
+    }
+
+    /**
+     * Constructs an instance of SharedPreferencesFileManager. Operating mode is always MODE_PRIVATE.
+     *
+     * @param context Interface to global information about an application environment.
+     * @param name The desired {@link android.content.SharedPreferences} file. It will be created if it does not exist.
+     * @param storageHelper The {@link IStorageHelper} to handle encryption/decryption of values.
+     * @return The SharedPreferencesFileManager instance.
+     */
+    public static SharedPreferencesFileManager getSharedPreferences(final Context context,
+                                                                    final String name,
+                                                                    final IStorageHelper storageHelper) {
+        return getSharedPreferences(context, name, Context.MODE_PRIVATE, storageHelper);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -75,6 +75,7 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
      * @param storageHelper The {@link IStorageHelper} to handle encryption/decryption of values.
      * @param operatingMode the mode in which to operate this
      */
+    @Deprecated
     public static SharedPreferencesFileManager getSharedPreferences(final Context context,
                                                                     final String name,
                                                                     final int operatingMode,

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -47,7 +47,7 @@ public class ClockSkewManager implements IClockSkewManager {
         mClockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
-                -1,
+                Context.MODE_PRIVATE,
                 null
         );
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/ClockSkewManager.java
@@ -47,7 +47,6 @@ public class ClockSkewManager implements IClockSkewManager {
         mClockSkewPreferences = SharedPreferencesFileManager.getSharedPreferences(
                 context,
                 PreferencesMetadata.SKEW_PREFERENCES_FILENAME,
-                Context.MODE_PRIVATE,
                 null
         );
     }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -64,7 +64,7 @@ public class TestUtils {
     public static SharedPreferencesFileManager getSharedPreferences(final String sharedPrefName) {
         final Context context = ApplicationProvider.getApplicationContext();
 
-        return SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, Context.MODE_PRIVATE, null);
+        return SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, null);
     }
 
     public static Activity getMockActivity(final Context context) {
@@ -83,7 +83,7 @@ public class TestUtils {
     public static SharedPreferencesFileManager getEncryptedSharedPreferences(final String sharedPrefName) {
         final Context context = ApplicationProvider.getApplicationContext();
         final StorageHelper storageHelper = new StorageHelper(context);
-        final SharedPreferencesFileManager barePreferences = SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, Context.MODE_PRIVATE, storageHelper);
+        final SharedPreferencesFileManager barePreferences = SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, storageHelper);
         return barePreferences;
     }
 


### PR DESCRIPTION
Brings the changes from https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1444 into `release/3.4.5`

Also cherry-picks 3e27ebff8f643e502a79bb853ff29ec13bd81467