### PR TITLE
Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging (#1687)
 - [PATCH] Remove unsafe key thumbprint generator (#1654)
 - [MAJOR] Rename LobalBroadcasterAliases to LocalBroadcasterAliases (#1584)
 - [PATCH] Make it clear if adding a query param should overwrite or leave as is (#1581)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -142,7 +142,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             if (isPkeyAuthUrl(formattedURL)) {
                 Logger.info(TAG, "WebView detected request for pkeyauth challenge.");
                 final PKeyAuthChallengeFactory factory = new PKeyAuthChallengeFactory();
-                final PKeyAuthChallenge pKeyAuthChallenge = factory.getPKeyAuthChallenge(url);
+                final PKeyAuthChallenge pKeyAuthChallenge = factory.getPKeyAuthChallengeFromWebViewRedirect(url);
                 final PKeyAuthChallengeHandler pKeyAuthChallengeHandler = new PKeyAuthChallengeHandler(view, getCompletionCallback());
                 pKeyAuthChallengeHandler.processChallenge(pKeyAuthChallenge);
             } else if (isRedirectUrl(formattedURL)) {

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -144,6 +144,7 @@ publishing {
 
 def sliceParameter = "" // will be blank unless specified by developer
 def dcParameter = "" // will be blank unless specified by developer
+def disableAcquireTokenSilentTimeoutParameter = false // will be false unless specified by developer
 
 if (project.hasProperty("slice")) {
     sliceParameter = slice
@@ -153,11 +154,18 @@ if (project.hasProperty("dc")) {
     dcParameter = dc
 }
 
+// By adding -PdisableAcquireTokenSilentTimeout in your dev environment, you will no longer subject to the ATS timeout,
+// and your life will be much happier during debugging.
+if (project.hasProperty("disableAcquireTokenSilentTimeout")) {
+    disableAcquireTokenSilentTimeoutParameter = true
+}
+
 sourceSets {
     main {
         java.srcDirs = ['src/main', "$project.buildDir/generated/source/buildConfig/main"]
         buildConfigField("String", "SLICE", "\"$sliceParameter\"")
         buildConfigField("String", "DC", "\"$dcParameter\"")
+        buildConfigField("boolean", "DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT", "${disableAcquireTokenSilentTimeoutParameter}")
     }
     test {
         java.srcDirs = ['src/test']

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -531,13 +531,16 @@ public class AuthenticationConstants {
 
         /**
          * Value of pkeyauth sent in the header.
+         *
+         * By declaring this, we're telling the server to use PKeyAuth instead of client TLS
+         * for device authentication (if there is any).
          */
-        public static final String CHALLENGE_TLS_INCAPABLE = "x-ms-PKeyAuth";
+        public static final String PKEYAUTH_HEADER = "x-ms-PKeyAuth";
 
         /**
          * Value of supported pkeyauth version.
          */
-        public static final String CHALLENGE_TLS_INCAPABLE_VERSION = "1.0";
+        public static final String PKEYAUTH_VERSION = "1.0";
 
         /**
          * Account type string.

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
@@ -45,127 +45,81 @@ import java.util.List;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import sun.rmi.runtime.Log;
 
 /**
  * A class/builder that represents PKeyAuth challenge.
  * see {@link PKeyAuthChallengeFactory}.
+ *
+ * Spec: https://microsoft.sharepoint.com/teams/aad/devex/Shared%20Documents/Core%20Design/Device%20authentication%20using%20PKeyAuth.docx?web=1
  * */
+@Builder
+@Getter
+@Accessors(prefix = "m")
 public class PKeyAuthChallenge implements Serializable {
     private static final String TAG = PKeyAuthChallenge.class.getSimpleName();
 
     enum RequestField {
-        Nonce, CertAuthorities, Version, SubmitUrl, Context, CertThumbprint
+        Nonce, CertAuthorities, Version, SubmitUrl, Context, CertThumbprint, TenantId
     }
 
     /**
-     * Serial version id.
+     * A challenge code issued to the client. The client is expected to return this nonce value in its response.
      */
-
     private final String mNonce;
 
+    /**
+     * An encrypted blob that is opaque to the client and contains information about the challenge
+     * such as the nonce and the timestamp at which the challenge was issued.
+     *
+     * This is expected to be replayed by the client to the server and provides
+     * a way for the server to validate the response
+     */
     private final String mContext;
 
     /**
-     * Authorization endpoint will return accepted authorities.
+     * An array of strings consisting of all the trusted certificate issuers for the device certificate –
+     * typically this is the DRS.
+     * This is used by the client in order to determine the right certificate to be presented
+     * by the client in order to perform device authentication.
+     *
      * The mCertAuthorities could be empty when either no certificate or no permission for ADFS
      * service account for the Device container in AD.
      */
     private final List<String> mCertAuthorities;
 
     /**
-     * Token endpoint will return thumbprint.
+     * The thumbprint of the device certificate that the client MUST present in order to complete proof of possession.
+     * This is used by the client in order to determine the right certificate to be presented by the client in order to perform device authentication.
      */
     private final String mThumbprint;
 
+    /**
+     * The version number of this challenge response protocol.
+     */
     private final String mVersion;
 
     private final String mSubmitUrl;
 
-    protected PKeyAuthChallenge(final Builder builder) {
-        mNonce = builder.mNonce;
-        mContext = builder.mContext;
-        mCertAuthorities = builder.mCertAuthorities;
-        mThumbprint = builder.mThumbprint;
-        mVersion = builder.mVersion;
-        mSubmitUrl = builder.mSubmitUrl;
-    }
-
-    public static class Builder {
-        private String mNonce = "";
-        private String mContext = "";
-        private List<String> mCertAuthorities;
-        private String mThumbprint = "";
-        private String mVersion;
-        private String mSubmitUrl;
-
-        public Builder setNonce(final String nonce) {
-            mNonce = nonce;
-            return self();
-        }
-
-        public Builder setContext(final String context) {
-            mContext = context;
-            return self();
-        }
-
-        public Builder setCertAuthorities(final List<String> certAuthorities) {
-            mCertAuthorities = certAuthorities;
-            return self();
-        }
-
-        public Builder setThumbprint(final String thumbprint) {
-            mThumbprint = thumbprint;
-            return self();
-        }
-
-        public Builder setVersion(final String version) {
-            mVersion = version;
-            return self();
-        }
-
-        public Builder setSubmitUrl(final String submitUrl) {
-            mSubmitUrl = submitUrl;
-            return self();
-        }
-
-        public Builder self() {
-            return this;
-        }
-
-        public PKeyAuthChallenge build() {
-            return new PKeyAuthChallenge(this);
-        }
-    }
-
-    public String getNonce() {
-        return mNonce;
-    }
-
-    public String getContext() {
-        return mContext;
-    }
-
-    public List<String> getCertAuthorities() {
-        return mCertAuthorities;
-    }
-
-    public String getThumbprint() {
-        return mThumbprint;
-    }
-
-    public String getVersion() {
-        return mVersion;
-    }
-
-    public String getSubmitUrl() {
-        return mSubmitUrl;
-    }
-
     public Map<String, String> getChallengeHeader() throws ClientException {
         final String methodName = ":getChallengeHeader";
 
-        String authorizationHeaderValue = String.format("%s Context=\"%s\",Version=\"%s\"",
-                CHALLENGE_RESPONSE_TYPE, mContext, mVersion);
+        // Either cert thumbprint or authorities must present
+        // Otherwise, we won't have enough information to look for the cert.
+        //
+        // In such case, Client should ideally ignore this scenario /
+        // send a response which is equivalent to no certificate present on client.
+        if ((mCertAuthorities == null || mCertAuthorities.size() == 0) &&
+                StringUtil.isNullOrEmpty(mThumbprint)) {
+            Logger.info(TAG + methodName,
+                    "Both cert Authorities and Thumbprint are not provided." +
+                            "Sending a response which is equivalent to no certificate present on client.");
+            return getChallengeHeaderWithoutSignedJwt();
+        }
 
         // If not device cert exists, alias or private key will not exist on the device
         // Suppressing unchecked warnings due to the generic type not provided in the object returned from method getDeviceCertificateProxy
@@ -173,35 +127,62 @@ public class PKeyAuthChallenge implements Serializable {
         final Class<IDeviceCertificate> certClazz =
                 (Class<IDeviceCertificate>) AuthenticationSettings.INSTANCE.getDeviceCertificateProxy();
 
-        if (certClazz != null) {
-            IDeviceCertificate deviceCertProxy = getWPJAPIInstance(certClazz);
-            if (deviceCertProxy.isValidIssuer(mCertAuthorities)
-                    || StringUtil.equalsIgnoreCase(deviceCertProxy.getThumbPrint(), mThumbprint)) {
-                final PrivateKey privateKey = deviceCertProxy.getPrivateKey();
-                if (privateKey == null) {
-                    throw new ClientException(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION);
-                }
-                final PublicKey publicKey = deviceCertProxy.getPublicKey();
-                final X509Certificate certificate = deviceCertProxy.getCertificate();
-                if (certificate == null) {
-                    throw new ClientException(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION);
-                }
-                final String jwt = (new JWSBuilder()).generateSignedJWT(
-                        mNonce,
-                        mSubmitUrl,
-                        privateKey,
-                        publicKey,
-                        certificate);
-                authorizationHeaderValue = String.format(
-                        "%s AuthToken=\"%s\",Context=\"%s\",Version=\"%s\"",
-                        CHALLENGE_RESPONSE_TYPE, jwt, mContext, mVersion);
-                Logger.info(TAG + methodName, "Receive challenge response. ");
-            }
+        if (certClazz == null) {
+            Logger.warn(TAG + methodName, "Device Certificate Proxy is not initialized");
+            return getChallengeHeaderWithoutSignedJwt();
         }
+
+        final IDeviceCertificate deviceCertProxy = getWPJAPIInstance(certClazz);
+        if (!deviceCertProxy.isValidIssuer(mCertAuthorities)
+                && !StringUtil.equalsIgnoreCase(deviceCertProxy.getThumbPrint(), mThumbprint)) {
+            Logger.info(TAG + methodName,
+                    "Cannot find a certificate matching the provided authority.");
+            return getChallengeHeaderWithoutSignedJwt();
+        }
+
+        return getChallengeHeaderWithSignedJwt(deviceCertProxy);
+    }
+
+    /**
+     * Returns a "we can do nothing" response to the server.
+     */
+    private Map<String, String> getChallengeHeaderWithoutSignedJwt() {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(CHALLENGE_RESPONSE_HEADER,
+                String.format("%s Context=\"%s\",Version=\"%s\"",
+                        CHALLENGE_RESPONSE_TYPE, mContext, mVersion));
+        return headers;
+    }
+
+    /**
+     * Generates a signed jwt and return it as part of the challenge header.
+     */
+    private Map<String, String> getChallengeHeaderWithSignedJwt(@NonNull final IDeviceCertificate deviceCertProxy) throws ClientException {
+        final String methodName = ":generateChallengeResponse";
+
+        final PrivateKey privateKey = deviceCertProxy.getPrivateKey();
+        if (privateKey == null) {
+            throw new ClientException(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION);
+        }
+        final PublicKey publicKey = deviceCertProxy.getPublicKey();
+        final X509Certificate certificate = deviceCertProxy.getCertificate();
+        if (certificate == null) {
+            throw new ClientException(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION);
+        }
+        final String jwt = (new JWSBuilder()).generateSignedJWT(
+                mNonce,
+                mSubmitUrl,
+                privateKey,
+                publicKey,
+                certificate);
+
+        Logger.info(TAG + methodName, "Generated a signed challenge response.");
 
         final Map<String, String> headers = new HashMap<>();
         headers.put(CHALLENGE_RESPONSE_HEADER,
-                authorizationHeaderValue);
+                String.format(
+                        "%s AuthToken=\"%s\",Context=\"%s\",Version=\"%s\"",
+                        CHALLENGE_RESPONSE_TYPE, jwt, mContext, mVersion));
         return headers;
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
@@ -79,7 +79,7 @@ public class PKeyAuthChallengeFactory {
                 .submitUrl(parameters.get(SubmitUrl.name()));
 
         if (parameters.containsKey(CertAuthorities.name())) {
-            String authorities = parameters.get(CertAuthorities.name());
+            final String authorities = parameters.get(CertAuthorities.name());
             builder.certAuthorities(StringUtil.getStringTokens(authorities,
                     CHALLENGE_REQUEST_CERT_AUTH_DELIMITER));
         }
@@ -124,12 +124,6 @@ public class PKeyAuthChallengeFactory {
         }
 
         return builder.build();
-    }
-
-    private boolean isWorkplaceJoined() {
-        @SuppressWarnings("unchecked")
-        Class<IDeviceCertificate> certClass = (Class<IDeviceCertificate>) AuthenticationSettings.INSTANCE.getDeviceCertificateProxy();
-        return certClass != null;
     }
 
     private void validateHeaderForPkeyAuthChallenge(@NonNull final String header) throws ClientException {

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
@@ -26,7 +26,6 @@ import lombok.NonNull;
 
 import com.microsoft.identity.common.java.AuthenticationSettings;
 import com.microsoft.identity.common.java.exception.ClientException;
-import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.UrlUtil;
 
@@ -59,24 +58,31 @@ public class PKeyAuthChallengeFactory {
      * This parses the redirectURI for challenge components and produces
      * response object.
      *
+     * This is retrieved from response from auth endpoint
+     * (read: it would be triggered in interactive flow only).
+     *
      * @param redirectUri Location: urn:http-auth:CertAuth?Nonce=<noncevalue>
      *                    &CertAuthorities=<distinguished names of CAs>&Version=1.0
      *                    &SubmitUrl=<URL to submit response>&Context=<server state that
      *                    client must convey back>
      * @return Return PKeyAuth challenge object
      */
-    public PKeyAuthChallenge getPKeyAuthChallenge(@NonNull final String redirectUri) throws ClientException {
+    public PKeyAuthChallenge getPKeyAuthChallengeFromWebViewRedirect(@NonNull final String redirectUri) throws ClientException {
         //get the PKeyAuthChallenge from redirect Uri sent from authorization endpoint
         final Map<String, String> parameters = UrlUtil.getParameters(redirectUri);
-        validatePKeyAuthChallenge(parameters);
+        validatePKeyAuthChallengeFromWebViewRedirect(parameters);
 
-        final PKeyAuthChallenge.Builder builder = new PKeyAuthChallenge.Builder();
-        builder.setNonce(parameters.get(Nonce.name().toLowerCase(Locale.US)))
-                .setContext(parameters.get(Context.name()))
-                .setCertAuthorities(StringUtil.getStringTokens(
-                        parameters.get(CertAuthorities.name()), CHALLENGE_REQUEST_CERT_AUTH_DELIMITER))
-                .setVersion(parameters.get(Version.name()))
-                .setSubmitUrl(parameters.get(SubmitUrl.name()));
+        final PKeyAuthChallenge.PKeyAuthChallengeBuilder builder = new PKeyAuthChallenge.PKeyAuthChallengeBuilder();
+        builder.nonce(parameters.get(Nonce.name().toLowerCase(Locale.US)))
+                .context(parameters.get(Context.name()))
+                .version(parameters.get(Version.name()))
+                .submitUrl(parameters.get(SubmitUrl.name()));
+
+        if (parameters.containsKey(CertAuthorities.name())) {
+            String authorities = parameters.get(CertAuthorities.name());
+            builder.certAuthorities(StringUtil.getStringTokens(authorities,
+                    CHALLENGE_REQUEST_CERT_AUTH_DELIMITER));
+        }
 
         return builder.build();
     }
@@ -84,41 +90,37 @@ public class PKeyAuthChallengeFactory {
     /**
      * Create the pkeyauth challenge with headers.
      *
+     * This is retrieved from response from token endpoint
+     * (read: it would be triggered in silent flow only).
+     *
      * @param header
      * @param authority
      * @throws ClientException
      * @throws UnsupportedEncodingException
      */
-    public PKeyAuthChallenge getPKeyAuthChallenge(@NonNull final String header, @NonNull final String authority)
+    public PKeyAuthChallenge getPKeyAuthChallengeFromTokenEndpointResponse(@NonNull final String header, @NonNull final String authority)
             throws ClientException, UnsupportedEncodingException {
         //get the PKeyAuthChallenge from http response headers sent from token endpoint
         validateHeaderForPkeyAuthChallenge(header);
         final Map<String, String> headerItems = getPKeyAuthHeader(header);
-        validatePKeyAuthChallenge(headerItems);
+        validatePKeyAuthChallengeFromTokenEndpointResponse(headerItems);
 
-        final PKeyAuthChallenge.Builder builder = new PKeyAuthChallenge.Builder();
-        builder.setSubmitUrl(authority)
-                .setNonce(headerItems.get(Nonce.name().toLowerCase(Locale.US)))
-                .setVersion(headerItems.get(Version.name()))
-                .setContext(headerItems.get(Context.name()));
+        final PKeyAuthChallenge.PKeyAuthChallengeBuilder builder = new PKeyAuthChallenge.PKeyAuthChallengeBuilder();
+        builder.submitUrl(authority)
+                .nonce(headerItems.get(Nonce.name().toLowerCase(Locale.US)))
+                .context(headerItems.get(Context.name()))
+                .version(headerItems.get(Version.name()));
 
         // When pkeyauth header is present, ADFS is always trying to device auth. When hitting token endpoint(device
         // challenge will be returned via 401 challenge), ADFS is sending back an empty cert thumbprint when they found
         // the device is not managed. To account for the behavior of how ADFS performs device auth, below code is checking
         // if it's already workplace joined before checking the existence of cert thumbprint or authority from returned challenge.
-        if (!isWorkplaceJoined()) {
-            Logger.info(TAG, "Device is not workplace joined. ");
-        } else if (!StringUtil.isNullOrEmpty(headerItems.get(CertThumbprint.name()))) {
-            Logger.info(TAG, "CertThumbprint exists in the device auth challenge.");
-            builder.setThumbprint(headerItems.get(CertThumbprint.name()));
+        if (!StringUtil.isNullOrEmpty(headerItems.get(CertThumbprint.name()))) {
+            builder.thumbprint(headerItems.get(CertThumbprint.name()));
         } else if (headerItems.containsKey(CertAuthorities.name())) {
-            Logger.info(TAG, "CertAuthorities exists in the device auth challenge.");
             String authorities = headerItems.get(CertAuthorities.name());
-            builder.setCertAuthorities(StringUtil.getStringTokens(authorities,
+            builder.certAuthorities(StringUtil.getStringTokens(authorities,
                     CHALLENGE_REQUEST_CERT_AUTH_DELIMITER));
-        } else {
-            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID,
-                    "Both certThumbprint and cert authorities are not present");
         }
 
         return builder.build();
@@ -141,23 +143,35 @@ public class PKeyAuthChallengeFactory {
         }
     }
 
-    private void validatePKeyAuthChallenge(Map<String, String> headerItems) throws
+    // Validated the required fields.
+    private void validatePKeyAuthChallengeFromTokenEndpointResponse(Map<String, String> headerItems) throws
             ClientException {
         if (!(headerItems.containsKey(Nonce.name()) || headerItems
                 .containsKey(Nonce.name().toLowerCase(Locale.US)))) {
             throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Nonce is empty.");
+        }
+        if (!headerItems.containsKey(Context.name())) {
+            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Context is empty");
+        }
+        if (!headerItems.containsKey(Version.name())) {
+            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Version name is empty");
+        }
+    }
+
+    private void validatePKeyAuthChallengeFromWebViewRedirect(Map<String, String> headerItems) throws
+            ClientException {
+        if (!(headerItems.containsKey(Nonce.name()) || headerItems
+                .containsKey(Nonce.name().toLowerCase(Locale.US)))) {
+            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Nonce is empty.");
+        }
+        if (!headerItems.containsKey(Context.name())) {
+            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Context is empty");
         }
         if (!headerItems.containsKey(Version.name())) {
             throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Version name is empty");
         }
         if (!headerItems.containsKey(SubmitUrl.name())) {
             throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "SubmitUrl is empty");
-        }
-        if (!headerItems.containsKey(Context.name())) {
-            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "Context is empty");
-        }
-        if (!headerItems.containsKey(CertAuthorities.name())) {
-            throw new ClientException(DEVICE_CERTIFICATE_REQUEST_INVALID, "CertAuthorities is empty");
         }
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.controllers;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.PKEYAUTH_HEADER;
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.PKEYAUTH_VERSION;
 import static com.microsoft.identity.common.java.authorities.Authority.B2C;
 
 
@@ -34,14 +36,12 @@ import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommand
 import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
 import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
 import com.microsoft.identity.common.java.constants.OAuth2SubErrorCode;
-import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsRopcTokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.GenerateShrResult;
 import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.java.telemetry.Telemetry;
 import com.microsoft.identity.common.java.providers.oauth2.IResult;
-import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.telemetry.events.CacheEndEvent;
 import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.WarningType;
@@ -306,6 +306,7 @@ public abstract class BaseController {
             completeRequestHeaders.put(AuthenticationConstants.AAD.APP_VERSION,
                     parameters.getApplicationVersion()
             );
+            completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
             setBuilderProperties(builder, parameters, interactiveTokenCommandParameters, completeRequestHeaders);

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -35,6 +35,7 @@ import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarker
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_FUTURE_OBJECT_CREATION_END;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_START;
 
+import com.microsoft.identity.common.java.BuildConfig;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.ICommandResult;
@@ -179,7 +180,11 @@ public class CommandDispatcher {
             throws BaseException {
         final CommandResult commandResult;
         try {
-            commandResult = submitSilentReturningFuture(command).get(ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
+            if (BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT){
+                commandResult = submitSilentReturningFuture(command).get();
+            } else {
+                commandResult = submitSilentReturningFuture(command).get(ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
+            }
         } catch (final InterruptedException | ExecutionException | TimeoutException e) {
             throw ExceptionAdapter.baseExceptionFromException(e);
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
@@ -221,6 +221,11 @@ public final class ErrorStrings {
     public static final String KEY_CHAIN_PRIVATE_KEY_EXCEPTION = "Key Chain private key exception";
 
     /**
+     * Key Chain public key exception.
+     */
+    public static final String KEY_CHAIN_PUBLIC_KEY_EXCEPTION = "Key Chain public key exception";
+
+    /**
      * Key Chain certificate exception.
      */
     public static final String KEY_CHAIN_CERTIFICATE_EXCEPTION = "Key Chain certificate exception";

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -28,7 +28,6 @@ import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
 import com.microsoft.identity.common.java.commands.parameters.RopcTokenCommandParameters;
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
-import com.microsoft.identity.common.java.exception.ArgumentException;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationResponse;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErrorResponse;
@@ -529,7 +528,7 @@ public class MicrosoftStsOAuth2Strategy
         try {
             final PKeyAuthChallengeFactory factory = new PKeyAuthChallengeFactory();
             final URL authority = new URL(mTokenEndpoint);
-            final PKeyAuthChallenge pkeyAuthChallenge = factory.getPKeyAuthChallenge(
+            final PKeyAuthChallenge pkeyAuthChallenge = factory.getPKeyAuthChallengeFromTokenEndpointResponse(
                     challengeHeader,
                     authority.toString()
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -71,6 +71,8 @@ import javax.net.ssl.HttpsURLConnection;
 import lombok.NonNull;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.CLIENT_REQUEST_ID;
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.PKEYAUTH_HEADER;
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.PKEYAUTH_VERSION;
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.ERROR;
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.ERROR_DESCRIPTION;
 
@@ -211,6 +213,7 @@ public abstract class OAuth2Strategy
         headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, Device.getProductVersion());
         headers.putAll(EstsTelemetry.getInstance().getTelemetryHeaders());
         headers.put(HttpConstants.HeaderField.CONTENT_TYPE, TOKEN_REQUEST_CONTENT_TYPE);
+        headers.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
         if (request instanceof MicrosoftTokenRequest) {
             headers.put(

--- a/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactoryTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactoryTest.java
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.challengehandlers;
+
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.PKEYAUTH_VERSION;
+import static com.microsoft.identity.common.java.exception.ErrorStrings.DEVICE_CERTIFICATE_REQUEST_INVALID;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+public class PKeyAuthChallengeFactoryTest {
+
+    private final String[] CERT_AUTHORITIES = new String[]{
+            "OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net"
+    };
+    private final String PKEYAUTH_AUTH_ENDPOINT_CONTEXT = "rQIIAa2RvW_TQBjGfXGSNqGFlImpytBKFegcn78dCYmmKZB-JAqFfi3obN8lVzl24kubNjMCxIQ6MgESA5mgYkAMiKlDB5QRwYZgQQwdI4EEKVX_A57h9z7TM_zedAJJumRfFhVJzk9pjuw5lqtAmyoG1DRkQsvxCFSpTFRDN6hF5OhiOjP_-3Dy-9JIef94vPIiR7_0QKXB8Xa7ns_l3LAhNThtS8wjQZu19yTXZ8Mmcdxo-kTyQxf7OdQptdZXWoUtszOtFOoIbTLKg1antrcYbUyrxbcA9AHYjwn9GPgcu1CZHY4rJwgj1iVPxLKiWVZeUW0TIw1DKnsIajpSoYVtAyqGRXXbVi1H16FsI4u6JoIKdUyoWbYNMbJ0iC0FuzKl1FZRT5yST6PCE57CPWtnORDHw6iGA9bFbRYG_Eic2eYkkiKCvWw2bJKAedmQUp8F5C52XcJ5thmFlPnkkwi-ipPM87FzrcH_XU0KgwZzo5CHQ11Db_04-BEfGwWZxKVUVpiZkMEgDp4nhsIn3qNvv-69mTt48HTjI6fCUSK3q1d3iwurZVIv-o621aTImMdygemVBWPZWa0u8PWdkotcs1W9aubR4yQ4SMZHhQw4So4tr8wuSbOBF4XMO07GHo4I71L_-4ODlNBLX1nb4V7neql2e_fWjRbVUbdwZ66EFpVFo9Je3URRszVXM9aUctCtvkqD_jnwYVwYnH_26PD1_Zd_ft78Cw2.AQABAAEAAAD--DLA3VO7QrddgJg7WevrS-SEPcQWHvmlxD6gDZD4tzKpufY8FnfGkxc4ZD_1S0UqyCs1aOsjmFmxdz8JIxakFka_Q5aaf-RlurMM4UAp9qjBryW6lR2_GJCMvauswa2GVowfL7H099Oo2j1EBe0ddzAZvImhXh7Q-fIXWNfA20OTMPSdKHPWRlgJJrxqG2EW5XcXwrUiCQ3Zw3vbDtULiibI8DvWfH2AbYachYABPaBHQu64twJXtOIZRUPMd5cQvFtNzBHBE_x907m9bB4F_kPeYkMZTXr42CCGDToVnsPwcx_dd2Zm7yxeBrN6PspSq_FysaHy0yJ1dYh3kOT2AjhEwvm9vLh2uPq2wbeJbHZ-sWvaSAeJpON8Q-AxNCxB8dTiAv96kQfDkryshQabQsb86CjIHY26oeBuXFZ4pNy6jZEEXdJ7z2pD5iuZFH9zpyQTQGuq6esy1nUKRA_feNtqBqIVo6HwRgAzmz1COwRdY7B_8NEy8XbWLercIn-d9o9PCVARSSDGs4e8AhZMV1w-a6TSNlW7D12d6FzwhwG5lRbxjeq1Xb3RuZ67OQylNYT0nEmqhSeiG3xuRCtFnaffk15lFmUSUGV-Ki98CGslIP7IwXQKOOwR9RQlaZl0e-Q-_VnPtl-2E5vX0eh1odBRayxnuCufRTuDT5ra1cvU5YbuLWTGxW2oNaQGMZuhH0r84bpmiULMfzFdh1uYSoQXVNEW5jJrw5FwF_pAD54sLgqGGKGkb4NEkjKV-R8gAA";
+    private final String PKEYAUTH_AUTH_ENDPOINT_NONCE = "MV50ggQuxKocqa9BV1Wzp8Gs16sfijXXlfpZJgYEpP4";
+    private final String PKEYAUTH_AUTH_ENDPOINT_SUBMIT_URL = "https://login.microsoftonline.com/common/DeviceAuthPKeyAuth";
+    private final String PKEYAUTH_AUTH_ENDPOINT_URL = "urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4-3e81-46ca-9c73-0950c1eaca97%2cCN%3dMS-Organization-Access%2cDC%3dwindows%2cDC%3dnet&Version=1.0&Context=rQIIAa2RvW_TQBjGfXGSNqGFlImpytBKFegcn78dCYmmKZB-JAqFfi3obN8lVzl24kubNjMCxIQ6MgESA5mgYkAMiKlDB5QRwYZgQQwdI4EEKVX_A57h9z7TM_zedAJJumRfFhVJzk9pjuw5lqtAmyoG1DRkQsvxCFSpTFRDN6hF5OhiOjP_-3Dy-9JIef94vPIiR7_0QKXB8Xa7ns_l3LAhNThtS8wjQZu19yTXZ8Mmcdxo-kTyQxf7OdQptdZXWoUtszOtFOoIbTLKg1antrcYbUyrxbcA9AHYjwn9GPgcu1CZHY4rJwgj1iVPxLKiWVZeUW0TIw1DKnsIajpSoYVtAyqGRXXbVi1H16FsI4u6JoIKdUyoWbYNMbJ0iC0FuzKl1FZRT5yST6PCE57CPWtnORDHw6iGA9bFbRYG_Eic2eYkkiKCvWw2bJKAedmQUp8F5C52XcJ5thmFlPnkkwi-ipPM87FzrcH_XU0KgwZzo5CHQ11Db_04-BEfGwWZxKVUVpiZkMEgDp4nhsIn3qNvv-69mTt48HTjI6fCUSK3q1d3iwurZVIv-o621aTImMdygemVBWPZWa0u8PWdkotcs1W9aubR4yQ4SMZHhQw4So4tr8wuSbOBF4XMO07GHo4I71L_-4ODlNBLX1nb4V7neql2e_fWjRbVUbdwZ66EFpVFo9Je3URRszVXM9aUctCtvkqD_jnwYVwYnH_26PD1_Zd_ft78Cw2.AQABAAEAAAD--DLA3VO7QrddgJg7WevrS-SEPcQWHvmlxD6gDZD4tzKpufY8FnfGkxc4ZD_1S0UqyCs1aOsjmFmxdz8JIxakFka_Q5aaf-RlurMM4UAp9qjBryW6lR2_GJCMvauswa2GVowfL7H099Oo2j1EBe0ddzAZvImhXh7Q-fIXWNfA20OTMPSdKHPWRlgJJrxqG2EW5XcXwrUiCQ3Zw3vbDtULiibI8DvWfH2AbYachYABPaBHQu64twJXtOIZRUPMd5cQvFtNzBHBE_x907m9bB4F_kPeYkMZTXr42CCGDToVnsPwcx_dd2Zm7yxeBrN6PspSq_FysaHy0yJ1dYh3kOT2AjhEwvm9vLh2uPq2wbeJbHZ-sWvaSAeJpON8Q-AxNCxB8dTiAv96kQfDkryshQabQsb86CjIHY26oeBuXFZ4pNy6jZEEXdJ7z2pD5iuZFH9zpyQTQGuq6esy1nUKRA_feNtqBqIVo6HwRgAzmz1COwRdY7B_8NEy8XbWLercIn-d9o9PCVARSSDGs4e8AhZMV1w-a6TSNlW7D12d6FzwhwG5lRbxjeq1Xb3RuZ67OQylNYT0nEmqhSeiG3xuRCtFnaffk15lFmUSUGV-Ki98CGslIP7IwXQKOOwR9RQlaZl0e-Q-_VnPtl-2E5vX0eh1odBRayxnuCufRTuDT5ra1cvU5YbuLWTGxW2oNaQGMZuhH0r84bpmiULMfzFdh1uYSoQXVNEW5jJrw5FwF_pAD54sLgqGGKGkb4NEkjKV-R8gAA&nonce=MV50ggQuxKocqa9BV1Wzp8Gs16sfijXXlfpZJgYEpP4&SubmitUrl=https%3a%2f%2flogin.microsoftonline.com%2fcommon%2fDeviceAuthPKeyAuth";
+
+    private final String PKEYAUTH_TOKEN_ENDPOINT_CONTEXT = "rQIIAeNiNdQz1bPUYjbSM7BSMUkySEmySDbStUwzMtM1MTE017VISknVNU4zSDU2MzVLs0g1KBLiEjjb_F946uHJbnNXzk0IdlaqfMHIeIGJ8RYTt79jaUmGUUh-dmreKmYVAwgw1gWRECIZxoKBTcwqaWYmpokplka6qcYWKbomKYaJukmmhga6KYZJBpaJ5iaJFsmJp5jVS4tTi_SKUhNTFPILUvMygVRaWk5mXmp8YnJyanGxQkFRflpmTuoEFsYLLCyvWMQ4GAVYJTgVGDQEDRi9ODhYBBgkGBQYFrEC3X_ObG2x7Ul_31bX6eesLnYxTGCTmcDGMYGNbQKb8CY2Fg4GAcZTbDy-wY4-eo55KUX5mSkf2Bg72Bl-cDLM4GK8wM14gJfhB9-c81N61q_9_8YDAA2.AQABAAEAAAD--DLA3VO7QrddgJg7WevritOStff29rmP7pxoNaAajotJtvq_lSIqVLdNZgszjRcnTW3gQPrpYxT6hydXcUMEuASqhFvxXPBs0JVggjbyO9s9oDTZQqRsoz9w1cQPpcagNBBUhdyw89DU4XvM4HWIQ_pdn6FcUX0ixrkCyNR6e3U-1TNP3ctH_l5kq--9IWJ8MIs4rrchcCSu_A7b66fOwyVFTJnQhnpTLd9d5crH1lAlYOuATsSKAu7q2oR5UNEMMqJS8gemwdxl2NtyA0yh4cyaxWOeeEdEVoRAehKCe0xFVgsfHoUOdf6WLHwWnWCh1ptV1xdaYVyLFCd1TFbUoFrM_wNWzfFo9vOT1Vy_JSSkkLmn3tZEYw4tCPKnG04b-qJPciDSVg2m9DIfZCYreQxgPCDAwjFhnIOmPz_-TP4dpS2bP-HVev0C1-l3t00EyNQDs4ZdbWwyL_zY_zWglsVwoedl3eF2w0DhAys2NFXEj4D6Nf5EoEQES3yDeSpDdZHyMQNxJoVRiN1SSqqrjUr1pwbExDjzJ1p19xvcQRJDn2iNdWAlxvRWrQC3D-3JPY4cRKYaip-HQ-HrHRGIC2V_ry36yGS73e0pEoCSKMaebO-6Jyiqmiy1fMzePRwTZzDeyBPBw3eYfMW-6H_KIAA";
+    private final String PKEYAUTH_TOKEN_ENDPOINT_NONCE = "ZS6jQlJQLnntAXLP2wMtDl9QvhnNyidmKuaC63rz_pA";
+    private final String PKEYAUTH_TOKEN_ENDPOINT_AUTHORITY = "https://login.microsoftonline.com/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/oAuth2/v2.0/token";
+    private final String PKEYAUTH_TOKEN_ENDPOINT_CHALLENGE_HEADER = "PKeyAuth CertAuthorities=\"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net\", Version=\"1.0\", Context=\"rQIIAeNiNdQz1bPUYjbSM7BSMUkySEmySDbStUwzMtM1MTE017VISknVNU4zSDU2MzVLs0g1KBLiEjjb_F946uHJbnNXzk0IdlaqfMHIeIGJ8RYTt79jaUmGUUh-dmreKmYVAwgw1gWRECIZxoKBTcwqaWYmpokplka6qcYWKbomKYaJukmmhga6KYZJBpaJ5iaJFsmJp5jVS4tTi_SKUhNTFPILUvMygVRaWk5mXmp8YnJyanGxQkFRflpmTuoEFsYLLCyvWMQ4GAVYJTgVGDQEDRi9ODhYBBgkGBQYFrEC3X_ObG2x7Ul_31bX6eesLnYxTGCTmcDGMYGNbQKb8CY2Fg4GAcZTbDy-wY4-eo55KUX5mSkf2Bg72Bl-cDLM4GK8wM14gJfhB9-c81N61q_9_8YDAA2.AQABAAEAAAD--DLA3VO7QrddgJg7WevritOStff29rmP7pxoNaAajotJtvq_lSIqVLdNZgszjRcnTW3gQPrpYxT6hydXcUMEuASqhFvxXPBs0JVggjbyO9s9oDTZQqRsoz9w1cQPpcagNBBUhdyw89DU4XvM4HWIQ_pdn6FcUX0ixrkCyNR6e3U-1TNP3ctH_l5kq--9IWJ8MIs4rrchcCSu_A7b66fOwyVFTJnQhnpTLd9d5crH1lAlYOuATsSKAu7q2oR5UNEMMqJS8gemwdxl2NtyA0yh4cyaxWOeeEdEVoRAehKCe0xFVgsfHoUOdf6WLHwWnWCh1ptV1xdaYVyLFCd1TFbUoFrM_wNWzfFo9vOT1Vy_JSSkkLmn3tZEYw4tCPKnG04b-qJPciDSVg2m9DIfZCYreQxgPCDAwjFhnIOmPz_-TP4dpS2bP-HVev0C1-l3t00EyNQDs4ZdbWwyL_zY_zWglsVwoedl3eF2w0DhAys2NFXEj4D6Nf5EoEQES3yDeSpDdZHyMQNxJoVRiN1SSqqrjUr1pwbExDjzJ1p19xvcQRJDn2iNdWAlxvRWrQC3D-3JPY4cRKYaip-HQ-HrHRGIC2V_ry36yGS73e0pEoCSKMaebO-6Jyiqmiy1fMzePRwTZzDeyBPBw3eYfMW-6H_KIAA\", nonce=\"ZS6jQlJQLnntAXLP2wMtDl9QvhnNyidmKuaC63rz_pA\"";
+
+    @Test
+    public void testParsingChallengeUrl() throws ClientException {
+        final PKeyAuthChallenge challenge = new PKeyAuthChallengeFactory().getPKeyAuthChallengeFromWebViewRedirect(PKEYAUTH_AUTH_ENDPOINT_URL);
+        Assert.assertArrayEquals(CERT_AUTHORITIES, challenge.getCertAuthorities().toArray());
+        Assert.assertEquals(PKEYAUTH_VERSION, challenge.getVersion());
+        Assert.assertEquals(PKEYAUTH_AUTH_ENDPOINT_CONTEXT, challenge.getContext());
+        Assert.assertEquals(PKEYAUTH_AUTH_ENDPOINT_NONCE, challenge.getNonce());
+        Assert.assertEquals(PKEYAUTH_AUTH_ENDPOINT_SUBMIT_URL, challenge.getSubmitUrl());
+        Assert.assertNull(challenge.getThumbprint());
+    }
+
+    @Test
+    public void testParsingChallengeUrl_Malformed() {
+        try{
+            new PKeyAuthChallengeFactory().getPKeyAuthChallengeFromWebViewRedirect(
+                    "urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4"
+            );
+            Assert.fail("Exception is expected");
+        } catch (final ClientException e) {
+            Assert.assertEquals(DEVICE_CERTIFICATE_REQUEST_INVALID, e.getErrorCode());
+        }
+    }
+
+    @Test
+    public void testParsingChallengeHeader() throws UnsupportedEncodingException, ClientException {
+        final PKeyAuthChallenge challenge = new PKeyAuthChallengeFactory().getPKeyAuthChallengeFromTokenEndpointResponse(
+                PKEYAUTH_TOKEN_ENDPOINT_CHALLENGE_HEADER,
+                PKEYAUTH_TOKEN_ENDPOINT_AUTHORITY);
+        Assert.assertArrayEquals(CERT_AUTHORITIES, challenge.getCertAuthorities().toArray());
+        Assert.assertEquals(PKEYAUTH_VERSION, challenge.getVersion());
+        Assert.assertEquals(PKEYAUTH_TOKEN_ENDPOINT_CONTEXT, challenge.getContext());
+        Assert.assertEquals(PKEYAUTH_TOKEN_ENDPOINT_NONCE, challenge.getNonce());
+        Assert.assertEquals(PKEYAUTH_TOKEN_ENDPOINT_AUTHORITY, challenge.getSubmitUrl());
+        Assert.assertNull(challenge.getThumbprint());
+    }
+
+    @Test
+    public void testParsingChallengeHeader_Malformed() throws UnsupportedEncodingException {
+        try{
+            new PKeyAuthChallengeFactory().getPKeyAuthChallengeFromTokenEndpointResponse(
+                    "urn:http-auth:PKeyAuth?CertAuthorities=OU%3d82dbaca4",
+                    PKEYAUTH_TOKEN_ENDPOINT_AUTHORITY
+            );
+            Assert.fail("Exception is expected");
+        } catch (final ClientException e) {
+            Assert.assertEquals(DEVICE_CERTIFICATE_REQUEST_INVALID, e.getErrorCode());
+        }
+    }
+}


### PR DESCRIPTION
Related: https://github.com/AzureAD/ad-accounts-for-android/pull/1827, https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1597

## Why?
1. We're not sending x-ms-PKeyAuth to both auth and token endpoint. 
       - we're only sending it to ADAL's token endpoint (which has a totally separate PKeyAuth stack).
2. However, for some reason, the auth endpoint sends us back PKeyAuth (tested in Broker) - that's why we're not aware that we're not sending x-ms-PKeyAuth there.
3. We do not get PKeyAuth in token endpoint's response, though.

## What I did
1. Make sure we send x-ms-PKeyAuth in both interactive and silent flow.
2. Make sure we're handling the content properly[ based on the spec](https://microsoft.sharepoint.com/:w:/t/aad/devex/EfksUgoBpPNGnACpeQ-_puwBj5JZ616HHxQYxvKJm3JTMg?e=USnvFj).
4. Add tests

## How I tested
1. Install broker
2. Install MSAL test app, signs in interactively* with idlab@msidlab4.onmicrosoft.com 
3. verify the token with jwt.ms, it should NOT have any deviceid claim in it.
5. Perform silent request with idlab@msidlab4.onmicrosoft.com **_with device id claim_**
6. You should get the following error back...

MsalUiRequiredException.
AADSTS50187: Failed to perform device authentication.
Trace ID: ed0290e9-2175-4f5c-85a5-1551076a8900
Correlation ID: b7bad247-913d-499d-b5de-3e94dd474484
Timestamp: 2022-03-03 23:58:12Z

7. signs in interactively with idlab1@msidlab4.onmicrosoft.com **_with device id claim_**
8. User is prompted for a WPJ registration
9. Click "Register"
10. Get a token back, the token should have deviceid claim in it.
11. Perform silent request with idlab@msidlab4.onmicrosoft.com **_with device id claim_**
    - We have a non-deviceid claim RT in the token cache for this account from step 2, so this will trigger pkeyauth in silent flow.
12. You should get a token back, now the device id claim should be in it.


* by signing in interactively, I mean do not enter login_hint, and select "Use another account" if prompted.
-----

I also added build param to disable silent flow timeout during debugging.
 
This is set to false by default. You can add -PdisableAcquireTokenSilentTimeout in your dev environment command line to turn this on. (In Android studio, go to Preferences -> Complier -> command-line Options and add this param)