### PR TITLE
Cherry picking latest changes from master to release/4.0.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 V.Next
 ----------
 - [PATCH] Synchronize updating refresh token in cache (saving new and removing old) to avoid race condition (#1659)
+- [PATCH] Remove unsafe key thumbprint generator (#1654)
+- [MAJOR] Rename LobalBroadcasterAliases to LocalBroadcasterAliases (#1584)
 - [PATCH] Make it clear if adding a query param should overwrite or leave as is (#1581)
 - [PATCH] Handle the scenario where broker activity is killed wrongly. (#1568)
 - [MINOR] Add GetOsForMats to IDeviceMetadata (#1552)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,10 @@
 V.Next
 ----------
+- [MINOR] Update exception name to match older (pre-refactoring) value to avoid breaking older msal clients (#1668)
 - [PATCH] Synchronize updating refresh token in cache (saving new and removing old) to avoid race condition (#1659)
 - [PATCH] Remove unsafe key thumbprint generator (#1654)
+- [PATCH] Move getUidFromHomeAccountId to common4j (from broker4j) + rename a constant (#1643)
+- [PATCH] Make LocalBroadcaster.broadcast method to be asynchronous (#1639)
 - [MAJOR] Rename LobalBroadcasterAliases to LocalBroadcasterAliases (#1584)
 - [PATCH] Make it clear if adding a query param should overwrite or leave as is (#1581)
 - [PATCH] Handle the scenario where broker activity is killed wrongly. (#1568)
@@ -63,6 +66,15 @@ V.Next
 - [PATCH] Fix extracting http response body (#1557)
 - [PATCH] Fix print stack trace for Throwable in Logs (#1556)
 - [PATCH] Support SSO token api (#1543)
+
+Version 3.6.7
+----------
+- [PATCH] Add helper method to fix account id missing in msal get account (#1641)
+- [PATCH] Avoid key overwriting for apps using shared user id (#1662)
+
+Version 3.6.6
+----------
+- [PATCH] Remove unsafe key thumbprint generator (#1655)
 
 Version 3.6.5
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -131,7 +131,7 @@ dependencies {
         transitive = false
     }
 
-    distApi("com.microsoft.identity:common4j:1.0.0") {
+    distApi("com.microsoft.identity:common4j:1.0.1") {
         transitive = false
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -37,6 +37,7 @@ import androidx.annotation.VisibleForTesting;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.java.crypto.key.KeyUtil;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.util.ported.DateUtilities;
 import com.microsoft.identity.common.internal.util.ProcessUtil;
@@ -89,6 +90,8 @@ import javax.security.auth.x500.X500Principal;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
+import static com.microsoft.identity.common.java.crypto.key.KeyUtil.getKeyThumbPrint;
+import static com.microsoft.identity.common.java.crypto.key.KeyUtil.getKeyThumbPrintFromHmacKey;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.LOCALE_CHANGE_LOCK;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.isLocaleCalendarNonGregorian;
 
@@ -137,13 +140,6 @@ public class StorageHelper implements IStorageHelper {
      * probably doing PKCS7. We decide to go with Java default string.
      */
     private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
-
-    /**
-     * We are going to attempt to track key changes when performing encryption/decryption.
-     * To do this, we're actually going to run this in ECB mode on a fixed input, and that
-     * should be OK only because we're going to further hash that value.
-     */
-    private static final String CIPHER_ALGORITHM_FOR_KEY_TRACKING = "AES/ECB/PKCS5Padding";
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
 
@@ -261,7 +257,7 @@ public class StorageHelper implements IStorageHelper {
         // load key for encryption if not loaded
         mEncryptionKey = loadSecretKeyForEncryption();
         mEncryptionHMACKey = getHMacKey(mEncryptionKey);
-        logIfKeyHasChanged(mEncryptionKey, mEncryptionHMACKey);
+        logIfKeyHasChanged(mEncryptionHMACKey);
 
         Logger.verbose(TAG + methodName, "Encrypt version:" + mBlobVersion);
         final byte[] blobVersion = mBlobVersion.getBytes(AuthenticationConstants.CHARSET_UTF8);
@@ -309,24 +305,13 @@ public class StorageHelper implements IStorageHelper {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public String testThumbprint() throws IOException, GeneralSecurityException {
         final SecretKey secretKey = loadSecretKeyForEncryption();
-        return getKeyThumbPrint(secretKey, getHMacKey(secretKey));
+        return getKeyThumbPrint(secretKey);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public boolean testKeyChange() throws IOException, GeneralSecurityException {
         final SecretKey secretKey = loadSecretKeyForEncryption();
-        return logIfKeyHasChanged(secretKey, getHMacKey(secretKey));
-    }
-
-    private String getKeyThumbPrint(final @NonNull SecretKey secretKey, final @NonNull SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
-        final Cipher thumbPrintCipher = Cipher.getInstance(CIPHER_ALGORITHM_FOR_KEY_TRACKING);
-        final byte[] thumbprintBytes = "012345678910111213141516".getBytes(AuthenticationConstants.CHARSET_UTF8);
-        thumbPrintCipher.init(Cipher.ENCRYPT_MODE, secretKey);
-        byte[] bytesOut = thumbPrintCipher.doFinal(thumbprintBytes);
-        Mac thumbprintMac = Mac.getInstance(HMAC_ALGORITHM);
-        thumbprintMac.init(hmacKey);
-        byte[] thumprintFinal = thumbprintMac.doFinal(bytesOut);
-        return Base64.encodeToString(thumprintFinal, Base64.NO_PADDING | Base64.NO_WRAP);
+        return logIfKeyHasChanged(getHMacKey(secretKey));
     }
 
     @Override
@@ -508,7 +493,7 @@ public class StorageHelper implements IStorageHelper {
         mac.update(bytes, 0, macIndex);
         final byte[] macDigest = mac.doFinal();
 
-        logIfKeyHasChanged(secretKey, hmacKey);
+        logIfKeyHasChanged(hmacKey);
 
         // Compare digest of input message and calculated digest
         assertHMac(bytes, macIndex, bytes.length, macDigest);
@@ -536,8 +521,8 @@ public class StorageHelper implements IStorageHelper {
         return decrypted;
     }
 
-    private boolean logIfKeyHasChanged(@NonNull SecretKey secretKey, SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
-        final String keyThumbPrint = getKeyThumbPrint(secretKey, hmacKey);
+    private boolean logIfKeyHasChanged(@NonNull final SecretKey hmacKey) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        final String keyThumbPrint = getKeyThumbPrintFromHmacKey(hmacKey);
         if (!LAST_KNOWN_THUMBPRINT.get().equals(keyThumbPrint)) {
             LAST_KNOWN_THUMBPRINT.set(keyThumbPrint);
             if(!FIRST_TIME.compareAndSet(false, true)) {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -185,8 +185,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
     }
 
     @Override
-    @NonNull
-    public byte[] decrypt(@NonNull final byte[] cipherText) throws ClientException {
+    public byte[] decrypt(final byte[] cipherText) throws ClientException {
         final String methodName = ":decrypt";
         Logger.verbose(TAG + methodName, "Starting decryption");
 

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.0
+versionName=1.0.1
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.0
+versionName=4.0.1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### In this change
- Cherry-picking these two changes which are released from master to release/4.0.0
#1662 , (released in [3.6.7](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/releases/tag/v3.6.7))
#1654  [corresponding change in master #1655 released in [3.6.6](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/releases/tag/v3.6.6))
- Bumping up version for common and common4j