### PR TITLE
Directly support DayNight in http_auth_dialog.xml

### DIFF
--- a/common/src/main/res/layout/http_auth_dialog.xml
+++ b/common/src/main/res/layout/http_auth_dialog.xml
@@ -8,6 +8,7 @@
     android:paddingRight="@dimen/http_auth_dialog_padding_right" >
 
     <EditText
+        style="@style/Theme.AppCompat.DayNight"
         android:inputType="text"
         android:id="@+id/editUserName"
         android:layout_width="match_parent"
@@ -20,6 +21,7 @@
     </EditText>
 
     <EditText
+        style="@style/Theme.AppCompat.DayNight"
         android:id="@+id/editPassword"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Had a recent ICM (https://portal.microsofticm.com/imp/v3/incidents/details/300034065/home) where a user was running into NTLM prompt on teams device and text entered in username/password boxes was matching colors with the background of the TextEdit object, so the text was invisible to the user. This looked like the font color was set from dark mode, but background color was not. Could not reproduce this locally, think this would fix the problem of mishandling DayNight Mode.