### PR TITLE
Add method to clear the singleton cache for shared prefs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.6.1
+----------
+- [PATCH] Additional API for method to clear the singleton shared preferences cache
+
 Version 3.6.0
 ----------
 - [PATCH] Allow retry generation of Device PoP key without attempting attestation cert gen (#1456, #1507)

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesFileManagerTests.java
@@ -29,16 +29,19 @@ import static junit.framework.Assert.assertTrue;
 import androidx.test.InstrumentationRegistry;
 
 import com.microsoft.identity.common.adal.internal.AndroidSecretKeyEnabledHelper;
+import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -95,6 +98,70 @@ public class SharedPreferencesFileManagerTests extends AndroidSecretKeyEnabledHe
     public void testGetString() {
         mSharedPreferencesFileManager.putString(sTEST_KEY, sTEST_VALUE);
         assertEquals(sTEST_VALUE, mSharedPreferencesFileManager.getString(sTEST_KEY));
+    }
+
+    @Test
+    public void testGetSharedPreferences() throws Exception {
+        Field f = SharedPreferencesFileManager.class.getDeclaredField("mStorageHelper");
+        f.setAccessible(true);
+
+        Assert.assertSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                (IStorageHelper) f.get(mSharedPreferencesFileManager)
+        ));
+    }
+
+    @Test
+    public void testGetSharedPreferencesNoStorageHelper() throws Exception {
+        Field f = SharedPreferencesFileManager.class.getDeclaredField("mStorageHelper");
+        f.setAccessible(true);
+        IStorageHelper storageHelper = (IStorageHelper) f.get(mSharedPreferencesFileManager);
+        IStorageHelper newStorageHelper;
+        if (storageHelper == null) {
+            newStorageHelper = new StorageHelper(InstrumentationRegistry.getTargetContext());
+        } else {
+            newStorageHelper = null;
+        }
+        Assert.assertNotSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                newStorageHelper)
+        );
+        Assert.assertSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                storageHelper)
+        );
+    }
+
+    @Test
+    public void testGetSharedPreferencesWithAndWithoutStorageHelper() throws Exception {
+        Assert.assertNotSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                null)
+        );
+    }
+
+    @Test
+    public void testGetSharedPreferencesClear() throws Exception {
+        Field f = SharedPreferencesFileManager.class.getDeclaredField("mStorageHelper");
+        f.setAccessible(true);
+
+        Assert.assertSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                (IStorageHelper) f.get(mSharedPreferencesFileManager)
+        ));
+
+        SharedPreferencesFileManager.clearSingletonCache();
+
+        Assert.assertNotSame(mSharedPreferencesFileManager, SharedPreferencesFileManager.getSharedPreferences(
+                InstrumentationRegistry.getTargetContext(),
+                mSharedPreferencesFileManager.getSharedPreferencesFileName(),
+                (IStorageHelper) f.get(mSharedPreferencesFileManager)
+        ));
     }
 
     @Test

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -80,7 +80,8 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
                                                                     final String name,
                                                                     final int operatingMode,
                                                                     final IStorageHelper storageHelper) {
-        String key = name + "/" + context.getPackageName() + "/" + (operatingMode == -1 ? Context.MODE_PRIVATE : operatingMode);
+        String key = name + "/" + context.getPackageName() + "/" + (operatingMode == -1 ? Context.MODE_PRIVATE : operatingMode) +
+                "/" + ((storageHelper == null) ? "clear" : storageHelper.getClass().getCanonicalName());
         SharedPreferencesFileManager cachedFileManager = objectCache.get(key);
         if(cachedFileManager == null) {
             cachedFileManager = objectCache.putIfAbsent(key, new SharedPreferencesFileManager(context, name, operatingMode, storageHelper));
@@ -89,6 +90,14 @@ public class SharedPreferencesFileManager implements ISharedPreferencesFileManag
             }
         }
         return cachedFileManager;
+    }
+
+    /**
+     * This method clears the singleton cache in use by the system, in the case that unsafe operations
+     * have been performed on disk and the actual data needs to be removed.
+     */
+    public static void clearSingletonCache() {
+        objectCache.clear();
     }
 
     /**


### PR DESCRIPTION
Another group has observed that post-account-data migration office seems to have difficulty getting accounts until an app restart.
Experimentally, performing a clear on the singleton cache resolves that issue.  This PR just implements that method.

https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1533351