### PR TITLE
Adjust signing parameters, add failure checking

### DIFF
--- a/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
+++ b/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
@@ -5,26 +5,84 @@ sudo apt-get install -y gnupg2
 GPG_TTY=$TTY
 export GPG_TTY
 
+GPG_DIR=~/.gnupg
+
+mkdir -p $GPG_DIR
+chmod 700 $GPG_DIR
+GPG_FILE="$GPG_DIR/gpg.conf"
+touch $GPG_FILE
+echo 'use-agent' > $GPG_FILE
+echo 'pinentry-mode loopback' >> $GPG_FILE
+echo 'batch' >> $GPG_FILE
+echo 'no-tty' >> $GPG_FILE
+
+GPG_AGENT_FILE="$GPG_DIR/gpg-agent.conf"
+echo 'allow-loopback-pinentry' > $GPG_AGENT_FILE
+echo 'RELOADAGENT' | gpg-connect-agent
+
 gpg --import $PUBLIC_SECUREFILEPATH
 gpg --import $PRIVATE_SECUREFILEPATH
 
+signed=0
+
 if [ $JAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION.jar not found."
+    fi
 fi
 
 if [ $AAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.aar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.aar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION.aar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION.aar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION.aar not found."
+    fi
 fi
 
 if [ $SOURCESJAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-sources.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-sources.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION-sources.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION-sources.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION-sources.jar not found."
+    fi
 fi
 
 if [ $JAVADOCJAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-javadoc.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-javadoc.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION-javadoc.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION-javadoc.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION-javadoc.jar not found."
+    fi
 fi
 
-gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
+gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
+signed=$?
+
+if [ $signed -ne 0 ]; then
+    echo "GPG signing failed with for pom-default.xml with error code $signed"
+    exit $signed
+fi
+if [ ! -f pom-default.xml.asc ]; then
+    exit "Signature file for pom-default.xml not found."
+fi
 
 for file in *; do
     if [[ -f $file ]]; then


### PR DESCRIPTION
Courtesy of the deprecation of ubuntu 16, we seem to be running with a new version of gpg.  We need to do a few things
differently in this version, and I think we want to fail more thoroughly when things go wrong.

Fix command error, check for signature existence

There is no set in the --pinentry-mode paramteter

Attempt to configure the now-required agent

unquote home directory character

Gpg.conf files use dashes, not underscores

Add a few more options to the gpg.conf