### PR TITLE
if it's the same external logger object with a different alias, do not set.

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
@@ -115,15 +115,21 @@ public class Logger {
         }
     }
 
-    public static void setLogger(@NonNull String identifier,
-                                 ILoggerCallback callback) {
+    public static boolean setLogger(@NonNull String identifier,
+                                    ILoggerCallback callback) {
         sLoggersLock.writeLock().lock();
         try {
             if (callback == null) {
                 sLoggers.remove(identifier);
-                return;
+                return true;
             }
+
+            if (sLoggers.containsValue(callback)){
+                return false;
+            }
+
             sLoggers.put(identifier, callback);
+            return true;
         } finally {
             sLoggersLock.writeLock().unlock();
         }


### PR DESCRIPTION
Scenario:
1. Authapp calls ADAL's Logger.setExternalLogger(), which uses a hardcoded alias.
2. It also calls common4j's Logger.setLogger() with an alias.
