### PR TITLE
Common 3.5.0

### DIFF
--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.5.0-RC2
+versionName=3.5.0-RC3
 versionCode=1
 latestPatchVersion=180

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.5.0-RC3
+versionName=3.5.0
 versionCode=1
 latestPatchVersion=180

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -191,7 +191,6 @@ dependencies {
         implementation(group: 'com.microsoft.identity', name: 'labapi', version: '0.0.+')
     }
 
-    implementation "org.mockito:mockito-inline:$rootProject.ext.mockitoCoreVersion"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -34,8 +34,6 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCred
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.dto.CredentialType;
 
-import org.mockito.Mockito;
-
 import java.util.Map;
 
 public class TestUtils {
@@ -65,13 +63,6 @@ public class TestUtils {
         final Context context = ApplicationProvider.getApplicationContext();
 
         return SharedPreferencesFileManager.getSharedPreferences(context, sharedPrefName, null);
-    }
-
-    public static Activity getMockActivity(final Context context) {
-        final Activity mockedActivity = Mockito.mock(Activity.class);
-        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(context);
-
-        return mockedActivity;
     }
 
     /**


### PR DESCRIPTION
This is one of a trio of changes unblocking the automation tests once more.  We saw a failure design objenesis (dependency of mockito), and it looks like a versioning problem.  So we bump the mockitol versions and sever the test dependency on mockito so as to avoid including mockito-inline and mockito-android in the same closure (See: https://github.com/mockito/mockito/pull/2024 ). Additional changes accommodate it.

Automated testing builds here: https://console.firebase.google.com/u/1/project/msal-automation-app-764c7/testlab/histories/bh.10e97d500b7740a/matrices/5378680702194906044/executions/bs.3ac3f21216073230

MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1467
Ad-Accounts: https://github.com/AzureAD/ad-accounts-for-android/pull/1642