### PR TITLE
Add Oneauth in assemble consumers

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -246,8 +246,7 @@ stages:
       - task: MavenAuthenticate@0
         displayName: Authenticate to the IdentityDivision Android Maven feed
         inputs:
-          artifactsFeeds: 'IDDP'
-          # mavenServiceConnections: 'AndroidADALEngineering'
+          MavenServiceConnections: IdentityDivision
 
       - task: Bash@3
         displayName: Install ninja
@@ -264,12 +263,12 @@ stages:
       - task: Gradle@2
         displayName: Assemble OneAuth
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/OneAuthAndroidCommonWrapper
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: clean assembleOneAuth
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/OneAuthAndroidCommonWrapper
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -31,8 +31,8 @@ resources:
     endpoint: ANDROID_GITHUB
   - repository: OneAuth
       type: git
-      name: OneAuth/OneAuth-Experiments
-      ref: oneauthwrapper
+      name: OneAuth/OneAuthAndroidCommonWrapper
+      ref: main
       endpoint: OneAuthServiceConnection
 
 stages:
@@ -213,15 +213,15 @@ stages:
         submodules: true
         persistCredentials: True
       - task: CmdLine@2
-        displayName: Checkout oneAuthWrapper submodule oneauthwrapper
+        displayName: Checkout OneAuthAndroidCommonWrapper
         inputs:
           script: |
             git fetch
-            git checkout oneauthwrapper
+            git checkout main
             git pull
             git status
             git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper
+          workingDirectory: $(Agent.BuildDirectory)/s/
       - task: CmdLine@2
         displayName: Checkout common submodule $(commonBranch)
         inputs:
@@ -231,7 +231,7 @@ stages:
             git pull
             git status
             git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper/common
+          workingDirectory: $(Agent.BuildDirectory)/s/common
       - task: CmdLine@2
         displayName: Checkout OneAuth submodule $(oneAuthBranchName)
         inputs:
@@ -241,9 +241,11 @@ stages:
             git pull
             git status
             git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper/OneAuth
+          workingDirectory: $(Agent.BuildDirectory)/s/OneAuth
       - task: MavenAuthenticate@0
         displayName: Authenticate to the IdentityDivision Android Maven feed
+        inputs:
+          artifactsFeeds: IDDP
       - task: Bash@3
         displayName: Install ninja
         inputs:
@@ -259,12 +261,12 @@ stages:
       - task: Gradle@2
         displayName: Assemble OneAuth
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/OneAuthWrapper
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthWrapper/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: clean assembleOneAuth
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/OneAuthWrapper
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthWrapper/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -246,8 +246,8 @@ stages:
       - task: MavenAuthenticate@0
         displayName: Authenticate to the IdentityDivision Android Maven feed
         inputs:
-          artifactsFeeds: 'AndroidADAL, IDDP'
-          mavenServiceConnections: 'AndroidADALEngineering'
+          artifactsFeeds: 'IDDP'
+          # mavenServiceConnections: 'AndroidADALEngineering'
 
       - task: Bash@3
         displayName: Install ninja

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -33,7 +33,7 @@ resources:
     type: git
     name: OneAuth/OneAuthAndroidCommonWrapper
     ref: main
-    endpoint: OneAuthServiceConnection
+    endpoint: OneAuthServiceConnection_2
 
 stages:
 - stage: validateConsumers

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -29,6 +29,11 @@ resources:
     name: AzureAD/azure-activedirectory-library-for-android
     ref: dev
     endpoint: ANDROID_GITHUB
+  - repository: OneAuth
+      type: git
+      name: OneAuth/OneAuth-Experiments
+      ref: oneauthwrapper
+      endpoint: OneAuthServiceConnection
 
 stages:
 - stage: validateConsumers
@@ -194,3 +199,72 @@ stages:
       displayName: Run adal Unit tests
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # OneAuth
+  - job: oneAuthValidation
+    displayName: OneAuth
+    dependsOn: setupBranch
+    variables:
+      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    steps:
+      # - template: ../templates/steps/automation-cert.yml
+      - checkout: OneAuth
+        displayName: Checkout OneAuth repository
+        clean: true
+        submodules: true
+        persistCredentials: True
+      - task: CmdLine@2
+        displayName: Checkout oneAuthWrapper submodule oneauthwrapper
+        inputs:
+          script: |
+            git fetch
+            git checkout oneauthwrapper
+            git pull
+            git status
+            git rev-parse HEAD
+          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper
+      - task: CmdLine@2
+        displayName: Checkout common submodule $(commonBranch)
+        inputs:
+          script: |
+            git fetch
+            git checkout $(commonBranch)
+            git pull
+            git status
+            git rev-parse HEAD
+          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper/common
+      - task: CmdLine@2
+        displayName: Checkout OneAuth submodule $(oneAuthBranchName)
+        inputs:
+          script: |
+            git fetch
+            git checkout $(oneAuthBranchName)
+            git pull
+            git status
+            git rev-parse HEAD
+          workingDirectory: $(Agent.BuildDirectory)/s/OneAuthWrapper/OneAuth
+      - task: MavenAuthenticate@0
+        displayName: Authenticate to the IdentityDivision Android Maven feed
+      - task: Bash@3
+        displayName: Install ninja
+        inputs:
+          targetType: inline
+          script: |
+            if [[ "$AGENT_OS" == "Darwin" ]]; then
+              HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
+            elif [[ "$AGENT_OS" == "Windows_NT" ]]; then
+              choco install -y ninja
+            elif [[ "$AGENT_OS" == "Linux" ]]; then
+              sudo apt-get install -y ninja-build
+            fi
+      - task: Gradle@2
+        displayName: Assemble OneAuth
+        inputs:
+          cwd: $(Agent.BuildDirectory)/s/OneAuthWrapper
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthWrapper/gradlew.bat
+          tasks: clean assembleOneAuth
+      - task: Gradle@2
+        displayName: Run OneAuth Unit tests
+        inputs:
+          cwd: $(Agent.BuildDirectory)/s/OneAuthWrapper
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthWrapper/gradlew.bat
+          tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -32,7 +32,7 @@ resources:
   - repository: OneAuth
     type: git
     name: OneAuth/OneAuthAndroidCommonWrapper
-    ref: matyu/modules
+    ref: main
     endpoint: OneAuthServiceConnection_2
 
 stages:
@@ -217,7 +217,7 @@ stages:
         inputs:
           script: |
             git fetch
-            git checkout matyu/modules
+            git checkout main
             git pull
             git status
             git rev-parse HEAD

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -14,21 +14,21 @@ variables:
 
 resources:
   repositories:
-  - repository: msal
-    type: github
-    name: AzureAD/microsoft-authentication-library-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
-  - repository: broker
-    type: github
-    name: AzureAD/ad-accounts-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
-  - repository: adal
-    type: github
-    name: AzureAD/azure-activedirectory-library-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
+  # - repository: msal
+  #   type: github
+  #   name: AzureAD/microsoft-authentication-library-for-android
+  #   ref: dev
+  #   endpoint: ANDROID_GITHUB
+  # - repository: broker
+  #   type: github
+  #   name: AzureAD/ad-accounts-for-android
+  #   ref: dev
+  #   endpoint: ANDROID_GITHUB
+  # - repository: adal
+  #   type: github
+  #   name: AzureAD/azure-activedirectory-library-for-android
+  #   ref: dev
+  #   endpoint: ANDROID_GITHUB
   - repository: OneAuth
     type: git
     name: OneAuth/OneAuthAndroidCommonWrapper

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -30,10 +30,10 @@ resources:
     ref: dev
     endpoint: ANDROID_GITHUB
   - repository: OneAuth
-      type: git
-      name: OneAuth/OneAuth-Experiments
-      ref: oneauthwrapper
-      endpoint: OneAuthServiceConnection
+    type: git
+    name: OneAuth/OneAuth-Experiments
+    ref: oneauthwrapper
+    endpoint: OneAuthServiceConnection
 
 stages:
 - stage: validateConsumers

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -264,12 +264,12 @@ stages:
       - task: Gradle@2
         displayName: Assemble OneAuth
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/OneAuthAndroidCommonWrapper
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
           tasks: clean assembleOneAuth
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
-          cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
+          cwd: $(Agent.BuildDirectory)/s/OneAuthAndroidCommonWrapper
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
           tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -242,8 +242,13 @@ stages:
             git status
             git rev-parse HEAD
           workingDirectory: $(Agent.BuildDirectory)/s/OneAuth
+
       - task: MavenAuthenticate@0
         displayName: Authenticate to the IdentityDivision Android Maven feed
+        inputs:
+          artifactsFeeds: 'AndroidADAL, IDDP'
+          mavenServiceConnections: 'AndroidADALEngineering'
+
       - task: Bash@3
         displayName: Install ninja
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -32,7 +32,7 @@ resources:
   - repository: OneAuth
     type: git
     name: OneAuth/OneAuthAndroidCommonWrapper
-    ref: main
+    ref: matyu/modules
     endpoint: OneAuthServiceConnection_2
 
 stages:
@@ -217,7 +217,7 @@ stages:
         inputs:
           script: |
             git fetch
-            git checkout main
+            git checkout matyu/modules
             git pull
             git status
             git rev-parse HEAD

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -265,11 +265,11 @@ stages:
         displayName: Assemble OneAuth
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
           tasks: clean assembleOneAuth
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
           tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -244,8 +244,6 @@ stages:
           workingDirectory: $(Agent.BuildDirectory)/s/OneAuth
       - task: MavenAuthenticate@0
         displayName: Authenticate to the IdentityDivision Android Maven feed
-        inputs:
-          artifactsFeeds: IDDP
       - task: Bash@3
         displayName: Install ninja
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -14,21 +14,21 @@ variables:
 
 resources:
   repositories:
-  # - repository: msal
-  #   type: github
-  #   name: AzureAD/microsoft-authentication-library-for-android
-  #   ref: dev
-  #   endpoint: ANDROID_GITHUB
-  # - repository: broker
-  #   type: github
-  #   name: AzureAD/ad-accounts-for-android
-  #   ref: dev
-  #   endpoint: ANDROID_GITHUB
-  # - repository: adal
-  #   type: github
-  #   name: AzureAD/azure-activedirectory-library-for-android
-  #   ref: dev
-  #   endpoint: ANDROID_GITHUB
+  - repository: msal
+    type: github
+    name: AzureAD/microsoft-authentication-library-for-android
+    ref: dev
+    endpoint: ANDROID_GITHUB
+  - repository: broker
+    type: github
+    name: AzureAD/ad-accounts-for-android
+    ref: dev
+    endpoint: ANDROID_GITHUB
+  - repository: adal
+    type: github
+    name: AzureAD/azure-activedirectory-library-for-android
+    ref: dev
+    endpoint: ANDROID_GITHUB
   - repository: OneAuth
     type: git
     name: OneAuth/OneAuthAndroidCommonWrapper
@@ -79,126 +79,126 @@ stages:
       name: echovar
       displayName: Echo branch name
   # msal
-  # - job: msalValidation
-  #   displayName: MSAL
-  #   dependsOn: setupBranch
-  #   variables:
-  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-  #   steps:
-  #   - template: ../templates/steps/automation-cert.yml
-  #   - checkout: msal
-  #     displayName: Checkout msal repository
-  #     clean: true
-  #     submodules: recursive
-  #     persistCredentials: True
-  #   - task: CmdLine@2
-  #     displayName: Checkout common submodule $(commonBranch)
-  #     inputs:
-  #       script: |
-  #         git fetch
-  #         git checkout $(commonBranch)
-  #         git pull
-  #         git status
-  #         git rev-parse HEAD
-  #       workingDirectory: $(Agent.BuildDirectory)/s/common
-  #   - task: Gradle@2
-  #     displayName: Assemble msal
-  #     inputs:
-  #       tasks: clean msal:assembleLocal
-  #   - task: Gradle@2
-  #     displayName: Run msal Unit tests
-  #     inputs:
-  #       tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-  # # broker
-  # - job: brokerValidation
-  #   displayName: Broker
-  #   dependsOn: setupBranch
-  #   variables:
-  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-  #   steps:
-  #   - template: ../templates/steps/automation-cert.yml
-  #   - checkout: broker
-  #     displayName: Checkout broker repository
-  #     clean: true
-  #     submodules: recursive
-  #     persistCredentials: True
-  #   - task: CmdLine@2
-  #     displayName: Checkout common submodule $(commonBranch)
-  #     inputs:
-  #       script: |
-  #         git fetch
-  #         git checkout $(commonBranch)
-  #         git pull
-  #         git status
-  #         git rev-parse HEAD
-  #       workingDirectory: $(Agent.BuildDirectory)/s/common
-  #   - task: PowerShell@2
-  #     displayName: Install Flatbuffers Compiler
-  #     enabled: False
-  #     inputs:
-  #       targetType: inline
-  #       script: >-
-  #         Write-Output "Downloading flatbuffers"
+  - job: msalValidation
+    displayName: MSAL
+    dependsOn: setupBranch
+    variables:
+      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    steps:
+    - template: ../templates/steps/automation-cert.yml
+    - checkout: msal
+      displayName: Checkout msal repository
+      clean: true
+      submodules: recursive
+      persistCredentials: True
+    - task: CmdLine@2
+      displayName: Checkout common submodule $(commonBranch)
+      inputs:
+        script: |
+          git fetch
+          git checkout $(commonBranch)
+          git pull
+          git status
+          git rev-parse HEAD
+        workingDirectory: $(Agent.BuildDirectory)/s/common
+    - task: Gradle@2
+      displayName: Assemble msal
+      inputs:
+        tasks: clean msal:assembleLocal
+    - task: Gradle@2
+      displayName: Run msal Unit tests
+      inputs:
+        tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # broker
+  - job: brokerValidation
+    displayName: Broker
+    dependsOn: setupBranch
+    variables:
+      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    steps:
+    - template: ../templates/steps/automation-cert.yml
+    - checkout: broker
+      displayName: Checkout broker repository
+      clean: true
+      submodules: recursive
+      persistCredentials: True
+    - task: CmdLine@2
+      displayName: Checkout common submodule $(commonBranch)
+      inputs:
+        script: |
+          git fetch
+          git checkout $(commonBranch)
+          git pull
+          git status
+          git rev-parse HEAD
+        workingDirectory: $(Agent.BuildDirectory)/s/common
+    - task: PowerShell@2
+      displayName: Install Flatbuffers Compiler
+      enabled: False
+      inputs:
+        targetType: inline
+        script: >-
+          Write-Output "Downloading flatbuffers"
 
-  #         $downloadLink = "https://github.com/google/flatbuffers/releases/download/v1.12.0/flatc_windows.zip"
+          $downloadLink = "https://github.com/google/flatbuffers/releases/download/v1.12.0/flatc_windows.zip"
 
-  #         Write-Output "Using download link: $downloadLink"
+          Write-Output "Using download link: $downloadLink"
 
-  #         $dest = "$env:Temp\FlatBufferInstaller.zip"
+          $dest = "$env:Temp\FlatBufferInstaller.zip"
 
-  #         (New-Object Net.WebClient).DownloadFile($downloadLink, $dest)
+          (New-Object Net.WebClient).DownloadFile($downloadLink, $dest)
 
-  #         Write-Output "Extracting flatbuffers archive on machine...."
+          Write-Output "Extracting flatbuffers archive on machine...."
 
-  #         Expand-Archive -Path $dest -DestinationPath .\flatc-extracted
+          Expand-Archive -Path $dest -DestinationPath .\flatc-extracted
 
-  #         Write-Output "Finished extracting flatbuffers archive on machine...."
+          Write-Output "Finished extracting flatbuffers archive on machine...."
 
-  #         Write-Output "Run flatc"
+          Write-Output "Run flatc"
 
-  #         .\flatc-extracted\flatc
+          .\flatc-extracted\flatc
 
-  #         echo '##vso[task.setvariable variable=path]$(PATH):$(CWD)\flatc-extracted\'
+          echo '##vso[task.setvariable variable=path]$(PATH):$(CWD)\flatc-extracted\'
 
-  #         flatc
-  #   - task: Gradle@2
-  #     displayName: Assemble broker
-  #     inputs:
-  #       tasks: clean AADAuthenticator:assembleLocal
-  #   - task: Gradle@2
-  #     displayName: Run broker Unit tests
-  #     inputs:
-  #       tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-  # # adal
-  # - job: adalValidation
-  #   displayName: ADAL
-  #   dependsOn: setupBranch
-  #   variables:
-  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-  #   steps:
-  #   - checkout: adal
-  #     displayName: Checkout adal repository
-  #     clean: true
-  #     submodules: recursive
-  #     persistCredentials: True
-  #   - task: CmdLine@2
-  #     displayName: Checkout common submodule $(commonBranch)
-  #     inputs:
-  #       script: |
-  #         git fetch
-  #         git checkout $(commonBranch)
-  #         git pull
-  #         git status
-  #         git rev-parse HEAD
-  #       workingDirectory: $(Agent.BuildDirectory)/s/common
-  #   - task: Gradle@2
-  #     displayName: Assemble adal
-  #     inputs:
-  #       tasks: clean adal:assembleLocal
-  #   - task: Gradle@2
-  #     displayName: Run adal Unit tests
-  #     inputs:
-  #       tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+          flatc
+    - task: Gradle@2
+      displayName: Assemble broker
+      inputs:
+        tasks: clean AADAuthenticator:assembleLocal
+    - task: Gradle@2
+      displayName: Run broker Unit tests
+      inputs:
+        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # adal
+  - job: adalValidation
+    displayName: ADAL
+    dependsOn: setupBranch
+    variables:
+      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    steps:
+    - checkout: adal
+      displayName: Checkout adal repository
+      clean: true
+      submodules: recursive
+      persistCredentials: True
+    - task: CmdLine@2
+      displayName: Checkout common submodule $(commonBranch)
+      inputs:
+        script: |
+          git fetch
+          git checkout $(commonBranch)
+          git pull
+          git status
+          git rev-parse HEAD
+        workingDirectory: $(Agent.BuildDirectory)/s/common
+    - task: Gradle@2
+      displayName: Assemble adal
+      inputs:
+        tasks: clean adal:assembleLocal
+    - task: Gradle@2
+      displayName: Run adal Unit tests
+      inputs:
+        tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # OneAuth
   - job: oneAuthValidation
     displayName: OneAuth
@@ -206,7 +206,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:
-      # - template: ../templates/steps/automation-cert.yml
       - checkout: OneAuth
         displayName: Checkout OneAuth repository
         clean: true

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -265,11 +265,11 @@ stages:
         displayName: Assemble OneAuth
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: clean assembleOneAuth
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/OneAuthAndroidCommonWrapper/gradlew.bat
+          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
           tasks: runOneAuthTests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -30,10 +30,10 @@ resources:
     ref: dev
     endpoint: ANDROID_GITHUB
   - repository: OneAuth
-      type: git
-      name: OneAuth/OneAuthAndroidCommonWrapper
-      ref: main
-      endpoint: OneAuthServiceConnection
+    type: git
+    name: OneAuth/OneAuthAndroidCommonWrapper
+    ref: main
+    endpoint: OneAuthServiceConnection
 
 stages:
 - stage: validateConsumers

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -79,126 +79,126 @@ stages:
       name: echovar
       displayName: Echo branch name
   # msal
-  - job: msalValidation
-    displayName: MSAL
-    dependsOn: setupBranch
-    variables:
-      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    steps:
-    - template: ../templates/steps/automation-cert.yml
-    - checkout: msal
-      displayName: Checkout msal repository
-      clean: true
-      submodules: recursive
-      persistCredentials: True
-    - task: CmdLine@2
-      displayName: Checkout common submodule $(commonBranch)
-      inputs:
-        script: |
-          git fetch
-          git checkout $(commonBranch)
-          git pull
-          git status
-          git rev-parse HEAD
-        workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: Gradle@2
-      displayName: Assemble msal
-      inputs:
-        tasks: clean msal:assembleLocal
-    - task: Gradle@2
-      displayName: Run msal Unit tests
-      inputs:
-        tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-  # broker
-  - job: brokerValidation
-    displayName: Broker
-    dependsOn: setupBranch
-    variables:
-      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    steps:
-    - template: ../templates/steps/automation-cert.yml
-    - checkout: broker
-      displayName: Checkout broker repository
-      clean: true
-      submodules: recursive
-      persistCredentials: True
-    - task: CmdLine@2
-      displayName: Checkout common submodule $(commonBranch)
-      inputs:
-        script: |
-          git fetch
-          git checkout $(commonBranch)
-          git pull
-          git status
-          git rev-parse HEAD
-        workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: PowerShell@2
-      displayName: Install Flatbuffers Compiler
-      enabled: False
-      inputs:
-        targetType: inline
-        script: >-
-          Write-Output "Downloading flatbuffers"
+  # - job: msalValidation
+  #   displayName: MSAL
+  #   dependsOn: setupBranch
+  #   variables:
+  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+  #   steps:
+  #   - template: ../templates/steps/automation-cert.yml
+  #   - checkout: msal
+  #     displayName: Checkout msal repository
+  #     clean: true
+  #     submodules: recursive
+  #     persistCredentials: True
+  #   - task: CmdLine@2
+  #     displayName: Checkout common submodule $(commonBranch)
+  #     inputs:
+  #       script: |
+  #         git fetch
+  #         git checkout $(commonBranch)
+  #         git pull
+  #         git status
+  #         git rev-parse HEAD
+  #       workingDirectory: $(Agent.BuildDirectory)/s/common
+  #   - task: Gradle@2
+  #     displayName: Assemble msal
+  #     inputs:
+  #       tasks: clean msal:assembleLocal
+  #   - task: Gradle@2
+  #     displayName: Run msal Unit tests
+  #     inputs:
+  #       tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # # broker
+  # - job: brokerValidation
+  #   displayName: Broker
+  #   dependsOn: setupBranch
+  #   variables:
+  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+  #   steps:
+  #   - template: ../templates/steps/automation-cert.yml
+  #   - checkout: broker
+  #     displayName: Checkout broker repository
+  #     clean: true
+  #     submodules: recursive
+  #     persistCredentials: True
+  #   - task: CmdLine@2
+  #     displayName: Checkout common submodule $(commonBranch)
+  #     inputs:
+  #       script: |
+  #         git fetch
+  #         git checkout $(commonBranch)
+  #         git pull
+  #         git status
+  #         git rev-parse HEAD
+  #       workingDirectory: $(Agent.BuildDirectory)/s/common
+  #   - task: PowerShell@2
+  #     displayName: Install Flatbuffers Compiler
+  #     enabled: False
+  #     inputs:
+  #       targetType: inline
+  #       script: >-
+  #         Write-Output "Downloading flatbuffers"
 
-          $downloadLink = "https://github.com/google/flatbuffers/releases/download/v1.12.0/flatc_windows.zip"
+  #         $downloadLink = "https://github.com/google/flatbuffers/releases/download/v1.12.0/flatc_windows.zip"
 
-          Write-Output "Using download link: $downloadLink"
+  #         Write-Output "Using download link: $downloadLink"
 
-          $dest = "$env:Temp\FlatBufferInstaller.zip"
+  #         $dest = "$env:Temp\FlatBufferInstaller.zip"
 
-          (New-Object Net.WebClient).DownloadFile($downloadLink, $dest)
+  #         (New-Object Net.WebClient).DownloadFile($downloadLink, $dest)
 
-          Write-Output "Extracting flatbuffers archive on machine...."
+  #         Write-Output "Extracting flatbuffers archive on machine...."
 
-          Expand-Archive -Path $dest -DestinationPath .\flatc-extracted
+  #         Expand-Archive -Path $dest -DestinationPath .\flatc-extracted
 
-          Write-Output "Finished extracting flatbuffers archive on machine...."
+  #         Write-Output "Finished extracting flatbuffers archive on machine...."
 
-          Write-Output "Run flatc"
+  #         Write-Output "Run flatc"
 
-          .\flatc-extracted\flatc
+  #         .\flatc-extracted\flatc
 
-          echo '##vso[task.setvariable variable=path]$(PATH):$(CWD)\flatc-extracted\'
+  #         echo '##vso[task.setvariable variable=path]$(PATH):$(CWD)\flatc-extracted\'
 
-          flatc
-    - task: Gradle@2
-      displayName: Assemble broker
-      inputs:
-        tasks: clean AADAuthenticator:assembleLocal
-    - task: Gradle@2
-      displayName: Run broker Unit tests
-      inputs:
-        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-  # adal
-  - job: adalValidation
-    displayName: ADAL
-    dependsOn: setupBranch
-    variables:
-      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    steps:
-    - checkout: adal
-      displayName: Checkout adal repository
-      clean: true
-      submodules: recursive
-      persistCredentials: True
-    - task: CmdLine@2
-      displayName: Checkout common submodule $(commonBranch)
-      inputs:
-        script: |
-          git fetch
-          git checkout $(commonBranch)
-          git pull
-          git status
-          git rev-parse HEAD
-        workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: Gradle@2
-      displayName: Assemble adal
-      inputs:
-        tasks: clean adal:assembleLocal
-    - task: Gradle@2
-      displayName: Run adal Unit tests
-      inputs:
-        tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  #         flatc
+  #   - task: Gradle@2
+  #     displayName: Assemble broker
+  #     inputs:
+  #       tasks: clean AADAuthenticator:assembleLocal
+  #   - task: Gradle@2
+  #     displayName: Run broker Unit tests
+  #     inputs:
+  #       tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # # adal
+  # - job: adalValidation
+  #   displayName: ADAL
+  #   dependsOn: setupBranch
+  #   variables:
+  #     commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+  #   steps:
+  #   - checkout: adal
+  #     displayName: Checkout adal repository
+  #     clean: true
+  #     submodules: recursive
+  #     persistCredentials: True
+  #   - task: CmdLine@2
+  #     displayName: Checkout common submodule $(commonBranch)
+  #     inputs:
+  #       script: |
+  #         git fetch
+  #         git checkout $(commonBranch)
+  #         git pull
+  #         git status
+  #         git rev-parse HEAD
+  #       workingDirectory: $(Agent.BuildDirectory)/s/common
+  #   - task: Gradle@2
+  #     displayName: Assemble adal
+  #     inputs:
+  #       tasks: clean adal:assembleLocal
+  #   - task: Gradle@2
+  #     displayName: Run adal Unit tests
+  #     inputs:
+  #       tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # OneAuth
   - job: oneAuthValidation
     displayName: OneAuth


### PR DESCRIPTION
**Summary**
- This effort aims to build OneAuth project with every change made in Common and reflected in a PR, to ensure we do not break OneAuth by catching build problems or regressions early on. We currently have a pipeline which does this for ADAL, MSAL and Broker: https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1393&_a=summary
- We have added OneAuth to the above-mentioned pipeline.

**Execution**
- Since OneAuth does not consume Common like the way Broker, ADAL and MSAL do it, which is as a submodule, we ended up creating a wrapper project ([OneAuthAndroidCommonWrapper](https://office.visualstudio.com/OneAuth/_git/OneAuthAndroidCommonWrapper)) 
- This wrapper project encapsulates OneAuth and Common as submodules, which makes it possible to track new changes in Common.
- Once the submodules are pointing the changes we want (task in the pipeline is self-configured), we build the Common with OneAuth (default branch dev).


`Successful run`: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=939438&view=logs&j=270c859f-93fe-5540-73d4-837dd60f0a89