### PR TITLE
Adding support for prompt=create

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add prompt=create support.
 - [PATCH] Fixing potential deadlock state in executor service for interactive requests (#1696)
 - [PATCH] Ensure consistent logging tags (#1701)
 - [PATCH] Update gson version to 2.8.9 (#1694)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [MINOR] Add prompt=create support.
+- [MINOR] Add prompt=create support. (#1707)
 - [PATCH] Fixing potential deadlock state in executor service for interactive requests (#1696)
 - [PATCH] Ensure consistent logging tags (#1701)
 - [PATCH] Update gson version to 2.8.9 (#1694)

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -61,7 +61,10 @@ public enum OpenIdConnectPromptParameter {
     CONSENT,
 
     /**
-     * acquireToken will send prompt=create to the authorize endpoint.  The use will be prompted to create a new account.
+     * acquireToken will send prompt=create to the /authorize endpoint.  The user will be prompted to create a new account.
+     * Requires configuring authority as type "AzureADMyOrg" with a tenant_id.
+     * <p>
+     * Prerequisite: https://docs.microsoft.com/en-us/azure/active-directory/external-identities/self-service-sign-up-user-flow
      */
     CREATE;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdConnectPromptParameter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdConnectPromptParameter.java
@@ -58,7 +58,12 @@ public enum OpenIdConnectPromptParameter {
     /**
      * acquireToken will send prompt=consent to the authorize endpoint.  The user will be prompted to consent even if consent was granted before.
      */
-    CONSENT;
+    CONSENT,
+
+    /**
+     * acquireToken will send prompt=create to the authorize endpoint.  The use will be prompted to create a new account.
+     */
+    CREATE;
 
     @Override
     public String toString() {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptParameter.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptParameter.java
@@ -29,5 +29,6 @@ public enum PromptParameter {
     SELECT_ACCOUNT,
     LOGIN,
     CONSENT,
+    CREATE,
     WHEN_REQUIRED
 }


### PR DESCRIPTION
**What**
Pre-requisite Common PR for adding support for prompt=create in MSAL, where user is prompted to create a new account. MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1611

**Why**
Other MSAL Libraries also adding support: https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1233365

**How**
Adding fields to enumerator classes `OpenIdConnectPromptParameter` and `PromptParameter`.

**Testing**
Tested this end-to-end on local device in a tenant with a specified sign-up user flow. Added some unit tests in MSAL PR. 