### PR TITLE
[WIP] Return an error if the interactive thread pool is maxed out

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -632,7 +632,9 @@ public class CommandDispatcher {
                                 commandParameters.getSdkVersion()
                         );
                         try {
-                            sRunningInteractiveSessionCount++;
+                            synchronized (sLock) {
+                                sRunningInteractiveSessionCount++;
+                            }
 
                             // set correlation id on parameters as it may not already be set
                             commandParameters.setCorrelationId(correlationId);
@@ -674,7 +676,9 @@ public class CommandDispatcher {
                             Telemetry.getInstance().flush(correlationId);
                             returnCommandResult(command, commandResult);
                         } finally {
-                            sRunningInteractiveSessionCount--;
+                            synchronized (sLock) {
+                                sRunningInteractiveSessionCount--;
+                            }
                             DiagnosticContext.INSTANCE.clear();
                         }
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -189,6 +189,10 @@ public class ClientException extends BaseException {
     public static final String DUPLICATE_COMMAND = "duplicate_command";
 
     /**
+     * An interactive session is already in progress.
+     */
+    public static final String INTERACTIVE_SESSION_IN_PROGRESS = "interactive_session_in_progress";
+    /**
      * Emitted when the KeyStore generates a certificate that does not match the designated key size.
      * Due to a bug in some versions of Android, keySizes may not be exactly as specified
      * To generate a 2048-bit key, two primes of length 1024 are multiplied -- this product


### PR DESCRIPTION
Issue:
1) Launch MSAL test app, launch a new task A, click acquireToken. webview is launched
2) launch another task B, click acquireToken, nothing happened (because the thread pool is full.)

I accidentally stumbled across this issue during bugbash issue investigation, and from task B, there is no clear way to unblock myself. (You'll have to go to the activity hub, then manually kill/finish task A's interactive session).

--

Proposed fix: Throw an exception when this happens.

Alternatively, we could
1. cancel the ongoing session.
2. Increase thread pool size and support simultaneous interactive session (might still run into the same issue if someone abuses the api).

Merging this to dev because this is a behavior-changing (ish) change.