### PR TITLE
Modified base class for BrokerAppMetadata cache.  Implemented as sing…

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -129,7 +129,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         // Our test context
         final Context context = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        mApplicationMetadataCache = new SharedPreferencesBrokerApplicationMetadataCache(context);
+        mApplicationMetadataCache = SharedPreferencesBrokerApplicationMetadataCache.getInstance(context);
 
         // Test Configs for caches...
         initFociCache(context);
@@ -888,7 +888,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final BrokerOAuth2TokenCache brokerOAuth2TokenCache = new BrokerOAuth2TokenCache(
                 context,
                 TEST_APP_UID,
-                new SharedPreferencesBrokerApplicationMetadataCache(context)
+                SharedPreferencesBrokerApplicationMetadataCache.getInstance(context)
         );
 
         assertEquals(
@@ -899,7 +899,7 @@ public class BrokerOAuth2TokenCacheTest extends AndroidSecretKeyEnabledHelper {
         final BrokerOAuth2TokenCache brokerOAuth2TokenCache2 = new BrokerOAuth2TokenCache(
                 context,
                 TEST_APP_UID,
-                new SharedPreferencesBrokerApplicationMetadataCache(context)
+                SharedPreferencesBrokerApplicationMetadataCache.getInstance(context)
         );
 
         assertEquals(

--- a/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/SharedPreferencesBrokerApplicationMetadataCacheTest.java
@@ -50,7 +50,7 @@ public class SharedPreferencesBrokerApplicationMetadataCacheTest {
 
     @Before
     public void setUp() {
-        mMetadataCache = new SharedPreferencesBrokerApplicationMetadataCache(
+        mMetadataCache = SharedPreferencesBrokerApplicationMetadataCache.getInstance(
                 InstrumentationRegistry.getContext()
         );
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesBrokerApplicationMetadataCache.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.reflect.TypeToken;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.lang.reflect.Type;
@@ -41,13 +42,23 @@ public class SharedPreferencesBrokerApplicationMetadataCache
         extends SharedPreferencesSimpleCacheImpl<BrokerApplicationMetadata>
         implements IBrokerApplicationMetadataCache {
 
+    private static SharedPreferencesBrokerApplicationMetadataCache INSTANCE;
+
     private static final String TAG = SharedPreferencesBrokerApplicationMetadataCache.class.getSimpleName();
 
     private static final String DEFAULT_APP_METADATA_CACHE_NAME = "com.microsoft.identity.app-meta-cache";
 
     private static final String KEY_CACHE_LIST = "app-meta-cache";
 
-    public SharedPreferencesBrokerApplicationMetadataCache(@NonNull final Context context) {
+    public synchronized static SharedPreferencesBrokerApplicationMetadataCache getInstance(@NonNull final Context context){
+        if(INSTANCE == null){
+            INSTANCE = new SharedPreferencesBrokerApplicationMetadataCache(context);
+        }
+
+        return INSTANCE;
+    }
+
+    protected SharedPreferencesBrokerApplicationMetadataCache(@NonNull final Context context) {
         super(context, DEFAULT_APP_METADATA_CACHE_NAME, KEY_CACHE_LIST);
     }
 
@@ -65,7 +76,14 @@ public class SharedPreferencesBrokerApplicationMetadataCache
 
     public void remove(@NonNull final String clientId,
                        final int processUid) {
-        final List<BrokerApplicationMetadata> allMetadata = getAll();
+        Set<BrokerApplicationMetadata> allMetadata = null;
+        readLock.lock();
+        try {
+            //Get a copy of list first
+            allMetadata = new HashSet<BrokerApplicationMetadata>(mList);
+        }finally{
+            readLock.unlock();
+        }
 
         for (final BrokerApplicationMetadata metadata : allMetadata) {
             if (clientId.equalsIgnoreCase(metadata.getClientId())
@@ -78,7 +96,14 @@ public class SharedPreferencesBrokerApplicationMetadataCache
     private void disposeOfDuplicateRecords(@NonNull final String clientId,
                                            @NonNull final String environment,
                                            final int uid) {
-        final List<BrokerApplicationMetadata> allMetadata = getAll();
+        Set<BrokerApplicationMetadata> allMetadata = null;
+        readLock.lock();
+        try {
+            //Get a copy of list first
+            allMetadata = new HashSet<BrokerApplicationMetadata>(mList);
+        }finally{
+            readLock.unlock();
+        }
 
         for (final BrokerApplicationMetadata metadata : allMetadata) {
             if (clientId.equalsIgnoreCase(metadata.getClientId())
@@ -95,8 +120,13 @@ public class SharedPreferencesBrokerApplicationMetadataCache
 
         final Set<String> allClientIds = new HashSet<>();
 
-        for (final BrokerApplicationMetadata metadata : getAll()) {
-            allClientIds.add(metadata.getClientId());
+        readLock.lock();
+        try {
+            for (final BrokerApplicationMetadata metadata : mList) {
+                allClientIds.add(metadata.getClientId());
+            }
+        }finally{
+            readLock.unlock();
         }
 
         Logger.verbose(
@@ -121,19 +151,24 @@ public class SharedPreferencesBrokerApplicationMetadataCache
 
     @Override
     public List<BrokerApplicationMetadata> getAllFociApplicationMetadata() {
-        final Set<String> fociClientIds = getAllFociClientIds();
-
         final List<BrokerApplicationMetadata> result = new ArrayList<>();
 
-        final List<BrokerApplicationMetadata> allMetadata = getAll();
+        //The following method has it's own read locks... don't want to nest
+        final Set<String> fociClientIds = getAllFociClientIds();
 
-        for (final BrokerApplicationMetadata metadata : allMetadata) {
-            if (fociClientIds.contains(metadata.getClientId())) {
-                result.add(metadata);
+        readLock.lock();
+        try {
+            for (final BrokerApplicationMetadata metadata : mList) {
+                if (fociClientIds.contains(metadata.getClientId())) {
+                    result.add(metadata);
+                }
             }
+        }finally{
+            readLock.unlock();
         }
 
         return result;
+
     }
 
     /**
@@ -147,16 +182,22 @@ public class SharedPreferencesBrokerApplicationMetadataCache
 
         final Set<String> allFociClientIds = new HashSet<>();
 
-        for (final BrokerApplicationMetadata metadata : getAll()) {
-            if (!inverseMatch) { // match FoCI
-                if (!TextUtils.isEmpty(metadata.getFoci())) {
-                    allFociClientIds.add(metadata.getClientId());
-                }
-            } else { // match non FoCI
-                if (TextUtils.isEmpty(metadata.getFoci())) {
-                    allFociClientIds.add(metadata.getClientId());
+        readLock.lock();
+        try {
+
+            for (final BrokerApplicationMetadata metadata : mList) {
+                if (!inverseMatch) { // match FoCI
+                    if (!TextUtils.isEmpty(metadata.getFoci())) {
+                        allFociClientIds.add(metadata.getClientId());
+                    }
+                } else { // match non FoCI
+                    if (TextUtils.isEmpty(metadata.getFoci())) {
+                        allFociClientIds.add(metadata.getClientId());
+                    }
                 }
             }
+        }finally{
+            readLock.unlock();
         }
 
         Logger.verbose(
@@ -176,21 +217,25 @@ public class SharedPreferencesBrokerApplicationMetadataCache
                                                  final int processUid) {
         final String methodName = ":getMetadata";
 
-        final List<BrokerApplicationMetadata> allMetadata = getAll();
         BrokerApplicationMetadata result = null;
 
-        for (final BrokerApplicationMetadata metadata : allMetadata) {
-            if (clientId.equals(metadata.getClientId())
-                    && environment.equals(metadata.getEnvironment())
-                    && processUid == metadata.getUid()) {
-                Logger.verbose(
-                        TAG + metadata,
-                        "Metadata located."
-                );
+        readLock.lock();
+        try {
+            for (final BrokerApplicationMetadata metadata : mList) {
+                if (clientId.equals(metadata.getClientId())
+                        && environment.equals(metadata.getEnvironment())
+                        && processUid == metadata.getUid()) {
+                    Logger.verbose(
+                            TAG + metadata,
+                            "Metadata located."
+                    );
 
-                result = metadata;
-                break;
+                    result = metadata;
+                    break;
+                }
             }
+        }finally{
+            readLock.unlock();
         }
 
         if (null == result) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/registry/DefaultBrokerApplicationRegistry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/registry/DefaultBrokerApplicationRegistry.java
@@ -64,6 +64,7 @@ public class DefaultBrokerApplicationRegistry
         final String methodName = ":getMetadata";
 
         final List<BrokerApplicationRegistryData> allMetadata = getAll();
+
         BrokerApplicationRegistryData result = null;
 
         for (final BrokerApplicationRegistryData metadata : allMetadata) {


### PR DESCRIPTION
- Added ReentrantReadWriteLock to base class
- Added member variable to in-memory list to reduce the number of times reading from SharedPreferences and deserializing from JSON
- Added readLock around read operations
- Added writeLock around update/remove/clear operations
- Converted getAll to use a copy constructor and return a copy of the in-memory list/set
- 