### PR TITLE
Revert getOS in AndroidDeviceMetadata

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -56,10 +56,11 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
         return "UNKNOWN";
     }
 
+    // Returns a SDK version (i.e. 24) instead of a user-friendly android version (i.e. 7.0)
     @Override
     @NonNull
     public String getOs() {
-        return android.os.Build.VERSION.RELEASE;
+        return String.valueOf(Build.VERSION.SDK_INT);
     }
 
     @Override


### PR DESCRIPTION
Build.VERSION.SDK_INT returns SDK version (i.e. 24)
android.os.Build.VERSION.RELEASE returns user-friendly version (i.e. 7.0)

I'm seeing inconsistency, as in, we're sending 7.0 in the registration call, however, we can patch this later with another request.

The broker/common code seems to be using 24 always.

Therefore, i'm inclining to keeping the same behavior here.

