### PR TITLE
Update SharedPreferencesBrokerApplicationMetadataCache.java

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
@@ -63,6 +63,18 @@ public class SharedPreferencesBrokerApplicationMetadataCache
         return super.insert(brokerApplicationMetadata);
     }
 
+    public void remove(@NonNull final String clientId,
+                       final int processUid) {
+        final List<BrokerApplicationMetadata> allMetadata = getAll();
+
+        for (final BrokerApplicationMetadata metadata : allMetadata) {
+            if (clientId.equalsIgnoreCase(metadata.getClientId())
+                    && processUid == metadata.getUid()) {
+                remove(metadata);
+            }
+        }
+    }
+
     private void disposeOfDuplicateRecords(@NonNull final String clientId,
                                            @NonNull final String environment,
                                            final int uid) {


### PR DESCRIPTION
Added method to help remove the metadata cache entry not containing the information of FOCI cache availability.
This would help us the include FOCI cache while doing the account lookup