### PR TITLE
Handle the scenario where broker activity is killed wrongly

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ Version 3.6.1
 - [PATCH] Log and swallow failures from CustomTabsService unbind (#1549)
 - [PATCH] Fix correlation id error
 - [PATCH] Fix crash related to fall back to webview when no browser present
-
+- [PATCH] Handle the scenario where broker activity is killed wrongly.
 
 Version 3.6.0
 ----------


### PR DESCRIPTION
The pre-broker-refactored version of  https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1568