### PR TITLE
bump up common4j version 1.0.0-RC1 and dep

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -131,7 +131,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:0.0.+") {
+    distApi("com.microsoft.identity:common4j:1.0.0-RC1") {
         transitive = false
     }
 

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=0.0.5
+versionName=1.0.0-RC1
 versionCode=1
 latestPatchVersion=227


### PR DESCRIPTION
### In this change

- Bumping up the common4j version to 1.0.0-RC1
- Updating the common4j dep in android-common to point to 1.0.0-RC1