### PR TITLE
Code changes for new OneAuth cache key migration API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Adds new cache encryption key migration API for OneAuth (#1464)
 - [MAJOR] Migrate StorageHelper to common4j (#1450)
 - [MAJOR] Migrate Exceptions from common to common4j (#1442)
 - [PATCH] Fixing removeAccount method for msal cpp when the realm is empty (#1422)

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/DefaultSharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/DefaultSharedPrefsFileManagerReencrypter.java
@@ -31,6 +31,7 @@ import java.util.Map;
 /**
  * Default implementation of {@link ISharedPrefsFileManagerReencrypter}.
  */
+@Deprecated
 public class DefaultSharedPrefsFileManagerReencrypter implements ISharedPrefsFileManagerReencrypter {
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/migration/DefaultSharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/DefaultSharedPrefsFileManagerReencrypter.java
@@ -1,0 +1,209 @@
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallback;
+import com.microsoft.identity.common.logging.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Default implementation of {@link ISharedPrefsFileManagerReencrypter}.
+ */
+public class DefaultSharedPrefsFileManagerReencrypter implements ISharedPrefsFileManagerReencrypter {
+
+    private static final String TAG = DefaultSharedPrefsFileManagerReencrypter.class.getSimpleName();
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Override
+    public IMigrationOperationResult reencrypt(@NonNull final ISharedPreferencesFileManager fileManager,
+                                               @NonNull final IStringEncrypter encrypter,
+                                               @NonNull final IStringDecrypter decrypter,
+                                               @NonNull final ReencryptionParams params) {
+        final String methodName = ":reencrypt (sync)";
+        final Map<String, String> cacheEntries = new HashMap<>(fileManager.getAll());
+        Logger.verbose(TAG + methodName,
+                "Attempting to migrate cache entries: " + cacheEntries.size());
+        final MigrationOperationResult result = new MigrationOperationResult();
+        result.setCountOfTotalRecords(cacheEntries.size());
+        final Set<String> keysMarkedForRemoval = new HashSet<>();
+        final AtomicBoolean shouldAbort = new AtomicBoolean(false);
+        final Set<String> skipKeys = new HashSet<>();
+
+        // Decrypt everything
+        applyCacheMutation(
+                cacheEntries,
+                new Callable<Map.Entry<String, String>>() {
+                    @Override
+                    public void call(final Map.Entry<String, String> entry) throws Exception {
+                        final String decryptedText = decrypter.decrypt(entry.getValue());
+                        entry.setValue(decryptedText);
+                    }
+                },
+                result,
+                params,
+                keysMarkedForRemoval,
+                skipKeys,
+                shouldAbort
+        );
+
+        // Clear any keys marked for removal...
+        clearEntriesMarkedForRemoval(fileManager, cacheEntries, keysMarkedForRemoval);
+
+        if (shouldAbort.get()) {
+            Logger.info(TAG + methodName, "Aborting after decrypt.");
+            return result;
+        }
+
+        // Reencrypt everything
+        applyCacheMutation(
+                cacheEntries,
+                new Callable<Map.Entry<String, String>>() {
+                    @Override
+                    public void call(final Map.Entry<String, String> entry) throws Exception {
+                        final String reencryptedText = encrypter.encrypt(entry.getValue());
+                        entry.setValue(reencryptedText);
+                    }
+                },
+                result,
+                params,
+                keysMarkedForRemoval,
+                skipKeys,
+                shouldAbort
+        );
+
+        // Clear any keys marked for removal...
+        clearEntriesMarkedForRemoval(fileManager, cacheEntries, keysMarkedForRemoval);
+
+        if (shouldAbort.get()) {
+            Logger.info(TAG + methodName, "Aborting after reencrypt.");
+            return result;
+        }
+
+        // Write the newly encrypted records...
+        Logger.info(TAG + methodName, "Writing reencrypted cache entries.");
+        for (final Map.Entry<String, String> cacheEntry : cacheEntries.entrySet()) {
+            fileManager.putString(cacheEntry.getKey(), cacheEntry.getValue());
+        }
+
+        return result;
+    }
+
+    private interface Callable<T> {
+        void call(T t) throws Exception;
+    }
+
+    /**
+     * Utility function for reencryption operations. Accepts the contents of a {@link Map} and
+     * applies the mutation defined by {@link Callable} to it.
+     *
+     * @param cacheEntries         The Cache entries to which the supplied mutation is applied.
+     * @param callable             The callable definining the mutation.
+     * @param inputResult          A {@link MigrationOperationResult} used to track error states which may
+     *                             occur during a mutation.
+     * @param params               The {@link com.microsoft.identity.common.migration.ISharedPrefsFileManagerReencrypter.ReencryptionParams}
+     *                             defining how errors should be handled/surfaced.
+     * @param keysMarkedForRemoval A {@link Set} of cache keys to be removed from the underlying
+     *                             cache if an error is encountered. Please note that this function
+     *                             does not perform the removal operation itself; see
+     *                             {@link #clearEntriesMarkedForRemoval(ISharedPreferencesFileManager, Map, Set)}.
+     * @param skipKeys             Cache keys which should not have the supplied mutation applied to it, usually
+     *                             due to an error reading the value stored at this key (for example, cannot
+     *                             be decrypted).
+     * @param shouldAbort          A pass-by-reference boolean, allowing this method to dictate that abortive
+     *                             action must be taken by the caller.
+     */
+    private void applyCacheMutation(@NonNull final Map<String, String> cacheEntries,
+                                    @NonNull final Callable<Map.Entry<String, String>> callable,
+                                    @NonNull final MigrationOperationResult inputResult,
+                                    @NonNull final ReencryptionParams params,
+                                    @NonNull final Set<String> keysMarkedForRemoval,
+                                    @NonNull final Set<String> skipKeys,
+                                    @NonNull AtomicBoolean shouldAbort) {
+        final String methodName = ":applyCacheMutation";
+        for (final Map.Entry<String, String> cacheEntry : cacheEntries.entrySet()) {
+            try {
+                if (skipKeys.contains(cacheEntry.getKey())) {
+                    Logger.warn(TAG + methodName, "Skipping entry.");
+                    continue;
+                }
+                callable.call(cacheEntry);
+            } catch (final Exception e) {
+                Logger.error(TAG + methodName, "Error during mutation", e);
+                Logger.errorPII(TAG + methodName, "Failed key: " + cacheEntry.getKey(), e);
+                inputResult.addFailure(e);
+                skipKeys.add(cacheEntry.getKey());
+
+                if (params.eraseEntryOnError()) {
+                    Logger.warn(TAG + methodName, "Marking key for removal.");
+                    keysMarkedForRemoval.add(cacheEntry.getKey());
+                }
+
+                if (params.eraseAllOnError()) {
+                    Logger.warn(TAG + methodName, "Marking all keys for removal.");
+                    keysMarkedForRemoval.addAll(cacheEntries.keySet());
+                    shouldAbort.set(true);
+                    break;
+                }
+
+                if (params.abortOnError()) {
+                    shouldAbort.set(true);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void clearEntriesMarkedForRemoval(@NonNull final ISharedPreferencesFileManager fileManager,
+                                              @NonNull final Map<String, String> cacheEntries,
+                                              @NonNull final Set<String> keysMarkedForRemoval) {
+        final String methodName = ":clearEntriesMarkedForRemoval";
+        Logger.warn(TAG + methodName, "Removing entries marked for removal");
+        for (final String removedKey : keysMarkedForRemoval) {
+            cacheEntries.remove(removedKey);
+            fileManager.remove(removedKey);
+        }
+    }
+
+    @Override
+    public void reencryptAsync(@NonNull final ISharedPreferencesFileManager fileManager,
+                               @NonNull final IStringEncrypter encrypter,
+                               @NonNull final IStringDecrypter decrypter,
+                               @NonNull final ReencryptionParams params,
+                               @NonNull final TaskCompletedCallback<IMigrationOperationResult> callback) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                callback.onTaskCompleted(reencrypt(fileManager, encrypter, decrypter, params));
+            }
+        });
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/migration/IMigrationOperationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/IMigrationOperationResult.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import java.util.Map;
+
+/**
+ * Result object from a cache migration operation. Provides count and error information for total
+ * and failed records.
+ */
+public interface IMigrationOperationResult {
+
+    /**
+     * Gets the total number of records contained within the cache.
+     *
+     * @return The total number of records.
+     */
+    int getCountOfTotalRecords();
+
+    /**
+     * Gets the number of failed records.
+     *
+     * @return The number of failed records.
+     */
+    int getCountOfFailedRecords();
+
+    /**
+     * Gets an {@link Map} of Exception types + message -> total count of errors.
+     * <p>
+     * Example: "IOException::Invalid byte array input for decryption" -> 1
+     *
+     * @return The error map.
+     */
+    Map<String, Integer> getFailures();
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/migration/ISharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/ISharedPrefsFileManagerReencrypter.java
@@ -20,15 +20,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.internal.cache;
+package com.microsoft.identity.common.migration;
 
-import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallback;
 
 /**
  * Interface describing an object that can reencrypt instances of
  * {@link ISharedPreferencesFileManager}.
  */
-@Deprecated
 public interface ISharedPrefsFileManagerReencrypter {
 
     /**
@@ -113,11 +113,11 @@ public interface ISharedPrefsFileManagerReencrypter {
      * @param decrypter   The delegate object to handle decryption of the existing data.
      * @param params      Params to control error handling behavior.
      */
-    void reencrypt(ISharedPreferencesFileManager fileManager,
-                   IStringEncrypter encrypter,
-                   IStringDecrypter decrypter,
-                   ReencryptionParams params
-    ) throws Exception;
+    IMigrationOperationResult reencrypt(ISharedPreferencesFileManager fileManager,
+                                        IStringEncrypter encrypter,
+                                        IStringDecrypter decrypter,
+                                        ReencryptionParams params
+    );
 
     /**
      * Performs reencryption of the provided {@link ISharedPreferencesFileManager} asynchronously,
@@ -138,6 +138,6 @@ public interface ISharedPrefsFileManagerReencrypter {
                         IStringEncrypter encrypter,
                         IStringDecrypter decrypter,
                         ReencryptionParams params,
-                        TaskCompletedCallbackWithError<Void, Exception> callback
+                        TaskCompletedCallback<IMigrationOperationResult> callback
     );
 }

--- a/common/src/main/java/com/microsoft/identity/common/migration/MigrationOperationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/MigrationOperationResult.java
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * The result of a cache reencryption operation.
+ */
+@Accessors(prefix = "m")
+class MigrationOperationResult implements IMigrationOperationResult {
+
+    /**
+     * The total number of records we attempted to migrate.
+     */
+    @Getter
+    @Setter
+    private int mCountOfTotalRecords;
+
+    /**
+     * The count of records that could not be successfully migrated.
+     */
+    @Getter
+    private int mCountOfFailedRecords;
+
+    /**
+     * Errors encountered during migration, a {@link Map} indicating unique errors + count of
+     * occurrences.
+     */
+    @Getter
+    private Map<String, Integer> mFailures = new HashMap<>();
+
+    void addFailure(@NonNull final Exception exception) {
+        final String exceptionKey = createExceptionKey(exception);
+        final Integer currentCountOfException = mFailures.get(exceptionKey);
+
+        if (null == currentCountOfException) {
+            mFailures.put(exceptionKey, 1); // First time we've hit this error
+        } else {
+            mFailures.put(exceptionKey, currentCountOfException + 1); // increment
+        }
+
+        // Increment failure count...
+        mCountOfFailedRecords++;
+    }
+
+    private static String createExceptionKey(@NonNull final Exception exception) {
+        final String simpleName = exception.getClass().getSimpleName();
+        final String msg = exception.getMessage();
+        return simpleName + "::" + msg;
+    }
+}


### PR DESCRIPTION
Redux of changes in #1463, but this time they're additive.

Reimplements the `ADAL#setSecretKey` migration API exposed for OneAuth.

Changes:
- Deprecates classes formerly used for `setSecretKey` migration
- Allows for behavioral control via `ReencryptionParams`
    * `abortOnFailure`
    * `eraseEntryOnFailure`
    * `eraseAllOnFailure`
- Data will not be written/overwritten unless explicitly overridden to do so
- Returns a new `IMigrationOperationResult` class to surface information about successes/failures