### PR TITLE
Move predefined key loader to common4j from common

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Move predefined key loader to common4j from common (#1477)
 - [PATCH] Add method to check if two authorities belong to same cloud (#1471)
 - [MINOR] Adds new cache encryption key migration API for OneAuth (#1464)
 - [MAJOR] Migrate StorageHelper to common4j (#1450)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -28,10 +28,10 @@ import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.java.crypto.StorageEncryptionManager;
 import com.microsoft.identity.common.java.crypto.key.AES256KeyLoader;
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
 import com.microsoft.identity.common.java.telemetry.ITelemetryCallback;
 import com.microsoft.identity.common.logging.Logger;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidBrokerStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidBrokerStorageEncryptionManager.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.java.crypto.StorageEncryptionManager;
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
 import com.microsoft.identity.common.java.telemetry.ITelemetryCallback;
 import com.microsoft.identity.common.logging.Logger;
 

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
@@ -29,6 +29,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
 import com.microsoft.identity.common.java.crypto.key.KeyUtil;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidBrokerStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidBrokerStorageEncryptionManagerTest.java
@@ -29,6 +29,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowAndroidSdkStorageEncryptionManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowAndroidSdkStorageEncryptionManager.java
@@ -23,7 +23,7 @@
 package com.microsoft.identity.common.shadows;
 
 import com.microsoft.identity.common.crypto.AndroidAuthSdkStorageEncryptionManager;
-import com.microsoft.identity.common.crypto.PredefinedKeyLoader;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
 import com.microsoft.identity.common.java.crypto.key.AES256KeyLoader;
 
 import org.robolectric.annotation.Implements;

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/key/PredefinedKeyLoader.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/key/PredefinedKeyLoader.java
@@ -20,9 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.crypto;
-
-import com.microsoft.identity.common.java.crypto.key.AES256KeyLoader;
+package com.microsoft.identity.common.java.crypto.key;
 
 import javax.crypto.SecretKey;
 
@@ -42,7 +40,7 @@ public class PredefinedKeyLoader extends AES256KeyLoader {
     private final SecretKey mKey;
 
     public PredefinedKeyLoader(@NonNull final String alias,
-                               @NonNull final byte[] rawBytes){
+                               @NonNull final byte[] rawBytes) {
         mAlias = alias;
         mKey = generateKeyFromRawBytes(rawBytes);
     }


### PR DESCRIPTION
Because I need it in the LinuxBroker as well.

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1632
Related MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1466