### PR TITLE
Added auth scheme PoP changes in uiautomationutilities for enabling AT-PoP scenario automation

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerPara
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AdfsLoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AdfsPromptHandler;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
@@ -134,19 +135,18 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
         );
 
         if (isFederatedUser) {
-            final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
+            final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                     .prompt(PromptParameter.LOGIN)
                     .consentPageExpected(false)
                     .expectingLoginPageAccountPicker(false)
                     .sessionExpected(false)
-                    .isFederated(true)
                     .loginHint(null)
                     .build();
 
-            final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler(promptHandlerParameters);
-            AdfsLoginComponentHandler adfsLoginComponentHandler = ((AdfsLoginComponentHandler) microsoftStsPromptHandler.getLoginComponentHandler());
-            // Handle prompt in ADFS login page
-            adfsLoginComponentHandler.handlePrompt(username, password);
+            final AdfsPromptHandler adfsPromptHandler = new AdfsPromptHandler(promptHandlerParameters);
+            Logger.i(TAG, "Handle prompt of ADFS login page for Device Registration..");
+            // handle ADFS login page
+            adfsPromptHandler.handlePrompt(username, password);
         } else {
             final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                     .broker(this)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -40,6 +40,9 @@ import com.microsoft.identity.client.ui.automation.installer.PlayStore;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AdfsLoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
@@ -59,6 +62,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
     public final static IAppInstaller DEFAULT_BROKER_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
             .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
+
     @Override
     public void uninstall() {
         super.uninstall();
@@ -112,7 +116,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
 
     @Override
     public void performJoinViaJoinActivity(@NonNull final String username,
-                                           @NonNull final String password) {
+                                           @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Perform Join Via Join Activity for the given account..");
         // Enter username
         UiAutomatorUtils.handleInput(
@@ -129,18 +133,40 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
                 )
         );
 
-        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
-                .broker(this)
-                .prompt(PromptParameter.SELECT_ACCOUNT)
-                .loginHint(username)
-                .sessionExpected(false)
-                .build();
+        if (isFederatedUser) {
+            final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
+                    .prompt(PromptParameter.LOGIN)
+                    .consentPageExpected(false)
+                    .expectingLoginPageAccountPicker(false)
+                    .sessionExpected(false)
+                    .isFederated(true)
+                    .loginHint(null)
+                    .build();
 
-        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+            final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler(promptHandlerParameters);
+            AdfsLoginComponentHandler adfsLoginComponentHandler = ((AdfsLoginComponentHandler) microsoftStsPromptHandler.getLoginComponentHandler());
+            // Handle prompt in ADFS login page
+            adfsLoginComponentHandler.handlePrompt(username, password);
+        } else {
+            final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                    .broker(this)
+                    .prompt(PromptParameter.SELECT_ACCOUNT)
+                    .loginHint(username)
+                    .sessionExpected(false)
+                    .build();
 
-        Logger.i(TAG, "Handle prompt in AAD login page for Join Via Join Activity..");
-        // Handle prompt in AAD login page
-        aadPromptHandler.handlePrompt(username, password);
+            final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+
+            Logger.i(TAG, "Handle prompt in AAD login page for Join Via Join Activity..");
+            // Handle prompt in AAD login page
+            aadPromptHandler.handlePrompt(username, password);
+        }
+    }
+
+    @Override
+    public void performJoinViaJoinActivity(@NonNull final String username,
+                                           @NonNull final String password) {
+        performJoinViaJoinActivity(username, password, false);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -88,6 +88,17 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         );
     }
 
+    public void performDeviceRegistrationForFederatedUser(@NonNull final String username,
+                                          @NonNull final String password, final boolean isFederatedUser) {
+        Logger.i(TAG, "Perform Device Registration for the given federate account..");
+        TestContext.getTestContext().getTestDevice().getSettings().addWorkAccount(
+                this,
+                username,
+                password,
+                true
+        );
+    }
+
     @Override
     public void performSharedDeviceRegistration(@NonNull final String username,
                                                 @NonNull final String password) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -88,14 +88,16 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         );
     }
 
-    public void performDeviceRegistrationForFederatedUser(@NonNull final String username,
-                                          @NonNull final String password, final boolean isFederatedUser) {
+    @Override
+    public void performDeviceRegistration(@NonNull final String username,
+                                          @NonNull final String password,
+                                          final boolean isFederatedUser) {
         Logger.i(TAG, "Perform Device Registration for the given federate account..");
         TestContext.getTestContext().getTestDevice().getSettings().addWorkAccount(
                 this,
                 username,
                 password,
-                true
+                isFederatedUser
         );
     }
 
@@ -182,7 +184,8 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     }
 
     public void enrollDevice(@NonNull final String username,
-                             @NonNull final String password, final boolean isFederated) {
+                             @NonNull final String password,
+                             final boolean isFederated) {
         Logger.i(TAG, "Enroll Device for the given account..");
         launch(); // launch CP app
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -36,6 +36,7 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AdfsPromptHandler;
 import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -79,12 +80,18 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     @Override
     public void performDeviceRegistration(@NonNull final String username,
                                           @NonNull final String password) {
+        performDeviceRegistration(username, password, false);
+    }
+
+    @Override
+    public void performDeviceRegistration(String username, String password, boolean isFederatedUser) {
         Logger.i(TAG, "Performing Device Registration for the given account..");
         performDeviceRegistrationHelper(
                 username,
                 password,
                 "com.azure.authenticator:id/email_input",
-                "com.azure.authenticator:id/register_button"
+                "com.azure.authenticator:id/register_button",
+                isFederatedUser
         );
 
 
@@ -132,7 +139,8 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
                 username,
                 password,
                 "com.azure.authenticator:id/shared_device_registration_email_input",
-                "com.azure.authenticator:id/shared_device_registration_button"
+                "com.azure.authenticator:id/shared_device_registration_button",
+                false
         );
 
         final UiDevice device =
@@ -345,7 +353,8 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     private void performDeviceRegistrationHelper(@NonNull final String username,
                                                  @NonNull final String password,
                                                  @NonNull final String emailInputResourceId,
-                                                 @NonNull final String registerBtnResourceId) {
+                                                 @NonNull final String registerBtnResourceId,
+                                                 final boolean isFederatedUser) {
         Logger.i(TAG, "Execution of Helper for Device Registration..");
         // open device registration page
         openDeviceRegistrationPage();
@@ -369,11 +378,18 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
                 .loginHint(username)
                 .build();
 
-        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+        if (isFederatedUser) {
+            final AdfsPromptHandler adfsPromptHandler = new AdfsPromptHandler(promptHandlerParameters);
+            Logger.i(TAG, "Handle prompt of ADFS login page for Device Registration..");
+            // handle ADFS login page
+            adfsPromptHandler.handlePrompt(username, password);
+        } else {
+            final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
 
-        Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
-        // handle AAD login page
-        aadPromptHandler.handlePrompt(username, password);
+            Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
+            // handle AAD login page
+            aadPromptHandler.handlePrompt(username, password);
+        }
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
@@ -67,6 +67,15 @@ public interface ITestBroker extends IApp {
     void performJoinViaJoinActivity(String username, String password);
 
     /**
+     * Perform device registration from the Join Activity using the supplied user account.
+     *
+     * @param username username of the account to use for registration
+     * @param password password of the account to use for registration
+     * @param isFederatedUser true if it is a federated user
+     */
+    void performJoinViaJoinActivity(String username, String password, boolean isFederatedUser);
+
+    /**
      * Confirm that device registered with the supplied UPN by comparing it with the UPN
      * displayed in Join Activity.
      *

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
@@ -50,6 +50,15 @@ public interface ITestBroker extends IApp {
     void performDeviceRegistration(String username, String password);
 
     /**
+     * Perform device registration with supplied username.
+     *
+     * @param username username of the account to use for registration
+     * @param password password of the account to use for registration
+     * @param isFederatedUser set to true if the user is a federated user
+     */
+    void performDeviceRegistration(String username, String password, boolean isFederatedUser);
+
+    /**
      * Perform shared device registration with supplied username. This user must be a cloud device
      * admin for the registration to actually succeed.
      *

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client.ui.automation.constants;
 
 public enum AuthScheme {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
@@ -1,0 +1,6 @@
+package com.microsoft.identity.client.ui.automation.constants;
+
+public enum AuthScheme {
+    BEARER,
+    POP
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -121,7 +121,8 @@ public class GoogleSettings extends BaseSettings {
 
     public void addWorkAccount(@NonNull final ITestBroker broker,
                                @NonNull final String username,
-                               @NonNull final String password, final boolean isFederatedUser) {
+                               @NonNull final String password,
+                               final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Google Device..");
         launchAddAccountPage();
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -116,6 +116,12 @@ public class GoogleSettings extends BaseSettings {
     public void addWorkAccount(@NonNull final ITestBroker broker,
                                @NonNull final String username,
                                @NonNull final String password) {
+        addWorkAccount(broker, username, password, false);
+    }
+
+    public void addWorkAccount(@NonNull final ITestBroker broker,
+                               @NonNull final String username,
+                               @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Google Device..");
         launchAddAccountPage();
 
@@ -127,7 +133,7 @@ public class GoogleSettings extends BaseSettings {
             workAccount.click();
 
             // perform Join using the supplied broker
-            broker.performJoinViaJoinActivity(username, password);
+            broker.performJoinViaJoinActivity(username, password, isFederatedUser);
 
             final UiDevice device =
                     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
@@ -245,7 +251,6 @@ public class GoogleSettings extends BaseSettings {
                 Text
         );
     }
-
 
     private UiObject obtainDisableAdminButton(final DeviceAdmin deviceAdmin) {
         Logger.i(TAG, "Obtain Disable Admin Button on Google Device..");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -73,6 +73,19 @@ public interface ISettings {
                         final String password);
 
     /**
+     * Add the supplied account to the device via Account Manager.
+     *
+     * @param expectedBroker  the broker expected to be used for the account type
+     * @param username        the username of the account to add
+     * @param password        the password of the account to add
+     * @param isFederatedUser whether the user is federated user or not
+     */
+    void addWorkAccount(final ITestBroker expectedBroker,
+                        final String username,
+                        final String password,
+                        final boolean isFederatedUser);
+
+    /**
      * Launch the date & time page in Settings app.
      */
     void launchDateTimeSettingsPage();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -115,6 +115,12 @@ public class SamsungSettings extends BaseSettings {
     public void addWorkAccount(@NonNull final ITestBroker broker,
                                @NonNull final String username,
                                @NonNull final String password) {
+        addWorkAccount(broker, username, password, false);
+    }
+
+    @Override
+    public void addWorkAccount(@NonNull final ITestBroker broker, @NonNull final String username,
+                               @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Samsung Device..");
         launchAddAccountPage();
 
@@ -129,7 +135,7 @@ public class SamsungSettings extends BaseSettings {
             workAccount.click();
 
             // add work account by performing join via the broker
-            broker.performJoinViaJoinActivity(username, password);
+            broker.performJoinViaJoinActivity(username, password, isFederatedUser);
 
             // activate broker app as admin
             activateAdmin();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -119,8 +119,10 @@ public class SamsungSettings extends BaseSettings {
     }
 
     @Override
-    public void addWorkAccount(@NonNull final ITestBroker broker, @NonNull final String username,
-                               @NonNull final String password, final boolean isFederatedUser) {
+    public void addWorkAccount(@NonNull final ITestBroker broker,
+                               @NonNull final String username,
+                               @NonNull final String password,
+                               final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Samsung Device..");
         launchAddAccountPage();
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -54,7 +54,14 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
         // handle AAD login page for username
         UiAutomatorUtils.handleInput("i0116", username);
         UiAutomatorUtils.handleButtonClick("idSIButton9");
+    }
 
+    /**
+     * Enters username, password in email, password fields of a login page
+     */
+    public void handlePrompt(@NonNull final String username, @NonNull final String password) {
+        Logger.i(TAG, "Handle prompt in ADFS login page for login");
+        handleEmailField(username);
         handlePasswordField(password);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -55,13 +55,4 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
         UiAutomatorUtils.handleInput("i0116", username);
         UiAutomatorUtils.handleButtonClick("idSIButton9");
     }
-
-    /**
-     * Enters username, password in email, password fields of a login page
-     */
-    public void handlePrompt(@NonNull final String username, @NonNull final String password) {
-        Logger.i(TAG, "Handle prompt in ADFS login page for login");
-        handleEmailField(username);
-        handlePasswordField(password);
-    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/LoadLabUserTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/LoadLabUserTestRule.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class LoadLabUserTestRule implements TestRule {
 
-    private final static String TAG = LoadLabUserTestRule.class.getSimpleName();
+    private static final String TAG = LoadLabUserTestRule.class.getSimpleName();
 
     public static final long TEMP_USER_WAIT_TIME = TimeUnit.SECONDS.toMillis(20);
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthResult.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthResult.java
@@ -79,4 +79,8 @@ public abstract class AuthResult {
     public boolean isAccessTokenEqual(String accessToken){
         return accessToken.equals(this.accessToken);
     }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthTestParams.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthTestParams.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.client.ui.automation.sdk;
 
 import android.app.Activity;
 
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -41,4 +43,5 @@ public class AuthTestParams {
     private final String redirectUri;
     private final String authority;
     private final Activity activity;
+    private final AuthScheme authScheme;
 }


### PR DESCRIPTION
What : Added some msal automation test cases in this PR https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1637.  
The current PR is for : 
1. adding auth scheme to auth params.
2. When we perform device registration for federated users, we should be able to use ADFSHandler instead of AADHandler in the automation test cases. Hence made changes to methods files like addWorkAccount and performJoin that carry the federated flag forward till the time the promptHandler is created in the broker.

Testing : Tested the new test cases added using this common PR changes. Also tested the existing testcases that were using performDeviceRegistration and addWorkAccount methods to see if they are working successfully after this change.