### PR TITLE
Fix UI automation for authenticator app's device registration screen

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -26,6 +26,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.ui.automation.broker.BrokerImplFactory;
 import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
 import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
 import com.microsoft.identity.client.ui.automation.installer.PlayStore;
@@ -101,6 +102,8 @@ public abstract class App implements IApp {
         // the app is just installed, first run should be handled
         // this value can (should) be changed to false by child classes as appropriate
         shouldHandleFirstRun = true;
+
+        BrokerImplFactory.setBrokerImpl(this.appName);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -40,6 +40,9 @@ import com.microsoft.identity.client.ui.automation.installer.PlayStore;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AdfsLoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
@@ -59,6 +62,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
     public final static IAppInstaller DEFAULT_BROKER_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
             .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
+
     @Override
     public void uninstall() {
         super.uninstall();
@@ -112,7 +116,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
 
     @Override
     public void performJoinViaJoinActivity(@NonNull final String username,
-                                           @NonNull final String password) {
+                                           @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Perform Join Via Join Activity for the given account..");
         // Enter username
         UiAutomatorUtils.handleInput(
@@ -129,18 +133,40 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
                 )
         );
 
-        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
-                .broker(this)
-                .prompt(PromptParameter.SELECT_ACCOUNT)
-                .loginHint(username)
-                .sessionExpected(false)
-                .build();
+        if (isFederatedUser) {
+            final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
+                    .prompt(PromptParameter.LOGIN)
+                    .consentPageExpected(false)
+                    .expectingLoginPageAccountPicker(false)
+                    .sessionExpected(false)
+                    .isFederated(true)
+                    .loginHint(null)
+                    .build();
 
-        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+            final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler(promptHandlerParameters);
+            AdfsLoginComponentHandler adfsLoginComponentHandler = ((AdfsLoginComponentHandler) microsoftStsPromptHandler.getLoginComponentHandler());
+            // Handle prompt in ADFS login page
+            adfsLoginComponentHandler.handlePrompt(username, password);
+        } else {
+            final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                    .broker(this)
+                    .prompt(PromptParameter.SELECT_ACCOUNT)
+                    .loginHint(username)
+                    .sessionExpected(false)
+                    .build();
 
-        Logger.i(TAG, "Handle prompt in AAD login page for Join Via Join Activity..");
-        // Handle prompt in AAD login page
-        aadPromptHandler.handlePrompt(username, password);
+            final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+
+            Logger.i(TAG, "Handle prompt in AAD login page for Join Via Join Activity..");
+            // Handle prompt in AAD login page
+            aadPromptHandler.handlePrompt(username, password);
+        }
+    }
+
+    @Override
+    public void performJoinViaJoinActivity(@NonNull final String username,
+                                           @NonNull final String password) {
+        performJoinViaJoinActivity(username, password, false);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorPreviousVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorPreviousVersionImpl.java
@@ -1,0 +1,159 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.broker;
+
+import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+import org.junit.Assert;
+
+/**
+ * A model for interacting with the Microsoft Authenticator Broker App during UI Test
+ * when version number of Authenticator app under test is < "6.2206.3949"
+ */
+public class BrokerAuthenticatorPreviousVersionImpl extends BrokerMicrosoftAuthenticator {
+
+    private static final String TAG = BrokerAuthenticatorPreviousVersionImpl.class.getSimpleName();
+
+    @Override
+    public void performDeviceRegistration(@NonNull final String username,
+                                          @NonNull final String password) {
+
+        Logger.i(TAG, "Performing Device Registration for the given account..");
+        performDeviceRegistrationHelper(
+                username,
+                password,
+                "com.azure.authenticator:id/email_input",
+                "com.azure.authenticator:id/register_button"
+        );
+
+        try {
+            // after device registration, make sure that we see the unregister btn to confirm successful
+            // registration
+            final UiObject unRegisterBtn = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                    "com.azure.authenticator:id/unregister_button"
+            );
+            Assert.assertTrue(
+                    "Microsoft Authenticator - Unregister Button appears.",
+                    unRegisterBtn.exists()
+            );
+
+            Assert.assertTrue(
+                    "Microsoft Authenticator - Unregister Button is clickable.",
+                    unRegisterBtn.isClickable()
+            );
+
+            // after device registration, make sure that the current registration upn matches with
+            // with what was passed in
+            final UiObject currentRegistration = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                    "com.azure.authenticator:id/current_registered_email"
+            );
+
+            Assert.assertTrue(
+                    "Microsoft Authenticator - Registered account info appears.",
+                    currentRegistration.exists()
+            );
+
+            Assert.assertTrue(
+                    "Microsoft Authenticator - Registered account upn matches provided upn.",
+                    currentRegistration.getText().equalsIgnoreCase(username)
+            );
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void performSharedDeviceRegistration(@NonNull final String username,
+                                                @NonNull final String password) {
+        Logger.i(TAG, "Performing Shared Device Registration for the given account..");
+        performDeviceRegistrationHelper(
+                username,
+                password,
+                "com.azure.authenticator:id/shared_device_registration_email_input",
+                "com.azure.authenticator:id/shared_device_registration_button"
+        );
+
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiSelector sharedDeviceConfirmationSelector = new UiSelector()
+                .descriptionContains("Shared Device Mode")
+                .className("android.widget.ImageView");
+
+        //confirm that we are in Shared Device Mode inside Authenticator
+        final UiObject sharedDeviceConfirmation = device.findObject(sharedDeviceConfirmationSelector);
+        sharedDeviceConfirmation.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+        Assert.assertTrue(
+                "Microsoft Authenticator - Shared Device Confirmation page appears.",
+                sharedDeviceConfirmation.exists());
+
+        isInSharedDeviceMode = true;
+    }
+
+
+    private void performDeviceRegistrationHelper(@NonNull final String username,
+                                                 @NonNull final String password,
+                                                 @NonNull final String emailInputResourceId,
+                                                 @NonNull final String registerBtnResourceId) {
+        Logger.i(TAG, "Execution of Helper for Device Registration..");
+        // open device registration page
+        openDeviceRegistrationPage();
+
+        // enter email
+        UiAutomatorUtils.handleInput(
+                emailInputResourceId,
+                username
+        );
+
+        // click register
+        UiAutomatorUtils.handleButtonClick(registerBtnResourceId);
+
+        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                .prompt(PromptParameter.LOGIN)
+                .broker(this)
+                .consentPageExpected(false)
+                .expectingBrokerAccountChooserActivity(false)
+                .expectingLoginPageAccountPicker(false)
+                .sessionExpected(false)
+                .loginHint(username)
+                .build();
+
+        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+
+        Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
+        // handle AAD login page
+        aadPromptHandler.handlePrompt(username, password);
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorPreviousVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorPreviousVersionImpl.java
@@ -31,9 +31,6 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
-import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
-import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
@@ -95,6 +92,7 @@ public class BrokerAuthenticatorPreviousVersionImpl extends BrokerMicrosoftAuthe
         }
     }
 
+    @Override
     public void performSharedDeviceRegistration(@NonNull final String username,
                                                 @NonNull final String password) {
         Logger.i(TAG, "Performing Shared Device Registration for the given account..");
@@ -120,40 +118,5 @@ public class BrokerAuthenticatorPreviousVersionImpl extends BrokerMicrosoftAuthe
                 sharedDeviceConfirmation.exists());
 
         isInSharedDeviceMode = true;
-    }
-
-
-    private void performDeviceRegistrationHelper(@NonNull final String username,
-                                                 @NonNull final String password,
-                                                 @NonNull final String emailInputResourceId,
-                                                 @NonNull final String registerBtnResourceId) {
-        Logger.i(TAG, "Execution of Helper for Device Registration..");
-        // open device registration page
-        openDeviceRegistrationPage();
-
-        // enter email
-        UiAutomatorUtils.handleInput(
-                emailInputResourceId,
-                username
-        );
-
-        // click register
-        UiAutomatorUtils.handleButtonClick(registerBtnResourceId);
-
-        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
-                .prompt(PromptParameter.LOGIN)
-                .broker(this)
-                .consentPageExpected(false)
-                .expectingBrokerAccountChooserActivity(false)
-                .expectingLoginPageAccountPicker(false)
-                .sessionExpected(false)
-                .loginHint(username)
-                .build();
-
-        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
-
-        Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
-        // handle AAD login page
-        aadPromptHandler.handlePrompt(username, password);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
@@ -1,0 +1,196 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.broker;
+
+import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
+
+import com.microsoft.identity.client.ui.automation.TestContext;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+import org.junit.Assert;
+
+/**
+ * A model for interacting with the Microsoft Authenticator Broker App during UI Test
+ * when version number of Authenticator app under test is >= "6.2206.3949"
+ * contains changes for new resourceIds for device registration UI
+ */
+public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthenticator {
+
+    private static final String TAG = BrokerAuthenticatorUpdatedVersionImpl.class.getSimpleName();
+    private static final boolean isExpectingMFA = true;
+
+    @Override
+    public void performDeviceRegistration(@NonNull final String username,
+                                          @NonNull final String password) {
+
+        Logger.i(TAG, "Performing Device Registration for the given account..");
+        if (isExpectingMFA) {
+            TestContext.getTestContext().getTestDevice().getSettings().addWorkAccount(
+                    this,
+                    username,
+                    password
+            );
+        }
+        else {
+            performDeviceRegistrationHelper(
+                    username,
+                    password,
+                    "workPlaceTextField",
+                    "workPlaceRegisterButton"
+            );
+
+
+            try {
+                // after device registration, make sure that we see the unregister btn to confirm successful
+                // registration
+                final UiObject unRegisterBtn = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                        "com.azure.authenticator:id/unregister_button"
+                );
+                Assert.assertTrue(
+                        "Microsoft Authenticator - Unregister Button appears.",
+                        unRegisterBtn.exists()
+                );
+
+                Assert.assertTrue(
+                        "Microsoft Authenticator - Unregister Button is clickable.",
+                        unRegisterBtn.isClickable()
+                );
+
+                // after device registration, make sure that the current registration upn matches with
+                // with what was passed in
+                final UiObject currentRegistration = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                        "com.azure.authenticator:id/current_registered_email"
+                );
+
+                Assert.assertTrue(
+                        "Microsoft Authenticator - Registered account info appears.",
+                        currentRegistration.exists()
+                );
+
+                Assert.assertTrue(
+                        "Microsoft Authenticator - Registered account upn matches provided upn.",
+                        currentRegistration.getText().equalsIgnoreCase(username)
+                );
+            } catch (final UiObjectNotFoundException e) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+
+    public void performSharedDeviceRegistration(@NonNull final String username,
+                                                @NonNull final String password) {
+        Logger.i(TAG, "Performing Shared Device Registration for the given account..");
+        performDeviceRegistrationHelper(
+                username,
+                password,
+                "com.azure.authenticator:id/shared_device_registration_email_input",
+                "com.azure.authenticator:id/shared_device_registration_button"
+        );
+
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiSelector sharedDeviceConfirmationSelector = new UiSelector()
+                .descriptionContains("Shared Device Mode")
+                .className("android.widget.ImageView");
+
+        //confirm that we are in Shared Device Mode inside Authenticator
+        final UiObject sharedDeviceConfirmation = device.findObject(sharedDeviceConfirmationSelector);
+        sharedDeviceConfirmation.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+        Assert.assertTrue(
+                "Microsoft Authenticator - Shared Device Confirmation page appears.",
+                sharedDeviceConfirmation.exists());
+
+        isInSharedDeviceMode = true;
+    }
+
+    private void performDeviceRegistrationHelper(@NonNull final String username,
+                                                 @NonNull final String password,
+                                                 @NonNull final String emailInputResourceId,
+                                                 @NonNull final String registerBtnResourceId) {
+        Logger.i(TAG, "Execution of Helper for Device Registration..");
+        // open device registration page
+        openDeviceRegistrationPage();
+
+        // enter email
+        UiAutomatorUtils.handleInput(
+                emailInputResourceId,
+                username
+        );
+
+        // click register
+        UiAutomatorUtils.handleButtonClick(registerBtnResourceId);
+
+        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                .prompt(PromptParameter.LOGIN)
+                .broker(this)
+                .consentPageExpected(false)
+                .expectingBrokerAccountChooserActivity(false)
+                .expectingLoginPageAccountPicker(false)
+                .sessionExpected(false)
+                .loginHint(username)
+                .build();
+
+        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
+
+        Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
+        // handle AAD login page
+        aadPromptHandler.handlePrompt(username, password);
+    }
+
+    @Override
+    protected void goToDeviceRegistrationPage() {
+        // scroll down the recycler view to find device registration btn
+        try {
+            // click the 3 dot menu icon in top right
+            UiAutomatorUtils.handleButtonClick("com.azure.authenticator:id/menu_overflow");
+
+            // select Settings from drop down
+            final UiObject settings = UiAutomatorUtils.obtainUiObjectWithText("Settings");
+            settings.click();
+
+            final UiObject deviceRegistration = UiAutomatorUtils.obtainChildInScrollable(
+                    "settingsScrollView",
+                    "Device Registration"
+            );
+
+            assert deviceRegistration != null;
+
+            // click the device registration button
+            deviceRegistration.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
@@ -32,9 +32,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.TestContext;
-import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
-import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
@@ -108,6 +105,7 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
         }
     }
 
+    @Override
     public void performSharedDeviceRegistration(@NonNull final String username,
                                                 @NonNull final String password) {
         Logger.i(TAG, "Performing Shared Device Registration for the given account..");
@@ -133,40 +131,6 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
                 sharedDeviceConfirmation.exists());
 
         isInSharedDeviceMode = true;
-    }
-
-    private void performDeviceRegistrationHelper(@NonNull final String username,
-                                                 @NonNull final String password,
-                                                 @NonNull final String emailInputResourceId,
-                                                 @NonNull final String registerBtnResourceId) {
-        Logger.i(TAG, "Execution of Helper for Device Registration..");
-        // open device registration page
-        openDeviceRegistrationPage();
-
-        // enter email
-        UiAutomatorUtils.handleInput(
-                emailInputResourceId,
-                username
-        );
-
-        // click register
-        UiAutomatorUtils.handleButtonClick(registerBtnResourceId);
-
-        final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
-                .prompt(PromptParameter.LOGIN)
-                .broker(this)
-                .consentPageExpected(false)
-                .expectingBrokerAccountChooserActivity(false)
-                .expectingLoginPageAccountPicker(false)
-                .sessionExpected(false)
-                .loginHint(username)
-                .build();
-
-        final AadPromptHandler aadPromptHandler = new AadPromptHandler(promptHandlerParameters);
-
-        Logger.i(TAG, "Handle AAD Login page prompt for Device Registration..");
-        // handle AAD login page
-        aadPromptHandler.handlePrompt(username, password);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -88,6 +88,17 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         );
     }
 
+    public void performDeviceRegistrationForFederatedUser(@NonNull final String username,
+                                          @NonNull final String password, final boolean isFederatedUser) {
+        Logger.i(TAG, "Perform Device Registration for the given federate account..");
+        TestContext.getTestContext().getTestDevice().getSettings().addWorkAccount(
+                this,
+                username,
+                password,
+                true
+        );
+    }
+
     @Override
     public void performSharedDeviceRegistration(@NonNull final String username,
                                                 @NonNull final String password) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerImplFactory.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerImplFactory.java
@@ -29,19 +29,20 @@ import android.content.pm.PackageManager;
 import androidx.test.core.app.ApplicationProvider;
 
 /**
- * Factory class to create broker implementations based on the version of Authenticator app under test
+ * Factory class to create broker implementations based on the version of Broker app under test
  */
-public class BrokerMicrosoftAuthenticatorFactory {
+public class BrokerImplFactory {
 
     public final static String LATEST_VERSION_NUMBER = "6.2206.3949";
 
     /**
-     *
-     * @param broker handle to interacting with the Broker App during UI Test.
-     * @return broker implementation based on version of the app installed
+     * Set broker implementation based on the version of the app installed
+     * @param appName appName of the app installed that acts as brokerImpl
      */
-    public ITestBroker getAuthenticator(ITestBroker broker) {
-        if (broker instanceof BrokerMicrosoftAuthenticator) {
+    public static void setBrokerImpl(String appName) {
+        // Currently, added version check for authenticator and assigning impl
+        // This can be extended to other broker apps as well.
+        if (appName == BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_NAME) {
             final Context context = ApplicationProvider.getApplicationContext();
             try {
                 PackageInfo packageInfo = context.getPackageManager().getPackageInfo("com.azure.authenticator", 0);
@@ -51,14 +52,13 @@ public class BrokerMicrosoftAuthenticatorFactory {
                 // String comparison of versions should work for this format
                 if (packageInfo.versionName.compareTo(LATEST_VERSION_NUMBER) >= 0) {
                     // Use latest automation code as this is the new updated authenticator app
-                    return new BrokerAuthenticatorUpdatedVersionImpl();
+                    BrokerMicrosoftAuthenticator.brokerMicrosoftAuthenticatorImpl = new BrokerAuthenticatorUpdatedVersionImpl();
                 } else {
-                    return new BrokerAuthenticatorPreviousVersionImpl();
+                    BrokerMicrosoftAuthenticator.brokerMicrosoftAuthenticatorImpl = new BrokerAuthenticatorPreviousVersionImpl();
                 }
             } catch (final PackageManager.NameNotFoundException e) {
                 throw new AssertionError(e);
             }
         }
-        return broker;
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -36,11 +36,11 @@ import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
-import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
-import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
+import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
@@ -281,10 +281,10 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
         }
     }
 
-    private void performDeviceRegistrationHelper(@NonNull final String username,
-                                                 @NonNull final String password,
-                                                 @NonNull final String emailInputResourceId,
-                                                 @NonNull final String registerBtnResourceId) {
+    protected void performDeviceRegistrationHelper(@NonNull final String username,
+                                                   @NonNull final String password,
+                                                   @NonNull final String emailInputResourceId,
+                                                   @NonNull final String registerBtnResourceId) {
         Logger.i(TAG, "Execution of Helper for Device Registration..");
         // open device registration page
         openDeviceRegistrationPage();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -67,6 +67,9 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
 
     protected boolean isInSharedDeviceMode = false;
 
+    public static BrokerMicrosoftAuthenticator brokerMicrosoftAuthenticatorImpl;
+
+
     public BrokerMicrosoftAuthenticator() {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
         localApkFileName = AUTHENTICATOR_APK;
@@ -79,12 +82,12 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
 
     @Override
     public void performDeviceRegistration(String username, String password) {
-        // implemented in sub-classes
+        brokerMicrosoftAuthenticatorImpl.performDeviceRegistration(username, password);
     }
 
     @Override
     public void performSharedDeviceRegistration(String username, String password) {
-        // implemented in sub-classes
+        brokerMicrosoftAuthenticatorImpl.performSharedDeviceRegistration(username, password);
     }
 
     @Nullable

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticatorFactory.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticatorFactory.java
@@ -1,0 +1,56 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.broker;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import androidx.test.core.app.ApplicationProvider;
+
+/**
+ * Factory class to create broker implementations based on the version of Authenticator app under test
+ */
+public class BrokerMicrosoftAuthenticatorFactory {
+
+    public final static String LATEST_VERSION_NUMBER = "6.2206.3949";
+
+    public BrokerMicrosoftAuthenticator getAuthenticator() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        try {
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo("com.azure.authenticator", 0);
+            // authenticator app follows version number format - V.YYMM.XXXX
+            // V is the major version, YYMM are last two digits of an year followed by month
+            // XXXX is number of hours passed after Jan1st 00.00 of current year
+            // String comparison of versions should work for this format
+            if (packageInfo.versionName.compareTo(LATEST_VERSION_NUMBER) >= 0) {
+                // Use latest automation code as this is the new updated authenticator app
+                return new BrokerAuthenticatorUpdatedVersionImpl();
+            } else {
+                return new BrokerAuthenticatorPreviousVersionImpl();
+            }
+        } catch (final PackageManager.NameNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticatorFactory.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticatorFactory.java
@@ -35,22 +35,30 @@ public class BrokerMicrosoftAuthenticatorFactory {
 
     public final static String LATEST_VERSION_NUMBER = "6.2206.3949";
 
-    public BrokerMicrosoftAuthenticator getAuthenticator() {
-        final Context context = ApplicationProvider.getApplicationContext();
-        try {
-            PackageInfo packageInfo = context.getPackageManager().getPackageInfo("com.azure.authenticator", 0);
-            // authenticator app follows version number format - V.YYMM.XXXX
-            // V is the major version, YYMM are last two digits of an year followed by month
-            // XXXX is number of hours passed after Jan1st 00.00 of current year
-            // String comparison of versions should work for this format
-            if (packageInfo.versionName.compareTo(LATEST_VERSION_NUMBER) >= 0) {
-                // Use latest automation code as this is the new updated authenticator app
-                return new BrokerAuthenticatorUpdatedVersionImpl();
-            } else {
-                return new BrokerAuthenticatorPreviousVersionImpl();
+    /**
+     *
+     * @param broker handle to interacting with the Broker App during UI Test.
+     * @return broker implementation based on version of the app installed
+     */
+    public ITestBroker getAuthenticator(ITestBroker broker) {
+        if (broker instanceof BrokerMicrosoftAuthenticator) {
+            final Context context = ApplicationProvider.getApplicationContext();
+            try {
+                PackageInfo packageInfo = context.getPackageManager().getPackageInfo("com.azure.authenticator", 0);
+                // authenticator app follows version number format - V.YYMM.XXXX
+                // V is the major version, YYMM are last two digits of an year followed by month
+                // XXXX is number of hours passed after Jan1st 00.00 of current year
+                // String comparison of versions should work for this format
+                if (packageInfo.versionName.compareTo(LATEST_VERSION_NUMBER) >= 0) {
+                    // Use latest automation code as this is the new updated authenticator app
+                    return new BrokerAuthenticatorUpdatedVersionImpl();
+                } else {
+                    return new BrokerAuthenticatorPreviousVersionImpl();
+                }
+            } catch (final PackageManager.NameNotFoundException e) {
+                throw new AssertionError(e);
             }
-        } catch (final PackageManager.NameNotFoundException e) {
-            throw new AssertionError(e);
         }
+        return broker;
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/ITestBroker.java
@@ -67,6 +67,15 @@ public interface ITestBroker extends IApp {
     void performJoinViaJoinActivity(String username, String password);
 
     /**
+     * Perform device registration from the Join Activity using the supplied user account.
+     *
+     * @param username username of the account to use for registration
+     * @param password password of the account to use for registration
+     * @param isFederatedUser true if it is a federated user
+     */
+    void performJoinViaJoinActivity(String username, String password, boolean isFederatedUser);
+
+    /**
      * Confirm that device registered with the supplied UPN by comparing it with the UPN
      * displayed in Join Activity.
      *

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/AuthScheme.java
@@ -1,0 +1,6 @@
+package com.microsoft.identity.client.ui.automation.constants;
+
+public enum AuthScheme {
+    BEARER,
+    POP
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -116,6 +116,12 @@ public class GoogleSettings extends BaseSettings {
     public void addWorkAccount(@NonNull final ITestBroker broker,
                                @NonNull final String username,
                                @NonNull final String password) {
+        addWorkAccount(broker, username, password, false);
+    }
+
+    public void addWorkAccount(@NonNull final ITestBroker broker,
+                               @NonNull final String username,
+                               @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Google Device..");
         launchAddAccountPage();
 
@@ -127,7 +133,7 @@ public class GoogleSettings extends BaseSettings {
             workAccount.click();
 
             // perform Join using the supplied broker
-            broker.performJoinViaJoinActivity(username, password);
+            broker.performJoinViaJoinActivity(username, password, isFederatedUser);
 
             final UiDevice device =
                     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
@@ -245,7 +251,6 @@ public class GoogleSettings extends BaseSettings {
                 Text
         );
     }
-
 
     private UiObject obtainDisableAdminButton(final DeviceAdmin deviceAdmin) {
         Logger.i(TAG, "Obtain Disable Admin Button on Google Device..");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -73,6 +73,19 @@ public interface ISettings {
                         final String password);
 
     /**
+     * Add the supplied account to the device via Account Manager.
+     *
+     * @param expectedBroker  the broker expected to be used for the account type
+     * @param username        the username of the account to add
+     * @param password        the password of the account to add
+     * @param isFederatedUser whether the user is federated user or not
+     */
+    void addWorkAccount(final ITestBroker expectedBroker,
+                        final String username,
+                        final String password,
+                        final boolean isFederatedUser);
+
+    /**
      * Launch the date & time page in Settings app.
      */
     void launchDateTimeSettingsPage();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -115,6 +115,12 @@ public class SamsungSettings extends BaseSettings {
     public void addWorkAccount(@NonNull final ITestBroker broker,
                                @NonNull final String username,
                                @NonNull final String password) {
+        addWorkAccount(broker, username, password, false);
+    }
+
+    @Override
+    public void addWorkAccount(@NonNull final ITestBroker broker, @NonNull final String username,
+                               @NonNull final String password, final boolean isFederatedUser) {
         Logger.i(TAG, "Adding Work Account on Samsung Device..");
         launchAddAccountPage();
 
@@ -129,7 +135,7 @@ public class SamsungSettings extends BaseSettings {
             workAccount.click();
 
             // add work account by performing join via the broker
-            broker.performJoinViaJoinActivity(username, password);
+            broker.performJoinViaJoinActivity(username, password, isFederatedUser);
 
             // activate broker app as admin
             activateAdmin();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -54,7 +54,14 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
         // handle AAD login page for username
         UiAutomatorUtils.handleInput("i0116", username);
         UiAutomatorUtils.handleButtonClick("idSIButton9");
+    }
 
+    /**
+     * Enters username, password in email, password fields of a login page
+     */
+    public void handlePrompt(@NonNull final String username, @NonNull final String password) {
+        Logger.i(TAG, "Handle prompt in ADFS login page for login");
+        handleEmailField(username);
         handlePasswordField(password);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/BrokerSupportRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/BrokerSupportRule.java
@@ -78,7 +78,7 @@ public class BrokerSupportRule implements TestRule {
                     Logger.i(TAG, "Received supported broker annotation with value: " + supportedBrokerClasses.toString());
                     Assume.assumeTrue(
                             "Ignoring test as not applicable with supplied broker",
-                            supportedBrokerClasses.contains(mBroker.getClass())
+                            (supportedBrokerClasses.contains(mBroker.getClass()) || supportedBrokerClasses.contains(mBroker.getClass().getSuperclass()))
                     );
                 }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthResult.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthResult.java
@@ -79,4 +79,8 @@ public abstract class AuthResult {
     public boolean isAccessTokenEqual(String accessToken){
         return accessToken.equals(this.accessToken);
     }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthTestParams.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/sdk/AuthTestParams.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.client.ui.automation.sdk;
 
 import android.app.Activity;
 
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -41,4 +43,5 @@ public class AuthTestParams {
     private final String redirectUri;
     private final String authority;
     private final Activity activity;
+    private final AuthScheme authScheme;
 }


### PR DESCRIPTION
**What** :  UI Automation with authenticator app  was broken in the device registration flow. This was because the resourceIds were removed from the settings screen on the authenticator app. Now Authenticator team has added some new resourceIds and minor string changes were made in the settings screen. 
1. This PR fixes the automation flow by changing the resouceIds when we are testing on updated versions 
2. We will still keep the previous files with old resourceIds to be able to test the old versions of authenticator. 

**How** : Created a factory to generate the BrokerAuthenticatorPreviousVersionImpl when we are testing on previous versions of authenticator app and to generate the BrokerAuthenticatorUpdatedVersionImp when we are testing with the latest version of authenticator app. The factory does a version compare against a hardcoded version which is 6.2206.3949 (This version has the new resourceIds added)
The method getBroker in the factory will be invoked in the classes like AbstractFirstPartyBrokerTest.java, AbstractMsalBrokerTest.java during the setup. This will ensure that the app is already installed (during the rules evaluation) and the version is available to decide on the implementation to be used.

