### PR TITLE
Re-enabling the ability to set version number for common4j independently

### DIFF
--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -42,7 +42,7 @@ repositories {
     mavenCentral()
 }
 
-apply from: '../versioning/version_tasks.gradle'
+apply from: './versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,0 +1,4 @@
+#Wed May 12 20:08:39 UTC 2021
+versionName=1.0.5
+versionCode=1
+latestPatchVersion=227

--- a/common4j/versioning/version_tasks.gradle
+++ b/common4j/versioning/version_tasks.gradle
@@ -1,0 +1,71 @@
+def getVersionFile() {
+    return file("../versioning/version.properties")
+}
+
+def getVersionProps() {
+    def versionProps = new Properties()
+    getVersionFile().withInputStream { stream -> versionProps.load(stream) }
+    return versionProps
+}
+
+private String getVersionNamePatch() {
+    return (getVersionProps()['versionName'] =~ /[^.]+/)[2].toString()
+}
+
+private Integer getVersionNameMinor() {
+    return (getVersionProps()['versionName'] =~ /\d+/)[1].toInteger()
+}
+
+private Integer getVersionNameMajor() {
+    return (getVersionProps()['versionName'] =~ /\d+/)[0].toInteger()
+}
+
+private Integer getLatestPatchVersion() {
+    return getVersionProps()['latestPatchVersion'].toInteger()
+}
+
+ext.getAppVersionCode = {
+    getVersionProps()['versionCode'].toInteger()
+}
+
+ext.getAppVersionName = {
+    project.findProperty('projVersion') ?: getVersionProps()['versionName'].toString()
+}
+
+private void saveChanges(String versionName) {
+    def versionProps = getVersionProps()
+    versionProps['versionName'] = versionName
+    versionProps.store(getVersionFile().newWriter(), null)
+}
+
+private void incrementLatestVersion() {
+    def versionProps = getVersionProps()
+    versionProps["latestPatchVersion"] = (getLatestPatchVersion() + 1).toString()
+    versionProps.store(getVersionFile().newWriter(), null)
+}
+
+task incrementLatestVersionNumber() {
+    doLast {
+        incrementLatestVersion()
+    }
+}
+
+task versionSnapshot {
+    doLast {
+        def versionNameMajor = getVersionNameMajor()
+        def versionNameMinor = getVersionNameMinor()
+        def versionNamePatch = getVersionNamePatch()
+        def versionName = "${versionNameMajor}.${versionNameMinor}.${versionNamePatch}-SNAPSHOT".toString()
+        saveChanges(versionName)
+    }
+}
+
+task versionLatest {
+    doLast {
+        def versionNameMajor = '0'
+        def versionNameMinor = '0'
+        def versionNamePatch = getLatestPatchVersion()
+        def versionName = "${versionNameMajor}.${versionNameMinor}.${versionNamePatch}".toString()
+        saveChanges(versionName)
+    }
+}

--- a/common4j/versioning/version_tasks.gradle
+++ b/common4j/versioning/version_tasks.gradle
@@ -1,5 +1,5 @@
 def getVersionFile() {
-    return file("../versioning/version.properties")
+    return file("./versioning/version.properties")
 }
 
 def getVersionProps() {


### PR DESCRIPTION
Re-enabling the ability to set version number for common4j independently (was removed in PR#1625

- Adding version,properties and version_tasks.gradle file back for common4j, which are used to define the version number for common4j library.