### PR TITLE
Fix path separators for maven pipeline

### DIFF
--- a/azure-pipelines/maven-release/common.yml
+++ b/azure-pipelines/maven-release/common.yml
@@ -24,9 +24,9 @@ jobs:
     envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
     gradleAssembleReleaseTask: common:clean common:build common:assembleDistRelease
     gradleGeneratePomFiletask: common:generatePomFileForDistReleasePublication
-    aarSourceFolder: common\build\outputs\aar
-    jarSourceFolder: common\build\outputs\jar
-    pomSourceFolder: common\build\publications\distRelease
+    aarSourceFolder: common/build/outputs/aar
+    jarSourceFolder: common/build/outputs/jar
+    pomSourceFolder: common/build/publications/distRelease
     gpgAar: true
     gpgSourcesJar: true
     gpgJavadocJar: false

--- a/azure-pipelines/maven-release/common4j.yml
+++ b/azure-pipelines/maven-release/common4j.yml
@@ -20,9 +20,9 @@ jobs:
     projectVersion: $(common4jVersion)
     gradleAssembleReleaseTask: common4j:clean common4j:assemble common4j:test -Psugar=true
     gradleGeneratePomFiletask: common4j:generatePomFileForAarPublication
-    jarSourceFolder: common4j\build\outputs\jars
-    pomSourceFolder: common4j\build\publications\aar
-    extraSourceFolder: common4j\build\libs
+    jarSourceFolder: common4j/build/outputs/jars
+    pomSourceFolder: common4j/build/publications/aar
+    extraSourceFolder: common4j/build/libs
     extraContents: '**/*.jar'
     gpgAar: false
     gpgSourcesJar: true


### PR DESCRIPTION
Fix path separators for maven pipeline to match linux style


related to https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1608