### PR TITLE
Set the version to 4.0.0-RC2 to prepare release

### DIFF
--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=3.6.2
+versionName=4.0.0-RC2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### In this change
Bumping the version to 4.0.0-RC2 to start the release process for Refactored Android Broker

note: 4.0.0-RC1 is already used in the past to publish so we can't use it anymore, 