### PR TITLE
Update gson version to 2.8.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,14 +37,6 @@ allprojects {
                 password project.vstsPassword
             }
         }
-        maven {
-            name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
-            credentials {
-                username project.vstsUsername
-                password project.vstsPassword
-            }
-        }
         //Required for google published packages not published to maven central
         google()
         /*

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,14 @@ allprojects {
                 password project.vstsPassword
             }
         }
+        maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsPassword
+            }
+        }
         //Required for google published packages not published to maven central
         google()
         /*

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Update gson version to 2.8.9 (#1694)
 - [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689) 
 - [PATCH] Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging (#1687)
 - [MINOR] Hook telemetry to LocalAuthenticationResult and BaseException (#1636)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -26,7 +26,7 @@ ext {
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"
     espressoCoreVersion = "3.1.0"
-    gsonVersion = "2.8.5"
+    gsonVersion = "2.8.9"
     junitVersion = "4.12"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"


### PR DESCRIPTION
**What**
Upgrading gson version used from 2.8.5 -> 2.8.9 

**Why**
Vulnerability reported here in the existing version https://identitydivision.visualstudio.com/Engineering/_componentGovernance/181889/alert/6139944?typeId=9846578
and recommendation is update to 2.8.9

**How**
Updating the value of gsonVersion field to 2.8.9, which is used in build.gradle (along with similar change in msal, broker, aad and android-complete)

**Test**
Ran UTs locally and triggered build here https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=891750&view=results. This does not have component governance task run. I am figuring out how it can be run in this branch.

**Other**
This will only address distDebugCompileClasspath, distDebugRuntimeClasspath, distReleaseCompileClasspath, distReleaseRuntimeClasspath.
Similar changes in msal, broker, adal and android-complete.
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1838
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1603
ADAL: https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1680
Android Complete: https://github.com/AzureAD/android-complete/pull/130