### PR TITLE
Fix accidental code change that disabled PoP for auth code grant flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -64,6 +64,7 @@ V.Next
 - [PATCH] Support SSO token api (#1543)
 - [MINOR] Add flighting parameters to commmandParameters (#1562)
 - [MINOR] Hook telemetry to LocalAuthenticationResult and BaseException (#1636)
+- [PATCH] Fix accidental code change that disabled PoP for auth code grant flow (#1661)
 
 Version 3.6.3
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -381,7 +381,26 @@ public class MicrosoftStsOAuth2Strategy
         }
 
         if (PopAuthenticationSchemeInternal.SCHEME_POP.equals(authScheme.getName())) {
-            throw new UnsupportedOperationException("MSAL Android supports ROPC on Bearer flows only for testing purposes.");
+            // Add a token_type
+            tokenRequest.setTokenType(TokenRequest.TokenType.POP);
+
+            final IDevicePopManager devicePopManager =
+                    mStrategyParameters.getPlatformComponents().getDefaultDevicePopManager();
+
+            // Generate keys if they don't already exist...
+            if (!devicePopManager.asymmetricKeyExists()) {
+                final String thumbprint = devicePopManager.generateAsymmetricKey();
+
+                Logger.verbosePII(
+                        TAG,
+                        "Generated new PoP asymmetric key with thumbprint: "
+                                + thumbprint
+                );
+            }
+
+            final String reqCnf = devicePopManager.getRequestConfirmation();
+            // Set the req_cnf
+            tokenRequest.setRequestConfirmation(reqCnf);
         }
 
         return tokenRequest;
@@ -453,16 +472,7 @@ public class MicrosoftStsOAuth2Strategy
         setTokenRequestCorrelationId(request);
 
         if (PopAuthenticationSchemeInternal.SCHEME_POP.equals(parameters.getAuthenticationScheme().getName())) {
-            request.setTokenType(TokenRequest.TokenType.POP);
-
-            final IDevicePopManager devicePopManager =
-                    mStrategyParameters.getPlatformComponents().getDefaultDevicePopManager();
-
-            if (!devicePopManager.asymmetricKeyExists()) {
-                devicePopManager.generateAsymmetricKey();
-            }
-
-            request.setRequestConfirmation(devicePopManager.getRequestConfirmation());
+            throw new UnsupportedOperationException("MSAL Android supports ROPC on Bearer flows only for testing purposes.");
         }
 
         return request;


### PR DESCRIPTION
Accidentally had made the change in wrong location while addressing the following comment on original PR: 
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1539#discussion_r750633862