### PR TITLE
DevicePoPManager Tweaks to Improve Huawei Device Support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ V.Next
 - [PATCH] Avoid multiple reads of BAM-Cache when inserting new data (#1429)
 - [MAJOR] Relocate SSOStatesSerializer out of internal namespace (integration steps available at aka.ms/AAd2vt8) (#1448)
 - [MINOR] Adds new Device#isDevicePoPSupported() API to test PoP compat + support for retrying key generation without requesting cert attestation (#1456)
+- [MAJOR] Removes support for SHA-384/512, MD5 w. RSA due to incompatibilities on certain devices (#1489)
 
 Version 3.4.5
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerEncryptionTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerEncryptionTests.java
@@ -26,8 +26,8 @@ import android.os.Build;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
+import com.microsoft.identity.common.java.exception.ClientException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -45,8 +45,6 @@ import java.util.List;
 
 import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_ECB_OAEPWithSHA_1AndMGF1Padding;
 import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_ECB_OAEPWithSHA_256AndMGF1Padding;
-import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_ECB_OAEPWithSHA_384AndMGF1Padding;
-import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_ECB_OAEPWithSHA_512AndMGF1Padding;
 import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_ECB_PKCS1_PADDING;
 import static com.microsoft.identity.common.java.crypto.IDevicePopManager.Cipher.RSA_NONE_OAEPWithSHA_1AndMGF1Padding;
 
@@ -75,8 +73,6 @@ public class DevicePoPManagerEncryptionTests {
             ciphers.add(RSA_NONE_OAEPWithSHA_1AndMGF1Padding);
             ciphers.add(RSA_ECB_OAEPWithSHA_1AndMGF1Padding);
             ciphers.add(RSA_ECB_OAEPWithSHA_256AndMGF1Padding);
-            //ciphers.add(RSA_ECB_OAEPWithSHA_384AndMGF1Padding);
-            //ciphers.add(RSA_ECB_OAEPWithSHA_512AndMGF1Padding);
         }
 
         return ciphers;

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerEncryptionTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerEncryptionTests.java
@@ -75,8 +75,8 @@ public class DevicePoPManagerEncryptionTests {
             ciphers.add(RSA_NONE_OAEPWithSHA_1AndMGF1Padding);
             ciphers.add(RSA_ECB_OAEPWithSHA_1AndMGF1Padding);
             ciphers.add(RSA_ECB_OAEPWithSHA_256AndMGF1Padding);
-            ciphers.add(RSA_ECB_OAEPWithSHA_384AndMGF1Padding);
-            ciphers.add(RSA_ECB_OAEPWithSHA_512AndMGF1Padding);
+            //ciphers.add(RSA_ECB_OAEPWithSHA_384AndMGF1Padding);
+            //ciphers.add(RSA_ECB_OAEPWithSHA_512AndMGF1Padding);
         }
 
         return ciphers;

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -40,10 +40,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
-import java.util.List;
-
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.NONE_WITH_RSA;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_256_WITH_RSA;
+import java.util.Arrays;
 
 
 // Note: Test cannot use robolectric due to the following open issue
@@ -58,13 +55,7 @@ public class DevicePoPManagerSigningTests {
 
     @Parameterized.Parameters
     public static Iterable<SigningAlgorithm> testParams() {
-        final List<SigningAlgorithm> signingAlgs =
-                new ArrayList<SigningAlgorithm>() {{
-                    add(NONE_WITH_RSA);
-                    add(SHA_256_WITH_RSA);
-                }};
-
-        return signingAlgs;
+        return new ArrayList<>(Arrays.asList(SigningAlgorithm.values()));
     }
 
     @SuppressWarnings("unused")

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.ArrayList;
 import java.util.Arrays;
 
 
@@ -55,7 +54,7 @@ public class DevicePoPManagerSigningTests {
 
     @Parameterized.Parameters
     public static Iterable<SigningAlgorithm> testParams() {
-        return new ArrayList<>(Arrays.asList(SigningAlgorithm.values()));
+        return Arrays.asList(SigningAlgorithm.values());
     }
 
     @SuppressWarnings("unused")

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -22,13 +22,11 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
-import android.os.Build;
-
 import androidx.test.core.app.ApplicationProvider;
 
+import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 import com.microsoft.identity.common.java.crypto.SigningAlgorithm;
 import com.microsoft.identity.common.java.exception.ClientException;
-import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -44,14 +42,8 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.MD5_WITH_RSA;
 import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.NONE_WITH_RSA;
 import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_256_WITH_RSA;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_256_WITH_RSA_PSS;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_384_WITH_RSA;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_384_WITH_RSA_PSS;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_512_WITH_RSA;
-import static com.microsoft.identity.common.java.crypto.SigningAlgorithm.SHA_512_WITH_RSA_PSS;
 
 
 // Note: Test cannot use robolectric due to the following open issue
@@ -68,19 +60,9 @@ public class DevicePoPManagerSigningTests {
     public static Iterable<SigningAlgorithm> testParams() {
         final List<SigningAlgorithm> signingAlgs =
                 new ArrayList<SigningAlgorithm>() {{
-                    //add(MD5_WITH_RSA);
                     add(NONE_WITH_RSA);
                     add(SHA_256_WITH_RSA);
-                    //add(SHA_384_WITH_RSA);
-                    //add(SHA_512_WITH_RSA);
                 }};
-
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-//            // Only execute these tests at appropriate API levels...
-//            signingAlgs.add(SHA_256_WITH_RSA_PSS);
-//            signingAlgs.add(SHA_384_WITH_RSA_PSS);
-//            signingAlgs.add(SHA_512_WITH_RSA_PSS);
-//        }
 
         return signingAlgs;
     }

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/DevicePoPManagerSigningTests.java
@@ -68,19 +68,19 @@ public class DevicePoPManagerSigningTests {
     public static Iterable<SigningAlgorithm> testParams() {
         final List<SigningAlgorithm> signingAlgs =
                 new ArrayList<SigningAlgorithm>() {{
-                    add(MD5_WITH_RSA);
+                    //add(MD5_WITH_RSA);
                     add(NONE_WITH_RSA);
                     add(SHA_256_WITH_RSA);
-                    add(SHA_384_WITH_RSA);
-                    add(SHA_512_WITH_RSA);
+                    //add(SHA_384_WITH_RSA);
+                    //add(SHA_512_WITH_RSA);
                 }};
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            // Only execute these tests at appropriate API levels...
-            signingAlgs.add(SHA_256_WITH_RSA_PSS);
-            signingAlgs.add(SHA_384_WITH_RSA_PSS);
-            signingAlgs.add(SHA_512_WITH_RSA_PSS);
-        }
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+//            // Only execute these tests at appropriate API levels...
+//            signingAlgs.add(SHA_256_WITH_RSA_PSS);
+//            signingAlgs.add(SHA_384_WITH_RSA_PSS);
+//            signingAlgs.add(SHA_512_WITH_RSA_PSS);
+//        }
 
         return signingAlgs;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -1284,15 +1284,11 @@ public class DevicePopManager implements IDevicePopManager {
                 .setKeySize(keySize)
                 .setSignaturePaddings(
                         KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
-//                      KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-//                      KeyProperties.DIGEST_MD5,
                         KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-//                      KeyProperties.DIGEST_SHA384,
-//                      KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
@@ -1355,15 +1351,11 @@ public class DevicePopManager implements IDevicePopManager {
                 .setKeySize(keySize)
                 .setSignaturePaddings(
                         KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
-//                      KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-//                      KeyProperties.DIGEST_MD5,
                         KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-//                      KeyProperties.DIGEST_SHA384,
-//                      KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -38,7 +38,6 @@ import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.CodeMarkerManager;
 import com.microsoft.identity.common.internal.util.Supplier;
-import com.microsoft.identity.common.internal.util.ThreadUtils;
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 import com.microsoft.identity.common.java.crypto.IKeyManager;
 import com.microsoft.identity.common.java.crypto.SecureHardwareState;
@@ -63,7 +62,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
@@ -93,14 +91,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.security.auth.x500.X500Principal;
 
-import lombok.Getter;
 import lombok.SneakyThrows;
 
 import static com.microsoft.identity.common.PerfConstants.CodeMarkerConstants.GENERATE_AT_POP_ASYMMETRIC_KEYPAIR_END;
@@ -182,7 +178,6 @@ public class DevicePopManager implements IDevicePopManager {
      * Reference to our perf-marker object.
      */
     private static final CodeMarkerManager sCodeMarkerManager = CodeMarkerManager.getInstance();
-
 
     /**
      * Properties used by the self-signed certificate.
@@ -368,6 +363,7 @@ public class DevicePopManager implements IDevicePopManager {
         final String errCode;
 
         try {
+            sCodeMarkerManager.markCode(GENERATE_AT_POP_ASYMMETRIC_KEYPAIR_START);
             final KeyPair keyPair = generateNewRsaKeyPair(mContext, RSA_KEY_SIZE);
             final RSAKey rsaKey = getRsaKeyForKeyPair(keyPair);
             return getThumbprintForRsaKey(rsaKey);
@@ -1264,7 +1260,7 @@ public class DevicePopManager implements IDevicePopManager {
                             final boolean trySetAttestationChallenge) throws InvalidAlgorithmParameterException {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             initializePre23(context, keyPairGenerator, keySize);
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P){
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge);
         } else {
             initialize28(keyPairGenerator, keySize, useStrongbox, enableImport, trySetAttestationChallenge);
@@ -1288,15 +1284,15 @@ public class DevicePopManager implements IDevicePopManager {
                 .setKeySize(keySize)
                 .setSignaturePaddings(
                         KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
-                        //KeyProperties.SIGNATURE_PADDING_RSA_PSS
+//                      KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-//                        KeyProperties.DIGEST_MD5,
-//                        KeyProperties.DIGEST_NONE,
+//                      KeyProperties.DIGEST_MD5,
+//                      KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-//                        KeyProperties.DIGEST_SHA384,
-//                        KeyProperties.DIGEST_SHA512
+//                      KeyProperties.DIGEST_SHA384,
+//                      KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
@@ -1362,12 +1358,12 @@ public class DevicePopManager implements IDevicePopManager {
 //                      KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-//                        KeyProperties.DIGEST_MD5,
-//                        KeyProperties.DIGEST_NONE,
+//                      KeyProperties.DIGEST_MD5,
+//                      KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-//                        KeyProperties.DIGEST_SHA384,
-//                        KeyProperties.DIGEST_SHA512
+//                      KeyProperties.DIGEST_SHA384,
+//                      KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -1288,7 +1288,7 @@ public class DevicePopManager implements IDevicePopManager {
                 )
                 .setDigests(
 //                      KeyProperties.DIGEST_MD5,
-//                      KeyProperties.DIGEST_NONE,
+                        KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
 //                      KeyProperties.DIGEST_SHA384,
@@ -1359,7 +1359,7 @@ public class DevicePopManager implements IDevicePopManager {
                 )
                 .setDigests(
 //                      KeyProperties.DIGEST_MD5,
-//                      KeyProperties.DIGEST_NONE,
+                        KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
 //                      KeyProperties.DIGEST_SHA384,

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/DevicePopManager.java
@@ -1287,16 +1287,16 @@ public class DevicePopManager implements IDevicePopManager {
         )
                 .setKeySize(keySize)
                 .setSignaturePaddings(
-                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
-                        KeyProperties.SIGNATURE_PADDING_RSA_PSS
+                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
+                        //KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-                        KeyProperties.DIGEST_MD5,
-                        KeyProperties.DIGEST_NONE,
+//                        KeyProperties.DIGEST_MD5,
+//                        KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
-                        KeyProperties.DIGEST_SHA256,
-                        KeyProperties.DIGEST_SHA384,
-                        KeyProperties.DIGEST_SHA512
+                        KeyProperties.DIGEST_SHA256
+//                        KeyProperties.DIGEST_SHA384,
+//                        KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
@@ -1358,16 +1358,16 @@ public class DevicePopManager implements IDevicePopManager {
                 mKeyManager.getKeyAlias(), purposes)
                 .setKeySize(keySize)
                 .setSignaturePaddings(
-                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
-                        KeyProperties.SIGNATURE_PADDING_RSA_PSS
+                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
+//                      KeyProperties.SIGNATURE_PADDING_RSA_PSS
                 )
                 .setDigests(
-                        KeyProperties.DIGEST_MD5,
-                        KeyProperties.DIGEST_NONE,
+//                        KeyProperties.DIGEST_MD5,
+//                        KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
-                        KeyProperties.DIGEST_SHA256,
-                        KeyProperties.DIGEST_SHA384,
-                        KeyProperties.DIGEST_SHA512
+                        KeyProperties.DIGEST_SHA256
+//                        KeyProperties.DIGEST_SHA384,
+//                        KeyProperties.DIGEST_SHA512
                 ).setEncryptionPaddings(
                         KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
                         KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
@@ -123,29 +123,6 @@ public interface IDevicePopManager {
                 // https://issuetracker.google.com/issues/37075898#comment7
                 return new OAEPParameterSpec("SHA-256", MGF_1, new MGF1ParameterSpec(SHA_1), PSource.PSpecified.DEFAULT);
             }
-        },
-
-        //@RequiresApi(Build.VERSION_CODES.M)
-        RSA_ECB_OAEPWithSHA_384AndMGF1Padding("RSA/ECB/OAEPWithSHA-384AndMGF1Padding") {
-
-            @Override
-            public AlgorithmParameterSpec getParameters() {
-                // We're going to be forcing defaults in this cipher to correct a deficiency in certain
-                // android platform support.  See:
-                // https://issuetracker.google.com/issues/37075898#comment7
-                return new OAEPParameterSpec("SHA-384", MGF_1, new MGF1ParameterSpec(SHA_1), PSource.PSpecified.DEFAULT);
-            }
-        },
-
-        //@RequiresApi(Build.VERSION_CODES.M)
-        RSA_ECB_OAEPWithSHA_512AndMGF1Padding("RSA/ECB/OAEPWithSHA-512AndMGF1Padding") {
-            @Override
-            public AlgorithmParameterSpec getParameters() {
-                // We're going to be forcing defaults in this cipher to correct a deficiency in certain
-                // android platform support.  See:
-                // https://issuetracker.google.com/issues/37075898#comment7
-                return new OAEPParameterSpec("SHA-512", MGF_1, new MGF1ParameterSpec(SHA_1), PSource.PSpecified.DEFAULT);
-            }
         };
 
         private final String mValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
@@ -29,8 +29,6 @@ import lombok.NonNull;
  * levels.
  */
 public enum SigningAlgorithm {
-    //@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    MD5_WITH_RSA("MD5withRSA"),
 
     //@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
     NONE_WITH_RSA("NONEwithRSA"),
@@ -38,22 +36,7 @@ public enum SigningAlgorithm {
     SHA_1_WITH_RSA("SHA1withRSA"),
 
     //@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    SHA_256_WITH_RSA("SHA256withRSA"),
-
-    //@RequiresApi(Build.VERSION_CODES.M)
-    SHA_256_WITH_RSA_PSS("SHA256withRSA/PSS"),
-
-    //@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    SHA_384_WITH_RSA("SHA384withRSA"),
-
-    //@RequiresApi(Build.VERSION_CODES.M)
-    SHA_384_WITH_RSA_PSS("SHA384withRSA/PSS"),
-
-    //@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    SHA_512_WITH_RSA("SHA512withRSA"),
-
-    //@RequiresApi(Build.VERSION_CODES.M)
-    SHA_512_WITH_RSA_PSS("SHA512withRSA/PSS");
+    SHA_256_WITH_RSA("SHA256withRSA");
 
     private final String mValue;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
@@ -26,7 +26,11 @@ import lombok.NonNull;
 
 /**
  * Signing algorithms supported by our underlying keystore. Not all algs available at all device
- * levels.
+ * levels. Please note that Common supports a minimal subset of signing algorithms due to device/OEM
+ * specific incompatibilities when attempting AndroidKeystore-based key generations >256 bits.
+ * RSA-PKCS1 is favored over RSA-PSS for broader compatibility.
+ *
+ * More info: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1453707
  */
 public enum SigningAlgorithm {
 


### PR DESCRIPTION
In testing, Huawei devices encounter errors/exceptions when attempting to generate pop keys with any of the following properties:
- RSAPSS padding
- SHA384/512