### PR TITLE
Bring CommandDispatcher back to common4j

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/RefreshOnCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/RefreshOnCommand.java
@@ -27,7 +27,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.java.controllers.BaseController;
-import com.microsoft.identity.common.internal.result.VoidResult;
+import com.microsoft.identity.common.java.result.VoidResult;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommandParameters;
 import com.microsoft.identity.common.java.exception.ClientException;

--- a/common4j/src/main/com/microsoft/identity/common/java/result/VoidResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/VoidResult.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.internal.result;
+package com.microsoft.identity.common.java.result;
 
 /*
     Null Object Pattern for Commands who's result should be ignored.


### PR DESCRIPTION
Seems like CommandDispatcher was brought back to common in [this commit](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/commit/181c7148f65bb0f33f46bf8cfd479754ee73bff1)