### PR TITLE
Fix race condition

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -107,6 +107,9 @@ public abstract class AuthorizationFragment extends Fragment {
     }
 
     void finish() {
+        //We're finished here... stop listening for request cancellation
+        LocalBroadcastManager.getInstance(getContext()).unregisterReceiver(mCancelRequestReceiver);
+
         final FragmentActivity activity = getActivity();
         if (activity instanceof AuthorizationActivity) {
             activity.finish();


### PR DESCRIPTION
- Even though we had called finish on the AuthorizationFragment, which in turn calls finish on the activity.  The authorization fragment was not necessarily disposed of immediately.  
- A broadcast receiver was still registered in the authorization fragment resulting in the possibility, in particular during interrupt resolution... of a cancellation request being processed erroneously.

Fix

- Unregister from the broadcast when finish is invoked.