### PR TITLE
Seperate OS field in Device class for eSTS and DRS request

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -58,9 +58,13 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
 
     // Returns a SDK version (i.e. 24) instead of a user-friendly android version (i.e. 7.0)
     @Override
-    @NonNull
-    public String getOs() {
+    public @NonNull String getOsForEsts() {
         return String.valueOf(Build.VERSION.SDK_INT);
+    }
+
+    @Override
+    public @NonNull String getOsForDrs() {
+        return android.os.Build.VERSION.RELEASE;
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDeviceMetadata.java
@@ -35,6 +35,7 @@ public abstract class AbstractDeviceMetadata implements IDeviceMetadata {
         return getDeviceModel() + SEPARATOR +
                 getManufacturer() + SEPARATOR +
                 getCpu() + SEPARATOR +
-                getOs();
+                getOsForEsts() + SEPARATOR +
+                getOsForDrs();
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -81,7 +81,7 @@ public class Device {
 
             if (sDeviceMetadata != null) {
                 platformParameters.put(PlatformIdParameters.CPU_PLATFORM, sDeviceMetadata.getCpu());
-                platformParameters.put(PlatformIdParameters.OS, sDeviceMetadata.getOs());
+                platformParameters.put(PlatformIdParameters.OS, sDeviceMetadata.getOsForEsts());
                 platformParameters.put(PlatformIdParameters.DEVICE_MODEL, sDeviceMetadata.getDeviceModel());
             } else {
                 platformParameters.put(PlatformIdParameters.CPU_PLATFORM, NOT_SET);
@@ -142,17 +142,39 @@ public class Device {
     }
 
     /**
-     * Gets the OS of the current device.
+     * Get the OS of this device to be sent to eSTS.
+     *
+     * We have this because in Android, we're sending [SDK VERSION] (i.e. 24) to eSTS,
+     * not the [OS VERSION] (i.e. 7.0), and eSTS are using these [SDK VERSION] to gate features.
      *
      * @return The name/version of the device OS.
      */
     @NonNull
     @GuardedBy("sLock")
-    public static String getOs() {
+    public static String getOsForEsts() {
         sLock.readLock().lock();
         try {
             if (sDeviceMetadata != null) {
-                return sDeviceMetadata.getOs();
+                return sDeviceMetadata.getOsForEsts();
+            }
+            return NOT_SET;
+        } finally {
+            sLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get the OS of this device to be sent to DRS.
+     *
+     * @return a String representing the OS information
+     */
+    @NonNull
+    @GuardedBy("sLock")
+    public static String getOsForDrs() {
+        sLock.readLock().lock();
+        try {
+            if (sDeviceMetadata != null) {
+                return sDeviceMetadata.getOsForDrs();
             }
             return NOT_SET;
         } finally {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
@@ -42,12 +42,23 @@ public interface IDeviceMetadata {
     String getCpu();
 
     /**
-     * Get the OS of this device. This would include the OS name and version.
+     * Get the OS of this device to be sent to eSTS.
+     *
+     * We have this because in Android, we're sending [SDK VERSION] (i.e. 24) to eSTS,
+     * not the [OS VERSION] (i.e. 7.0), and eSTS are using these [SDK VERSION] to gate features.
      *
      * @return a String representing the OS information
      */
     @NonNull
-    String getOs();
+    String getOsForEsts();
+
+    /**
+     * Get the OS of this device to be sent to DRS.
+     *
+     * @return a String representing the OS information
+     */
+    @NonNull
+    String getOsForDrs();
 
     /**
      * Get the model name of this device.

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -148,7 +148,7 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
         mLibraryVersion = builder.mLibraryVersion;
         mLibraryName = builder.mLibraryName;
 
-        mDiagnosticOS = Device.getOs();
+        mDiagnosticOS = Device.getOsForEsts();
         mDiagnosticDM = Device.getModel();
         mDiagnosticCPU = Device.getCpu();
     }

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
@@ -69,7 +69,7 @@ public class DeviceTest {
         Assert.assertEquals(3, platformParameter.size());
         Assert.assertEquals(MockDeviceMetadata.TEST_CPU, platformParameter.get(Device.PlatformIdParameters.CPU_PLATFORM));
         Assert.assertEquals(MockDeviceMetadata.TEST_DEVICE_MODEL, platformParameter.get(Device.PlatformIdParameters.DEVICE_MODEL));
-        Assert.assertEquals(MockDeviceMetadata.TEST_OS, platformParameter.get(Device.PlatformIdParameters.OS));
+        Assert.assertEquals(MockDeviceMetadata.TEST_OS_ESTS, platformParameter.get(Device.PlatformIdParameters.OS));
     }
 
     @Test
@@ -87,7 +87,8 @@ public class DeviceTest {
     @Test
     public void testGetOs(){
         Device.setDeviceMetadata(new MockDeviceMetadata());
-        Assert.assertEquals(MockDeviceMetadata.TEST_OS, Device.getOs());
+        Assert.assertEquals(MockDeviceMetadata.TEST_OS_ESTS, Device.getOsForEsts());
+        Assert.assertEquals(MockDeviceMetadata.TEST_OS_DRS, Device.getOsForDrs());
     }
 
     @Test
@@ -128,7 +129,8 @@ public class DeviceTest {
         final String expectedResult = MockDeviceMetadata.TEST_DEVICE_MODEL + METADATA_SEPARATOR +
                 MockDeviceMetadata.TEST_MANUFACTURER + METADATA_SEPARATOR +
                 MockDeviceMetadata.TEST_CPU + METADATA_SEPARATOR +
-                MockDeviceMetadata.TEST_OS;
+                MockDeviceMetadata.TEST_OS_ESTS + METADATA_SEPARATOR +
+                MockDeviceMetadata.TEST_OS_DRS;
         Assert.assertEquals(expectedResult, deviceMetadata.getAllMetadata());
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
@@ -28,7 +28,8 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
 
     public static final String TEST_DEVICE_TYPE = "TestDeviceType";
     public static final String TEST_CPU = "TestCPU";
-    public static final String TEST_OS = "TestOS";
+    public static final String TEST_OS_ESTS = "TestOSEsts";
+    public static final String TEST_OS_DRS = "TestOSDrs";
     public static final String TEST_DEVICE_MODEL = "TestDeviceModel";
     public static final String TEST_MANUFACTURER = "TestManufacturer";
 
@@ -43,8 +44,13 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
     }
 
     @Override
-    public @NonNull String getOs() {
-        return TEST_OS;
+    public @NonNull String getOsForEsts() {
+        return TEST_OS_ESTS;
+    }
+
+    @Override
+    public @NonNull String getOsForDrs() {
+        return TEST_OS_DRS;
     }
 
     @Override

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequestTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequestTest.java
@@ -80,7 +80,7 @@ public class MicrosoftAuthorizationRequestTest {
                         "&code_challenge_method=" + MOCK_PKCE_CHALLENGE.getCodeChallengeMethod() +
                         "&x-client-Ver=" + MOCK_LIBRARY_VERSION +
                         "&x-client-SKU=" + MOCK_LIBRARY_NAME +
-                        "&x-client-OS=" + MockDeviceMetadata.TEST_OS +
+                        "&x-client-OS=" + MockDeviceMetadata.TEST_OS_ESTS +
                         "&x-client-CPU=" + MockDeviceMetadata.TEST_CPU +
                         "&x-client-DM=" + MockDeviceMetadata.TEST_DEVICE_MODEL +
                         "&instance_aware=" + MOCK_MULTIPLE_CLOUD_AWARE +
@@ -111,7 +111,7 @@ public class MicrosoftAuthorizationRequestTest {
         Device.setDeviceMetadata(new MockDeviceMetadata());
 
         final MockMicrosoftAuthorizationRequest request = new MockMicrosoftAuthorizationRequest.Builder().build();
-        Assert.assertEquals(MockDeviceMetadata.TEST_OS, request.getDiagnosticOS());
+        Assert.assertEquals(MockDeviceMetadata.TEST_OS_ESTS, request.getDiagnosticOS());
         Assert.assertEquals(MockDeviceMetadata.TEST_CPU, request.getDiagnosticCPU());
         Assert.assertEquals(MockDeviceMetadata.TEST_DEVICE_MODEL, request.getDiagnosticDM());
     }

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
@@ -134,7 +134,7 @@ public class MicrosoftStsAuthorizationRequestTests {
                         "&client-request-id=" + DEFAULT_TEST_CORRELATION_ID +
                         "&code_challenge=" + MOCK_PKCE_CHALLENGE.getCodeChallenge() +
                         "&code_challenge_method=" + MOCK_PKCE_CHALLENGE.getCodeChallengeMethod() +
-                        "&x-client-OS=" + MockDeviceMetadata.TEST_OS +
+                        "&x-client-OS=" + MockDeviceMetadata.TEST_OS_ESTS +
                         "&x-client-CPU=" + MockDeviceMetadata.TEST_CPU +
                         "&x-client-DM=" + MockDeviceMetadata.TEST_DEVICE_MODEL +
                         "&response_type=code" +


### PR DESCRIPTION
In Android, we send...
- SDK version to ESTS (i.e. 24)
- ANDROID_VERSION to DRS (i.e. 7.0)

Currently, ESTS is relying on SDK version to gate their feature, and (an engineer from) DRS doesn't seem to like the idea of replacing ANDROID_VERSION with SDK version.

Given that the concept of SDK VERSION doesn't make sense for xplat code, i'm separating out the fields based on the endpoint.