### PR TITLE
Increment latest Patch Version for VSTS release

### DIFF
--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
 versionName=3.5.0
 versionCode=1
-latestPatchVersion=225
+latestPatchVersion=234


### PR DESCRIPTION
The projects in common share  the same versioning code + properties file and pipeline.

Getting the latest version entails getting the latest version number and adding it up to generate the next version and applying that new version in the generation and publication of the new version in vsts.

The common versioning runs several pipelines together. Hence the latest versions are generated at the same time.

PS: VSTS does not accept duplicates during publication.

The challenge we have here is that the versions in vsts are sometimes different. 
This is brought about by contributors changing the latestPatchVersions Manually instead of having it done automatically by the pipeline run of the version number increment Task.

This is the current situation. (Different projects on different versions) 


                 | Run 1   | Run 2 | Run 3
                 | v10     |  v11  |  v12 
                 | v9      |  v10  |  v11 
                 | v8      |  v9   |  v10


Ideally, this ought to the outcome after every run:


                 | Run 1   | Run 2 | Run 3
                 | v10     |  v11  |  v12 
                 | v10     |  v11  |  v12 
                 | v10     |  v11  |  v12 


Changes made:
1. Run increment version count before every publishing count. (Changes made on the pipeline)
2.  Standardizing the latest version count.