### PR TITLE
Fix correlation id logic for silent broker request

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -314,9 +314,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
             );
         }
 
-        String correlationIdString = bundle.getString(
-                brokerRequest.getCorrelationId()
-        );
+        String correlationIdString = brokerRequest.getCorrelationId();
+
         if (TextUtils.isEmpty(correlationIdString)) {
             UUID correlationId = UUID.randomUUID();
             correlationIdString = correlationId.toString();


### PR DESCRIPTION
Addresses: https://identitydivision.visualstudio.com/Engineering/_queries/edit/1438631/?triage=true

Getting the correlation id was incorrect.