### PR TITLE
Update IDeviceMetadata for Linux broker

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add GetOsForMats to IDeviceMetadata (#1552)
 - [MINOR] Enabling refresh_in feature (#1310)
 - [PATCH] Msal removeAccount shouldn't invoke broker's removeAccount (#1336)
 - [MAJOR] Move Utility classes (#1526)

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -63,6 +63,9 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     }
 
     @Override
+    public @NonNull String getOsForMats() { return android.os.Build.VERSION.RELEASE; }
+
+    @Override
     public @NonNull String getOsForDrs() {
         return android.os.Build.VERSION.RELEASE;
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
@@ -61,6 +61,12 @@ public interface IDeviceMetadata {
     String getOsForDrs();
 
     /**
+     * Get the OS of this device to be sent to MATS.
+     */
+    @NonNull
+    String getOsForMats();
+
+    /**
      * Get the model name of this device.
      *
      * @return a String representing the device's model

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
@@ -29,6 +29,7 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
     public static final String TEST_DEVICE_TYPE = "TestDeviceType";
     public static final String TEST_CPU = "TestCPU";
     public static final String TEST_OS_ESTS = "TestOSEsts";
+    public static final String TEST_OS_MATS = "TestOSMats";
     public static final String TEST_OS_DRS = "TestOSDrs";
     public static final String TEST_DEVICE_MODEL = "TestDeviceModel";
     public static final String TEST_MANUFACTURER = "TestManufacturer";
@@ -47,6 +48,9 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
     public @NonNull String getOsForEsts() {
         return TEST_OS_ESTS;
     }
+
+    @Override
+    public @NonNull String getOsForMats() { return TEST_OS_MATS; }
 
     @Override
     public @NonNull String getOsForDrs() {


### PR DESCRIPTION
https://github.com/AzureAD/ad-accounts-for-android/pull/1674 in broker requires addition of `GetOsForMats()` into `IDeviceMetadata`