### PR TITLE
Make it clear if adding a query param should overwrite or leave as is

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParamet
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -42,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
@@ -128,14 +128,14 @@ public abstract class Authority {
      */
     public static Authority getAuthorityFromAuthorityUrl(String authorityUrl) {
         final String methodName = ":getAuthorityFromAuthorityUrl";
-        final URIBuilder authorityUriBuilder;
+        final CommonURIBuilder authorityCommonUriBuilder;
         try {
-            authorityUriBuilder = new URIBuilder(authorityUrl);
+            authorityCommonUriBuilder = new CommonURIBuilder(authorityUrl);
         } catch (final URISyntaxException e) {
             throw new IllegalArgumentException("Invalid authority URL");
         }
 
-        final List<String> pathSegments = authorityUriBuilder.getPathSegments();
+        final List<String> pathSegments = authorityCommonUriBuilder.getPathSegments();
 
         if (pathSegments.size() == 0) {
             return new UnknownAuthority();
@@ -150,7 +150,7 @@ public abstract class Authority {
             if (B2C.equalsIgnoreCase(authorityTypeStr)) {
                 authority = new AzureActiveDirectoryB2CAuthority(authorityUrl);
             } else {
-                authority = createAadAuthority(authorityUriBuilder, pathSegments);
+                authority = createAadAuthority(authorityCommonUriBuilder, pathSegments);
             }
         } else {
             String authorityType = pathSegments.get(0);
@@ -177,7 +177,7 @@ public abstract class Authority {
                             TAG + methodName,
                             "Authority type default: AAD"
                     );
-                    authority = createAadAuthority(authorityUriBuilder, pathSegments);
+                    authority = createAadAuthority(authorityCommonUriBuilder, pathSegments);
                     break;
             }
         }
@@ -222,10 +222,10 @@ public abstract class Authority {
         return null != getEquivalentConfiguredAuthority(authorityStr);
     }
 
-    private static Authority createAadAuthority(@NonNull final URIBuilder authorityUriBuilder,
+    private static Authority createAadAuthority(@NonNull final CommonURIBuilder authorityCommonUriBuilder,
                                                 @NonNull final List<String> pathSegments) {
         AzureActiveDirectoryAudience audience = AzureActiveDirectoryAudience.getAzureActiveDirectoryAudience(
-                authorityUriBuilder.getScheme() + "://" + authorityUriBuilder.getHost(),
+                authorityCommonUriBuilder.getScheme() + "://" + authorityCommonUriBuilder.getHost(),
                 pathSegments.get(0)
         );
 

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AuthorityDeserializer.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AuthorityDeserializer.java
@@ -28,13 +28,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import net.jcip.annotations.Immutable;
 
 import java.lang.reflect.Type;
 import java.util.List;
-
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 
 @Immutable
 public class AuthorityDeserializer implements JsonDeserializer<Authority> {
@@ -61,7 +60,7 @@ public class AuthorityDeserializer implements JsonDeserializer<Authority> {
 
                     if (aadAuthority != null) {
                         try {
-                            final URIBuilder uri = new URIBuilder(aadAuthority.getAuthorityUri());
+                            final CommonURIBuilder uri = new CommonURIBuilder(aadAuthority.getAuthorityUri());
                             final String cloudUrl = uri.getScheme() + "://" + uri.getHost();
                             final List<String> pathSegments = uri.getPathSegments();
                             if (pathSegments.size() > 0) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAudience.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAudience.java
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.authorities;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import lombok.NonNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -33,13 +32,13 @@ import com.microsoft.identity.common.java.providers.oauth2.OpenIdProviderConfigu
 import com.microsoft.identity.common.java.providers.oauth2.OpenIdProviderConfigurationClient;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Locale;
 
 import static com.microsoft.identity.common.java.authorities.AllAccounts.ALL_ACCOUNTS_TENANT_ID;
-import static com.microsoft.identity.common.java.authorities.AnyPersonalAccount.ANY_PERSONAL_ACCOUNT_TENANT_ID;
 
 public abstract class AzureActiveDirectoryAudience {
 
@@ -95,9 +94,9 @@ public abstract class AzureActiveDirectoryAudience {
                 loadOpenIdProviderConfigurationMetadata(authority);
 
         final String issuer = providerConfiguration.getIssuer();
-        final URIBuilder issuerUri;
+        final CommonURIBuilder issuerUri;
         try {
-            issuerUri = new URIBuilder(issuer);
+            issuerUri = new CommonURIBuilder(issuer);
         } catch (final URISyntaxException e) {
             throw new ClientException(ClientException.MALFORMED_URL,
                     "Failed to construct issuerUri", e);

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.authorities;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import lombok.NonNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -37,6 +36,7 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -121,12 +121,12 @@ public class AzureActiveDirectoryAuthority extends Authority {
     public URI getAuthorityUri() {
         try {
             getAzureActiveDirectoryCloud();
-            URIBuilder issuer;
+            CommonURIBuilder issuer;
 
             if (mAzureActiveDirectoryCloud == null) {
-                issuer = new URIBuilder(mAudience.getCloudUrl());
+                issuer = new CommonURIBuilder(mAudience.getCloudUrl());
             } else {
-                issuer = new URIBuilder("https://" + mAzureActiveDirectoryCloud.getPreferredNetworkHostName());
+                issuer = new CommonURIBuilder("https://" + mAzureActiveDirectoryCloud.getPreferredNetworkHostName());
             }
 
             if (!StringUtil.isNullOrEmpty(mAudience.getTenantId())) {

--- a/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParamet
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 import com.microsoft.identity.common.java.util.ported.ObjectUtils;
 
 import java.io.IOException;
@@ -50,7 +51,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.UUID;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
@@ -101,7 +101,7 @@ public class FociQueryUtilities {
         final MicrosoftStsOAuth2Configuration config = new MicrosoftStsOAuth2Configuration();
 
         //Get authority url
-        final URIBuilder requestUrlBuilder = new URIBuilder();
+        final CommonURIBuilder requestUrlBuilder = new CommonURIBuilder();
         requestUrlBuilder.setScheme("https")
                 .setHost(refreshTokenRecord.getEnvironment())
                 .setPath(StringUtil.isNullOrEmpty(accountRecord.getRealm()) ? ALL_ACCOUNTS_TENANT_ID : accountRecord.getRealm());

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import lombok.NonNull;
 
 import com.google.gson.Gson;
@@ -39,6 +38,7 @@ import com.microsoft.identity.common.java.providers.IdentityProvider;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import org.json.JSONException;
 
@@ -184,9 +184,9 @@ public class AzureActiveDirectory
     public static synchronized void performCloudDiscovery()
             throws IOException, URISyntaxException {
         final String methodName = ":performCloudDiscovery";
-        final URI instanceDiscoveryRequestUri = new URIBuilder(getDefaultCloudUrl() + AAD_INSTANCE_DISCOVERY_ENDPOINT)
-                .addParameter(API_VERSION, API_VERSION_VALUE)
-                .addParameter(AUTHORIZATION_ENDPOINT, AUTHORIZATION_ENDPOINT_VALUE)
+        final URI instanceDiscoveryRequestUri = new CommonURIBuilder(getDefaultCloudUrl() + AAD_INSTANCE_DISCOVERY_ENDPOINT)
+                .setParameter(API_VERSION, API_VERSION_VALUE)
+                .setParameter(AUTHORIZATION_ENDPOINT, AUTHORIZATION_ENDPOINT_VALUE)
                 .build();
 
         final HttpResponse response =

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import lombok.NonNull;
 
 import com.microsoft.identity.common.java.WarningType;
@@ -43,9 +42,9 @@ import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URISyntaxException;
 
 import static com.microsoft.identity.common.java.exception.ErrorStrings.AUTHORITY_URL_NOT_VALID;
@@ -147,7 +146,7 @@ public class AzureActiveDirectoryOAuth2Strategy
         Logger.info(TAG, "Building authority URI");
 
         try {
-            final String issuerCacheIdentifier = new URIBuilder(authRequest.getAuthority().toString())
+            final String issuerCacheIdentifier = new CommonURIBuilder(authRequest.getAuthority().toString())
                     .setHost(cloud.getPreferredCacheHostName())
                     .build().toString();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.UrlUtil;
 
@@ -37,7 +38,6 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -206,22 +206,22 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
 
     @Override
     public URI getAuthorizationRequestAsHttpRequest() throws ClientException {
-        final URIBuilder builder = new URIBuilder(super.getAuthorizationRequestAsHttpRequest());
-        appendParameterToBuilder(builder, mFlightParameters);
+        final CommonURIBuilder builder = new CommonURIBuilder(super.getAuthorizationRequestAsHttpRequest());
+        builder.addParametersIfAbsent(mFlightParameters);
 
         if (mSlice != null) {
             if (!StringUtil.isNullOrEmpty(mSlice.getSlice())) {
-                builder.addParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, mSlice.getSlice());
+                builder.addParameterIfAbsent(AzureActiveDirectorySlice.SLICE_PARAMETER, mSlice.getSlice());
             }
             if (!StringUtil.isNullOrEmpty(mSlice.getDataCenter())) {
-                builder.addParameter(AzureActiveDirectorySlice.DC_PARAMETER, mSlice.getDataCenter());
+                builder.addParameterIfAbsent(AzureActiveDirectorySlice.DC_PARAMETER, mSlice.getDataCenter());
             }
         }
 
         // If login_hint is provided, block the user from switching user during login.
         // hsu = HideSwitchUser
         if (!StringUtil.isNullOrEmpty(getLoginHint())) {
-            builder.addParameter(HIDE_SWITCH_USER_QUERY_PARAMETER, "1");
+            builder.addParameterIfAbsent(HIDE_SWITCH_USER_QUERY_PARAMETER, "1");
         }
 
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -36,8 +36,6 @@ import com.microsoft.identity.common.java.providers.oauth2.IAuthorizationStrateg
 import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
-
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
@@ -66,6 +64,7 @@ import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -669,7 +668,7 @@ public class MicrosoftStsOAuth2Strategy
             @NonNull final MicrosoftStsAuthorizationResponse response) throws ClientException {
         if (!StringUtil.isNullOrEmpty(response.getCloudInstanceHostName())) {
             try {
-                return new URIBuilder(mTokenEndpoint)
+                return new CommonURIBuilder(mTokenEndpoint)
                         .setHost(response.getCloudInstanceHostName())
                         .build()
                         .toString();

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
@@ -26,20 +26,17 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 
 import java.io.Serializable;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.experimental.Accessors;
 
 /**
@@ -241,34 +238,12 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
      */
     public URI getAuthorizationRequestAsHttpRequest() throws ClientException {
         try {
-            final URIBuilder builder = new URIBuilder(getAuthorizationEndpoint());
-            appendParameterToBuilder(builder, ObjectMapper.serializeObjectHashMap(this));
-            appendParameterToBuilder(builder, mExtraQueryParams);
+            final CommonURIBuilder builder = new CommonURIBuilder(getAuthorizationEndpoint());
+            builder.addParametersIfAbsent(ObjectMapper.serializeObjectHashMap(this));
+            builder.addParametersIfAbsent(mExtraQueryParams);
             return builder.build();
         } catch (final URISyntaxException e) {
             throw new ClientException(ClientException.MALFORMED_URL, e.getMessage(), e);
-        }
-    }
-
-    protected void appendParameterToBuilder(@NonNull final URIBuilder builder,
-                                            @Nullable final Map<String, ?> params) {
-        if (params == null) {
-            return;
-        }
-
-        for (final Map.Entry<String, ?> entry : params.entrySet()) {
-            builder.addParameter(entry.getKey(), String.valueOf(entry.getValue()));
-        }
-    }
-
-    protected void appendParameterToBuilder(@NonNull final URIBuilder builder,
-                                            @Nullable final List<Map.Entry<String, String>> params) {
-        if (params == null) {
-            return;
-        }
-
-        for (Map.Entry<String, String> entry : params) {
-            builder.addParameter(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -52,6 +52,7 @@ import com.microsoft.identity.common.java.telemetry.events.UiShownEvent;
 import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -66,7 +67,6 @@ import java.util.concurrent.Future;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import lombok.NonNull;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.CLIENT_REQUEST_ID;
@@ -263,14 +263,14 @@ public abstract class OAuth2Strategy
 
             if (slice != null) {
                 try {
-                    final URIBuilder uriBuilder = new URIBuilder(mTokenEndpoint);
+                    final CommonURIBuilder commonUriBuilder = new CommonURIBuilder(mTokenEndpoint);
                     if (!StringUtil.isNullOrEmpty(slice.getSlice())) {
-                        uriBuilder.addParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, slice.getSlice());
+                        commonUriBuilder.setParameter(AzureActiveDirectorySlice.SLICE_PARAMETER, slice.getSlice());
                     }
                     if (!StringUtil.isNullOrEmpty(slice.getDataCenter())) {
-                        uriBuilder.addParameter(AzureActiveDirectorySlice.DC_PARAMETER, slice.getDataCenter());
+                        commonUriBuilder.setParameter(AzureActiveDirectorySlice.DC_PARAMETER, slice.getDataCenter());
                     }
-                    mTokenEndpoint = uriBuilder.build().toString();
+                    mTokenEndpoint = commonUriBuilder.build().toString();
                 } catch (final URISyntaxException e) {
                     throw new ClientException(ClientException.MALFORMED_URL, e.getMessage(), e);
                 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -30,12 +30,12 @@ import com.microsoft.identity.common.java.net.HttpClient;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +43,6 @@ import java.util.concurrent.Executors;
 
 import static com.microsoft.identity.common.java.exception.ServiceException.OPENID_PROVIDER_CONFIGURATION_FAILED_TO_LOAD;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
 
@@ -78,7 +77,7 @@ public class OpenIdProviderConfigurationClient {
     public OpenIdProviderConfigurationClient(@NonNull final String authority,
                                              @NonNull final String path, @NonNull final String endpointVersion)
             throws URISyntaxException {
-        mIssuer = new URIBuilder()
+        mIssuer = new CommonURIBuilder()
                 .setScheme("https")
                 .setHost(authority)
                 .setPathSegments(path, endpointVersion)

--- a/common4j/src/main/com/microsoft/identity/common/java/util/CommonURIBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/CommonURIBuilder.java
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import cz.msebera.android.httpclient.NameValuePair;
+import cz.msebera.android.httpclient.client.utils.URIBuilder;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.NonNull;
+
+/**
+ * Our URIBuilder.
+ * We want to make sure we never send duplicated parameters to the server.
+ * This is done by
+ * 1. disabling {@link cz.msebera.android.httpclient.client.utils.URIBuilder#addParameter(String, String)} and
+ *    {@link cz.msebera.android.httpclient.client.utils.URIBuilder#addParameters(List))}
+ * 2. adding {@link CommonURIBuilder#addParametersIfAbsent}
+ */
+public class CommonURIBuilder extends cz.msebera.android.httpclient.client.utils.URIBuilder {
+
+    public CommonURIBuilder(){
+        super();
+    }
+
+    public CommonURIBuilder(final String string) throws URISyntaxException {
+        super(string);
+    }
+
+    public CommonURIBuilder(final URI uri) {
+        super(uri);
+    }
+
+    @Override
+    public CommonURIBuilder addParameters(@NonNull final List<NameValuePair> nvps) {
+        throw new UnsupportedOperationException("This should never be used. Either use setParameter or addParametersIfAbsent");
+    }
+
+    @Override
+    public CommonURIBuilder addParameter(@NonNull final String param, @NonNull final String value) {
+        throw new UnsupportedOperationException("This should never be used. Either use setParameter or addParametersIfAbsent");
+    }
+
+    @Override
+    public CommonURIBuilder setParameters(List<NameValuePair> nvps) {
+        super.setParameters(nvps);
+        return this;
+    }
+
+    @Override
+    public CommonURIBuilder setParameters(NameValuePair... nvps) {
+        super.setParameters(nvps);
+        return this;
+    }
+
+    @Override
+    public CommonURIBuilder setParameter(String param, String value) {
+        super.setParameter(param, value);
+        return this;
+    }
+
+    /**
+     * Adds parameters to URI query if it does not already exist.
+     * The parameter name and value are expected to be unescaped and may contain non ASCII characters.
+     * <p>
+     * Please note query parameters and custom query component are mutually exclusive. This method
+     * will remove custom query if present.
+     * </p>
+     *
+     * @param params list of parameters.
+     * @return {@link CommonURIBuilder}
+     */
+    public CommonURIBuilder addParametersIfAbsent(@Nullable final Map<String, ?> params) {
+        if (params == null) {
+            return this;
+        }
+
+        for (final Map.Entry<String, ?> entry : params.entrySet()) {
+            addParameterIfAbsent(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds parameters to URI query if it does not already exist.
+     * The parameter name and value are expected to be unescaped and may contain non ASCII characters.
+     * <p>
+     * Please note query parameters and custom query component are mutually exclusive. This method
+     * will remove custom query if present.
+     * </p>
+     *
+     * @param params list of parameters.
+     * @return {@link CommonURIBuilder}
+     */
+    public CommonURIBuilder addParametersIfAbsent(@Nullable final List<Map.Entry<String, String>> params) {
+        if (params == null) {
+            return this;
+        }
+
+        for (final Map.Entry<String, String> entry : params) {
+            addParameterIfAbsent(entry.getKey(), entry.getValue());
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds parameter to URI query if it does not already exist.
+     * The parameter name and value are expected to be unescaped and may contain non ASCII characters.
+     * <p>
+     * Please note query parameters and custom query component are mutually exclusive. This method
+     * will remove custom query if present.
+     * </p>
+     *
+     * @param param parameter name.
+     * @param value parameter value.
+     * @return {@link CommonURIBuilder}
+     */
+    public CommonURIBuilder addParameterIfAbsent(@NonNull final String param, @NonNull final String value) {
+        if (containsParam(param)) {
+            return this;
+        }
+
+        super.addParameter(param, value);
+        return this;
+    }
+
+    private boolean containsParam(@NonNull final String param){
+        for (final NameValuePair pair: getQueryParams()) {
+            if (pair.getName().equalsIgnoreCase(param)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/util/UrlUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/UrlUtil.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
@@ -59,12 +58,12 @@ public class UrlUtil {
             return urlToAppend;
         }
 
-        final URIBuilder pathBuilder = new URIBuilder();
+        final CommonURIBuilder pathBuilder = new CommonURIBuilder();
         pathBuilder.setPath(pathString);
 
         final List<String> pathSegmentsToAppend = pathBuilder.getPathSegments();
 
-        final URIBuilder builder = new URIBuilder(urlToAppend.toString());
+        final CommonURIBuilder builder = new CommonURIBuilder(urlToAppend.toString());
         final List<String> pathSegments = builder.getPathSegments();
 
         final List<String> combinedPathSegments = new ArrayList<>(pathSegments);

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequestTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequestTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.microsoft.identity.common.java.providers.Constants.MOCK_PKCE_CHALLENGE;

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 
 import static com.microsoft.identity.common.java.providers.Constants.MOCK_PKCE_CHALLENGE;
 import static com.microsoft.identity.common.java.providers.Constants.MOCK_STATE;
+import static com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest.HIDE_SWITCH_USER_QUERY_PARAMETER;
 import static org.junit.Assert.assertTrue;
 
 public class MicrosoftStsAuthorizationRequestTests {
@@ -168,6 +169,20 @@ public class MicrosoftStsAuthorizationRequestTests {
         final String actualCodeRequestUrlWithLoginHint = requestWithLoginHint.getAuthorizationRequestAsHttpRequest().toString();
         assertTrue("Matching login hint", actualCodeRequestUrlWithLoginHint.contains("login_hint=" + DEFAULT_TEST_LOGIN_HINT));
         assertTrue("Matching HideSwitchUser", actualCodeRequestUrlWithLoginHint.contains("hsu=1"));
+    }
+
+    @Test
+    public void testGetCodeRequestWithDuplicatedExtraQueryParametersHsu() throws MalformedURLException, ClientException {
+        final int expectedCount = 1;
+        final MicrosoftStsAuthorizationRequest.Builder requestWithLoginHint = new MicrosoftStsAuthorizationRequest.Builder()
+                .setLoginHint(DEFAULT_TEST_LOGIN_HINT)
+                .setAuthority(getValidRequestUrl());
+        final List<Map.Entry<String, String>> extraQueryParameter = new LinkedList<>();
+        extraQueryParameter.add(new AbstractMap.SimpleEntry<>(HIDE_SWITCH_USER_QUERY_PARAMETER, "1"));
+        requestWithLoginHint.setExtraQueryParams(extraQueryParameter);
+        final String actualCodeRequestUrl = requestWithLoginHint.build().getAuthorizationRequestAsHttpRequest().toString();
+
+        Assert.assertEquals(expectedCount, TestUtils.countMatches(actualCodeRequestUrl, HIDE_SWITCH_USER_QUERY_PARAMETER));
     }
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/util/CommonURIBuilderTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/CommonURIBuilderTest.java
@@ -1,0 +1,143 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.java.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import cz.msebera.android.httpclient.NameValuePair;
+
+@RunWith(JUnit4.class)
+public class CommonURIBuilderTest {
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCallingAddParameter(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .addParameter("test", "test");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCallingAddParameters(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .addParameters(new ArrayList<NameValuePair>());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .addParameterIfAbsent("Test1", "Value1");
+
+        Assert.assertEquals(1, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+
+        builder.addParameterIfAbsent("Test2", "Value2");
+
+        Assert.assertEquals(2, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+        Assert.assertEquals("Test2", builder.getQueryParams().get(1).getName());
+        Assert.assertEquals("Value2", builder.getQueryParams().get(1).getValue());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent_ValueAlreadyExists(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .setParameter("Test1", "Value1")
+                .addParameterIfAbsent("Test1", "Value2");
+
+        Assert.assertEquals(1, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent_WithMap(){
+        final Map<String, String> map = new HashMap<>();
+        map.put("Test1", "Value1");
+        map.put("Test2", "Value2");
+
+        final CommonURIBuilder builder = new CommonURIBuilder().addParametersIfAbsent(map);
+
+        Assert.assertEquals(2, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+        Assert.assertEquals("Test2", builder.getQueryParams().get(1).getName());
+        Assert.assertEquals("Value2", builder.getQueryParams().get(1).getValue());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent_WithMap_ValueAlreadyExists(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .setParameter("Test1", "Value1");
+
+        final Map<String, String> map = new HashMap<>();
+        map.put("Test1", "Value2");
+
+        builder.addParametersIfAbsent(map);
+
+        Assert.assertEquals(1, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent_WithMapEntryList(){
+        final List<Map.Entry<String, String>> map = new ArrayList<>();
+        map.add(new AbstractMap.SimpleEntry<String, String>("Test1", "Value1"));
+        map.add(new AbstractMap.SimpleEntry<String, String>("Test2", "Value2"));
+
+        final CommonURIBuilder builder = new
+                CommonURIBuilder().addParametersIfAbsent(map);
+
+        Assert.assertEquals(2, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+        Assert.assertEquals("Test2", builder.getQueryParams().get(1).getName());
+        Assert.assertEquals("Value2", builder.getQueryParams().get(1).getValue());
+    }
+
+    @Test
+    public void testCallingAddParametersIfAbsent_WithMapEntryList_ValueAlreadyExists(){
+        final CommonURIBuilder builder = new CommonURIBuilder()
+                .setParameter("Test1", "Value1");
+
+        final List<Map.Entry<String, String>> map = new ArrayList<>();
+        map.add(new AbstractMap.SimpleEntry<String, String>("Test1", "Value1"));
+
+        builder.addParametersIfAbsent(map);
+
+        Assert.assertEquals(1, builder.getQueryParams().size());
+        Assert.assertEquals("Test1", builder.getQueryParams().get(0).getName());
+        Assert.assertEquals("Value1", builder.getQueryParams().get(0).getValue());
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/util/UrlUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/UrlUtilTest.java
@@ -31,8 +31,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
 
-import cz.msebera.android.httpclient.client.utils.URIBuilder;
-
 public class UrlUtilTest {
 
     @Test


### PR DESCRIPTION
Replace URIBuilder with our CommonURIBuilder,  which will force the caller to either
1. Overwrites query parameter if exists with `setParameter`
2. Only append the query param if there is no matching query parameter (key) with `addParameterIfAbsent`

This is to prevent us from sending duplicate query parameter, which eSTS doesn't like.

calling addParameters, which permits duplicate query params, will throw UnsupportedOperationException.

