### PR TITLE
Make the fromInteger method public.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ V.Next
 - [MINOR] Hook telemetry to LocalAuthenticationResult and BaseException (#1636)
 - [PATCH] Fix accidental code change that disabled PoP for auth code grant flow (#1661)
 - [PATCH] Synchronize updating refresh token in cache (saving new and removing old) to avoid race condition (#1659)
+- [PATCH] Make unknown RawAuthorizationResult codes UNKNOWN, not null (#1614)
 
 Version 3.6.3
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
@@ -109,13 +109,14 @@ public class RawAuthorizationResult {
          */
         MDM_FLOW(2009);
 
+        @Getter
         private final int mCode;
 
         ResultCode(final int code){
             mCode = code;
         }
 
-        static ResultCode fromInteger(@Nullable final Integer value){
+        public static ResultCode fromInteger(@Nullable final Integer value){
             if (value == null){
                 return ResultCode.UNKNOWN;
             }
@@ -126,7 +127,7 @@ public class RawAuthorizationResult {
                 }
             }
 
-            return null;
+            return ResultCode.UNKNOWN;
         }
     }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/RawAuthorizationResultTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/RawAuthorizationResultTest.java
@@ -99,6 +99,15 @@ public class RawAuthorizationResultTest {
     }
 
     @Test
+    public void testFromInteger() {
+        for (RawAuthorizationResult.ResultCode c : RawAuthorizationResult.ResultCode.values()) {
+            Assert.assertSame(c, RawAuthorizationResult.ResultCode.fromInteger(c.getCode()));
+        }
+        Assert.assertSame(UNKNOWN, RawAuthorizationResult.ResultCode.fromInteger(null));
+        Assert.assertSame(UNKNOWN, RawAuthorizationResult.ResultCode.fromInteger(Integer.MIN_VALUE));
+    }
+
+    @Test
     public void testFromException() {
         final RawAuthorizationResult result = RawAuthorizationResult.fromException(
                 new ClientException(MOCK_ERROR_CODE, MOCK_ERROR_MESSAGE)


### PR DESCRIPTION
Additionally, make sure that the UNKNOWN result is not null.  Mainly of use to people integrating with common, for whom there may be no clean way to make the conversion.