### PR TITLE
Release 3.5.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.5.0
+----------
+- [MINOR] Code changes for new OneAuth cache key migration API (#1464)
+
 Version 3.4.5
 ----------
 - [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,3 @@
-VNext
-----------
-
 Version 3.4.5
 ----------
 - [PATCH] Fix for misconfigured ADALOAuth2TokenCache, adds new SharedPreferencesFileManager that defaults to MODE_PRIVATE (#1444)

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -30,9 +30,11 @@ import androidx.annotation.RequiresApi;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import com.microsoft.identity.common.exception.ClientException;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -57,6 +59,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.Map;
 
 import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.JWK;
 import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
@@ -392,26 +395,23 @@ public class DevicePoPManagerTests {
         final String publicKey = mDevicePopManager.getPublicKey(JWK);
 
         // Convert it to JSON, parse to verify fields
-        final JsonElement jwkElement = new JsonParser().parse(publicKey);
-
-        // Convert to JsonObject to extract claims
-        final JsonObject jwkObj = jwkElement.getAsJsonObject();
+        final Map<String, String> jwkObj = new Gson().fromJson(publicKey, new TypeToken<Map<String, String>>(){}.getType());
 
         // We should expect the following claims...
         // 'kty' - Key Type - Identifies the cryptographic alg used with this key (ex: RSA, EC)
         // 'e' - Public Exponent - The exponent used on signed/encoded data to decode the orig value
         // 'n' - Modulus - The product of two prime numbers used to generate the key pair
-        final JsonElement kty = jwkObj.get("kty");
+        final String kty = jwkObj.get("kty");
         Assert.assertNotNull(kty);
-        Assert.assertFalse(kty.getAsString().isEmpty());
+        Assert.assertFalse(kty.isEmpty());
 
-        final JsonElement e = jwkObj.get("e");
+        final String e = jwkObj.get("e");
         Assert.assertNotNull(e);
-        Assert.assertFalse(e.getAsString().isEmpty());
+        Assert.assertFalse(e.isEmpty());
 
-        final JsonElement n = jwkObj.get("n");
+        final String n = jwkObj.get("n");
         Assert.assertNotNull(n);
-        Assert.assertFalse(n.getAsString().isEmpty());
+        Assert.assertFalse(n.isEmpty());
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/DefaultSharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/DefaultSharedPrefsFileManagerReencrypter.java
@@ -31,6 +31,7 @@ import java.util.Map;
 /**
  * Default implementation of {@link ISharedPrefsFileManagerReencrypter}.
  */
+@Deprecated
 public class DefaultSharedPrefsFileManagerReencrypter implements ISharedPrefsFileManagerReencrypter {
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -36,6 +36,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.util.Supplier;
@@ -55,6 +57,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -143,6 +146,8 @@ class DevicePopManager implements IDevicePopManager {
      * Log message when private key material cannot be found.
      */
     private static final String PRIVATE_KEY_NOT_FOUND = "Not an instance of a PrivateKeyEntry";
+    public static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>(){}.getType();
+    public static final Gson GSON = new Gson();
 
     /**
      * Manager class for interacting with key storage mechanism.
@@ -813,7 +818,7 @@ class DevicePopManager implements IDevicePopManager {
 
         try {
             final Map<String, Object> jwkMap = getDevicePopJwkMinifiedJson();
-            return jwkMap.get(SignedHttpRequestJwtClaims.JWK).toString();
+            return GSON.toJson(jwkMap.get(SignedHttpRequestJwtClaims.JWK), MAP_STRING_STRING_TYPE);
         } catch (final UnrecoverableEntryException e) {
             exception = e;
             errCode = INVALID_PROTECTION_PARAMS;

--- a/common/src/main/java/com/microsoft/identity/common/migration/DefaultSharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/DefaultSharedPrefsFileManagerReencrypter.java
@@ -1,0 +1,209 @@
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallback;
+import com.microsoft.identity.common.logging.Logger;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Default implementation of {@link ISharedPrefsFileManagerReencrypter}.
+ */
+public class DefaultSharedPrefsFileManagerReencrypter implements ISharedPrefsFileManagerReencrypter {
+
+    private static final String TAG = DefaultSharedPrefsFileManagerReencrypter.class.getSimpleName();
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Override
+    public IMigrationOperationResult reencrypt(@NonNull final ISharedPreferencesFileManager fileManager,
+                                               @NonNull final IStringEncrypter encrypter,
+                                               @NonNull final IStringDecrypter decrypter,
+                                               @NonNull final ReencryptionParams params) {
+        final String methodName = ":reencrypt (sync)";
+        final Map<String, String> cacheEntries = new HashMap<>(fileManager.getAll());
+        Logger.verbose(TAG + methodName,
+                "Attempting to migrate cache entries: " + cacheEntries.size());
+        final MigrationOperationResult result = new MigrationOperationResult();
+        result.setCountOfTotalRecords(cacheEntries.size());
+        final Set<String> keysMarkedForRemoval = new HashSet<>();
+        final AtomicBoolean shouldAbort = new AtomicBoolean(false);
+        final Set<String> skipKeys = new HashSet<>();
+
+        // Decrypt everything
+        applyCacheMutation(
+                cacheEntries,
+                new Callable<Map.Entry<String, String>>() {
+                    @Override
+                    public void call(final Map.Entry<String, String> entry) throws Exception {
+                        final String decryptedText = decrypter.decrypt(entry.getValue());
+                        entry.setValue(decryptedText);
+                    }
+                },
+                result,
+                params,
+                keysMarkedForRemoval,
+                skipKeys,
+                shouldAbort
+        );
+
+        // Clear any keys marked for removal...
+        clearEntriesMarkedForRemoval(fileManager, cacheEntries, keysMarkedForRemoval);
+
+        if (shouldAbort.get()) {
+            Logger.info(TAG + methodName, "Aborting after decrypt.");
+            return result;
+        }
+
+        // Reencrypt everything
+        applyCacheMutation(
+                cacheEntries,
+                new Callable<Map.Entry<String, String>>() {
+                    @Override
+                    public void call(final Map.Entry<String, String> entry) throws Exception {
+                        final String reencryptedText = encrypter.encrypt(entry.getValue());
+                        entry.setValue(reencryptedText);
+                    }
+                },
+                result,
+                params,
+                keysMarkedForRemoval,
+                skipKeys,
+                shouldAbort
+        );
+
+        // Clear any keys marked for removal...
+        clearEntriesMarkedForRemoval(fileManager, cacheEntries, keysMarkedForRemoval);
+
+        if (shouldAbort.get()) {
+            Logger.info(TAG + methodName, "Aborting after reencrypt.");
+            return result;
+        }
+
+        // Write the newly encrypted records...
+        Logger.info(TAG + methodName, "Writing reencrypted cache entries.");
+        for (final Map.Entry<String, String> cacheEntry : cacheEntries.entrySet()) {
+            fileManager.putString(cacheEntry.getKey(), cacheEntry.getValue());
+        }
+
+        return result;
+    }
+
+    private interface Callable<T> {
+        void call(T t) throws Exception;
+    }
+
+    /**
+     * Utility function for reencryption operations. Accepts the contents of a {@link Map} and
+     * applies the mutation defined by {@link Callable} to it.
+     *
+     * @param cacheEntries         The Cache entries to which the supplied mutation is applied.
+     * @param callable             The callable definining the mutation.
+     * @param inputResult          A {@link MigrationOperationResult} used to track error states which may
+     *                             occur during a mutation.
+     * @param params               The {@link com.microsoft.identity.common.migration.ISharedPrefsFileManagerReencrypter.ReencryptionParams}
+     *                             defining how errors should be handled/surfaced.
+     * @param keysMarkedForRemoval A {@link Set} of cache keys to be removed from the underlying
+     *                             cache if an error is encountered. Please note that this function
+     *                             does not perform the removal operation itself; see
+     *                             {@link #clearEntriesMarkedForRemoval(ISharedPreferencesFileManager, Map, Set)}.
+     * @param skipKeys             Cache keys which should not have the supplied mutation applied to it, usually
+     *                             due to an error reading the value stored at this key (for example, cannot
+     *                             be decrypted).
+     * @param shouldAbort          A pass-by-reference boolean, allowing this method to dictate that abortive
+     *                             action must be taken by the caller.
+     */
+    private void applyCacheMutation(@NonNull final Map<String, String> cacheEntries,
+                                    @NonNull final Callable<Map.Entry<String, String>> callable,
+                                    @NonNull final MigrationOperationResult inputResult,
+                                    @NonNull final ReencryptionParams params,
+                                    @NonNull final Set<String> keysMarkedForRemoval,
+                                    @NonNull final Set<String> skipKeys,
+                                    @NonNull AtomicBoolean shouldAbort) {
+        final String methodName = ":applyCacheMutation";
+        for (final Map.Entry<String, String> cacheEntry : cacheEntries.entrySet()) {
+            try {
+                if (skipKeys.contains(cacheEntry.getKey())) {
+                    Logger.warn(TAG + methodName, "Skipping entry.");
+                    continue;
+                }
+                callable.call(cacheEntry);
+            } catch (final Exception e) {
+                Logger.error(TAG + methodName, "Error during mutation", e);
+                Logger.errorPII(TAG + methodName, "Failed key: " + cacheEntry.getKey(), e);
+                inputResult.addFailure(e);
+                skipKeys.add(cacheEntry.getKey());
+
+                if (params.eraseEntryOnError()) {
+                    Logger.warn(TAG + methodName, "Marking key for removal.");
+                    keysMarkedForRemoval.add(cacheEntry.getKey());
+                }
+
+                if (params.eraseAllOnError()) {
+                    Logger.warn(TAG + methodName, "Marking all keys for removal.");
+                    keysMarkedForRemoval.addAll(cacheEntries.keySet());
+                    shouldAbort.set(true);
+                    break;
+                }
+
+                if (params.abortOnError()) {
+                    shouldAbort.set(true);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void clearEntriesMarkedForRemoval(@NonNull final ISharedPreferencesFileManager fileManager,
+                                              @NonNull final Map<String, String> cacheEntries,
+                                              @NonNull final Set<String> keysMarkedForRemoval) {
+        final String methodName = ":clearEntriesMarkedForRemoval";
+        Logger.warn(TAG + methodName, "Removing entries marked for removal");
+        for (final String removedKey : keysMarkedForRemoval) {
+            cacheEntries.remove(removedKey);
+            fileManager.remove(removedKey);
+        }
+    }
+
+    @Override
+    public void reencryptAsync(@NonNull final ISharedPreferencesFileManager fileManager,
+                               @NonNull final IStringEncrypter encrypter,
+                               @NonNull final IStringDecrypter decrypter,
+                               @NonNull final ReencryptionParams params,
+                               @NonNull final TaskCompletedCallback<IMigrationOperationResult> callback) {
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                callback.onTaskCompleted(reencrypt(fileManager, encrypter, decrypter, params));
+            }
+        });
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/migration/IMigrationOperationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/IMigrationOperationResult.java
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import java.util.Map;
+
+/**
+ * Result object from a cache migration operation. Provides count and error information for total
+ * and failed records.
+ */
+public interface IMigrationOperationResult {
+
+    /**
+     * Gets the total number of records contained within the cache.
+     *
+     * @return The total number of records.
+     */
+    int getCountOfTotalRecords();
+
+    /**
+     * Gets the number of failed records.
+     *
+     * @return The number of failed records.
+     */
+    int getCountOfFailedRecords();
+
+    /**
+     * Gets an {@link Map} of Exception types + message -> total count of errors.
+     * <p>
+     * Example: "IOException::Invalid byte array input for decryption" -> 1
+     *
+     * @return The error map.
+     */
+    Map<String, Integer> getFailures();
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/migration/ISharedPrefsFileManagerReencrypter.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/ISharedPrefsFileManagerReencrypter.java
@@ -20,15 +20,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.internal.cache;
+package com.microsoft.identity.common.migration;
 
-import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallback;
 
 /**
  * Interface describing an object that can reencrypt instances of
  * {@link ISharedPreferencesFileManager}.
  */
-@Deprecated
 public interface ISharedPrefsFileManagerReencrypter {
 
     /**
@@ -113,11 +113,11 @@ public interface ISharedPrefsFileManagerReencrypter {
      * @param decrypter   The delegate object to handle decryption of the existing data.
      * @param params      Params to control error handling behavior.
      */
-    void reencrypt(ISharedPreferencesFileManager fileManager,
-                   IStringEncrypter encrypter,
-                   IStringDecrypter decrypter,
-                   ReencryptionParams params
-    ) throws Exception;
+    IMigrationOperationResult reencrypt(ISharedPreferencesFileManager fileManager,
+                                        IStringEncrypter encrypter,
+                                        IStringDecrypter decrypter,
+                                        ReencryptionParams params
+    );
 
     /**
      * Performs reencryption of the provided {@link ISharedPreferencesFileManager} asynchronously,
@@ -138,6 +138,6 @@ public interface ISharedPrefsFileManagerReencrypter {
                         IStringEncrypter encrypter,
                         IStringDecrypter decrypter,
                         ReencryptionParams params,
-                        TaskCompletedCallbackWithError<Void, Exception> callback
+                        TaskCompletedCallback<IMigrationOperationResult> callback
     );
 }

--- a/common/src/main/java/com/microsoft/identity/common/migration/MigrationOperationResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/migration/MigrationOperationResult.java
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.migration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * The result of a cache reencryption operation.
+ */
+@Accessors(prefix = "m")
+class MigrationOperationResult implements IMigrationOperationResult {
+
+    /**
+     * The total number of records we attempted to migrate.
+     */
+    @Getter
+    @Setter
+    private int mCountOfTotalRecords;
+
+    /**
+     * The count of records that could not be successfully migrated.
+     */
+    @Getter
+    private int mCountOfFailedRecords;
+
+    /**
+     * Errors encountered during migration, a {@link Map} indicating unique errors + count of
+     * occurrences.
+     */
+    @Getter
+    private Map<String, Integer> mFailures = new HashMap<>();
+
+    void addFailure(@NonNull final Exception exception) {
+        final String exceptionKey = createExceptionKey(exception);
+        final Integer currentCountOfException = mFailures.get(exceptionKey);
+
+        if (null == currentCountOfException) {
+            mFailures.put(exceptionKey, 1); // First time we've hit this error
+        } else {
+            mFailures.put(exceptionKey, currentCountOfException + 1); // increment
+        }
+
+        // Increment failure count...
+        mCountOfFailedRecords++;
+    }
+
+    private static String createExceptionKey(@NonNull final Exception exception) {
+        final String simpleName = exception.getClass().getSimpleName();
+        final String msg = exception.getMessage();
+        return simpleName + "::" + msg;
+    }
+}

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.4.5
+versionName=3.5.0-RC1
 versionCode=1
 latestPatchVersion=180

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.5.0-RC2
+versionName=3.5.0
 versionCode=1
 latestPatchVersion=180

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.5.0-RC1
+versionName=3.5.0-RC2
 versionCode=1
 latestPatchVersion=180

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -191,7 +191,6 @@ dependencies {
         implementation(group: 'com.microsoft.identity', name: 'labapi', version: '0.0.+')
     }
 
-    implementation "org.mockito:mockito-inline:$rootProject.ext.mockitoCoreVersion"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -34,8 +34,6 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCred
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.dto.CredentialType;
 
-import org.mockito.Mockito;
-
 import java.util.Map;
 
 public class TestUtils {
@@ -65,13 +63,6 @@ public class TestUtils {
         final Context context = ApplicationProvider.getApplicationContext();
 
         return SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, null);
-    }
-
-    public static Activity getMockActivity(final Context context) {
-        final Activity mockedActivity = Mockito.mock(Activity.class);
-        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(context);
-
-        return mockedActivity;
     }
 
     /**


### PR DESCRIPTION
This contains only one change, the new OneAuth-related migration API that has failure information, and a bug fix in Android Common where an update to one of our dependencies caused failures when using PoP tokens.