### PR TITLE
Add exception handling in Content Provider strategy, for broker communication

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,11 @@
 V.Next
 ----------
+- [PATCH] Add exception handling in Content Provider strategy, for broker communication (#1722)
 - [MINOR] Support TenantID value from eSTS in PKeyAuth flows (#1712)
 - [MINOR] Implement cert loader for both multiple and legacy WPJ data store in PKeyAuth (#1711)
+
+Version 4.1.0
+----------
 - [PATCH] Add null check to avoid NPE when checking for AccountTypesWithManagementDisabled (#1713)
 - [MINOR] Add prompt=create support. (#1707)
 - [PATCH] Clears client cert preferences so that multiple CBA login attempts can be completed in same session (#1688)
@@ -14,6 +18,9 @@ V.Next
 - [MINOR] Add flighting parameters to commmandParameters (#1562)
 - [MINOR] Add ropc command and ropc flow to BaseController (#1539)
 - [PATCH] Move to commitNow() instead of commit() when removing authorization fragment from provided fragment manager.  Add exception handling/logging.  (#1695851)
+
+Version 4.0.5
+----------
 - [PATCH] Ensure a device pop manager is provided when PoPAuthenticationScheme is requested of the broker (#1706)
 
 Version 4.0.4

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
@@ -22,6 +22,12 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker.ipc;
 
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.AUTHORITY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.CONTENT_SCHEME;
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
+
 import android.content.Context;
 import android.content.pm.ProviderInfo;
 import android.database.Cursor;
@@ -37,12 +43,6 @@ import com.microsoft.identity.common.internal.util.ParcelableUtil;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;
-
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.AUTHORITY;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.BrokerContentProvider.CONTENT_SCHEME;
-import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
-import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE;
-import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
 
 /**
  * A strategy for communicating with the targeted broker via Content Provider.
@@ -90,18 +90,25 @@ public class ContentProviderStrategy implements IIpcStrategy {
         );
 
         if (cursor != null) {
-            final Bundle resultBundle = cursor.getExtras();
-            cursor.close();
+            try {
+                final Bundle resultBundle = cursor.getExtras();
 
-            if (resultBundle == null) {
-                final String message = "Received an empty bundle. This means the operation is not supported on the other side. " +
-                        "If you're using a newer feature, please bump the minimum protocol version.";
-                Logger.error(methodTag, message, null);
-                throw new BrokerCommunicationException(OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE, getType(), message, null);
+                if (resultBundle == null) {
+                    final String message = "Received an empty bundle. This means the operation is not supported on the other side. " +
+                            "If you're using a newer feature, please bump the minimum protocol version.";
+                    Logger.error(methodTag, message, null);
+                    throw new BrokerCommunicationException(OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE, getType(), message, null);
+                }
+
+                Logger.info(methodTag, "Received successful result from Broker Content Provider.");
+                return resultBundle;
+            } catch (final RuntimeException exception) {
+                final String message = "Failed to get result from Broker Content Provider";
+                Logger.error(methodTag, message, exception);
+                throw new BrokerCommunicationException(CONNECTION_ERROR, getType(), message, null);
+            } finally {
+                cursor.close();
             }
-
-            Logger.info(methodTag, "Received successful result from Broker Content Provider.");
-            return resultBundle;
         } else {
             final String message = "Failed to get result from Broker Content Provider, cursor is null";
             Logger.error(methodTag, message, null);


### PR DESCRIPTION
### What
Adding Exception handling for handling RuntimeException in ContentProvider Strategy, when communicating to Broker

### Why
OneAuth Bug: https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20CPP/Backlog%20items/?workitem=1634341
There are a number of failures being reported in telemetry on oneauth side due to Runtime Exception during Broker Communication via ContentProvider.
As this exception is not handled the communication fails and does not fallback to other strategies.

From AOSP [source code](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/database/BulkCursorToCursorAdaptor.java;l=61;drc=master) this looks like due to a reliability issue with ContentProvider
![image](https://user-images.githubusercontent.com/75644120/164561217-4f27badd-bcb4-4057-b57f-0f7a121efe0f.png)


### How
Adding exception handling around RuntimeException and throwing BrokerCommunicationException so that we can fallback and retry with other strategies. (BoundService and AccoutnManager)