### PR TITLE
Allow for the cache directory to be null.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
+++ b/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
@@ -63,6 +63,7 @@ import com.microsoft.identity.common.java.util.ported.Predicate;
 import com.microsoft.identity.common.logging.Logger;
 import com.microsoft.identity.common.java.strategies.IAuthorizationStrategyFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -110,7 +111,12 @@ public class AndroidPlatformComponents implements IPlatformComponents {
         if (!sInitialized) {
             Device.setDeviceMetadata(new AndroidDeviceMetadata());
             Logger.setAndroidLogger();
-            HttpCache.initialize(context.getCacheDir());
+            final File cacheDir = context.getCacheDir();
+            if (cacheDir != null) {
+                HttpCache.initialize(cacheDir);
+            } else {
+                Logger.warn(TAG, "Http caching is not enabled because the cache dir is null");
+            }
             sInitialized = true;
         }
     }


### PR DESCRIPTION
While debugging an ADAL test failure I tripped across this oddity.  It looks like our mock contexts there don't have this method implemented, and so explode if you call it when in debugging mode.  I just thought it would be better to tolerate the behavior.