### PR TITLE
Handle the scenario where broker activity is killed wrongly.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Handle the scenario where broker activity is killed wrongly. (#1568)
 - [MINOR] Add GetOsForMats to IDeviceMetadata (#1552)
 - [MINOR] Enabling refresh_in feature (#1310)
 - [PATCH] Msal removeAccount shouldn't invoke broker's removeAccount (#1336)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -29,14 +29,13 @@ import android.os.Bundle;
 import com.microsoft.identity.common.PropertyBagUtil;
 import com.microsoft.identity.common.internal.result.BrokerResultAdapterFactory;
 import com.microsoft.identity.common.internal.result.IBrokerResultAdapter;
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
-import com.microsoft.identity.common.java.exception.UserCancelException;
 import com.microsoft.identity.common.java.request.SdkType;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.logging.Logger;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LobalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
@@ -92,20 +91,24 @@ public final class BrokerActivity extends Activity {
         // If result hasn't been received. It means that this activity is prematurely killed.
         // In this case, we want to properly cancel the activity so that it doesn't block MSAL from making a subsequent interactive call.
         if (!mBrokerResultReceived) {
-            final IBrokerResultAdapter resultAdapter = BrokerResultAdapterFactory.getBrokerResultAdapter(SdkType.MSAL);
-            final Bundle resultBundle = resultAdapter.bundleFromBaseException(
-                    new UserCancelException(ErrorStrings.USER_CANCELLED,
-                            "Activity is killed by user"), null);
-
-            final PropertyBag propertyBag = PropertyBagUtil.fromBundle(resultBundle);
-            propertyBag.put(REQUEST_CODE, BROKER_FLOW);
-            propertyBag.put(RESULT_CODE, BROKER_OPERATION_CANCELLED);
-
-            LocalBroadcaster.INSTANCE.broadcast(
-                    RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT, propertyBag);
+            returnsExceptionOnActivityUnexpectedlyKilled();
         }
 
         super.onDestroy();
+    }
+
+    private void returnsExceptionOnActivityUnexpectedlyKilled() {
+        final IBrokerResultAdapter resultAdapter = BrokerResultAdapterFactory.getBrokerResultAdapter(SdkType.MSAL);
+        final Bundle resultBundle = resultAdapter.bundleFromBaseException(
+                new ClientException(ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "The activity is killed unexpectedly."), null);
+
+        final PropertyBag propertyBag = PropertyBagUtil.fromBundle(resultBundle);
+        propertyBag.put(REQUEST_CODE, BROKER_FLOW);
+        propertyBag.put(RESULT_CODE, BROKER_OPERATION_CANCELLED);
+
+        LocalBroadcaster.INSTANCE.broadcast(
+                RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT, propertyBag);
     }
 
     @Override
@@ -134,12 +137,23 @@ public final class BrokerActivity extends Activity {
 
         mBrokerResultReceived = true;
 
-        final PropertyBag propertyBag = PropertyBagUtil.fromBundle(data.getExtras());
-        propertyBag.put(REQUEST_CODE, BROKER_FLOW);
-        propertyBag.put(RESULT_CODE, resultCode);
+        final PropertyBag propertyBag;
+        if (resultCode == BROKER_SUCCESS_RESPONSE
+                || resultCode == BROKER_OPERATION_CANCELLED
+                || resultCode == BROKER_ERROR_RESPONSE) {
 
-        LocalBroadcaster.INSTANCE.broadcast(
-                RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT, propertyBag);
+            Logger.verbose(TAG + methodName, "Completing interactive request ");
+
+            propertyBag = PropertyBagUtil.fromBundle(data.getExtras());
+            propertyBag.put(REQUEST_CODE, BROKER_FLOW);
+            propertyBag.put(RESULT_CODE, resultCode);
+
+            LocalBroadcaster.INSTANCE.broadcast(
+                    RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT, propertyBag);
+        } else {
+            // This means the broker is unexpectedly killed.
+            returnsExceptionOnActivityUnexpectedlyKilled();
+        }
 
         finish();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -88,8 +88,8 @@ public final class BrokerActivity extends Activity {
 
     @Override
     protected void onDestroy() {
-        // If result hasn't been received. It means that this activity is prematurely killed.
-        // In this case, we want to properly cancel the activity so that it doesn't block MSAL from making a subsequent interactive call.
+        // If the broker process crashes, onActivityResult() will not be triggered.
+        // (tested by throwing an exception in AccountChooserActivity, and by killing the activity via App Switcher).
         if (!mBrokerResultReceived) {
             returnsExceptionOnActivityUnexpectedlyKilled();
         }
@@ -151,7 +151,7 @@ public final class BrokerActivity extends Activity {
             LocalBroadcaster.INSTANCE.broadcast(
                     RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT, propertyBag);
         } else {
-            // This means the broker is unexpectedly killed.
+            // This means the broker is unexpectedly killed. (tested by killing the broker process via adb).
             returnsExceptionOnActivityUnexpectedlyKilled();
         }
 


### PR DESCRIPTION
Scenario:
1. MSAL app launches an interactive request.
2. A broker activity (AccountChooserActivity) is launched.
3. Somehow, that Activity is prematurely killed. (i.e. you could go to the app switcher and kill it)
4. In the MSAL app, try launching an interactive session again. You won't be able to, because it's still waiting for the result from the previous interactive request.

Fix:
If the BrokerActivity is destroyed BEFORE receiving any result, return a UserCanceledException.

Tests:
1. if the broker process is killed via adb, then onActivityResult is still triggered. We just need to handle the error code = 0.
2. if i kill the activity from the activity switcher, then onActivityResult will not be triggered. in that case, onDestroy logic is triggered.
3. If Broker throws an unhandled exception, same as 2)