### PR TITLE
Use default provider in Android for creating SSLContext's KeyManagerFactory

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 4.0.3
+----------
+- [PATCH] Use default provider in Android for creating SSLContext's KeyManagerFactory (#1697)
+
 Version 4.0.2
 ----------
 - [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689, #1690) 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -48,9 +48,12 @@ import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.ui.BrowserDescriptor;
 import com.microsoft.identity.common.java.util.IPlatformUtil;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+
+import javax.net.ssl.KeyManagerFactory;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.AllArgsConstructor;
@@ -160,6 +163,11 @@ public class AndroidPlatformUtil implements IPlatformUtil {
     public void postCommandResult(@NonNull Runnable runnable) {
         final Handler handler = new Handler(Looper.getMainLooper());
         handler.post(runnable);
+    }
+
+    @Override
+    public KeyManagerFactory getSslContextKeyManagerFactory() throws NoSuchAlgorithmException {
+        return KeyManagerFactory.getInstance("X509");
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/components/SettablePlatformComponents.java
+++ b/common4j/src/main/com/microsoft/identity/common/components/SettablePlatformComponents.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.net.ssl.KeyManagerFactory;
+
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.Builder;
 import lombok.Getter;
@@ -406,6 +408,11 @@ public class SettablePlatformComponents implements IPlatformComponents {
 
         @Override
         public void postCommandResult(@NonNull Runnable runnable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public KeyManagerFactory getSslContextKeyManagerFactory() {
             throw new UnsupportedOperationException();
         }
     };

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -23,12 +23,14 @@
 package com.microsoft.identity.common.java.util;
 
 import com.microsoft.identity.common.java.commands.ICommand;
-import com.microsoft.identity.common.java.eststelemetry.LastRequestTelemetryCache;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.ui.BrowserDescriptor;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
+
+import javax.net.ssl.KeyManagerFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -97,4 +99,19 @@ public interface IPlatformUtil {
      * Posts a runnable for returning the command execution result.
      */
     void postCommandResult(@NonNull final Runnable runnable);
+
+    /**
+     * BouncyCastle doesn't play well with Conscrypt (Android 11's default SSLSocket implementation)
+     * https://developer.android.com/about/versions/11/behavior-changes-all#ssl-sockets-conscrypt
+     *
+     * This causes the DRS request TLS handshake to fail - 'key not found' - even if cert is provided.
+     *
+     * As a short-term work around, we're going to use the 'default' KeyManagerFactory in Android,
+     * and keeps using BouncyCastle in Linux.
+     *
+     * Long term, we're going to move away from platform's default implementation
+     * and use external libraries that are FIPS compliant.
+     *
+     * @return*/
+    KeyManagerFactory getSslContextKeyManagerFactory() throws NoSuchAlgorithmException;
 }

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.2
+versionName=1.0.3
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.2
+versionName=4.0.3
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
### Issue:

Android updated their SSLSocket implementation to Conscript in Android 11 - and it doesn't play well with BouncyCastle
https://developer.android.com/about/versions/11/behavior-changes-all#ssl-sockets-conscrypt

This causes the DRS request TLS handshake to fail - 'key not found' - even if cert is provided.

As a short-term work around, we're going to use the 'default' KeyManagerFactory in Android, and keeps using BouncyCastle in Linux.

Long term, we're going to move away from platform's default implementation and use external libraries that are FIPS compliant.

Tested the flow with Android 10 and 11.