### PR TITLE
Fix extracting http response body

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -54,6 +54,7 @@ V.Next
 - [MINOR] Migrate broker application metadata cache to common4j (#1530)
 - [PATCH] Replace unsafe TypeToken instance with TypeToken#getParameterized (#1485)
 - [MINOR] Add msal linux sdk type (#1554)
+- [PATCH] Fix extracting http response body (#1557)
 
 Version 3.6.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/HashMapExtensions.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/HashMapExtensions.java
@@ -43,10 +43,10 @@ public class HashMapExtensions {
         final HashMap<String, String> response = new HashMap<>();
         if (webResponse != null && !StringUtil.isNullOrEmpty(webResponse.getBody())) {
             final JSONObject jsonObject = new JSONObject(webResponse.getBody());
-            final Iterator<?> i = jsonObject.keys();
-            while (i.hasNext()) {
-                String key = (String) i.next();
-                response.put(key, jsonObject.getString(key));
+            final Iterator<String> keyIterator = jsonObject.keys();
+            while (keyIterator.hasNext()) {
+                String key = keyIterator.next();
+                response.put(key, jsonObject.get(key).toString());
             }
         }
         return response;


### PR DESCRIPTION
The response from server looks like this:

```json
{
  "error": "some-string",
  "error_description": "some-string",
  "error_codes": [700003],
  "timestamp": "2021-09-03 19:50:35Z",
  "trace_id": "some-string",
  "correlation_id": "some-string",
  "error_uri": "some-string",
  "suberror": "some-string"
}
```

So the **error_codes** field is NOT a String, and with the existing code it throws a JSON Exception:

**JSONException("JSONObject[" + quote(key) + "] not a string.");**

So I've updated the code to accommodate any type that isn't a String. 

I don't know why we're running into this now but I suspect may be something got changed somewhere as part of the refactoring, but it isn't clear what changed. At least the code in this file seemed to be the same even prior to refactoring.
