### PR TITLE
Add command line support for gradle to generate a build with custom version number

### DIFF
--- a/common4j/versioning/version_tasks.gradle
+++ b/common4j/versioning/version_tasks.gradle
@@ -3,7 +3,7 @@ def getVersionFile() {
 }
 
 def getVersionProps() {
-    def versionProps = new Properties();
+    def versionProps = new Properties()
     getVersionFile().withInputStream {stream -> versionProps.load(stream)}
     return versionProps
 }
@@ -29,7 +29,7 @@ ext.getAppVersionCode = {
 }
 
 ext.getAppVersionName = {
-    getVersionProps()['versionName'].toString()
+    project.findProperty('projVersion') ?: getVersionProps()['versionName'].toString()
 }
 
 private void saveChanges(String versionName) {

--- a/versioning/version_tasks.gradle
+++ b/versioning/version_tasks.gradle
@@ -3,7 +3,7 @@ def getVersionFile() {
 }
 
 def getVersionProps() {
-    def versionProps = new Properties();
+    def versionProps = new Properties()
     getVersionFile().withInputStream { stream -> versionProps.load(stream) }
     return versionProps
 }
@@ -29,7 +29,7 @@ ext.getAppVersionCode = {
 }
 
 ext.getAppVersionName = {
-    getVersionProps()['versionName'].toString()
+    project.findProperty('projVersion') ?: getVersionProps()['versionName'].toString()
 }
 
 private void saveChanges(String versionName) {


### PR DESCRIPTION
### What 
Add support to generate build with custom version numbers by supplying command line argument "projVersion" to gradle. When this argument is passed it will override the version number defined in the version.properties file and generate a build with the version number passed as "projVersion" argument to gradle

> example: below command will assemble and publish common4j library with version number "0.0.20211101.1" to maven local.
> `.\gradlew -PprojVersion=0.0.20211101.1 :common4j:assemble :common4j:publishToMaveLocal`

### Why
I am planning to use this  to generate daily builds from `dev` branch with latest code. This can then be used to generate daily Apks from Authenticator and CompanyPortal and those can be used to run broker automation on daily basis verifying latest code.
This will also enable us to quickly  generate private builds to share with partners for testing without requiring any code changes to version.properties file for each of the projects.

### How
gradle uses `Version `property on the `Project `object to determine the version number. currently this is being set in the getAppVersionName method in version_task.gradle file, which reads the version.properties file to get and return the version number. I updating the method to check if `projVersion` property is set then use it to set the version number otherwise use version.properties file. `projVersion` property can be set by passing the gradle command line argument `-PprojVersion="4.0.0"`

### Testing
Verified running the command locally and publishing custom versions to maven local.

### Other
Similar PR for broker https://github.com/AzureAD/ad-accounts-for-android/pull/1769