### PR TITLE
Adding orientation flag to BrokerActivity android:configChanges to prevent it from getting restarted on orientation change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Adding orientation flag to BrokerActivity android:configChanges to prevent it from getting restarted on orientation change (#1705)
 - [PATCH] Ensure consistent logging tags (#1701)
 - [PATCH] Update gson version to 2.8.9 (#1694)
 - [PATCH] Fix silent flow pkeyauth, add build param to disable silent flow timeout during debugging (#1687)

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
 
         <!-- Activity to invoke an interactive request to the intent passed by ad-accounts(Broker) -->
         <activity
-            android:name="com.microsoft.identity.common.internal.broker.BrokerActivity" />
+            android:name="com.microsoft.identity.common.internal.broker.BrokerActivity"
+            android:configChanges="orientation|screenSize|screenLayout" />
     </application>
 
     <!-- Required for API Level 30 to make sure we can detect browsers and other apps we want to

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -22,14 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_ERROR_RESPONSE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_OPERATION_CANCELLED;
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_SUCCESS_RESPONSE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROKER_FLOW;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -40,9 +32,17 @@ import com.microsoft.identity.common.internal.result.IBrokerResultAdapter;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.request.SdkType;
-import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
+import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.logging.Logger;
+
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROKER_FLOW;
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_OPERATION_CANCELLED;
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_ERROR_RESPONSE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_SUCCESS_RESPONSE;
 
 public final class BrokerActivity extends Activity {
 
@@ -90,7 +90,7 @@ public final class BrokerActivity extends Activity {
     protected void onDestroy() {
         // If the broker process crashes, onActivityResult() will not be triggered.
         // (tested by throwing an exception in AccountChooserActivity, and by killing the activity via App Switcher).
-        if (isFinishing() && !mBrokerResultReceived) {
+        if (!mBrokerResultReceived) {
             returnsExceptionOnActivityUnexpectedlyKilled();
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -22,6 +22,14 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_ERROR_RESPONSE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_OPERATION_CANCELLED;
+import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_SUCCESS_RESPONSE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
+import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROKER_FLOW;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -32,17 +40,9 @@ import com.microsoft.identity.common.internal.result.IBrokerResultAdapter;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.request.SdkType;
-import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
+import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.logging.Logger;
-
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROKER_FLOW;
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_OPERATION_CANCELLED;
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_ERROR_RESPONSE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.BrokerResponse.BROKER_SUCCESS_RESPONSE;
 
 public final class BrokerActivity extends Activity {
 
@@ -90,7 +90,7 @@ public final class BrokerActivity extends Activity {
     protected void onDestroy() {
         // If the broker process crashes, onActivityResult() will not be triggered.
         // (tested by throwing an exception in AccountChooserActivity, and by killing the activity via App Switcher).
-        if (!mBrokerResultReceived) {
+        if (isFinishing() && !mBrokerResultReceived) {
             returnsExceptionOnActivityUnexpectedlyKilled();
         }
 


### PR DESCRIPTION
### What
Adding orientation flag to BrokerActivity [android:configChanges](https://developer.android.com/guide/topics/manifest/activity-element#config) to prevent it from getting restarted on orientation change, which is the default behavior

### Why
From [Android Documentation](https://developer.android.com/reference/android/app/Activity.html#ConfigurationChanges)
A configuration change (such as a change in screen orientation, language, input devices, etc) causes current activity to be destroyed, going through the normal activity lifecycle process of [onPause()](https://developer.android.com/reference/android/app/Activity#onPause()), [onStop()](https://developer.android.com/reference/android/app/Activity#onStop()), and [onDestroy()](https://developer.android.com/reference/android/app/Activity#onDestroy()) as appropriate. If the activity had been in the foreground or visible to the user, once [onDestroy()](https://developer.android.com/reference/android/app/Activity#onDestroy()) is called in that instance then a new instance of the activity will be created, with whatever savedInstanceState the previous instance had generated from [onSaveInstanceState(Bundle)](https://developer.android.com/reference/android/app/Activity#onSaveInstanceState(android.os.Bundle)).

So when the orientation change occurs during the interactive sign in, before broker has returned a result, it causes onDestroy to be called in BrokerActivity.java, which returns activityUnexpectedlyKilled exception back to Msal application, even if the broker is still processing the request. When broker is done it sends the result, but  that result is not returned to the application as we unregister the listener.

### How
Added "`orientation`" flag to BrokerActivity [android:configChanges](https://developer.android.com/guide/topics/manifest/activity-element#config). This prevents the activity to get shutdown and restarted upon orientation change, and rather the [onConfigurationChanged()](https://developer.android.com/reference/android/app/Activity#onConfigurationChanged(android.content.res.Configuration)) method is called. Since this activity is only used for sending and receiving result from Broker we don't need any special handling on orientation change, 

### Testing
Tested with orientation change with MsalTestApp while interactive request is in progress, doesnt result in "Activity unexpectedly killed" result after the fix, and we are able to get the actual token back
This issue was discovered and reported by Authenticator team from their upcoming release test pass. I shared the fix with them and they confirmed that it fixes the issue for them.

Authenticator bugs:
[Bug 1829902](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1829902): A: Bug Bash March 2022 Bug: Rotating while signing in to Add Account results in broker auth failure
[Bug 1824875](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1824875): A: Bug Bash March 2022 Bug: Fails to complete device registration if rotation happens midway

