### PR TITLE
Correct the production of JSON JWKs by the popManager code

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerTests.java
@@ -30,9 +30,11 @@ import androidx.annotation.RequiresApi;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
 import com.microsoft.identity.common.exception.ClientException;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -57,6 +59,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.Map;
 
 import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.JWK;
 import static com.microsoft.identity.common.internal.platform.IDevicePopManager.PublicKeyFormat.X_509_SubjectPublicKeyInfo_ASN_1;
@@ -392,26 +395,23 @@ public class DevicePoPManagerTests {
         final String publicKey = mDevicePopManager.getPublicKey(JWK);
 
         // Convert it to JSON, parse to verify fields
-        final JsonElement jwkElement = new JsonParser().parse(publicKey);
-
-        // Convert to JsonObject to extract claims
-        final JsonObject jwkObj = jwkElement.getAsJsonObject();
+        final Map<String, String> jwkObj = new Gson().fromJson(publicKey, new TypeToken<Map<String, String>>(){}.getType());
 
         // We should expect the following claims...
         // 'kty' - Key Type - Identifies the cryptographic alg used with this key (ex: RSA, EC)
         // 'e' - Public Exponent - The exponent used on signed/encoded data to decode the orig value
         // 'n' - Modulus - The product of two prime numbers used to generate the key pair
-        final JsonElement kty = jwkObj.get("kty");
+        final String kty = jwkObj.get("kty");
         Assert.assertNotNull(kty);
-        Assert.assertFalse(kty.getAsString().isEmpty());
+        Assert.assertFalse(kty.isEmpty());
 
-        final JsonElement e = jwkObj.get("e");
+        final String e = jwkObj.get("e");
         Assert.assertNotNull(e);
-        Assert.assertFalse(e.getAsString().isEmpty());
+        Assert.assertFalse(e.isEmpty());
 
-        final JsonElement n = jwkObj.get("n");
+        final String n = jwkObj.get("n");
         Assert.assertNotNull(n);
-        Assert.assertFalse(n.getAsString().isEmpty());
+        Assert.assertFalse(n.isEmpty());
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -36,6 +36,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.util.Supplier;
@@ -55,6 +57,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -143,6 +146,8 @@ class DevicePopManager implements IDevicePopManager {
      * Log message when private key material cannot be found.
      */
     private static final String PRIVATE_KEY_NOT_FOUND = "Not an instance of a PrivateKeyEntry";
+    public static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>(){}.getType();
+    public static final Gson GSON = new Gson();
 
     /**
      * Manager class for interacting with key storage mechanism.
@@ -813,7 +818,7 @@ class DevicePopManager implements IDevicePopManager {
 
         try {
             final Map<String, Object> jwkMap = getDevicePopJwkMinifiedJson();
-            return jwkMap.get(SignedHttpRequestJwtClaims.JWK).toString();
+            return GSON.toJson(jwkMap.get(SignedHttpRequestJwtClaims.JWK), MAP_STRING_STRING_TYPE);
         } catch (final UnrecoverableEntryException e) {
             exception = e;
             errCode = INVALID_PROTECTION_PARAMS;

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.5.0-RC1
+versionName=3.5.0-RC2
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
When we upgraded nimbus to v 9.x, we started emitting invalid JWKs in the getPublicKey method of our AsymmetricKey implementation.  This looks like it was masking a bug, previously, but it was not.  The code changed in an incompatible but compile-friendly way, and the json parser we were using during our tests did not reject the invalid json.  MSAL-Cpp's parser, however, does reject it.

Previously, the method we call: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/8.x/src/main/java/com/nimbusds/jose/jwk/RSAKey.java#lines-1984

returned a JSONObject.  In 9, this now returns a Map<String, Object>.  So in previous nimbus versions, the toString method would have worked.

First, fix the production of the JSON to not be a call to map.toString.  Then actually change the parser in the tests to be one that rejects the invalid json if it was produced.