### PR TITLE
Add distCommon4j project parameter to set common4j dependency for continuous delivery pipeline for common

### DIFF
--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -1,8 +1,8 @@
-# File: azure-pipelines/continous-delivery/common.yml
-# Description: Assemble & publish common release to internal feed
-# Variable: 'ENV_VSTS_MVN_ANDROIDADAL_USERNAME' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
-# Variable: 'customVersion' was defined in the Variables tab
+# File: azure-pipelines/continuous-delivery/common-cd.yml
+# Description: Assemble & publish latest common4j, common, keyvault, labapi, labapiutilities, testutil release to internal vsts feed
+# Variable: 'ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME' was defined in the Variables tab
+# Variable: 'mvnAccessToken' access token to access internal vsts feed
+# Variable: 'customVersion' overrides the version number of the published libraries
 
 name: 0.0.$(Date:yyyyMMdd)$(Rev:.r) # $(Build.BuildNumber) = name
 
@@ -23,11 +23,11 @@ jobs:
 - job: common4j_phase
   displayName: 'common4j: Build, Test and Publish'
   steps:
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: common4j
-      prjVersion: $(versionNumber)
-      publishFolder: common4j/build/output
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'common4j/build/output'
 # common
 - job: common_phase
   displayName: 'common: Build, Test and Publish'
@@ -37,29 +37,29 @@ jobs:
   - template: ../templates/steps/automation-cert.yml
     parameters:
       envVstsMvnAt: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: common
-      prjVersion: $(versionNumber)
-      publishFolder: common/build/outputs
+      buildArguments: '-PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)'
+      artifactFolder: 'common/build/outputs'
 # Key Vault
 - job: keyvault_phase
   displayName: 'Key Vault: Build, Test and Publish'
   steps:
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: keyvault
-      prjVersion: $(versionNumber)
-      publishFolder: keyvault/build/libs
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'keyvault/build/libs'
 # Lab API
 - job: labapi_phase
   displayName: 'Lab API: Build, Test and Publish'
   steps:
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: labapi
-      prjVersion: $(versionNumber)
-      publishFolder: labapi/build/libs
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'labapi/build/libs'
 # Lab API Utilities
 - job: labapiutilities_phase
   displayName: 'Lab API Utilities: Build, Test and Publish'
@@ -77,11 +77,11 @@ jobs:
       KeyVaultName: 'ADALTestInfo'
       SecretsFilter: 'AndroidAutomationRunnerAppSecret'
       RunAsPreJob: false
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: LabApiUtilities
-      prjVersion: $(versionNumber)
-      publishFolder: LabApiUtilities/build/libs
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'LabApiUtilities/build/libs'
       testArguments: "-PlabSecret=$(AndroidAutomationRunnerAppSecret)"
 # Test utils
 - job: testutils_phase
@@ -91,11 +91,11 @@ jobs:
   - labapi_phase
   - common_phase
   steps:
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: testutils
-      prjVersion: $(versionNumber)
-      publishFolder: testutils/build/outputs
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'testutils/build/outputs'
 # UI Automation utilities
 - job: uiautomationutilities_phase
   displayName: 'UI Automation utilities: Build, Test and Publish'
@@ -103,9 +103,9 @@ jobs:
   - testutils_phase
   - common_phase
   steps:
-  - template: ../templates/steps/continous-delivery/assemble-publish-projversion.yml
+  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
       project: uiautomationutilities
-      prjVersion: $(versionNumber)
-      publishFolder: uiautomationutilities/build/outputs
+      buildArguments: '-PprojVersion=$(versionNumber)'
+      artifactFolder: 'uiautomationutilities/build/outputs'
 ...

--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -1,21 +1,23 @@
-# File: azure-pipelines/templates/steps/continous-delivery/assemble-publish-projversion.yml
-# Description: Template to assemble and publish, using PprojVersion
+# File: azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+# Description: Template to assemble and publish
 # parameters: 'project' gradle project
-# parameters: 'envVstsMvnAt' Enviroment VSTS Maven Access Token
+# parameters: 'envVstsMvnAt' Environment VSTS Maven Access Token
 # parameters: 'variant' gradle variant for test assemble and publish
-# parameters: 'prjVersion' define the version tu publish
-# parameters: 'publishFolder' path to publish artifacts
+# parameters: 'artifactFolder' path to publish artifacts
+# parameters: 'buildArguments' additional arguments for build
+# parameters: 'publishArguments' additional arguments for publish
 # parameters: 'testArguments' additional arguments for test
 parameters:
 - name: project
-- name: prjVersion
 - name: envVstsMvnAt
   default: 'ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN'
 - name: variant
   default: ''
-- name: publishFolder
+- name: buildArguments
   default: ''
 - name: testArguments
+  default: ''
+- name: artifactFolder
   default: ''
 
 steps:
@@ -31,20 +33,20 @@ steps:
 - task: Gradle@2
   displayName: Assemble ${{ parameters.project }} ${{ parameters.variant }}
   inputs:
-    tasks: '${{ parameters.project }}:clean ${{ parameters.project }}:assemble${{ parameters.variant }} -PprojVersion=${{ parameters.prjVersion }}'
+    tasks: '${{ parameters.project }}:clean ${{ parameters.project }}:assemble${{ parameters.variant }} ${{ parameters.buildArguments }}'
 - task: Gradle@2
   displayName: Run unit tests
   inputs:
-    tasks: ${{ parameters.project }}:test${{ parameters.variant }} ${{ parameters.testArguments }}
+    tasks: '${{ parameters.project }}:test${{ parameters.variant }} ${{ parameters.testArguments }}'
 - task: Gradle@2
   displayName: Publish
   inputs:
-    tasks: '${{ parameters.project }}:publish${{ parameters.variant }} -PprojVersion=${{ parameters.prjVersion }}'
-- ${{ if ne(parameters.publishFolder, '') }}:
+    tasks: '${{ parameters.project }}:publish${{ parameters.variant }} ${{ parameters.buildArguments }}'
+- ${{ if ne(parameters.artifactFolder, '') }}:
   - task: CopyFiles@2
     displayName: Copy Files to Artifact Staging Directory
     inputs:
-      SourceFolder: ${{ parameters.publishFolder }}
+      SourceFolder: ${{ parameters.artifactFolder }}
       TargetFolder: $(build.artifactstagingdirectory)
   - task: PublishPipelineArtifact@1
     name: PublishPipelineArtifacts1

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,11 @@ buildSystem {
     desugar = desugarCode
 }
 
+def common4jVersion = "0.0.+"
+if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
+    common4jVersion = project.distCommon4jVersion
+}
+
 android {
 
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -109,7 +114,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:0.0.+") {
+    distApi("com.microsoft.identity:common4j:${common4jVersion}") {
         transitive = false
     }
 


### PR DESCRIPTION
### What
 - Adding the ability to provide `common4j `dependency version for the continuous delivery pipeline when building `common`
 - Renamed the yml file for Continuous delivery pipeline to `common-cd.yml` (was `common.yml`)
 - Updated template `assemble-publish-projversion.yml` to take buildArguments as parameter

### Why 
Currently the continuous delivery pipeline uses `0.0.+` to pick the latest `common4j `dependency. which may or may not be the same version that is published during the pipeline run. (in case there exists a common4j version `0.0.xyz` which is higher than the one published by the pipeline). This may create a problem if wrong `common4j `version number is used when building `common`.

### How
To ensure we are using the latest version of `common4j` as published by the pipeline, I am adding a variable "`distCommon4jVersion`" which can be used to set the `common4j` dist dependency version. When building/publishing `common`  this variable is used to set the `common4j` dep version to the same as published by the pipeline run. This makes sure that latest version` X `of common as generated by continuous-delivery pipeline will be consuming latest version` X `of common4j, where `X` is same as the buildNumber e.g. `0.0.20211122.2`

### Testing
Sample pipeline run https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=848479&view=results
