### PR TITLE
Add null check to avoid NPE when checking for AccountTypesWithManagementDisabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Add null check to avoid NPE when checking for AccountTypesWithManagementDisabled (#1713)
 - [MINOR] Add prompt=create support. (#1707)
 - [PATCH] Clears client cert preferences so that multiple CBA login attempts can be completed in same session (#1688)
 - [PATCH] Fixing potential deadlock state in executor service for interactive requests (#1696)

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.identity.common.internal.util;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -31,10 +33,7 @@ import android.os.UserManager;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.logging.Logger;
-
-import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 
 public final class AccountManagerUtil {
     private static final String TAG = AccountManagerUtil.class.getSimpleName();
@@ -61,10 +60,15 @@ public final class AccountManagerUtil {
             // Check if our account type is disabled.
             final DevicePolicyManager devicePolicyManager =
                     (DevicePolicyManager) context.getSystemService(Context.DEVICE_POLICY_SERVICE);
-            for (final String accountType : devicePolicyManager.getAccountTypesWithManagementDisabled()) {
-                if (BROKER_ACCOUNT_TYPE.equalsIgnoreCase(accountType)) {
-                    Logger.verbose(methodTag, "Broker account type is disabled by MDM.");
-                    return false;
+            if (devicePolicyManager != null) {
+                final String[] accountTypesWithManagementDisabled = devicePolicyManager.getAccountTypesWithManagementDisabled();
+                if (accountTypesWithManagementDisabled != null) {
+                    for (final String accountType : accountTypesWithManagementDisabled) {
+                        if (BROKER_ACCOUNT_TYPE.equalsIgnoreCase(accountType)) {
+                            Logger.verbose(methodTag, "Broker account type is disabled by MDM.");
+                            return false;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Adding null checks to avoid NPE when checking for AccountTypesWithManagementDisabled

The method getAccountTypesWithManagementDisabled is defined as Nullable. Adding a null check before using the return value in for loop to avoid NullPointerException being thrown in the for loop. as it results in a crash.

For more details see oneauth crash bug: https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20CPP/Backlog%20items/?workitem=1853626
