### PR TITLE
Fixing potential deadlock state in executor service for interactive requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Fixing potential deadlock state in executor service for interactive requests (#1696)
 - [PATCH] Update gson version to 2.8.9 (#1694)
 - [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689) 
 - [PATCH] Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging (#1687)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -636,6 +636,9 @@ public class CommandDispatcher {
                         // for "CANCEL_AUTHORIZATION_REQUEST". This results in the sInteractiveExecutor thread being in deadlock
                         // state and not able to process any more interactive requests. To get out of this deadlock and be able to
                         // process future interactive request we need to shutdown and restart the sInteractiveExecutor executor service.
+                        Logger.info(TAG + methodName,
+                                "The previous interactive request was queued but never got processed and is blocking the interactive thread. " +
+                                        "Restarting the interactive executor service to enable processing interactive requests again.");
                         sInteractiveExecutor.shutdownNow();
                         sInteractiveExecutor = Executors.newSingleThreadExecutor();
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -639,8 +639,9 @@ public class CommandDispatcher {
                         Logger.info(TAG + methodName,
                                 "The previous interactive request was queued but never got processed and is blocking the interactive thread. " +
                                         "Restarting the interactive executor service to enable processing interactive requests again.");
-                        sInteractiveExecutor.shutdownNow();
+                        List<Runnable> cancelledRequests = sInteractiveExecutor.shutdownNow();
                         sInteractiveExecutor = Executors.newSingleThreadExecutor();
+                        Logger.info(TAG + methodName, "Cancelled execution of " + cancelledRequests.size() + " interactive requests.");
                     }
                 }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -83,24 +83,11 @@ import java.util.concurrent.TimeoutException;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.CANCEL_AUTHORIZATION_REQUEST;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
-import static com.microsoft.identity.common.java.commands.SilentTokenCommand.ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS;
-import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_COMMAND_EXECUTION_END;
-import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_COMMAND_EXECUTION_START;
-import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_EXECUTOR_START;
-import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_FUTURE_OBJECT_CREATION_END;
-import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_SILENT_START;
-
 public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
-    private static final ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
+    private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
     private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
@@ -641,7 +628,17 @@ public class CommandDispatcher {
                 //Cancel interactive request if authorizationInCurrentTask() returns true OR this is a broker request.
                 if (LibraryConfiguration.getInstance().isAuthorizationInCurrentTask() || command.getParameters() instanceof BrokerInteractiveTokenCommandParameters) {
                     // Send a broadcast to cancel if any active auth request is present.
-                    LocalBroadcaster.INSTANCE.broadcast(CANCEL_AUTHORIZATION_REQUEST, new PropertyBag());
+                    if(LocalBroadcaster.INSTANCE.hasReceivers(CANCEL_AUTHORIZATION_REQUEST)) {
+                        LocalBroadcaster.INSTANCE.broadcast(CANCEL_AUTHORIZATION_REQUEST, new PropertyBag());
+                    } else if (LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT)) {
+                        // This means that there is previous interactive request(s) waiting for Authorization result, however
+                        // the actual authorization process for that request has not been started as there are no registered listener/receivers
+                        // for "CANCEL_AUTHORIZATION_REQUEST". This results in the sInteractiveExecutor thread being in deadlock
+                        // state and not able to process any more interactive requests. To get out of this deadlock and be able to
+                        // process future interactive request we need to shutdown and restart the sInteractiveExecutor executor service.
+                        sInteractiveExecutor.shutdownNow();
+                        sInteractiveExecutor = Executors.newSingleThreadExecutor();
+                    }
                 }
 
                 sInteractiveExecutor.execute(new Runnable() {

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -318,6 +318,14 @@ public class ExceptionAdapter {
             );
         }
 
+        if (e instanceof InterruptedException) {
+            return new ClientException(
+                    ClientException.INTERRUPTED_OPERATION,
+                    "SDK cancelled operation, the thread execution was interrupted",
+                    e
+            );
+        }
+
         if (e instanceof BaseException) {
             return (BaseException) e;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -61,6 +61,10 @@ public enum LocalBroadcaster {
         mReceivers.remove(alias);
     }
 
+    public boolean hasReceivers(@NonNull final String alias) {
+        return mReceivers.containsKey(alias);
+    }
+
     public void broadcast(@NonNull final String alias, @NonNull final PropertyBag propertyBag) {
         final String methodName = ":broadcast";
         sBroadcastExecutor.execute(new Runnable() {


### PR DESCRIPTION
### What
Fixing a potential deadlock issue in executor service for interactive request, by shutting down and recreating it.
This issue is reported in this ICM https://portal.microsofticm.com/imp/v3/incidents/details/264456886/home

### Why
The interactive request executor service can get into a state where an interactive request gets started in CommandDispatcher, but the actual AuthorizationActivity never starts. This can happen when user immediately press home button after starting an acquireToken (interactive) call to push the app in the background. Android 10 (API level 29) and higher place [restrictions ](https://developer.android.com/guide/components/activities/background-starts) on when apps can start activities when the app is running in the background. Because of this the AuthorizationActivity does not start and the request keep waiting for the Authorization Result. Even after broadcasting a "CANCEL_AUTHORIZATION_REQUEST" it doesnt finish the request as there are no listener for it.
This blocks any future interactive requests going through the broker as none of them can be assigned the thread. and the user sees an infinite spinner https://portal.microsofticm.com/imp/v3/incidents/details/264456886/home

### How
When we detect that there is no listener for "CANCEL_AUTHORIZATION_REQUEST" (which means that `AuthorizationActivity`/`AuthorizationFragment` hasn't started) but a previous request is still waiting for "RETURN_AUTHORIZATION_REQUEST_RESULT" (which means that an interactive request was started in the past), We identify the interactive thread getting stuck (deadlock). Once we run into this situation inorder to process incoming interactive requests, we shutdown the executor service and recreate it since it only has a single thread. This terminates the older thread and starts processing the interactive requests in new thread.

### Testing
**Repro** 
1. Launch MsalTestApp
2. Press AcquireToken
3. Quickly press home button
4. Go back to MsalTestApp to see if it gets stuck in infinite spinner case, if not try from step 2.
5. Press back button to cancel the request, 
6. Try acquireToken again
**Expected**: User should see the credentials page to perform interactive sign-in
**Actual**: User sees the spinner spinning. If you debug in CommandDispatcher.java, you can see that these requests are getting queued but there is already an active request which is still getting processed and doesnt finish.
**AfterFix**: The fix terminates the previous request and continues to process the new request and user sees the credential page to perform sign-in.


