### PR TITLE
Remove RC label for final release

### DIFF
--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.4.5-RC2
+versionName=3.4.5
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
Removes RC tagging for final release.

Reviewers (@AdamBJohnsonx, @shahzaibj) - please double-check me to ensure that no other labels, tags, or version identifiers need to be updated prior to this release.