### PR TITLE
Update method to compare if two authorities belong to same cloud

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [PATCH] Add method to check if preferred_network_host_name matches for two authorities (#1470)
+- [PATCH] Add method to check if two authorities belong to same cloud (#1471)
 - [MINOR] Adds new cache encryption key migration API for OneAuth (#1464)
 - [MAJOR] Migrate StorageHelper to common4j (#1450)
 - [MAJOR] Migrate Exceptions from common to common4j (#1442)

--- a/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthority.java
@@ -186,20 +186,18 @@ public class AzureActiveDirectoryAuthority extends Authority {
     }
 
     /**
-     * Checks if current authority cloud has same preferred network host name as the passed in authority cloud.
+     * Checks if current authority belongs to same cloud as the passed in authority.
      *
-     * @param authorityToCheck authority to check against
-     * @return true if preferred network host name matches for both authorities, otherwise false
+     * @param authorityToCheck authority to check against.
+     * @return true if both authorities belong to same cloud, otherwise false.
      */
     @WorkerThread
-    public synchronized boolean isSamePreferredNetworkHostAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck) throws IOException {
+    public synchronized boolean isSameCloudAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck) throws IOException {
         if (!AzureActiveDirectory.isInitialized()) {
             // Cloud discovery is needed in order to make sure that we have a preferred_network_host_name to cloud aliases mappings
             AzureActiveDirectory.performCloudDiscovery();
         }
 
-        final String preferredNetworkHostName = getAzureActiveDirectoryCloud().getPreferredNetworkHostName();
-        final String authorityToCheckPreferredNetworkHostName = authorityToCheck.getAzureActiveDirectoryCloud().getPreferredNetworkHostName();
-        return preferredNetworkHostName.equals(authorityToCheckPreferredNetworkHostName);
+        return getAzureActiveDirectoryCloud().equals(authorityToCheck.getAzureActiveDirectoryCloud());
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -22,12 +22,13 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory;
 
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class contains information about a specific Azure Active Directory Cloud.  Azure Active Directory
@@ -120,8 +121,18 @@ public class AzureActiveDirectoryCloud {
      * @param cloudObjectToCheck AzureActiveDirectoryCloud object to check against.
      * @return true if PreferredNetworkHostName and PreferredCacheHostName matches, otherwise false.
      */
-    public boolean equals(@NonNull final AzureActiveDirectoryCloud cloudObjectToCheck) {
-        return  mPreferredNetworkHostName.equals(cloudObjectToCheck.mPreferredNetworkHostName) &&
-                mPreferredCacheHostName.equals(cloudObjectToCheck.mPreferredCacheHostName);
+    @Override
+    public boolean equals(@Nullable final Object cloudObjectToCheck) {
+        if(cloudObjectToCheck == null || getClass() != cloudObjectToCheck.getClass()) {
+            return false;
+        }
+
+        return  mPreferredNetworkHostName.equals(((AzureActiveDirectoryCloud) cloudObjectToCheck).mPreferredNetworkHostName) &&
+                mPreferredCacheHostName.equals(((AzureActiveDirectoryCloud) cloudObjectToCheck).mPreferredCacheHostName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mPreferredNetworkHostName, mPreferredCacheHostName);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -22,25 +22,27 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory;
 
-import androidx.annotation.Nullable;
-
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+
+import lombok.EqualsAndHashCode;
 
 /**
  * This class contains information about a specific Azure Active Directory Cloud.  Azure Active Directory
  * as a service is available in multiple clouds.  World wide is the default; however their are sovereign clouds
  * available for Germany, China, etc....
  */
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class AzureActiveDirectoryCloud {
 
     @SerializedName("preferred_network")
+    @EqualsAndHashCode.Include
     private final String mPreferredNetworkHostName;
 
     @SerializedName("preferred_cache")
+    @EqualsAndHashCode.Include
     private final String mPreferredCacheHostName;
 
     @SerializedName("aliases")
@@ -112,27 +114,5 @@ public class AzureActiveDirectoryCloud {
      */
     void setIsValidated(final boolean isValidated) {
         mIsValidated = isValidated;
-    }
-
-    /**
-     * Checks for equality with passed in AzureActiveDirectoryCloud object based on
-     * PreferredNetworkHostName and PreferredCacheHostName.
-     *
-     * @param cloudObjectToCheck AzureActiveDirectoryCloud object to check against.
-     * @return true if PreferredNetworkHostName and PreferredCacheHostName matches, otherwise false.
-     */
-    @Override
-    public boolean equals(@Nullable final Object cloudObjectToCheck) {
-        if(cloudObjectToCheck == null || getClass() != cloudObjectToCheck.getClass()) {
-            return false;
-        }
-
-        return  mPreferredNetworkHostName.equals(((AzureActiveDirectoryCloud) cloudObjectToCheck).mPreferredNetworkHostName) &&
-                mPreferredCacheHostName.equals(((AzureActiveDirectoryCloud) cloudObjectToCheck).mPreferredCacheHostName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(mPreferredNetworkHostName, mPreferredCacheHostName);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
@@ -111,4 +113,15 @@ public class AzureActiveDirectoryCloud {
         mIsValidated = isValidated;
     }
 
+    /**
+     * Checks for equality with passed in AzureActiveDirectoryCloud object based on
+     * PreferredNetworkHostName and PreferredCacheHostName.
+     *
+     * @param cloudObjectToCheck AzureActiveDirectoryCloud object to check against.
+     * @return true if PreferredNetworkHostName and PreferredCacheHostName matches, otherwise false.
+     */
+    public boolean equals(@NonNull final AzureActiveDirectoryCloud cloudObjectToCheck) {
+        return  mPreferredNetworkHostName.equals(cloudObjectToCheck.mPreferredNetworkHostName) &&
+                mPreferredCacheHostName.equals(cloudObjectToCheck.mPreferredCacheHostName);
+    }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(RobolectricTestRunner.class)
 public class AzureActiveDirectoryAuthorityTests {
     @Test
-    public void isSamePreferredNetworkHostAsAuthority_Returns_True_For_Authority_With_ValidAliases_For_SameCloud() throws IOException {
+    public void isSameCloudAsAuthority_Returns_True_For_Authority_With_ValidAliases_For_SameCloud() throws IOException {
         final String[] cloudAliasesWW = new String[]{"https://login.microsoftonline.com", "https://login.windows.net", "https://login.microsoft.com", "https://sts.windows.net"};
         final String[] cloudAliasesCN = new String[]{"https://login.chinacloudapi.cn", "https://login.partner.microsoftonline.cn"};
         final String[] cloudAliasesUSGov = new String[]{"https://login.microsoftonline.us", "https://login.usgovcloudapi.net"};
@@ -42,29 +42,29 @@ public class AzureActiveDirectoryAuthorityTests {
         final  AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesWW[0]));
         for (final  String cloudUrl : cloudAliasesWW) {
             final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
-            assertTrue(authorityWW.isSamePreferredNetworkHostAsAuthority(authority));
+            assertTrue(authorityWW.isSameCloudAsAuthority(authority));
         }
 
         final  AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesCN[0]));
         for (final String cloudUrl : cloudAliasesCN) {
             final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
-            assertTrue(authorityCN.isSamePreferredNetworkHostAsAuthority(authority));
+            assertTrue(authorityCN.isSameCloudAsAuthority(authority));
         }
 
         final AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts(cloudAliasesUSGov[0]));
         for (final String cloudUrl : cloudAliasesUSGov) {
             final AzureActiveDirectoryAuthority authority = new AzureActiveDirectoryAuthority(new AnyOrganizationalAccount(cloudUrl));
-            assertTrue(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authority));
+            assertTrue(authorityUSGov.isSameCloudAsAuthority(authority));
         }
     }
 
     @Test
-    public void isSamePreferredNetworkHostAsAuthority_Returns_False_For_Authorities_From_Different_Clouds() throws IOException {
+    public void isSameCloudAsAuthority_Returns_False_For_Authorities_From_Different_Clouds() throws IOException {
         final AzureActiveDirectoryAuthority authorityWW = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.com"));
         final AzureActiveDirectoryAuthority authorityCN = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.partner.microsoftonline.cn"));
         final AzureActiveDirectoryAuthority authorityUSGov = new AzureActiveDirectoryAuthority(new AllAccounts("https://login.microsoftonline.us"));
-        assertFalse(authorityWW.isSamePreferredNetworkHostAsAuthority(authorityCN));
-        assertFalse(authorityCN.isSamePreferredNetworkHostAsAuthority(authorityUSGov));
-        assertFalse(authorityUSGov.isSamePreferredNetworkHostAsAuthority(authorityWW));
+        assertFalse(authorityWW.isSameCloudAsAuthority(authorityCN));
+        assertFalse(authorityCN.isSameCloudAsAuthority(authorityUSGov));
+        assertFalse(authorityUSGov.isSameCloudAsAuthority(authorityWW));
     }
 }


### PR DESCRIPTION
Renamed method "isSamePreferredNetworkHostAsAuthority" to "isSameCloudAsAuthority" in AzureActiveDirectoryAuthority.
Added equals method in AzureActiveDirectoryCloud class to compare two instances based on PreferredNetworkHostName and PreferredCacheHostName.
Updated the tests to reflect the naming change.

isSameCloudAsAuthority will be used to check if two authorities belong to same cloud or not. This is useful  in cross cloud scenarios where we want to make sure that we only use PRT for home authority, and if a token requests comes for foreign authority we don't use PRT and trigger normal cross cloud auth flow.

Related PR: #1470 