### PR TITLE
Apply (additively) changes from #1448 to increase SSOStateSerializer visibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.6.0
+----------
+[MINOR] Increase visibility of internal SSOStateSerializer for OneAuth usage (integration steps available at aka.ms/AAd2vt8) (#1448, )
+
 Version 3.5.0
 ----------
 - [MINOR] Code changes for new OneAuth cache key migration API (#1464)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version 3.6.0
 ----------
-[MINOR] Increase visibility of internal SSOStateSerializer for OneAuth usage (integration steps available at aka.ms/AAd2vt8) (#1448, )
+[MINOR] Increase visibility of internal SSOStateSerializer for OneAuth usage (integration steps available at aka.ms/AAd2vt8) (#1448, #1509)
 
 Version 3.5.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/SSOStateSerializer.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/tokensharing/SSOStateSerializer.java
@@ -41,7 +41,7 @@ import java.util.List;
  * deserialization details. It provides a serializer to serialize the
  * TokenCacheItem and a deserializer to return the TokenCacheItem.
  */
-final class SSOStateSerializer {
+public final class SSOStateSerializer {
     /**
      * The version number of {@link SSOStateSerializer }.
      */
@@ -146,7 +146,7 @@ final class SSOStateSerializer {
      * @param item ADALTokenCacheItem to convert to serialized json
      * @return String
      */
-    static String serialize(final ADALTokenCacheItem item) {
+    public static String serialize(final ADALTokenCacheItem item) {
         SSOStateSerializer ssoStateSerializer = new SSOStateSerializer(item);
         return ssoStateSerializer.internalSerialize();
     }
@@ -161,7 +161,7 @@ final class SSOStateSerializer {
      * @return ADALTokenCacheItem
      * @throws ClientException
      */
-    static ADALTokenCacheItem deserialize(final String serializedBlob) throws ClientException {
+    public static ADALTokenCacheItem deserialize(final String serializedBlob) throws ClientException {
         SSOStateSerializer ssoStateSerializer = new SSOStateSerializer();
         return ssoStateSerializer.internalDeserialize(serializedBlob);
     }


### PR DESCRIPTION
Redux of #1448 but avoids the namespace to prevent this from needing a major version rev