### PR TITLE
Update version number for common and common4j to RC1 for next release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 V.Next
 ----------
+
+Version 4.1.0
+----------
 - [PATCH] Add null check to avoid NPE when checking for AccountTypesWithManagementDisabled (#1713)
 - [MINOR] Add prompt=create support. (#1707)
 - [PATCH] Clears client cert preferences so that multiple CBA login attempts can be completed in same session (#1688)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "0.0.+"
+def common4jVersion = "1.1.0-RC1"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -42,7 +42,7 @@ repositories {
     mavenCentral()
 }
 
-apply from: '../versioning/version_tasks.gradle'
+apply from: './versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,0 +1,4 @@
+#Wed May 12 20:08:39 UTC 2021
+versionName=1.0.5
+versionCode=1
+latestPatchVersion=227

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.0.5
+versionName=1.1.0-RC1
 versionCode=1
 latestPatchVersion=227

--- a/common4j/versioning/version_tasks.gradle
+++ b/common4j/versioning/version_tasks.gradle
@@ -1,0 +1,71 @@
+def getVersionFile() {
+    return file("./versioning/version.properties")
+}
+
+def getVersionProps() {
+    def versionProps = new Properties()
+    getVersionFile().withInputStream { stream -> versionProps.load(stream) }
+    return versionProps
+}
+
+private String getVersionNamePatch() {
+    return (getVersionProps()['versionName'] =~ /[^.]+/)[2].toString()
+}
+
+private Integer getVersionNameMinor() {
+    return (getVersionProps()['versionName'] =~ /\d+/)[1].toInteger()
+}
+
+private Integer getVersionNameMajor() {
+    return (getVersionProps()['versionName'] =~ /\d+/)[0].toInteger()
+}
+
+private Integer getLatestPatchVersion() {
+    return getVersionProps()['latestPatchVersion'].toInteger()
+}
+
+ext.getAppVersionCode = {
+    getVersionProps()['versionCode'].toInteger()
+}
+
+ext.getAppVersionName = {
+    project.findProperty('projVersion') ?: getVersionProps()['versionName'].toString()
+}
+
+private void saveChanges(String versionName) {
+    def versionProps = getVersionProps()
+    versionProps['versionName'] = versionName
+    versionProps.store(getVersionFile().newWriter(), null)
+}
+
+private void incrementLatestVersion() {
+    def versionProps = getVersionProps()
+    versionProps["latestPatchVersion"] = (getLatestPatchVersion() + 1).toString()
+    versionProps.store(getVersionFile().newWriter(), null)
+}
+
+task incrementLatestVersionNumber() {
+    doLast {
+        incrementLatestVersion()
+    }
+}
+
+task versionSnapshot {
+    doLast {
+        def versionNameMajor = getVersionNameMajor()
+        def versionNameMinor = getVersionNameMinor()
+        def versionNamePatch = getVersionNamePatch()
+        def versionName = "${versionNameMajor}.${versionNameMinor}.${versionNamePatch}-SNAPSHOT".toString()
+        saveChanges(versionName)
+    }
+}
+
+task versionLatest {
+    doLast {
+        def versionNameMajor = '0'
+        def versionNameMinor = '0'
+        def versionNamePatch = getLatestPatchVersion()
+        def versionName = "${versionNameMajor}.${versionNameMinor}.${versionNamePatch}".toString()
+        saveChanges(versionName)
+    }
+}

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.0.3
+versionName=4.1.0-RC1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
In this change
- Cherry-Picked #1714 
- Update version number for common4j to 1.1.0-RC1
- Update version number for common to 4.1.0-RC1
- Update changelog to reflect changes in release 4.1.0