### PR TITLE
port key stomping fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689) 
 - [PATCH] Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging (#1687)
 - [MINOR] Hook telemetry to LocalAuthenticationResult and BaseException (#1636)
 - [PATCH] Fix accidental code change that disabled PoP for auth code grant flow (#1661)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -221,7 +221,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     /**
      * Encrypt the given unencrypted symmetric key with Keystore key and save to storage.
      */
-    private void saveSecretKeyToStorage(@NonNull SecretKey unencryptedKey) throws ClientException {
+    private void saveSecretKeyToStorage(@NonNull final SecretKey unencryptedKey) throws ClientException {
         final String methodName = ":saveSecretKeyToStorage";
         /*
          * !!WARNING!!

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -222,7 +222,30 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * Encrypt the given unencrypted symmetric key with Keystore key and save to storage.
      */
     private void saveSecretKeyToStorage(@NonNull SecretKey unencryptedKey) throws ClientException {
-        final KeyPair keyPair = generateKeyStoreKeyPair();
+        final String methodName = ":saveSecretKeyToStorage";
+        /*
+         * !!WARNING!!
+         * Multiple apps as of Today (1/4/2022) can still share a linux user id, by configuring
+         * the sharedUserId attribute in their Android Manifest file.  If multiple apps reference
+         * the same value for sharedUserId and are signed with the same keys, they will use
+         * the same AndroidKeyStore and may obtain access to the files and shared preferences
+         * of other applications by invoking createPackageContext.
+         *
+         * Support for sharedUserId is deprecated, however some applications still use this Android capability.
+         * See: https://developer.android.com/guide/topics/manifest/manifest-element
+         *
+         * To address apps in this scenario we will attempt to load an existing KeyPair
+         * instead of immediately generating a new key pair.  This will use the same keypair
+         * to encrypt the symmetric key generated separately for each
+         * application using a shared linux user id... and avoid these applications from
+         * stomping/overwriting one another's keypair.
+         */
+        KeyPair keyPair = readKeyStoreKeyPair();
+        if(keyPair == null){
+            Logger.info(TAG + methodName, "No existing keypair. Generating a new one.");
+            keyPair = generateKeyStoreKeyPair();
+        }
+
         final byte[] keyWrapped = AndroidKeyStoreUtil.wrap(unencryptedKey, keyPair, WRAP_ALGORITHM);
         FileUtil.writeDataToFile(keyWrapped, getKeyFile());
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -117,7 +117,7 @@ public class AndroidKeyStoreUtil {
             applyKeyStoreLocaleWorkarounds(currentLocale);
 
             try {
-                Logger.verbose(TAG + methodName, "Generating KeyPair from KeyStore");
+                Logger.info(TAG + methodName, "Generating KeyPair from KeyStore");
 
                 // Generate a key with the given algorithm spec
                 final KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm, ANDROID_KEY_STORE_TYPE);


### PR DESCRIPTION
Port https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1662 into the new common4j class - since StorageHelper is no longer used.

