### PR TITLE
Remove RC tag from common and common4j version

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -131,7 +131,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:1.0.0-RC8") {
+    distApi("com.microsoft.identity:common4j:1.0.0") {
         transitive = false
     }
 

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.0-RC8
+versionName=1.0.0
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.0-RC9
+versionName=4.0.0
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### What
Removing RC tag from common and common4j version to prepare final release build for `4.0.0` release