### PR TITLE
Add wrapper to allow injecting http response without using Robolectric

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
+++ b/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
@@ -37,7 +37,6 @@ import androidx.fragment.app.Fragment;
 import com.microsoft.identity.common.crypto.AndroidAuthSdkStorageEncryptionManager;
 import com.microsoft.identity.common.crypto.AndroidBrokerStorageEncryptionManager;
 import com.microsoft.identity.common.internal.net.cache.HttpCache;
-import com.microsoft.identity.common.java.broker.ICallValidator;
 import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.platform.AndroidDeviceMetadata;
@@ -52,8 +51,10 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 import com.microsoft.identity.common.java.crypto.IKeyAccessor;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.interfaces.IHttpClientWrapper;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.net.DefaultHttpClientWrapper;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.oauth2.IStateGenerator;
 import com.microsoft.identity.common.java.util.ClockSkewManager;
@@ -333,5 +334,10 @@ public class AndroidPlatformComponents implements IPlatformComponents {
     @Override
     public @NonNull IPlatformUtil getPlatformUtil() {
         return new AndroidPlatformUtil(mContext, mActivity);
+    }
+
+    @Override
+    public @NonNull IHttpClientWrapper getHttpClientWrapper() {
+        return new DefaultHttpClientWrapper();
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/components/SettablePlatformComponents.java
+++ b/common4j/src/main/com/microsoft/identity/common/components/SettablePlatformComponents.java
@@ -33,8 +33,10 @@ import com.microsoft.identity.common.java.crypto.IKeyAccessor;
 import com.microsoft.identity.common.java.crypto.SecureHardwareState;
 import com.microsoft.identity.common.java.crypto.SigningAlgorithm;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.interfaces.IHttpClientWrapper;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.net.DefaultHttpClientWrapper;
 import com.microsoft.identity.common.java.providers.oauth2.IAuthorizationStrategy;
 import com.microsoft.identity.common.java.providers.oauth2.IStateGenerator;
 import com.microsoft.identity.common.java.strategies.IAuthorizationStrategyFactory;
@@ -354,6 +356,11 @@ public class SettablePlatformComponents implements IPlatformComponents {
             ret = (INameValueStorage<String>) mStores.get(storeName);
         }
         return ret;
+    }
+
+    @Override
+    public @NonNull IHttpClientWrapper getHttpClientWrapper() {
+        return new DefaultHttpClientWrapper();
     }
 
     @Builder.Default

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/IHttpClientWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/IHttpClientWrapper.java
@@ -31,6 +31,11 @@ import lombok.NonNull;
  */
 public interface IHttpClientWrapper {
 
+    /**
+     * Wrap the given {@link HttpClient} object.
+     * e.g. For test cases, we could wraps the given {@link HttpClient} object with a Mock HttpClient.
+     *      while we can just return the given object in prod code.
+     */
     @NonNull
     HttpClient wrap(@NonNull final HttpClient client);
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/IHttpClientWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/IHttpClientWrapper.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.interfaces;
+
+import com.microsoft.identity.common.java.net.HttpClient;
+
+import lombok.NonNull;
+
+/**
+ * A wrapper interface around {@link HttpClient}, allowing us to inject responses in test cases.
+ */
+public interface IHttpClientWrapper {
+
+    @NonNull
+    HttpClient wrap(@NonNull final HttpClient client);
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/IPlatformComponents.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/IPlatformComponents.java
@@ -55,7 +55,7 @@ public interface IPlatformComponents {
     /**
      * Gets the default {@link IDevicePopManager}
      *
-     * @throws ClientException if it fails to initalize, or if the operation is not supported by the platform.
+     * @throws ClientException if it fails to initialize, or if the operation is not supported by the platform.
      */
     @NonNull
     IDevicePopManager getDefaultDevicePopManager() throws ClientException;
@@ -102,6 +102,12 @@ public interface IPlatformComponents {
      */
     IMultiTypeNameValueStorage getFileStore(String storeName);
 
+    /**
+     * Retrieve a multi-process safe name-value store with a given identifier.
+     *
+     * @param storeName The name of a new KeyValue store. May not be null.
+     * @return a INameValueStorage instance based around data stored with the same storeName.
+     */
     INameValueStorage<String> getMultiProcessStringStore(@NonNull String storeName);
 
     /**
@@ -123,4 +129,11 @@ public interface IPlatformComponents {
      */
     @NonNull
     IPlatformUtil getPlatformUtil();
+
+    /**
+     * Returns a wrapper of {@link com.microsoft.identity.common.java.net.HttpClient} objects.
+     * This will allow test cases to interject an interceptor - to mock HTTP requests/responses.
+     * */
+    @NonNull
+    IHttpClientWrapper getHttpClientWrapper();
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/net/DefaultHttpClientWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/DefaultHttpClientWrapper.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.net;
+
+import com.microsoft.identity.common.java.interfaces.IHttpClientWrapper;
+
+import lombok.NonNull;
+
+/**
+ * The default http client wrapper. Does nothing.
+ * We should always ship this in production.
+ */
+public class DefaultHttpClientWrapper implements IHttpClientWrapper {
+
+    @Override
+    public @NonNull HttpClient wrap(@NonNull HttpClient client) {
+        return client;
+    }
+}

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClient.java
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.internal.testutils;
+
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.java.net.AbstractHttpClient;
+import com.microsoft.identity.common.java.net.HttpClient;
+import com.microsoft.identity.common.java.net.HttpResponse;
+import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
+import com.microsoft.identity.internal.testutils.HttpRequestInterceptor;
+import com.microsoft.identity.internal.testutils.MockHttpClient;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
+import lombok.NonNull;
+
+/**
+ * A client that wraps around another client, allowing the use of {@link HttpRequestInterceptor}
+ */
+public class InterceptedHttpClient extends AbstractHttpClient {
+    private final HttpClient mClient;
+
+    public InterceptedHttpClient(@NonNull final HttpClient httpClient) {
+        mClient = httpClient;
+    }
+
+    @Override
+    public HttpResponse method(@NonNull final HttpMethod httpMethod,
+                               @NonNull final URL requestUrl,
+                               @NonNull final Map<String, String> requestHeaders,
+                               @Nullable final byte[] requestContent,
+                               @Nullable final SSLContext sslContext) throws IOException {
+        final HttpRequestInterceptor interceptor = MockHttpClient.getInterceptor(httpMethod, requestUrl, requestHeaders, requestContent);
+        if (interceptor == null) {
+            return mClient.method(httpMethod, requestUrl, requestHeaders, requestContent, sslContext);
+        } else {
+            return interceptor.performIntercept(httpMethod, requestUrl, requestHeaders, requestContent);
+        }
+    }
+}

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClientWrapper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClientWrapper.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.internal.testutils;
+
+import com.microsoft.identity.common.java.interfaces.IHttpClientWrapper;
+import com.microsoft.identity.common.java.net.HttpClient;
+
+import lombok.NonNull;
+
+/**
+ * Wraps any given {@link HttpClient} with {@link InterceptedHttpClient},
+ * allowing it to work with {@link MockHttpClient}.
+ * */
+public class InterceptedHttpClientWrapper implements IHttpClientWrapper {
+    @Override
+    public @NonNull HttpClient wrap(@NonNull final HttpClient client) {
+        return new InterceptedHttpClient(client);
+    }
+}

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
@@ -46,7 +46,6 @@ import java.util.function.Predicate;
  */
 public class MockHttpClient {
 
-
     /**
      * Store a map with HttpRequestMatcher as the key. This allows us to have different
      * interceptors for matching different request patterns.
@@ -156,7 +155,6 @@ public class MockHttpClient {
         });
     }
 
-
     /**
      * Quickly match all the http requests with the specified interceptor
      *
@@ -165,7 +163,6 @@ public class MockHttpClient {
     public void intercept(@NonNull final HttpRequestInterceptor interceptor) {
         intercept(HttpRequestMatcher.builder().build(), interceptor);
     }
-
 
     /**
      * Quickly match all the http requests that match the url specified
@@ -273,7 +270,6 @@ public class MockHttpClient {
         }
         MockHttpClient.interceptors.put(matcher, interceptor);
     }
-
 
     /**
      * Removes all the set http request interceptors for this mock instance

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -155,7 +155,10 @@ public class TestUtils {
             final int timeoutInSeconds)
             throws Exception {
         try {
-            return performOperationInThreadPool(request, operation, timeoutInSeconds);
+            final ResultType result =
+                    performOperationInThreadPool(request, operation, timeoutInSeconds);
+            Assert.assertNotNull("returned result should not be null", result);
+            return result;
         } catch (final Exception e) {
             Assert.fail("expected result to be returned");
             throw e;

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/TestUtils.java
@@ -33,12 +33,26 @@ import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage;
 import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.util.ResultFuture;
+import com.microsoft.identity.common.java.util.ported.Function;
+
+import org.junit.Assert;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
 
 public class TestUtils {
 
     private static final Gson gson = new Gson();
+    private static final ExecutorService testPool = Executors.newFixedThreadPool(10);
 
     private static String getCacheKeyForAccessToken(Map<String, ?> cacheValues) {
         for (Map.Entry<String, ?> cacheValue : cacheValues.entrySet()) {
@@ -97,5 +111,85 @@ public class TestUtils {
     public static Context getContext() {
         return ApplicationProvider.getApplicationContext();
     }
+    /**
+     * Given a test function, performs it in a shared thread pool and return an expected exception.
+     * This will Assert and throw an exception if the function operates properly (a result is returned).
+     * This is a blocking operation.
+     *
+     * @param request the request object.
+     * @param operation the test function.
+     * @param timeoutInSeconds how long this method will wait for the exception before
+     *                         it throws a {@link RuntimeException}.
+     * @return an exception object.
+     */
+    public static <RequestType, ResultType> Exception testAndExpectException(
+            final RequestType request,
+            final BiFunction<RequestType, ResultFuture<ResultType>, Void> operation,
+            final int timeoutInSeconds) throws Exception {
+        try {
+            Assert.assertNull("expected exception to be thrown",
+                    performOperationInThreadPool(request, operation, timeoutInSeconds));
+            throw new RuntimeException("expected exception to be thrown");
+        } catch (final TimeoutException e) {
+            Assert.fail("Time out.");
+            throw e;
+        } catch (final Exception e) {
+            return e;
+        }
+    }
 
+    /**
+     * Given a test function, performs it in a shared thread pool and return result.
+     * This will Assert and throw an exception if it runs into any exception.
+     * This is a blocking operation.
+     *
+     * @param request the request object.
+     * @param operation the test function.
+     * @param timeoutInSeconds how long this method will wait for the result before
+     *                         it throws a {@link RuntimeException}.
+     * @return a result object.
+     */
+    public static <RequestType, ResultType> ResultType testAndExpectResult(
+            final RequestType request,
+            final BiFunction<RequestType, ResultFuture<ResultType>, Void> operation,
+            final int timeoutInSeconds)
+            throws Exception {
+        try {
+            return performOperationInThreadPool(request, operation, timeoutInSeconds);
+        } catch (final Exception e) {
+            Assert.fail("expected result to be returned");
+            throw e;
+        }
+    }
+
+    /**
+     * Given a test function, performs it in a shared thread pool and return result.
+     * This is a blocking operation.
+     *
+     * @param request the request object.
+     * @param operation the test function.
+     * @param timeoutInSeconds how long this method will wait for the result before
+     *                         it throws a {@link RuntimeException}.
+     * @return a result object.
+     */
+    public static <RequestType,ResultType> ResultType performOperationInThreadPool(
+            final RequestType request,
+            final BiFunction<RequestType, ResultFuture<ResultType>, Void> operation,
+            final int timeoutInSeconds) throws Exception {
+        final ResultFuture<ResultType> resultFuture = new ResultFuture<>();
+        testPool.submit(() -> {
+            operation.apply(request, resultFuture);
+        });
+
+        try {
+            return resultFuture.get(timeoutInSeconds, TimeUnit.MINUTES);
+        } catch (final TimeoutException e) {
+            Assert.fail("Time out.");
+            throw e;
+        } catch (ExecutionException e){
+            // Unwrap here, so that we don't have to unwrap it
+            // in multiple places down the line.
+            throw (Exception) Objects.requireNonNull(e.getCause());
+        }
+    }
 }


### PR DESCRIPTION
Inspired by (and took some code from) https://github.com/AzureAD/ad-accounts-for-android/pull/1719/files

This will allow us to directly inject http response to test cases.