### PR TITLE
Fix build pipeline.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,20 +22,11 @@ allprojects {
     Order of repositories is important.
      */
     repositories {
-        /*
-        This is the project main repository and contains all of the packages we publish.
-        This azure devops feed also has an upstream to Maven Central as well as several other
-        internal azure devops respositories
-
-        NOTE: This repository is not currently available to our public CI (Travis)
-         */
+        google()
+        mavenCentral()
+        // Adding here because Travis cannot access AndroidADAL feed.
         maven {
-            name "vsts-maven-adal-android"
-            url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
-            credentials {
-                username project.vstsUsername
-                password project.vstsPassword
-            }
+            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
         }
         maven {
             name "vsts-maven-adal-android"
@@ -44,24 +35,6 @@ allprojects {
                 username project.vstsUsername
                 password project.vstsPassword
             }
-        }
-        //Required for google published packages not published to maven central
-        google()
-        /*
-        Required for Android Studio / Android Tools (for example: linter) packages not published
-        to maven central.
-
-        NOTE: When building in Travis packages will be pulled from here
-         */
-        mavenCentral()
-        /*
-        Required since the DUO sdk is not published to any of the other large android
-        repositories... which is odd.
-
-        NOTE: This is required for Travis.
-         */
-        maven {
-            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
         }
     }
 }


### PR DESCRIPTION
Something is off with the VSTS feeds. it says some android dependencies are not found. 

Also, Since we should be pulling non-MSFT dependencies from google() and mavenCentral() (i.e. like what MSAL/ad-accounts/android-complete are doing), I'll also remove the Android feed and re-sort common's repository sources to align with those repos.

EDIT: for those dependencies, .pom is there but .jar isn't. This is why it fails to download (and gradle didn't proceed to try the next source - it thought this feed has it).
i.e. https://identitydivision.visualstudio.com/IDDP/_artifacts/feed/AndroidADAL/maven/androidx.core%2Fcore/1.0.1/overview