### PR TITLE
Unregister broadcast receiver when finished

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -104,6 +104,7 @@ public abstract class AuthorizationFragment extends Fragment {
     }
 
     void finish() {
+        LocalBroadcaster.INSTANCE.unregisterCallback(CANCEL_AUTHORIZATION_REQUEST);
         final FragmentActivity activity = getActivity();
         if (activity instanceof AuthorizationActivity) {
             activity.finish();


### PR DESCRIPTION
Porting fix from October release to release/4.0.0 for race condition.  When we "finish" the authorization fragment unregister the broadcast receiver.  