### PR TITLE
BrokerHost - utility functions added

### DIFF
--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -182,6 +182,7 @@ dependencies {
     implementation "androidx.test:monitor:$rootProject.ext.androidxTestMonitorVersion"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     implementation(project(":LabApiUtilities"))
+    implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     androidTestImplementation "androidx.test:runner:$rootProject.ext.androidxTestRunnerVersion"

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -162,4 +162,10 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
     public void setFlights(@Nullable final String flightsJson) {
         // Default implementation, Do nothing.
     }
+
+    @Override
+    public String getFlights() {
+        // Default implementation, Do nothing.
+        return "";
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -171,7 +171,7 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     }
 
     public void enrollDevice(@NonNull final String username,
-                             @NonNull final String password, @NonNull final Boolean isFederated) {
+                             @NonNull final String password, final boolean isFederated) {
         Logger.i(TAG, "Enroll Device for the given account..");
         launch(); // launch CP app
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -39,9 +39,7 @@ import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegrate
 import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
 import com.microsoft.identity.client.ui.automation.device.settings.SamsungSettings;
-import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
@@ -53,7 +51,7 @@ import java.util.Random;
 import lombok.Getter;
 
 import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
-import static org.junit.Assert.fail;
+
 
 /**
  * A model for interacting with the Company Portal Broker App during UI Test.
@@ -173,7 +171,7 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     }
 
     public void enrollDevice(@NonNull final String username,
-                             @NonNull final String password, @NonNull final boolean isFederated) {
+                             @NonNull final String password, @NonNull final Boolean isFederated) {
         Logger.i(TAG, "Enroll Device for the given account..");
         launch(); // launch CP app
 
@@ -193,14 +191,7 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
                     .build();
 
             final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler(promptHandlerParameters);
-
-            Logger.i(TAG, "Handle prompt in ADFS login page for enrolling device..");
-            // handle AAD login page for username
-            UiAutomatorUtils.handleInput("i0116", username);
-            UiAutomatorUtils.handleButtonClick("idSIButton9");
-
-            // handle ADFS login page for password
-            microsoftStsPromptHandler.getLoginComponentHandler().handlePasswordField(password);
+            ((AdfsLoginComponentHandler) microsoftStsPromptHandler.getLoginComponentHandler()).handleEnrollmentPrompt(username, password);
         } else {
             final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
                     .prompt(PromptParameter.LOGIN)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
@@ -101,4 +101,11 @@ public interface ITestBroker extends IApp {
      * @param flightsJson the json representation of the flight key and value pairs {"key1":"value"}.
      */
     void setFlights(@Nullable final String flightsJson);
+
+    /**
+     * The flight information set for this broker app.
+     *
+     * @return the flight information set for this broker app
+     */
+    String getFlights();
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -307,7 +307,7 @@ public class GoogleSettings extends BaseSettings {
         if (android.os.Build.VERSION.SDK_INT == 28) {
             UiAutomatorUtils.handleButtonClick("com.android.settings:id/redaction_done_button");
         } else {
-            final UiObject doneButton = UiAutomatorUtils.obtainUiObjectWithExactText("DONE");
+            final UiObject doneButton = UiAutomatorUtils.obtainUiObjectWithExactText("Done");
             doneButton.click();
         }
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -307,7 +307,7 @@ public class GoogleSettings extends BaseSettings {
         if (android.os.Build.VERSION.SDK_INT == 28) {
             UiAutomatorUtils.handleButtonClick("com.android.settings:id/redaction_done_button");
         } else {
-            final UiObject doneButton = UiAutomatorUtils.obtainUiObjectWithExactText("Done");
+            final UiObject doneButton = UiAutomatorUtils.obtainUiObjectWithExactText("DONE");
             doneButton.click();
         }
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -45,4 +45,16 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
         UiAutomatorUtils.handleInput("passwordInput", password);
         UiAutomatorUtils.handleButtonClick("submitButton");
     }
+
+    /**
+     * Enters username, password in email, password fields of an enrollment page
+     */
+    public void handleEnrollmentPrompt(@NonNull final String username, @NonNull final String password) {
+        Logger.i(TAG, "Handle prompt in ADFS login page for enrolling");
+        // handle AAD login page for username
+        UiAutomatorUtils.handleInput("i0116", username);
+        UiAutomatorUtils.handleButtonClick("idSIButton9");
+
+        handlePasswordField(password);
+    }
 }


### PR DESCRIPTION
**What** : Added utility functions like getAllAccounts, removeAccounts, confirmNoncePresent which are useful for testing the Broker APIs

**Why** : The utility functions added are emulating the user action to click on the getAccounts, getFlights and other buttons in BrokerHost app and also to test the response displayed in the dialog box after the functionality is completed.
These are some common functions used across test cases. Hence added these in BrokerHost class.
The utility functions added here are being used in the testcases introduced in the following PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1633

**Testing** :  Tested the utility functions by invoking them using the test cases introduced in this PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1633
The test cases ran successfully