### PR TITLE
Add additional logging/exception to identify root cause for office union app crash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 4.2.0-hf1
+----------
+- [PATCH] Add additional logging/exception to identify root cause for office union app crash (#1762)
+
 Version 4.2.0
 ----------
 - [PATCH] Add exception handling in Content Provider strategy, for broker communication (#1722)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "1.2.0"
+def common4jVersion = "1.2.0-hf1"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -76,16 +76,21 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
     @Override
     public @NonNull List<AbstractSecretKeyLoader> getKeyLoaderForDecryption(@NonNull byte[] cipherText) {
         final String methodTag = TAG + ":getKeyLoaderForDecryption";
-        if (mPredefinedKeyLoader != null &&
-                isEncryptedByThisKeyIdentifier(cipherText, PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER)) {
-            return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
-        }
 
-        if (isEncryptedByThisKeyIdentifier(cipherText, AndroidWrappedKeyLoader.KEY_IDENTIFIER)) {
+        final String keyIdentifier = getKeyIdentifierFromCipherText(cipherText);
+        if (PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
+            if (mPredefinedKeyLoader != null) {
+                return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
+            } else {
+                throw new IllegalStateException(
+                        "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, " +
+                                "but mPredefinedKeyLoader is null.");
+            }
+        } else if (AndroidWrappedKeyLoader.KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
             return Collections.<AbstractSecretKeyLoader>singletonList(mKeyStoreKeyLoader);
         }
 
         Logger.warn(methodTag, "Cannot find a matching key to decrypt the given blob");
-        return Collections.emptyList();
+        throw new IllegalStateException("Unknown keyIdentifier for cipher text: " + keyIdentifier);
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
@@ -22,6 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.crypto;
 
+import static com.microsoft.identity.common.crypto.MockData.PREDEFINED_KEY;
+import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_ANDROID_WRAPPED_KEY;
+import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_PREDEFINED_KEY;
+
 import android.content.Context;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -41,10 +45,6 @@ import java.util.List;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-
-import static com.microsoft.identity.common.crypto.MockData.PREDEFINED_KEY;
-import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_ANDROID_WRAPPED_KEY;
-import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_PREDEFINED_KEY;
 
 @RunWith(RobolectricTestRunner.class)
 public class AndroidAuthSdkStorageEncryptionManagerTest {
@@ -112,9 +112,13 @@ public class AndroidAuthSdkStorageEncryptionManagerTest {
     @Test
     public void testGetDecryptionKey_ForDataEncryptedWithPreDefinedKey() {
         final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
-        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
-
-        Assert.assertEquals(0, keyLoaderList.size());
+        try {
+            final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        } catch (IllegalStateException ex) {
+            Assert.assertEquals(
+                    "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, but mPredefinedKeyLoader is null.",
+                    ex.getMessage());
+        }
     }
 
     /**

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.2.0
+versionName=1.2.0-hf1
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.2.0
+versionName=4.2.0-hf1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
The office mobile union app is noticing a crash in the latest version (after upgrading to adal 4.1.0, common 4.2.0)
Adding additional logging/exception to figure out the root cause of the crash.

Stack Trace from the crash: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/990c353bb7e4cc3896857e7fb76e217f0ad34d43/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java#L203

java.lang.IllegalStateException: 
  at com.microsoft.identity.common.java.crypto.StorageEncryptionManager.decrypt (SourceFile:19)
  at com.microsoft.identity.common.java.crypto.KeyAccessorStringAdapter.decrypt (SourceFile:2)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.encryptDecryptInternal (SourceFile:3)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.decrypt (SourceFile:1)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.getString (SourceFile:6)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:2)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:1)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.getAccount (SourceFile:3)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.saveAccount (SourceFile:5)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.saveAccounts (SourceFile:2)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.setSingleSignOnState (SourceFile:6)
  at com.microsoft.identity.common.adal.internal.cache.ADALOAuth2TokenCache.save (SourceFile:24)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateTokenCacheUsingCommonCache (SourceFile:19)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateCachedItemWithResult (SourceFile:10)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.acquireTokenWithCachedItem (SourceFile:7)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryFRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryMRRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryRT (SourceFile:15)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.getAccessToken (SourceFile:9)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilentLocally (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.acquireTokenSilentFlow (SourceFile:4)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilent (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.performAcquireTokenRequest (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest.access$200 (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest$1.run (SourceFile:4)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)

Bug: https://office.visualstudio.com/OC/_workitems/edit/6103235