### PR TITLE
Add a method to allow for the setting of Fragment initial state

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@ V.Next
 - [MINOR] Move Account Manager User Data look-up constants from common, AADAuthenticator to common4j (#1486)
 - [MAJOR] Removes support for SHA-384/512, MD5 w. RSA due to incompatibilities on certain devices (#1489)
 - [MINOR] Implements a fix for sovereign cloud TSL scenarios (#1501)
+- [MINOR] Add a method to allow for the setting of Fragment initial state (#1506)
 
 Version 3.5.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.internal.providers.oauth2;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
@@ -123,4 +124,25 @@ public class AuthorizationActivityFactory {
         return fragment;
     }
 
+    /**
+     * Returns the correct authorization fragment for local (non-broker) authorization flows,
+     * supplying a start bundle for the Fragment state.
+     * Fragments include:
+     * {@link WebViewAuthorizationFragment}
+     * {@link BrowserAuthorizationFragment}
+     * {@link CurrentTaskBrowserAuthorizationFragment}
+     *
+     * @param intent the intent to use to create the fragment.
+     * @param bundle the bundle to add to the Fragment if it is an AuthorizationFragment.
+     * @return returns an Fragment that's used as to authorize a token request.
+     */
+    public static Fragment getAuthorizationFragmentFromStartIntentWithState(@NonNull final Intent intent,
+                                                                            @NonNull final Bundle bundle) {
+        final Fragment fragment = getAuthorizationFragmentFromStartIntent(intent);
+        if (fragment instanceof AuthorizationFragment) {
+            final AuthorizationFragment authFragment = (AuthorizationFragment) fragment;
+            authFragment.setInstanceState(bundle);
+        }
+        return fragment;
+    }
 }


### PR DESCRIPTION
See: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1490153

Since we removed this ability, users who wanted this functionality needed to add an ugly workaround.  Since this is a feature in use externally, add a method supporting it.

The motivation is to get rid of most of this change: https://github.com/AzureAD/microsoft-authentication-library-for-cpp/commit/e4f98faab7b4fa40911032b20d098438c3ca76c0

Note: this change is being held to a single commit.