### PR TITLE
fix CI GitHub Action, add incrementLatestPatch and build steps 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,37 @@ jobs:
           source_ref: ${{ github.ref }}
           target_branch: 'continuous-delivery'
           commit_message_template: '[Automated] Merged {source_ref} into target {target_branch}'
-  
+  incrementLatestPatch:
+    needs: mergeToContinuousDelivery
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.ACTION_PAT }}
+        ref: continuous-delivery
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: common:incrementLatestVersion common4j:incrementLatestVersion
+    - run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "Increment latest patch version"
+        git push
+  build:
+    # Make this workflow sequential by indicating what this job needs in order to run
+    needs: incrementLatestPatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure Pipelines Action
+        uses: Azure/pipelines@v1
+        with:
+          # Fullyqualified URL to the Azure DevOps organization along with project name(eg, https://dev.azure.com/organization/project-name or https://server.example.com:8080/tfs/DefaultCollection/project-name)
+          azure-devops-project-url: 'https://dev.azure.com/IdentityDivision/IDDP'
+          # Name of the Azure Pipline to be triggered
+          azure-pipeline-name: 'Latest Common VSTS Release'
+          # Paste personal access token of the user as value of secret variable:AZURE_DEVOPS_TOKEN
+          azure-devops-token: '${{ secrets.IDDP_PIPELINE }}'


### PR DESCRIPTION
The continousDeliveryUpdated action is not triggered by the automated push on merge 
I  added the following steps to dev_updated 
* increment Latest Patch in continuous-delivery branch 
* Trigger pipeline

Test Results using pedroro/dev and pedroro/continuous-delivery
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/actions/runs/1175512930
https://identitydivision.visualstudio.com/IDDP/_build?definitionId=1183

