### PR TITLE
bump up common and common4j RC versions

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -131,7 +131,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:1.0.0-RC3") {
+    distApi("com.microsoft.identity:common4j:1.0.0-RC4") {
         transitive = false
     }
 

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.0-RC3
+versionName=1.0.0-RC4
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.0-RC3
+versionName=4.0.0-RC4
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### In this change

- Bumping up common4j version to 1.0.0-RC4
- Bumping up android-common version to 4.0.0-RC4
- Update common4j dep in android-common to 1.0.0-RC4