### PR TITLE
Move Account Manager User Data look-up constants from common, AADAuthenticator to common4j

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ V.Next
 - [PATCH] Avoid multiple reads of BAM-Cache when inserting new data (#1429)
 - [MAJOR] Relocate SSOStatesSerializer out of internal namespace (integration steps available at aka.ms/AAd2vt8) (#1448)
 - [MINOR] Adds new Device#isDevicePoPSupported() API to test PoP compat + support for retrying key generation without requesting cert attestation (#1456)
+- [MINOR] Move Account Manager User Data look-up constants from common, AADAuthenticator to common4j (#1486)
 
 Version 3.4.5
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.adal.internal;
 import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.java.broker.BrokerAccountDataName;
 
 import java.nio.charset.Charset;
 
@@ -823,62 +824,62 @@ public final class AuthenticationConstants {
         /**
          * String of key for account name.
          */
-        public static final String ACCOUNT_HOME_ACCOUNT_ID = "account.home.account.id";
+        public static final String ACCOUNT_HOME_ACCOUNT_ID = BrokerAccountDataName.ACCOUNT_HOME_ACCOUNT_ID;
 
         /**
          * String of key for account id token.
          */
-        public static final String ACCOUNT_IDTOKEN = "account.idtoken";
+        public static final String ACCOUNT_IDTOKEN = BrokerAccountDataName.ACCOUNT_IDTOKEN;
 
         /**
          * String of key for user id.
          */
-        public static final String ACCOUNT_USERINFO_USERID = "account.userinfo.userid";
+        public static final String ACCOUNT_USERINFO_USERID = BrokerAccountDataName.ACCOUNT_USERINFO_USERID;
 
         /**
          * String of key for user id list.
          */
-        public static final String ACCOUNT_USERINFO_USERID_LIST = "account.userinfo.userid.list";
+        public static final String ACCOUNT_USERINFO_USERID_LIST = BrokerAccountDataName.ACCOUNT_USERINFO_USERID_LIST;
 
         /**
          * String of key for given name.
          */
-        public static final String ACCOUNT_USERINFO_GIVEN_NAME = "account.userinfo.given.name";
+        public static final String ACCOUNT_USERINFO_GIVEN_NAME = BrokerAccountDataName.ACCOUNT_USERINFO_GIVEN_NAME;
 
         /**
          * String of key for family name.
          */
-        public static final String ACCOUNT_USERINFO_FAMILY_NAME = "account.userinfo.family.name";
+        public static final String ACCOUNT_USERINFO_FAMILY_NAME = BrokerAccountDataName.ACCOUNT_USERINFO_FAMILY_NAME;
 
         /**
          * String of key for identity provider.
          */
-        public static final String ACCOUNT_USERINFO_IDENTITY_PROVIDER = "account.userinfo.identity.provider";
+        public static final String ACCOUNT_USERINFO_IDENTITY_PROVIDER = BrokerAccountDataName.ACCOUNT_USERINFO_IDENTITY_PROVIDER;
 
         /**
          * String of key for displayable id.
          */
-        public static final String ACCOUNT_USERINFO_USERID_DISPLAYABLE = "account.userinfo.userid.displayable";
+        public static final String ACCOUNT_USERINFO_USERID_DISPLAYABLE = BrokerAccountDataName.ACCOUNT_USERINFO_USERID_DISPLAYABLE;
 
         /**
          * String of key for tenant id.
          */
-        public static final String ACCOUNT_USERINFO_TENANTID = "account.userinfo.tenantid";
+        public static final String ACCOUNT_USERINFO_TENANTID = BrokerAccountDataName.ACCOUNT_USERINFO_TENANTID;
 
         /**
          * String of key for environment.
          */
-        public static final String ACCOUNT_USERINFO_ENVIRONMENT = "account.userinfo.environment";
+        public static final String ACCOUNT_USERINFO_ENVIRONMENT = BrokerAccountDataName.ACCOUNT_USERINFO_ENVIRONMENT;
 
         /**
          * String of key for authority type.
          */
-        public static final String ACCOUNT_USERINFO_AUTHORITY_TYPE = "account.userinfo.authority.type";
+        public static final String ACCOUNT_USERINFO_AUTHORITY_TYPE = BrokerAccountDataName.ACCOUNT_USERINFO_AUTHORITY_TYPE;
 
         /**
          * String of key for account id token record.
          */
-        public static final String ACCOUNT_USERINFO_ID_TOKEN = "account.userinfo.id.token";
+        public static final String ACCOUNT_USERINFO_ID_TOKEN = BrokerAccountDataName.ACCOUNT_USERINFO_ID_TOKEN;
 
         /**
          * String of key for adal version.
@@ -913,7 +914,7 @@ public final class AuthenticationConstants {
         /**
          * String of key for user data broker RT.
          */
-        public static final String USERDATA_BROKER_RT = "userdata.broker.rt";
+        public static final String USERDATA_BROKER_RT = BrokerAccountDataName.USERDATA_BROKER_RT;
 
         /**
          * String of key for user data broker PRT, RT.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AndroidBrokerAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AndroidBrokerAccount.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.logging.Logger;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -45,6 +46,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 @Getter
 @Accessors(prefix = "m")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
 public class AndroidBrokerAccount implements IBrokerAccount {
     private static final String TAG = AndroidBrokerAccount.class.getSimpleName();
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AndroidBrokerAccountTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AndroidBrokerAccountTest.java
@@ -1,0 +1,116 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.Context;
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.java.broker.IBrokerAccount;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import lombok.NonNull;
+
+/**
+ * Tests for {@link AndroidBrokerAccount} class.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N})
+public class AndroidBrokerAccountTest {
+
+    private final Context mContext = ApplicationProvider.getApplicationContext();
+
+    private static final String TEST_ACCOUNT_NAME = "test@microsoft.com";
+    private static final String ACCOUNT_TYPE = "com.microsoft.workaccount";
+
+    private final AccountManager ACCOUNT_MANAGER = AccountManager.get(mContext);
+
+    @Before
+    public void setup() {
+        final Account[] accounts = ACCOUNT_MANAGER.getAccountsByType(ACCOUNT_TYPE);
+        Assert.assertNotNull(accounts);
+        Assert.assertEquals(0, accounts.length);
+    }
+
+    @Test
+    public void testCanAdaptAccountManagerAccountWhenAccountProvided() {
+        final Account account = new Account(TEST_ACCOUNT_NAME, ACCOUNT_TYPE);
+        Assert.assertNotNull(account);
+
+        final AndroidBrokerAccount androidBrokerAccount = AndroidBrokerAccount.adapt(account);
+        Assert.assertNotNull(androidBrokerAccount);
+        Assert.assertEquals(TEST_ACCOUNT_NAME, androidBrokerAccount.getUsername());
+        Assert.assertEquals(account, androidBrokerAccount.getAccount());
+    }
+
+    @Test
+    public void testCanAdaptAccountManagerAccountWhenAccountNameAndTypeProvided() {
+        final AndroidBrokerAccount androidBrokerAccount = AndroidBrokerAccount.adapt(
+                ACCOUNT_MANAGER,
+                TEST_ACCOUNT_NAME,
+                ACCOUNT_TYPE
+        );
+
+        Assert.assertNotNull(androidBrokerAccount);
+        Assert.assertEquals(TEST_ACCOUNT_NAME, androidBrokerAccount.getUsername());
+        Assert.assertEquals(
+                new Account(TEST_ACCOUNT_NAME, ACCOUNT_TYPE),
+                androidBrokerAccount.getAccount()
+        );
+    }
+
+    @Test
+    public void testCanCastBrokerAccountToAndroidBrokerAccountWhenPossible() {
+        final IBrokerAccount brokerAccount = AndroidBrokerAccount.adapt(
+                ACCOUNT_MANAGER,
+                TEST_ACCOUNT_NAME,
+                ACCOUNT_TYPE
+        );
+
+        final AndroidBrokerAccount androidBrokerAccount = AndroidBrokerAccount.cast(brokerAccount);
+        Assert.assertNotNull(androidBrokerAccount);
+        Assert.assertEquals(brokerAccount, androidBrokerAccount);
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void testCannotCastBrokerAccountToAndroidBrokerAccountWhenNotPossible() {
+        final IBrokerAccount brokerAccount = new IBrokerAccount() {
+            @Override
+            public @NonNull String getUsername() {
+                return TEST_ACCOUNT_NAME;
+            }
+        };
+
+        AndroidBrokerAccount.cast(brokerAccount);
+        Assert.fail("Unexpected Success :(");
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/BrokerAccountDataName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/BrokerAccountDataName.java
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.broker;
+
+public final class BrokerAccountDataName {
+
+    private BrokerAccountDataName() {
+    }
+
+    /**
+     * Key for the data used by the PRTv3 protocol.
+     */
+    public static final String PRT_V3 = "workplaceJoin.key.prt3";
+
+    public static final String PRT = "workplaceJoin.key.prt";
+
+    public static final String PRT_AUTHORITY = "workplaceJoin.key.prt.authority";
+
+    public static final String BRT_AUTHORITY = "workplaceJoin.key.brt.authority";
+
+    public static final String PRT_ACQUISITION_TIME = "workplaceJoin.key.prt.acquisition.time";
+
+    public static final String PRT_ID_TOKEN = "workplaceJoin.key.prt.idtoken.key";
+
+    public static final String ENCODED_SESSION_KEY = "workplaceJoin.key.session.key";
+
+    public static final String EMAIL = "workplaceJoin.key.email";
+
+    /**
+     * String of key for account name.
+     */
+    public static final String ACCOUNT_HOME_ACCOUNT_ID = "account.home.account.id";
+
+    /**
+     * String of key for account id token.
+     */
+    public static final String ACCOUNT_IDTOKEN = "account.idtoken";
+
+    /**
+     * String of key for user id.
+     */
+    public static final String ACCOUNT_USERINFO_USERID = "account.userinfo.userid";
+
+    /**
+     * String of key for user id list.
+     */
+    public static final String ACCOUNT_USERINFO_USERID_LIST = "account.userinfo.userid.list";
+
+    /**
+     * String of key for given name.
+     */
+    public static final String ACCOUNT_USERINFO_GIVEN_NAME = "account.userinfo.given.name";
+
+    /**
+     * String of key for family name.
+     */
+    public static final String ACCOUNT_USERINFO_FAMILY_NAME = "account.userinfo.family.name";
+
+    /**
+     * String of key for identity provider.
+     */
+    public static final String ACCOUNT_USERINFO_IDENTITY_PROVIDER = "account.userinfo.identity.provider";
+
+    /**
+     * String of key for displayable id.
+     */
+    public static final String ACCOUNT_USERINFO_USERID_DISPLAYABLE = "account.userinfo.userid.displayable";
+
+    /**
+     * String of key for tenant id.
+     */
+    public static final String ACCOUNT_USERINFO_TENANTID = "account.userinfo.tenantid";
+
+    /**
+     * String of key for environment.
+     */
+    public static final String ACCOUNT_USERINFO_ENVIRONMENT = "account.userinfo.environment";
+
+    /**
+     * String of key for authority type.
+     */
+    public static final String ACCOUNT_USERINFO_AUTHORITY_TYPE = "account.userinfo.authority.type";
+
+    /**
+     * String of key for account id token record.
+     */
+    public static final String ACCOUNT_USERINFO_ID_TOKEN = "account.userinfo.id.token";
+
+    /**
+     * String of key for user data broker RT.
+     */
+    public static final String USERDATA_BROKER_RT = "userdata.broker.rt";
+
+
+    public static final String DATA_IS_NGC = "com.microsoft.workaccount.isNGC";
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/JweResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/JweResponse.java
@@ -30,6 +30,7 @@ import org.json.JSONObject;
 
 import cz.msebera.android.httpclient.extras.Base64;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
@@ -38,6 +39,7 @@ public class JweResponse {
     @Builder
     @Getter
     @Accessors(prefix = "m")
+    @EqualsAndHashCode
     public static class JweHeader {
         private final String mAlgorithm;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
@@ -28,6 +28,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
@@ -40,6 +42,7 @@ import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 
+import cz.msebera.android.httpclient.extras.Base64;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
@@ -50,6 +53,8 @@ public class StringUtil {
     private static String TAG = StringUtil.class.getSimpleName();
 
     private static final String RFC3339_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+    private static final String TOKEN_HASH_ALGORITHM = "SHA256";
 
     /**
      * Checks if string is null or empty.
@@ -260,4 +265,20 @@ public class StringUtil {
         return RFC3339DateFormat.parse(dateStr);
     }
 
+    /**
+     * Create the Hash string of the message.
+     *
+     * @param msg String
+     * @return String in Hash
+     * @throws NoSuchAlgorithmException throws if no such algorithm.
+     */
+    public static String createHash(final String msg) throws NoSuchAlgorithmException {
+        if (!isNullOrEmpty(msg)) {
+            final MessageDigest digester = MessageDigest.getInstance(TOKEN_HASH_ALGORITHM);
+            final byte[] msgInBytes = msg.getBytes(ENCODING_UTF8);
+            return new String(Base64.encode(digester.digest(msgInBytes), Base64.NO_WRAP),
+                    ENCODING_UTF8);
+        }
+        return msg;
+    }
 }


### PR DESCRIPTION
Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1647

This PR achieves the following:

**- Move Account Manager User Data look-up constants from common, AADAuthenticator to common4j**
Move constants used for account manager storage data, and relocate them from common and AADAuthenticator to common4j. The reason is because we need to access them in LinuxBroker as well. The previous original constants now just references them from the new file created in this PR (BrokerAccountDataName). At a later point, we will just delete the older ones once the refactoring is complete.

**- Replicate createHash method in common4j's StringUtil.java (from StringExtensions.java)**
Add a `createHash` method to `StringUtils.java` because we need it in Linux too...this is the same code take from `StringExtensions.java`...leaving that old method there for now because that's being used in a lot of places too. Over the course of refactoring the usage will go away and we will delete the old one.

**- Add tests for AndroidBrokerAccount**
Add tests for AndroidBrokerAccount.java (also added EqualsAndHashCode to AndroidBrokerAccount to get the tests to pass)