### PR TITLE
Update exception name to match older (pre-refactoring) value to avoid breaking older msal clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ allprojects {
                 password project.vstsPassword
             }
         }
+        maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsMavenAccessToken
+            }
+        }
         //Required for google published packages not published to maven central
         google()
         /*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -131,7 +131,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:1.0.0-RC7") {
+    distApi("com.microsoft.identity:common4j:1.0.0-RC8") {
         transitive = false
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ArgumentException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ArgumentException.java
@@ -24,7 +24,7 @@ package com.microsoft.identity.common.java.exception;
 
 public class ArgumentException extends BaseException {
 
-    public static final String sName =  ArgumentException.class.getName();
+    public static final String sName =  "com.microsoft.identity.common.exception.ArgumentException";
     private static final long serialVersionUID = -6399451133831073876L;
 
     public final static String ACQUIRE_TOKEN_OPERATION_NAME = "acquireToken";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ArgumentException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ArgumentException.java
@@ -24,7 +24,12 @@ package com.microsoft.identity.common.java.exception;
 
 public class ArgumentException extends BaseException {
 
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
     public static final String sName =  "com.microsoft.identity.common.exception.ArgumentException";
+
     private static final long serialVersionUID = -6399451133831073876L;
 
     public final static String ACQUIRE_TOKEN_OPERATION_NAME = "acquireToken";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -36,7 +36,12 @@ import lombok.experimental.Accessors;
 
 public class BaseException extends Exception implements IErrorInformation {
 
-    public static final String sName =  BaseException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName =  "com.microsoft.identity.common.exception.BaseException";
+
     private static final long serialVersionUID = -5166242728507796770L;
 
     private static final TreeSet<String> nonCacheableErrorCodes = new TreeSet<>(

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -24,7 +24,12 @@ package com.microsoft.identity.common.java.exception;
 
 public class ClientException extends BaseException {
 
-    public static final String sName = ClientException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName = "com.microsoft.identity.common.exception.ClientException";
+
     private static final long serialVersionUID = -2318746536590284648L;
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/DeviceRegistrationRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/DeviceRegistrationRequiredException.java
@@ -25,14 +25,17 @@ package com.microsoft.identity.common.java.exception;
 
 import lombok.NonNull;
 
-import com.microsoft.identity.common.java.exception.BaseException;
-
 /**
  *  Internal exception thrown when a device needs to registered to access the required resource (MAM)
  */
 final public class DeviceRegistrationRequiredException extends BaseException {
 
-    public static final String sName =  DeviceRegistrationRequiredException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName =  "com.microsoft.identity.common.exception.DeviceRegistrationRequiredException";
+
     private static final long serialVersionUID = 5804977362169696152L;
 
     public DeviceRegistrationRequiredException(@NonNull final String errorCode,

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -37,7 +37,13 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 public class IntuneAppProtectionPolicyRequiredException extends ServiceException {
 
     private static final String TAG = IntuneAppProtectionPolicyRequiredException.class.getSimpleName();
-    public static final String sName = IntuneAppProtectionPolicyRequiredException.class.getName();
+
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName = "com.microsoft.identity.common.exception.IntuneAppProtectionPolicyRequiredException";
+
     private static final long serialVersionUID = -620109887467926354L;
 
     private String mAccountUpn;

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ServiceException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ServiceException.java
@@ -34,7 +34,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class ServiceException extends BaseException {
 
-    public static final String sName =  ServiceException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName =  "com.microsoft.identity.common.exception.ServiceException";
+
     private static final long serialVersionUID = 5139563940871615046L;
 
     public static final String OPENID_PROVIDER_CONFIGURATION_FAILED_TO_LOAD =

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/UiRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/UiRequiredException.java
@@ -29,7 +29,12 @@ package com.microsoft.identity.common.java.exception;
 
 public final class UiRequiredException extends ServiceException {
 
-    public static final String sName = UiRequiredException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName = "com.microsoft.identity.common.exception.UiRequiredException";
+
     private static final long serialVersionUID = 3039442374738287255L;
 
     public UiRequiredException(final String errorCode, final String errorMessage) {

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/UserCancelException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/UserCancelException.java
@@ -28,7 +28,12 @@ package com.microsoft.identity.common.java.exception;
  */
 final public class UserCancelException extends BaseException {
 
-    public static final String sName =  UserCancelException.class.getName();
+    // This is needed for backward compatibility with older versions of MSAL (pre 3.0.0)
+    // When MSAL converts the result bundle it looks for this value to know about exception type
+    // We moved the exception class to a new package with refactoring work,
+    // but need to keep this value to older package name to avoid breaking older MSAL clients.
+    public static final String sName =  "com.microsoft.identity.common.exception.UserCancelException";
+
     private static final long serialVersionUID = 5184560527352649832L;
 
     public UserCancelException() {

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.0-RC7
+versionName=1.0.0-RC8
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.0-RC8
+versionName=4.0.0-RC9
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### What
Update exception name to match older (pre-refactoring) value to avoid breaking older msal clients

### Why
With refactoring the exception classes have moved to a new package, but older clients still use older package name to compare the exception type from broker result bundle. So this breaks the scenario when Broker is using the new package  (refactored code0 but Msal client is on older version

### How
Changing the exception name to match older (pre-refactoring) value to avoid breaking older msal clients

### Testing
Verified locally with Msal test app and Broker Host app

### Other
MsalBrokerResultAdapter class code for comparing (for reference)
![image](https://user-images.githubusercontent.com/75644120/149194495-0798a1a2-7a2d-4d48-8432-55e7c07c15c6.png)
