### PR TITLE
Change to ubuntu-latest in maven-release-jobs.xml

### DIFF
--- a/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
+++ b/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
@@ -5,26 +5,84 @@ sudo apt-get install -y gnupg2
 GPG_TTY=$TTY
 export GPG_TTY
 
+GPG_DIR=~/.gnupg
+
+mkdir -p $GPG_DIR
+chmod 700 $GPG_DIR
+GPG_FILE="$GPG_DIR/gpg.conf"
+touch $GPG_FILE
+echo 'use-agent' > $GPG_FILE
+echo 'pinentry-mode loopback' >> $GPG_FILE
+echo 'batch' >> $GPG_FILE
+echo 'no-tty' >> $GPG_FILE
+
+GPG_AGENT_FILE="$GPG_DIR/gpg-agent.conf"
+echo 'allow-loopback-pinentry' > $GPG_AGENT_FILE
+echo 'RELOADAGENT' | gpg-connect-agent
+
 gpg --import $PUBLIC_SECUREFILEPATH
 gpg --import $PRIVATE_SECUREFILEPATH
 
+signed=0
+
 if [ $JAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION.jar not found."
+    fi
 fi
 
 if [ $AAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.aar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.aar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION.aar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION.aar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION.aar not found."
+    fi
 fi
 
 if [ $SOURCESJAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-sources.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-sources.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION-sources.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION-sources.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION-sources.jar not found."
+    fi
 fi
 
 if [ $JAVADOCJAR == "true" ]; then
-    gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-javadoc.jar
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-javadoc.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION-javadoc.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION-javadoc.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION-javadoc.jar not found."
+    fi
 fi
 
-gpg --batch --no-use-agent --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
+gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
+signed=$?
+
+if [ $signed -ne 0 ]; then
+    echo "GPG signing failed with for pom-default.xml with error code $signed"
+    exit $signed
+fi
+if [ ! -f pom-default.xml.asc ]; then
+    exit "Signature file for pom-default.xml not found."
+fi
 
 for file in *; do
     if [[ -f $file ]]; then

--- a/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
+++ b/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
@@ -112,7 +112,7 @@ jobs:
   cancelTimeoutInMinutes: 1
   dependsOn: sdl_maven
   pool:
-    name: Hosted Ubuntu 1604
+    vmImage: 'ubuntu-latest'
   steps:
   - ${{ if not(startsWith(parameters.project, 'common')) }}:
     - checkout: common


### PR DESCRIPTION
Ubuntu 16 has been deprecated in the agent pools, so use latest.

When we do this, we will need to set up gpg a little differently, because the version changes between 2.0 and 2.2 necessitate a different set of parameters.  Aside from that, we should fail the step if the signing fails or if the signatures are not produced.  We could validate the signature, as well, but I don't think that it increases the trustworthiness.