### PR TITLE
Errors in the web view don't crash the process without responding.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/PKeyAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/PKeyAuthChallengeHandler.java
@@ -68,14 +68,20 @@ public final class PKeyAuthChallengeHandler implements IChallengeHandler<PKeyAut
                     mWebView.loadUrl(loadUrl, header);
                 }
             });
-        } catch (final ClientException e) {
+        } catch (final Throwable e) {
             // It should return error code and finish the
             // activity, so that onActivityResult implementation
             // returns errors to callback.
             //TODO log the request info
             mChallengeCallback.onChallengeResponseReceived(
-                    RawAuthorizationResult.fromException(e)
+                    RawAuthorizationResult.fromThrowable(e)
             );
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            if (e instanceof Error) {
+                throw (Error) e;
+            }
         }
 
         return null;

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
@@ -182,9 +182,6 @@ public class PKeyAuthChallenge implements Serializable {
                     throw new ClientException(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION);
                 }
                 final PublicKey publicKey = deviceCertProxy.getPublicKey();
-                if (publicKey == null) {
-                    throw new ClientException(ErrorStrings.KEY_CHAIN_PUBLIC_KEY_EXCEPTION);
-                }
                 final X509Certificate certificate = deviceCertProxy.getCertificate();
                 if (certificate == null) {
                     throw new ClientException(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION);

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
@@ -37,6 +37,8 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.HashMap;
 import java.util.List;
@@ -179,12 +181,20 @@ public class PKeyAuthChallenge implements Serializable {
                 if (privateKey == null) {
                     throw new ClientException(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION);
                 }
+                final PublicKey publicKey = deviceCertProxy.getPublicKey();
+                if (publicKey == null) {
+                    throw new ClientException(ErrorStrings.KEY_CHAIN_PUBLIC_KEY_EXCEPTION);
+                }
+                final X509Certificate certificate = deviceCertProxy.getCertificate();
+                if (certificate == null) {
+                    throw new ClientException(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION);
+                }
                 final String jwt = (new JWSBuilder()).generateSignedJWT(
                         mNonce,
                         mSubmitUrl,
                         privateKey,
-                        deviceCertProxy.getPublicKey(),
-                        deviceCertProxy.getCertificate());
+                        publicKey,
+                        certificate);
                 authorizationHeaderValue = String.format(
                         "%s AuthToken=\"%s\",Context=\"%s\",Version=\"%s\"",
                         CHALLENGE_RESPONSE_TYPE, jwt, mContext, mVersion);

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
@@ -221,6 +221,16 @@ public final class ErrorStrings {
     public static final String KEY_CHAIN_PRIVATE_KEY_EXCEPTION = "Key Chain private key exception";
 
     /**
+     * Key Chain public key exception.
+     */
+    public static final String KEY_CHAIN_PUBLIC_KEY_EXCEPTION = "Key Chain public key exception";
+
+    /**
+     * Key Chain certificate exception.
+     */
+    public static final String KEY_CHAIN_CERTIFICATE_EXCEPTION = "Key Chain certificate exception";
+
+    /**
      * Signature exception.
      */
     public static final String SIGNATURE_EXCEPTION = "Signature exception";

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
@@ -153,6 +153,19 @@ public class RawAuthorizationResult {
     }
 
     @NonNull
+    public static RawAuthorizationResult fromThrowable(@NonNull final Throwable e) {
+        if (e instanceof BaseException) {
+            return fromException((BaseException) e);
+        }
+        return RawAuthorizationResult.builder()
+                .resultCode(ResultCode.NON_OAUTH_ERROR)
+                .exception(new BaseException(ClientException.UNKNOWN_ERROR,
+                        "Unknown error with class: " + e.getClass().getSimpleName(),
+                        e))
+                .build();
+    }
+
+    @NonNull
     public static RawAuthorizationResult fromException(@NonNull final BaseException e) {
         return RawAuthorizationResult.builder()
                 .resultCode(ResultCode.NON_OAUTH_ERROR)

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -129,9 +129,6 @@ public class JWSBuilder {
         if (privateKey == null) {
             throw new IllegalArgumentException("privateKey");
         }
-        if (pubKey == null) {
-            throw new IllegalArgumentException("pubKey");
-        }
 
         Gson gson = new Gson();
         Claims claims = new Claims();
@@ -146,7 +143,6 @@ public class JWSBuilder {
         final String signingInput;
         final String signature;
         try {
-
             // Server side expects x5c in the header to verify the signer and
             // lookup the certificate from device registration
             // Each string in the array is a base64

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -146,6 +146,7 @@ public class JWSBuilder {
         final String signingInput;
         final String signature;
         try {
+
             // Server side expects x5c in the header to verify the signer and
             // lookup the certificate from device registration
             // Each string in the array is a base64

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -129,6 +129,9 @@ public class JWSBuilder {
         if (privateKey == null) {
             throw new IllegalArgumentException("privateKey");
         }
+        if (pubKey == null) {
+            throw new IllegalArgumentException("pubKey");
+        }
 
         Gson gson = new Gson();
         Claims claims = new Claims();


### PR DESCRIPTION
When we have a situation that an unknown exception is thrown in this view, we throw it out into the web view, which
has poor characteristics about handling the error.  Instead, if it is not a critical error, catch it and report it to the callback
listener.  If it is a critical Error, report it and rethrow it.