### PR TITLE
Add method to check if preferred_network_host_name matches for two authorities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Add method to check if preferred_network_host_name matches for two authorities (#1470)
 - [MINOR] Adds new cache encryption key migration API for OneAuth (#1464)
 - [MAJOR] Migrate StorageHelper to common4j (#1450)
 - [MAJOR] Migrate Exceptions from common to common4j (#1442)

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
@@ -186,7 +186,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
     }
 
     /**
-     * Checks if current authority cloud has same preferred network host name as the passed in authority cloud
+     * Checks if current authority cloud has same preferred network host name as the passed in authority cloud.
      *
      * @param authorityToCheck authority to check against
      * @return true if preferred network host name matches for both authorities, otherwise false

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
@@ -25,19 +25,21 @@ package com.microsoft.identity.common.internal.authorities;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
 
 import com.google.gson.annotations.SerializedName;
-import com.microsoft.identity.common.java.WarningType;
-import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2StrategyParameters;
+import com.microsoft.identity.common.java.WarningType;
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
@@ -56,7 +58,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
 
     private AzureActiveDirectoryCloud mAzureActiveDirectoryCloud;
 
-    private void getAzureActiveDirectoryCloud() {
+    private AzureActiveDirectoryCloud getAzureActiveDirectoryCloud() {
         final String methodName = ":getAzureActiveDirectoryCloud";
         AzureActiveDirectoryCloud cloud = null;
 
@@ -73,13 +75,13 @@ public class AzureActiveDirectoryAuthority extends Authority {
             mKnownToMicrosoft = false;
         }
 
-        mAzureActiveDirectoryCloud = cloud;
+        return cloud;
     }
 
     public AzureActiveDirectoryAuthority(AzureActiveDirectoryAudience signInAudience) {
         mAudience = signInAudience;
         mAuthorityTypeString = "AAD";
-        getAzureActiveDirectoryCloud();
+        mAzureActiveDirectoryCloud = getAzureActiveDirectoryCloud();
     }
 
     public AzureActiveDirectoryAuthority() {
@@ -87,7 +89,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
         mAudience = new AllAccounts();
         mAuthorityTypeString = "AAD";
         mMultipleCloudsSupported = false;
-        getAzureActiveDirectoryCloud();
+        mAzureActiveDirectoryCloud = getAzureActiveDirectoryCloud();
     }
 
     /**
@@ -183,4 +185,21 @@ public class AzureActiveDirectoryAuthority extends Authority {
         return mAudience;
     }
 
+    /**
+     * Checks if current authority cloud has same preferred network host name as the passed in authority cloud
+     *
+     * @param authorityToCheck authority to check against
+     * @return true if preferred network host name matches for both authorities, otherwise false
+     */
+    @WorkerThread
+    public synchronized boolean isSamePreferredNetworkHostAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck) throws IOException {
+        if (!AzureActiveDirectory.isInitialized()) {
+            // Cloud discovery is needed in order to make sure that we have a preferred_network_host_name to cloud aliases mappings
+            AzureActiveDirectory.performCloudDiscovery();
+        }
+
+        final String preferredNetworkHostName = getAzureActiveDirectoryCloud().getPreferredNetworkHostName();
+        final String authorityToCheckPreferredNetworkHostName = authorityToCheck.getAzureActiveDirectoryCloud().getPreferredNetworkHostName();
+        return preferredNetworkHostName.equals(authorityToCheckPreferredNetworkHostName);
+    }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
@@ -35,34 +35,34 @@ import static org.junit.Assert.assertTrue;
 public class AzureActiveDirectoryAuthorityTests {
     @Test
     public void isSamePreferredNetworkHostAsAuthority_Returns_True_For_Authority_With_ValidAliases_For_SameCloud() throws IOException {
-        String[] cloudAliasesWW = new String[]{"https://login.microsoftonline.com", "https://login.windows.net", "https://login.microsoft.com", "https://sts.windows.net"};
-        String[] cloudAliasesCN = new String[]{"https://login.chinacloudapi.cn", "https://login.partner.microsoftonline.cn"};
-        String[] cloudAliasesUSGov = new String[]{"https://login.microsoftonline.us", "https://login.usgovcloudapi.net"};
+        final String[] cloudAliasesWW = new String[]{"https://login.microsoftonline.com", "https://login.windows.net", "https://login.microsoft.com", "https://sts.windows.net"};
+        final String[] cloudAliasesCN = new String[]{"https://login.chinacloudapi.cn", "https://login.partner.microsoftonline.cn"};
+        final String[] cloudAliasesUSGov = new String[]{"https://login.microsoftonline.us", "https://login.usgovcloudapi.net"};
 
-        AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesWW[0]));
-        for (String cloudUrl : cloudAliasesWW) {
-            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+        final  AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesWW[0]));
+        for (final  String cloudUrl : cloudAliasesWW) {
+            final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
             assertTrue(authorityWW.isSamePreferredNetworkHostAsAuthority(authority));
         }
 
-        AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesCN[0]));
-        for (String cloudUrl : cloudAliasesCN) {
-            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+        final  AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesCN[0]));
+        for (final String cloudUrl : cloudAliasesCN) {
+            final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
             assertTrue(authorityCN.isSamePreferredNetworkHostAsAuthority(authority));
         }
 
-        AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesUSGov[0]));
-        for (String cloudUrl : cloudAliasesUSGov) {
-            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+        final AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesUSGov[0]));
+        for (final String cloudUrl : cloudAliasesUSGov) {
+            final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
             assertTrue(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authority));
         }
     }
 
     @Test
     public void isSamePreferredNetworkHostAsAuthority_Returns_False_For_Authorities_From_Different_Clouds() throws IOException {
-        AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.com"));
-        AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.partner.microsoftonline.cn"));
-        AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.us"));
+        final AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.com"));
+        final AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.partner.microsoftonline.cn"));
+        final AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.us"));
         assertFalse(authorityWW.isSamePreferredNetworkHostAsAuthority(authorityCN));
         assertFalse(authorityCN.isSamePreferredNetworkHostAsAuthority(authorityUSGov));
         assertFalse(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authorityWW));

--- a/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
@@ -1,0 +1,70 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.authorities;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class AzureActiveDirectoryAuthorityTests {
+    @Test
+    public void isSamePreferredNetworkHostAsAuthority_Returns_True_For_Authority_With_ValidAliases_For_SameCloud() throws IOException {
+        String[] cloudAliasesWW = new String[]{"https://login.microsoftonline.com", "https://login.windows.net", "https://login.microsoft.com", "https://sts.windows.net"};
+        String[] cloudAliasesCN = new String[]{"https://login.chinacloudapi.cn", "https://login.partner.microsoftonline.cn"};
+        String[] cloudAliasesUSGov = new String[]{"https://login.microsoftonline.us", "https://login.usgovcloudapi.net"};
+
+        AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesWW[0]));
+        for (String cloudUrl : cloudAliasesWW) {
+            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+            assertTrue(authorityWW.isSamePreferredNetworkHostAsAuthority(authority));
+        }
+
+        AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesCN[0]));
+        for (String cloudUrl : cloudAliasesCN) {
+            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+            assertTrue(authorityCN.isSamePreferredNetworkHostAsAuthority(authority));
+        }
+
+        AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesUSGov[0]));
+        for (String cloudUrl : cloudAliasesUSGov) {
+            AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
+            assertTrue(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authority));
+        }
+    }
+
+    @Test
+    public void isSamePreferredNetworkHostAsAuthority_Returns_False_For_Authorities_From_Different_Clouds() throws IOException {
+        AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.com"));
+        AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.partner.microsoftonline.cn"));
+        AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.us"));
+        assertFalse(authorityWW.isSamePreferredNetworkHostAsAuthority(authorityCN));
+        assertFalse(authorityCN.isSamePreferredNetworkHostAsAuthority(authorityUSGov));
+        assertFalse(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authorityWW));
+    }
+}


### PR DESCRIPTION
Adding a method to compare if an instance of AzureActiveDirectoryAuthority has same preferred_network_host_name as another AzureActiveDirectoryAuthority instance.

Tests:
Added Unit tests to verify failure and success case for the new method