### PR TITLE
Remove unsafe key thumbprint generator

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Remove unsafe key thumbprint generator (#1654)
 - [MAJOR] Rename LobalBroadcasterAliases to LocalBroadcasterAliases (#1584)
 - [PATCH] Make it clear if adding a query param should overwrite or leave as is (#1581)
 - [PATCH] Handle the scenario where broker activity is killed wrongly. (#1568)

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -185,8 +185,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
     }
 
     @Override
-    @NonNull
-    public byte[] decrypt(@NonNull final byte[] cipherText) throws ClientException {
+    public byte[] decrypt(final byte[] cipherText) throws ClientException {
         final String methodName = ":decrypt";
         Logger.verbose(TAG + methodName, "Starting decryption");
 

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/key/KeyUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/key/KeyUtil.java
@@ -91,31 +91,29 @@ public class KeyUtil {
      * @return a thumbprint. Will return {@link KeyUtil#UNKNOWN_THUMBPRINT} if it fails to derived one.
      */
     public static String getKeyThumbPrint(@NonNull final SecretKey key) {
-        return getKeyThumbPrint(key, null);
+        final String methodName = ":getKeyThumbPrint";
+        try {
+            return getKeyThumbPrintFromHmacKey(getHMacKey(key));
+        } catch (NoSuchAlgorithmException e) {
+            Logger.warn(TAG + methodName, "failed to calculate thumbprint:" + e.getMessage());
+            return UNKNOWN_THUMBPRINT;
+        }
     }
 
     /**
-     * Derive a thumbprint from the given key.
+     * Derive a thumbprint from the given hmac key.
      *
-     * @param key SecretKey to calculate the thumbprint from.
-     * @param hmacKey hmacKey of the secretKey above. If not provided, this will be calculated on the fly.
+     * @param hmacKey hmacKey of the secretKey.
      *
      * @return a thumbprint. Will return {@link KeyUtil#UNKNOWN_THUMBPRINT} if it fails to derived one.
      */
-    public static String getKeyThumbPrint(@NonNull final SecretKey key,
-                                          @Nullable final SecretKey hmacKey) {
-        final String methodName = ":getKeyThumbPrint";
+    public static String getKeyThumbPrintFromHmacKey(@NonNull final SecretKey hmacKey) {
+        final String methodName = ":getKeyThumbPrintFromHmacKey";
         try {
             final byte[] thumbprintBytes = "012345678910111213141516".getBytes(ENCODING_UTF8);
 
             final Mac thumbprintMac = Mac.getInstance(HMAC_ALGORITHM);
-
-            if (hmacKey == null){
-                thumbprintMac.init(getHMacKey(key));
-            } else {
-                thumbprintMac.init(hmacKey);
-            }
-
+            thumbprintMac.init(hmacKey);
             byte[] thumbPrintFinal = thumbprintMac.doFinal(thumbprintBytes);
             return StringUtil.encodeUrlSafeString(thumbPrintFinal);
         } catch (final NoSuchAlgorithmException | InvalidKeyException e) {


### PR DESCRIPTION
Resolve : #1646 

We've been using an outdated encryption mode to generate thumbprints - to track the potential key change issue.

This pr is to get rid of this outdated logic, and make it call the new one.

(ps. We no longer use the StorageHelper in the main line scenario - eventually, the entire class will be gone).