### PR TITLE
Fix artifact path in vsts-release-template

### DIFF
--- a/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
+++ b/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
@@ -53,13 +53,13 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: 'Publish lint report'
     inputs:
-      targetPath: $(Build.SourcesDirectory)\${{ parameters.project }}\build\reports
+      targetPath: $(Build.SourcesDirectory)/${{ parameters.project }}/build/reports
       ArtifactName: Lint Report and Spotbugs
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ${{ parameters.project }} Release'
     inputs:
       ArtifactName: ${{ parameters.project }}Release
-      TargetPath:  $(Build.SourcesDirectory)\${{ parameters.project }}\build\outputs
+      TargetPath:  $(Build.SourcesDirectory)/${{ parameters.project }}/build/outputs
   - task: Gradle@2
     displayName: Publish to VSTS
     inputs:


### PR DESCRIPTION
Using the Linux based path separator as the pipeline runs on ubuntu agents

Successful run after the change: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=908018&view=results

Related #1716 