### PR TITLE
Updated to merge to continuous-delivery branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,45 +10,16 @@ on:
     - 'common/versioning/version.properties'
     - 'common4j/versioning/version.properties'
 
-#For Testing... runs when project is starred
-#on:
-#  watch:
-#    types: [started]
-#    branches: [dev]
-
-# Jobs run in parallel by default.  Use "needs:" to indicate dependencies run sequentially
 jobs:
-  # Increment 
-  incrementLatestPatch:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.ACTION_PAT }}
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: common:incrementLatestVersion common4j:incrementLatestVersion
-    - run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add .
-        git commit -m "Increment latest patch version"
-        git push
-  build:
-    # Make this workflow sequential by indicating what this job needs in order to run
-    needs: incrementLatestPatch
+  # Merge to continuous-delivery branch
+  mergeToContinuousDelivery:
     runs-on: ubuntu-latest
     steps:
-      - name: Azure Pipelines Action
-        uses: Azure/pipelines@v1
+      - uses: actions/checkout@v2
+      - uses: everlytic/branch-merge@1.1.2
         with:
-          # Fullyqualified URL to the Azure DevOps organization along with project name(eg, https://dev.azure.com/organization/project-name or https://server.example.com:8080/tfs/DefaultCollection/project-name)
-          azure-devops-project-url: 'https://dev.azure.com/IdentityDivision/IDDP'
-          # Name of the Azure Pipline to be triggered
-          azure-pipeline-name: 'Latest Common VSTS Release'
-          # Paste personal access token of the user as value of secret variable:AZURE_DEVOPS_TOKEN
-          azure-devops-token: '${{ secrets.IDDP_PIPELINE }}'
+          github_token: ${{ github.token }}
+          source_ref: ${{ github.ref }}
+          target_branch: 'continuous-delivery'
+          commit_message_template: '[Automated] Merged {source_ref} into target {target_branch}'
+  


### PR DESCRIPTION
- Modify github action to merge dev branch to continous-delivery branch when the dev branch is updated
- Next step once merge to continous-delivery occurs will be to run increment version and publish from that branch.