### PR TITLE
Log additional messages, swallow and log failures to unbind.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.6.1
+----------
+- [PATCH] Log and swallow failures from CustomTabsService unbind (#1549)
+
 Version 3.6.0
 ----------
 - [PATCH] Allow retry generation of Device PoP key without attempting attestation cert gen (#1456, #1507)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
@@ -78,6 +78,20 @@ public class CustomTabsManager {
             mCustomTabsClient.set(null);
             mClientLatch.countDown();
         }
+
+        @Override
+        public void onBindingDied(final ComponentName name) {
+            Logger.warn(TAG, "Binding died callback on custom tabs service, there will likely be failures. " +
+                    " Component class that failed: " + ((name == null) ? "null" : name.getClassName()));
+            super.onBindingDied(name);
+        }
+
+        @Override
+        public void onNullBinding(final ComponentName name) {
+            Logger.warn(TAG, "Null binding callback on custom tabs service, there will likely be failures."
+                    + " Component class that failed: " + ((name == null) ? "null" : name.getClassName()));
+            super.onNullBinding(name);
+        }
     };
 
     public CustomTabsIntent getCustomTabsIntent() {
@@ -160,8 +174,16 @@ public class CustomTabsManager {
      * Method to unbind custom tabs service {@link androidx.browser.customtabs.CustomTabsService}.
      */
     public synchronized void unbind() {
-        if (mContextRef.get() != null && mCustomTabsServiceIsBound) {
-            mContextRef.get().unbindService(mCustomTabsServiceConnection);
+        final Context context = mContextRef.get();
+        if (context != null && mCustomTabsServiceIsBound) {
+            try {
+                context.unbindService(mCustomTabsServiceConnection);
+            } catch(final Exception e) {
+                Logger.warn(TAG, "Error unbinding custom tabs service, likely failed to bind or previously died: " + e.getMessage());
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
 
         mCustomTabsServiceIsBound = false;


### PR DESCRIPTION
https://portal.microsofticm.com/imp/v3/incidents/details/257678975/home

The customer in this incident is seeing a crash due to multiple unbind attempts. At this point, I think swallowing and logging the error is preferable, since it probably shouldn't crash their application, and I don't see a path to actually cause this.  I'm also injecting a couple of logging statements in the CustomTabsActivity callback to alert us to potential issues.

At this point, however, I have been unable to reproduce this crash. Creating this review off of master, we may have to cherry-pick it into dev if we want it.