### PR TITLE
update rootProject.name com.microsoft.identity (was com.microsoft.ide…

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = "com.microsoft.identity.android"
+rootProject.name = "com.microsoft.identity"
 
 // Android Projects
 include(':common')


### PR DESCRIPTION
### What
Update rootProject.name to "com.microsoft.identity" (was com.microsoft.identity.android)

### Why
Apparently When generating pom.xml file for the subprojects under common `rootProject.name `property is used to define `groupid `for dependencies.  For example below are the dependencies for "`com.microsoft.identity:testutils 0.0.256`"
![image](https://user-images.githubusercontent.com/75644120/140832059-f082b945-df88-4e46-aff5-19136c0dc6a3.png)

![image](https://user-images.githubusercontent.com/75644120/140831132-b02b2b67-7fe5-482b-9e01-b26f9a47f3ed.png)

However the `labapi `and `keyvault `are not published under the groupid  `com.microsoft.identity.android` but rather `com.microsoft.identity`. 
Due to this gradle fail to resolve dependencies of `com.microsoft.identity:testutils`. This was discovered in OneAuth CI pipeline when tried to upgrade the testutil version.

### Testing
Locally generated the pom file by running the gradle task to verify that correct groupd id is written to pom.xml file