### PR TITLE
Fixing Redirect Uri for Authenticator App, when migrating to MSAL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 3.6.2
+----------
+- [MINOR] Fixing Redirect Uri for Authenticator App, when migrating to MSAL
+
 Version 3.6.1
 ----------
 - [PATCH] Additional API for method to clear the singleton shared preferences cache

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 3.6.2
 ----------
-- [MINOR] Fixing Redirect Uri for Authenticator App, when migrating to MSAL
+- [PATCH] Handle the scenario where broker activity is killed wrongly. (#1569)
+- [PATCH] Fixing Redirect Uri for Authenticator App, when migrating to MSAL (#1567)
 
 Version 3.6.1
 ----------
@@ -8,7 +9,6 @@ Version 3.6.1
 - [PATCH] Log and swallow failures from CustomTabsService unbind (#1549)
 - [PATCH] Fix correlation id error
 - [PATCH] Fix crash related to fall back to webview when no browser present
-- [PATCH] Handle the scenario where broker activity is killed wrongly.
 
 Version 3.6.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -308,12 +308,11 @@ public class BrokerValidator {
         final String methodName = ":isValidBrokerRedirect";
         final String expectedBrokerRedirectUri = getBrokerRedirectUri(context, packageName);
         boolean isValidBrokerRedirect = StringUtil.equalsIgnoreCase(redirectUri, expectedBrokerRedirectUri);
-        if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
-        {
+        if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
             final PackageHelper info = new PackageHelper(context.getPackageManager());
             final String signatureDigest = info.getCurrentSignatureForPackage(packageName);
-            if(signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash)
-                || signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash)) {
+            if (BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash.equals(signatureDigest)
+                || BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash.equals(signatureDigest)) {
                 // If the caller is the Authenticator, check if the redirect uri matches with either
                 // the one generated with package name and signature or broker redirect uri.
                 isValidBrokerRedirect |= StringUtil.equalsIgnoreCase(redirectUri, AuthenticationConstants.Broker.BROKER_REDIRECT_URI);

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -307,7 +307,18 @@ public class BrokerValidator {
                                                 @NonNull final String packageName) {
         final String methodName = ":isValidBrokerRedirect";
         final String expectedBrokerRedirectUri = getBrokerRedirectUri(context, packageName);
-        final boolean isValidBrokerRedirect = StringUtil.equalsIgnoreCase(redirectUri, expectedBrokerRedirectUri);
+        boolean isValidBrokerRedirect = StringUtil.equalsIgnoreCase(redirectUri, expectedBrokerRedirectUri);
+        if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
+        {
+            final PackageHelper info = new PackageHelper(context.getPackageManager());
+            final String signatureDigest = info.getCurrentSignatureForPackage(packageName);
+            if(signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash)
+                || signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash)) {
+                // If the caller is the Authenticator, check if the redirect uri matches with either
+                // the one generated with package name and signature or broker redirect uri.
+                isValidBrokerRedirect |= StringUtil.equalsIgnoreCase(redirectUri, AuthenticationConstants.Broker.BROKER_REDIRECT_URI);
+            }
+        }
 
         if (!isValidBrokerRedirect) {
             Logger.error(

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
@@ -140,13 +140,6 @@ public class PackageHelper {
     public static String getBrokerRedirectUrl(final String packageName, final String signatureDigest) {
         if (!StringExtensions.isNullOrBlank(packageName)
                 && !StringExtensions.isNullOrBlank(signatureDigest)) {
-            // If the caller is the Authenticator, then use the broker redirect URI.
-            if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
-                    && (signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_PROD.signatureHash)
-                    || signatureDigest.equals(BrokerData.MICROSOFT_AUTHENTICATOR_DEBUG.signatureHash))) {
-                return AuthenticationConstants.Broker.BROKER_REDIRECT_URI;
-            }
-
             try {
                 return String.format("%s://%s/%s", AuthenticationConstants.Broker.REDIRECT_PREFIX,
                         URLEncoder.encode(packageName, AuthenticationConstants.ENCODING_UTF8),


### PR DESCRIPTION
Address the following issue :
Broker redirect uri is invalid. Expected: urn:ietf:wg:oauth:2.0:oob Actual: msauth://.......

A test build was provided to the Authenticator app with this change and it all looks good,
we got a confirmation from the Authenticator team.

Initial PR which did not get into the prod to minimize the delta in the releases : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1399