### PR TITLE
UI Automation changes to support local install source for WordApp

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Support WordApp local apk install in UI automation flows (#1732)
 - [PATCH] Add exception handling in Content Provider strategy, for broker communication (#1722)
 - [MINOR] Support TenantID value from eSTS in PKeyAuth flows (#1712)
 - [MINOR] Implement cert loader for both multiple and legacy WPJ data store in PKeyAuth (#1711)

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -46,6 +46,8 @@ android {
     // defaults to LocalApkFile - the file must be pushed to the device before tests
     def brokerInstallationSource = installSourcePlayStore
 
+    def wordAppInstallationSource = installSourcePlayStore
+
     if (project.hasProperty("brokerSource")) {
         if (brokerSource.equalsIgnoreCase(installSourcePlayStore)) {
             brokerInstallationSource = installSourcePlayStore
@@ -58,6 +60,17 @@ android {
         }
     }
 
+    if (project.hasProperty("wordAppSource")) {
+        if (wordAppSource.equalsIgnoreCase(installSourcePlayStore)) {
+            wordAppInstallationSource = installSourcePlayStore
+        } else if (wordAppSource.equalsIgnoreCase(installSourceLocalApk)) {
+            wordAppInstallationSource = installSourceLocalApk
+        } else {
+            throw new InvalidUserDataException("Unsupported word app source provided: "
+                    + wordAppSource
+                    + " Only the following wordAppSource sources are supported: PlayStore , LocalApk");
+        }
+    }
 
     defaultConfig {
         multiDexEnabled true
@@ -68,6 +81,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BROKER_INSTALL_SOURCE", "\"$brokerInstallationSource\"")
+        buildConfigField("String", "WORD_APP_INSTALL_SOURCE", "\"$wordAppInstallationSource\"")
         buildConfigField("String", "INSTALL_SOURCE_PLAY_STORE", "\"$installSourcePlayStore\"")
         buildConfigField("String", "INSTALL_SOURCE_LOCAL_APK", "\"$installSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/WordApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/WordApp.java
@@ -29,6 +29,9 @@ import androidx.annotation.NonNull;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
+import com.microsoft.identity.client.ui.automation.BuildConfig;
+import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
+import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
 import com.microsoft.identity.client.ui.automation.installer.PlayStore;
 import com.microsoft.identity.client.ui.automation.interaction.FirstPartyAppPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
@@ -46,14 +49,20 @@ public class WordApp extends App implements IFirstPartyApp {
     private final static String TAG = WordApp.class.getSimpleName();
     public static final String WORD_PACKAGE_NAME = "com.microsoft.office.word";
     public static final String WORD_APP_NAME = "Microsoft Word";
+    public final static String WORD_APK = "Word.apk";
+    public final static IAppInstaller DEFAULT_WORD_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
+            .equalsIgnoreCase(BuildConfig.WORD_APP_INSTALL_SOURCE)
+            ? new LocalApkInstaller() : new PlayStore();
 
     public WordApp() {
-        super(WORD_PACKAGE_NAME, WORD_APP_NAME, new PlayStore());
+        super(WORD_PACKAGE_NAME, WORD_APP_NAME, DEFAULT_WORD_APP_INSTALLER);
+        localApkFileName = WORD_APK;
     }
 
     @Override
     public void handleFirstRun() {
-        CommonUtils.grantPackagePermission(); // grant permission to access storage
+        // First run side loaded in automation does not request for access storage permission
+        // CommonUtils.grantPackagePermission(); // grant permission to access storage
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -71,11 +71,6 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         localApkFileName = COMPANY_PORTAL_APK;
     }
 
-    public BrokerCompanyPortal(@NonNull final IAppInstaller appInstaller) {
-        super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME, appInstaller);
-        localApkFileName = COMPANY_PORTAL_APK;
-    }
-
     @Override
     public void performDeviceRegistration(@NonNull final String username,
                                           @NonNull final String password) {
@@ -165,7 +160,8 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     @Override
     public void handleFirstRun() {
         // click the I AGREE btn on privacy screen
-        UiAutomatorUtils.handleButtonClick("com.microsoft.windowsintune.companyportal:id/privacy_notice_agree_button");
+        // First run of CP from playstore does not have a privacy screen
+        // UiAutomatorUtils.handleButtonClick("com.microsoft.windowsintune.companyportal:id/privacy_notice_agree_button");
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -71,6 +71,11 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         localApkFileName = COMPANY_PORTAL_APK;
     }
 
+    public BrokerCompanyPortal(@NonNull final IAppInstaller appInstaller) {
+        super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME, appInstaller);
+        localApkFileName = COMPANY_PORTAL_APK;
+    }
+
     @Override
     public void performDeviceRegistration(@NonNull final String username,
                                           @NonNull final String password) {


### PR DESCRIPTION
**The Problem**
We currently support WordApp installation from the playstore; however, we now see that on API 29 on emulators, word app has stopped support for installation from playstore.

In this PR, Added support to install wordApp using a localAPK

**Implementation**
We need to add a WordAppSource build config field, which will be LocalApk when we need to install using the localApk. This is similar to how we install broker apps using the config

By default, we set it to playstore.

The -pWordAppSource build config field will be set while running the test cases.

![image](https://user-images.githubusercontent.com/69237821/167085831-c4c4eb3f-3b54-4f9b-bc0a-e6738b3945b4.png)

**Changes Made**

- Made changes in build.gradle to set the wordApp install source property
- Note : Also made changes to some first run UI automation for WordApp and CP as we no longer see some screens like Privacy consent and grant storage permission. 

**Testing**
Added UI test cases in BrokerAutomationApp module to verify the changes..  test case PR https://github.com/AzureAD/ad-accounts-for-android/pull/1879