### PR TITLE
Fix print stack trace for Throwable in Logs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,7 @@ V.Next
 - [MINOR] Migrate broker application metadata cache to common4j (#1530)
 - [PATCH] Replace unsafe TypeToken instance with TypeToken#getParameterized (#1485)
 - [MINOR] Add msal linux sdk type (#1554)
+- [PATCH] Fix print stack trace for Throwable in Logs (#1556)
 
 Version 3.6.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ThrowableUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ThrowableUtil.java
@@ -28,9 +28,9 @@ import java.io.StringWriter;
 public class ThrowableUtil {
     public static synchronized String getStackTraceAsString(final Throwable throwable) {
         final StringWriter sw = new StringWriter();
-        sw.flush();
         final PrintWriter pw = new PrintWriter(sw);
         throwable.printStackTrace(pw);
-        return pw.toString();
+        pw.flush();
+        return sw.toString();
     }
 }


### PR DESCRIPTION
We seem to have lost our ability to print our stack traces via `Logger.error`.