### PR TITLE
Do not send x-ms-PKeyAuth header to both auth and token endpoint.

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -306,7 +306,8 @@ public abstract class BaseController {
             completeRequestHeaders.put(AuthenticationConstants.AAD.APP_VERSION,
                     parameters.getApplicationVersion()
             );
-            completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
+            // ADO:TODO:1934500 - Reverting this change as this is considered a "breaking change" fix.
+            //completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
             setBuilderProperties(builder, parameters, interactiveTokenCommandParameters, completeRequestHeaders);

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -306,8 +306,7 @@ public abstract class BaseController {
             completeRequestHeaders.put(AuthenticationConstants.AAD.APP_VERSION,
                     parameters.getApplicationVersion()
             );
-            // ADO:TODO:1934500 - Reverting this change as this is considered a "breaking change" fix.
-            //completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
+            completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
             setBuilderProperties(builder, parameters, interactiveTokenCommandParameters, completeRequestHeaders);

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -213,7 +213,8 @@ public abstract class OAuth2Strategy
         headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, Device.getProductVersion());
         headers.putAll(EstsTelemetry.getInstance().getTelemetryHeaders());
         headers.put(HttpConstants.HeaderField.CONTENT_TYPE, TOKEN_REQUEST_CONTENT_TYPE);
-        headers.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
+        // ADO:TODO:1934500 - Reverting this change as this is considered a "breaking change" fix.
+        //headers.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
         if (request instanceof MicrosoftTokenRequest) {
             headers.put(


### PR DESCRIPTION
Sending the x-ms-PKeyAuth to both auth and token endpoint, included in the PR #1687 is considered as a "breaking change" fix. 

### Why
The clients in this particular scenario depend on that we are not sending the PkeyAuthHeader for the request to fail and fallback to the interruptflow without going through the performPKeyAuthRequest. (see [performTokenRequest](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/e1f1a640c612f650764158eab23ef1c9968e09a4/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java#L492))

As up today we do not know how many customers rely on this broken flow. We decide to revert this change in this current release (5.0.0) and add it to the next one as a major release with breaking changes.


related ICM: [31201066](https://portal.microsofticm.com/imp/v3/incidents/details/312010665/home)