### PR TITLE
changing changelog entry from minor to major with details

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [MINOR] Adding YubiKit SDK dependency; added keyboard flag to android:configChanges for all activities that could interact with a YubiKey. (#1729)
+- [MAJOR] Adding YubiKit SDK, which requires Java Version 8 and will thus bump up Java version overall to 8; added keyboard flag to android:configChanges for all activities that could interact with a YubiKey. (#1729)
 - [MINOR] Support WordApp local apk install in UI automation flows (#1732)
 - [PATCH] Add exception handling in Content Provider strategy, for broker communication (#1722)
 - [MINOR] Support TenantID value from eSTS in PKeyAuth flows (#1712)


### PR DESCRIPTION
This is a small change to the already merged PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1729
Due to the addition of YubiKit SDK, all host apps that consume libraries that use common will need to support Java Version 8, which is a MAJOR change instead of a MINOR change.