### PR TITLE
Stop setting NOT_SET

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import cz.msebera.httpclient.android.BuildConfig;
 import lombok.NonNull;
 
 /**
@@ -101,8 +102,8 @@ public class Device {
 
         final String version = DiagnosticContext.INSTANCE.getRequestContext().get(AuthenticationConstants.SdkPlatformFields.VERSION);
         if (StringUtil.isNullOrEmpty(version)) {
-            Logger.warn(TAG + methodName, "Product version is not set.");
-            return NOT_SET;
+            Logger.warn(TAG + methodName, "Product version is not set.", null);
+            return StringUtil.isNullOrEmpty(BuildConfig.VERSION_NAME) ? "1.5.9-default" : BuildConfig.VERSION_NAME + "-default";
         } else {
             return version;
         }


### PR DESCRIPTION
It looks like we used to not send NOT_SET in the product version.  ESTS depends on this version information in order to be able to determine whether a client is capable of MAM, for Android not so much the precise version information, but the presence. 

This just reverts back to that state, a little, with some additional information about where it came from.  1.5.9 was the "old" "default" version name.