### PR TITLE
Adding a constant

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 3.6.0
 - [MINOR] Add a method to allow for the setting of Fragment initial state (#1506, #1512)
 - [MINOR] Adds ContentProvider Constants used for Intune ContentProvider call (#1513, #1657)
 - [PATCH] Clear asymmetric pop key on KeyPermanentlyInvalidatedException if occurs during signing (#1505, #1517)
+- [MINOR] Adds Intune Application specific ContentProvider Constants (#1521, #1513)
 
 Version 3.5.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1062,6 +1062,11 @@ public final class AuthenticationConstants {
         public static final String BROKER_HOST_APP_PACKAGE_NAME = "com.microsoft.identity.testuserapp";
 
         /**
+         * Intune app package name.
+         */
+        public static final String INTUNE_APP_PACKAGE_NAME = "com.microsoft.intune";
+
+        /**
          * Azure Authenticator app package name.
          */
         public static final String AZURE_AUTHENTICATOR_APP_PACKAGE_NAME = "com.azure.authenticator";

--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.6.0-RC2
+versionName=3.6.0-RC3
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
A constant added INTUNE_APP_PACKAGE_NAME, bumped to RC3

Adding Intune Application specific constants to make it easier to amend/make changes through a single place.

Added a changelog entry.

corresponding ad-accounts PR : https://github.com/AzureAD/ad-accounts-for-android/pull/1664