### PR TITLE
Delete get storage file name method from IMultiTypeNameValueStorage

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -95,14 +95,6 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
     }
 
     @Test
-    public void testGetSharedPreferencesFileName() {
-        assertEquals(
-                sTEST_SHARED_PREFS_NAME,
-                mSharedPreferencesFileManager.getStorageFileName()
-        );
-    }
-
-    @Test
     public void testGetAll() {
         String[] testKeys = {"1", "2", "3"};
         String[] testValues = {"a", "b", "c"};
@@ -210,6 +202,7 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
         assertEquals(expectedSize, allMap.size());
         assertEquals("b", allMap.get("2"));
     }
+
     @Test
     public void testContainsTrue() {
         mSharedPreferencesFileManager.putString(sTEST_KEY, sTEST_VALUE);

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -92,9 +92,9 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
      * Constructs an instance of SharedPreferencesFileManager.
      * The default operating mode is {@link Context#MODE_PRIVATE}
      *
-     * @param context                  Interface to global information about an application environment.
-     * @param name                     The desired {@link android.content.SharedPreferences} file. It will be created
-     *                                 if it does not exist.
+     * @param context           Interface to global information about an application environment.
+     * @param name              The desired {@link android.content.SharedPreferences} file. It will be created
+     *                          if it does not exist.
      * @param encryptionManager The {@link IKeyAccessor} to handle encryption/decryption of values.
      */
     public SharedPreferencesFileManager(
@@ -185,11 +185,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         );
 
         remove(key);
-    }
-
-    @Override
-    public final String getStorageFileName() {
-        return mSharedPreferencesFileName;
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IMultiTypeNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IMultiTypeNameValueStorage.java
@@ -65,13 +65,6 @@ public interface IMultiTypeNameValueStorage {
     long getLong(String key);
 
     /**
-     * Returns the name of named resource that this data source is backed by.
-     *
-     * @return The name of the file.
-     */
-    String getStorageFileName();
-
-    /**
      * Returns all entries in the named resource.
      * <p>
      * Note that you must not modify the collection returned by this method, or alter any of its
@@ -84,6 +77,7 @@ public interface IMultiTypeNameValueStorage {
     /**
      * Returns an iterator on the shared preferences entries that views only those entries that
      * the predicate evaluates to true on the key.
+     *
      * @param keyFilter A predicate to use to evaluate the key, return true to include key value pair.
      * @return an iterator as a view on the shared preferences file.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MapBackedPreferencesManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MapBackedPreferencesManager.java
@@ -65,11 +65,6 @@ public class MapBackedPreferencesManager implements IMultiTypeNameValueStorage {
     }
 
     @Override
-    public String getStorageFileName() {
-        return mName;
-    }
-
-    @Override
     public Map<String, String> getAll() {
         return new HashMap<>(mBackingStore);
     }


### PR DESCRIPTION
Per @rpdome's comments on https://github.com/AzureAD/ad-accounts-for-android/pull/1667 it seems having this `getStorageFileName` method on this interface creates a lot of confusion because unique ways need to be developed to try to implement this, so deleting it. It was only being used in a test so it was useless anyway.