### PR TITLE
Remove RC1 tag from the version number to prepare for final release

### DIFF
--- a/common/versioning/version.properties
+++ b/common/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.6.2-RC1
+versionName=3.6.2
 versionCode=1
 latestPatchVersion=180


### PR DESCRIPTION
### What is in this change
Removing the RC1 suffix from the version number to prepare for production release
The RC1 build has already been verified by both CP and Authenticator