### PR TITLE
[UI Automation] Add helper method to set broker flights

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -158,4 +158,8 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
         ));
     }
 
+    @Override
+    public void setFlights(@Nullable final String flightsJson) {
+        // Default implementation, Do nothing.
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -282,4 +282,16 @@ public class BrokerHost extends AbstractTestBroker {
             UiAutomatorUtils.handleButtonClick("android:id/button1");
         }
     }
+
+    @Override
+    public void setFlights(@Nullable final String flightsJson) {
+        Logger.i(TAG, "Set Flights..");
+        launch();
+        // Make the set flights UI visible on screen
+        UiAutomatorUtils.obtainChildInScrollable("Set Flights");
+        // input flights string in flights input box
+        UiAutomatorUtils.handleInput("com.microsoft.identity.testuserapp:id/editTextFlights", flightsJson);
+        // Click Set Flights button
+        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.testuserapp:id/setFlightsButton");
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
@@ -95,4 +95,10 @@ public interface ITestBroker extends IApp {
      * @return the {@link DeviceAdmin} name for this broker app
      */
     DeviceAdmin getAdminName();
+
+    /**
+     * Sets the flight information.
+     * @param flightsJson the json representation of the flight key and value pairs {"key1":"value"}.
+     */
+    void setFlights(@Nullable final String flightsJson);
 }


### PR DESCRIPTION
##### What:
Adding a helper method to set Broker flights when running UI Automation.

##### Why:
Need this to write automation for cross cloud changes, which will be written behind the cross-cloud feature flight

##### How:
The method is currently only implemented for BrokerHost broker type, for other Broker types it does nothing,
In BrokerHost, it uses the Set Flights input Box and button to help set the flights for Broker.

##### Testing:
Wrote a sample test that uses this method and made sure that it is working as expected and sets the flights

##### Other:
We can implement the method for other Broker Types (Authenticator, CompanyPortal) once the Flighting feature is implemented fully.