### PR TITLE
Hook telemetry to LocalAuthenticationResult and BaseException to be a…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,7 @@ V.Next
 - [PATCH] Fix print stack trace for Throwable in Logs (#1556)
 - [PATCH] Support SSO token api (#1543)
 - [MINOR] Add flighting parameters to commmandParameters (#1562)
+- [MINOR] Hook telemetry to LocalAuthenticationResult and BaseException (#1636)
 
 Version 3.6.3
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -68,7 +68,7 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     @Nullable
     private String mUsername;
 
-    private List<Map<String, String>> mTelemetry = new ArrayList<>();
+    private final List<Map<String, String>> mTelemetry = new ArrayList<>();
 
     /**
      * {@link Exception#addSuppressed(Throwable)} requires API19 in Android, so we're creating our own.
@@ -210,7 +210,7 @@ public class BaseException extends Exception implements IErrorInformation, ITele
      * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
      */
     public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
-        mTelemetry = telemetry;
+        mTelemetry.addAll(telemetry);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -22,11 +22,13 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.exception;
 
+import com.microsoft.identity.common.java.telemetry.ITelemetryAccessor;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -34,9 +36,9 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
-public class BaseException extends Exception implements IErrorInformation {
+public class BaseException extends Exception implements IErrorInformation, ITelemetryAccessor {
 
-    public static final String sName =  BaseException.class.getName();
+    public static final String sName = BaseException.class.getName();
     private static final long serialVersionUID = -5166242728507796770L;
 
     private static final TreeSet<String> nonCacheableErrorCodes = new TreeSet<>(
@@ -66,6 +68,8 @@ public class BaseException extends Exception implements IErrorInformation {
     @Nullable
     private String mUsername;
 
+    private List<Map<String, String>> mTelemetry = new ArrayList<>();
+
     /**
      * {@link Exception#addSuppressed(Throwable)} requires API19 in Android, so we're creating our own.
      */
@@ -73,7 +77,7 @@ public class BaseException extends Exception implements IErrorInformation {
     @Accessors(prefix = "m")
     private final List<Exception> mSuppressedException = new ArrayList<>();
 
-    public void addSuppressedException(@NonNull final Exception e){
+    public void addSuppressedException(@NonNull final Exception e) {
         mSuppressedException.add(e);
     }
 
@@ -174,9 +178,11 @@ public class BaseException extends Exception implements IErrorInformation {
     }
 
     @Nullable
-    public String getCorrelationId() { return mCorrelationId; }
+    public String getCorrelationId() {
+        return mCorrelationId;
+    }
 
-    public void setCorrelationId(@Nullable final String correlationId){
+    public void setCorrelationId(@Nullable final String correlationId) {
         mCorrelationId = correlationId;
     }
 
@@ -189,12 +195,26 @@ public class BaseException extends Exception implements IErrorInformation {
         this.mUsername = username;
     }
 
-    public String getExceptionName(){
+    public String getExceptionName() {
         return sName;
     }
 
-    public boolean isCacheable(){
+    public boolean isCacheable() {
         //TODO : ADO 1373343 Add the whole transient exception category.
         return !nonCacheableErrorCodes.contains(mErrorCode);
+    }
+
+    /**
+     * Set the telemetry on base exception.
+     *
+     * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
+     */
+    public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
+        mTelemetry = telemetry;
+    }
+
+    @Override
+    public List<Map<String, String>> getTelemetry() {
+        return mTelemetry;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -29,10 +29,13 @@ import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.request.ILocalAuthenticationCallback;
 import com.microsoft.identity.common.java.request.SdkType;
+import com.microsoft.identity.common.java.telemetry.ITelemetryAccessor;
 import com.microsoft.identity.common.java.util.StringUtil;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -42,7 +45,7 @@ import lombok.NonNull;
  * Successful authentication result. When auth succeeds, token will be wrapped into the
  * {@link LocalAuthenticationResult} and passed back through the {@link ILocalAuthenticationCallback}.
  */
-public class LocalAuthenticationResult implements ILocalAuthenticationResult {
+public class LocalAuthenticationResult implements ILocalAuthenticationResult, ITelemetryAccessor {
 
     private String mRawIdToken;
     private final AccessTokenRecord mAccessTokenRecord;
@@ -54,6 +57,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult {
     private List<ICacheRecord> mCompleteResultFromCache;
     private boolean mServicedFromCache;
     private String mCorrelationId;
+    private List<Map<String, String>> mTelemetry = new ArrayList<>();
 
     private static final String TAG = LocalAuthenticationResult.class.getName();
 
@@ -218,5 +222,19 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult {
     @Override
     public String getCorrelationId() {
         return mCorrelationId;
+    }
+
+    /**
+     * Set the telemetry on local authentication result.
+     *
+     * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
+     */
+    public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
+        mTelemetry = telemetry;
+    }
+
+    @Override
+    public List<Map<String, String>> getTelemetry() {
+        return mTelemetry;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -57,7 +57,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
     private List<ICacheRecord> mCompleteResultFromCache;
     private boolean mServicedFromCache;
     private String mCorrelationId;
-    private List<Map<String, String>> mTelemetry = new ArrayList<>();
+    private final List<Map<String, String>> mTelemetry = new ArrayList<>();
 
     private static final String TAG = LocalAuthenticationResult.class.getName();
 
@@ -230,7 +230,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
      * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
      */
     public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
-        mTelemetry = telemetry;
+        mTelemetry.addAll(telemetry);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.telemetry;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An interface describing a telemetry accessor i.e. anyone that has the ability to return a
+ * telemetry object.
+ */
+public interface ITelemetryAccessor {
+
+    /**
+     * Obtain telemetry data.
+     *
+     * @return a {@link List<Map<String, String>>} containing telemetry data. Generally this would
+     * be the data produced from {@link Telemetry} class.
+     */
+    List<Map<String, String>> getTelemetry();
+
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
@@ -242,10 +242,6 @@ public class Telemetry {
         if (!mIsTelemetryEnabled) {
             return;
         }
-        if (null == mObservers) {
-            Logger.warn(TAG, "No telemetry observer set.");
-            return;
-        }
 
         if (StringUtil.isNullOrEmpty(correlationId)) {
             Logger.warn(TAG, "No correlation id set.");
@@ -269,6 +265,11 @@ public class Telemetry {
 
         //Add the telemetry context to the telemetry data
         finalRawMap.add(applyPiiOiiRule(mTelemetryContext.getProperties()));
+
+        if (null == mObservers) {
+            Logger.warn(TAG, "No telemetry observer set.");
+            return;
+        }
 
         for (@SuppressWarnings(WarningType.rawtype_warning) ITelemetryObserver observer : mObservers) {
             if (observer instanceof ITelemetryAggregatedObserver) {


### PR DESCRIPTION
…ble to supplied to caller

Related broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1779

Basically we need to send telemetry back to OneAuth-MSAL from Broker. Some of this telemetry is produced via the [common4j Event Based Telemetry infra](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/dev/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java), however, that telemetry wasn't actually being returned as part of any result objects...it is tied to lifecycle of commands and is flushed to observers upon completion of the command, but not provided as part of say the Authentication Result for a particular request. OneAuth-MSAL wants the telemetry back for a particular request along with the result data. To achieve this we grab the telemetry (prior to it being flushed), and we attach it to the result objects (LocalAuthenticationResult or BaseException), so that broker has it available in the result objects and can then run the [OneAuthTelemetryExtractor on it and send the sanitized version back to OneAuth](https://github.com/AzureAD/ad-accounts-for-android/pull/1779). 