### PR TITLE
[UI automation] support app update scenarios

### DIFF
--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -42,9 +42,13 @@ android {
 
     def final installSourcePlayStore = "PlayStore"
     def final installSourceLocalApk = "LocalApk"
+    def final updateSourcePlayStore = "PlayStore"
+    def final updateSourceLocalApk = "LocalApk"
 
     // defaults to LocalApkFile - the file must be pushed to the device before tests
     def brokerInstallationSource = installSourcePlayStore
+
+    def brokerUpdationSource = updateSourcePlayStore
 
     def wordAppInstallationSource = installSourcePlayStore
 
@@ -56,6 +60,18 @@ android {
         } else {
             throw new InvalidUserDataException("Unspported broker source provided: "
                     + brokerSource
+                    + " Only the following broker sources are supported: PlayStore , LocalApk");
+        }
+    }
+
+    if (project.hasProperty("brokerUpdateSource")) {
+        if (brokerUpdateSource.equalsIgnoreCase(updateSourcePlayStore)) {
+            brokerUpdationSource = updateSourcePlayStore
+        } else if (brokerUpdateSource.equalsIgnoreCase(updateSourceLocalApk)) {
+            brokerUpdationSource = updateSourceLocalApk
+        } else {
+            throw new InvalidUserDataException("Unspported update broker source provided: "
+                    + brokerUpdateSource
                     + " Only the following broker sources are supported: PlayStore , LocalApk");
         }
     }
@@ -81,10 +97,14 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "BROKER_INSTALL_SOURCE", "\"$brokerInstallationSource\"")
+        buildConfigField("String", "BROKER_UPDATE_SOURCE", "\"$brokerUpdationSource\"")
         buildConfigField("String", "WORD_APP_INSTALL_SOURCE", "\"$wordAppInstallationSource\"")
         buildConfigField("String", "INSTALL_SOURCE_PLAY_STORE", "\"$installSourcePlayStore\"")
         buildConfigField("String", "INSTALL_SOURCE_LOCAL_APK", "\"$installSourceLocalApk\"")
+        buildConfigField("String", "UPDATE_SOURCE_PLAY_STORE", "\"$updateSourcePlayStore\"")
+        buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$updateSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
+
 
         // Specifies a sorted list of flavors that the plugin should try to use from
         // a given dimension. The following tells the plugin that, when encountering

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -40,23 +40,21 @@ android {
 
     boolean usePreInstalledApks = project.hasProperty("preferPreInstalledApks")
 
-    def final installSourcePlayStore = "PlayStore"
-    def final installSourceLocalApk = "LocalApk"
-    def final updateSourcePlayStore = "PlayStore"
-    def final updateSourceLocalApk = "LocalApk"
+    def final appSourcePlayStore = "PlayStore"
+    def final appSourceLocalApk = "LocalApk"
 
     // defaults to LocalApkFile - the file must be pushed to the device before tests
-    def brokerInstallationSource = installSourcePlayStore
+    def brokerInstallationSource = appSourcePlayStore
 
-    def brokerUpdationSource = updateSourcePlayStore
+    def brokerUpdationSource = appSourcePlayStore
 
-    def wordAppInstallationSource = installSourcePlayStore
+    def wordAppInstallationSource = appSourcePlayStore
 
     if (project.hasProperty("brokerSource")) {
-        if (brokerSource.equalsIgnoreCase(installSourcePlayStore)) {
-            brokerInstallationSource = installSourcePlayStore
-        } else if (brokerSource.equalsIgnoreCase(installSourceLocalApk)) {
-            brokerInstallationSource = installSourceLocalApk
+        if (brokerSource.equalsIgnoreCase(appSourcePlayStore)) {
+            brokerInstallationSource = appSourcePlayStore
+        } else if (brokerSource.equalsIgnoreCase(appSourceLocalApk)) {
+            brokerInstallationSource = appSourceLocalApk
         } else {
             throw new InvalidUserDataException("Unspported broker source provided: "
                     + brokerSource
@@ -65,10 +63,10 @@ android {
     }
 
     if (project.hasProperty("brokerUpdateSource")) {
-        if (brokerUpdateSource.equalsIgnoreCase(updateSourcePlayStore)) {
-            brokerUpdationSource = updateSourcePlayStore
-        } else if (brokerUpdateSource.equalsIgnoreCase(updateSourceLocalApk)) {
-            brokerUpdationSource = updateSourceLocalApk
+        if (brokerUpdateSource.equalsIgnoreCase(appSourcePlayStore)) {
+            brokerUpdationSource = appSourcePlayStore
+        } else if (brokerUpdateSource.equalsIgnoreCase(appSourceLocalApk)) {
+            brokerUpdationSource = appSourceLocalApk
         } else {
             throw new InvalidUserDataException("Unspported update broker source provided: "
                     + brokerUpdateSource
@@ -77,10 +75,10 @@ android {
     }
 
     if (project.hasProperty("wordAppSource")) {
-        if (wordAppSource.equalsIgnoreCase(installSourcePlayStore)) {
-            wordAppInstallationSource = installSourcePlayStore
-        } else if (wordAppSource.equalsIgnoreCase(installSourceLocalApk)) {
-            wordAppInstallationSource = installSourceLocalApk
+        if (wordAppSource.equalsIgnoreCase(appSourcePlayStore)) {
+            wordAppInstallationSource = appSourcePlayStore
+        } else if (wordAppSource.equalsIgnoreCase(appSourceLocalApk)) {
+            wordAppInstallationSource = appSourceLocalApk
         } else {
             throw new InvalidUserDataException("Unsupported word app source provided: "
                     + wordAppSource
@@ -99,10 +97,10 @@ android {
         buildConfigField("String", "BROKER_INSTALL_SOURCE", "\"$brokerInstallationSource\"")
         buildConfigField("String", "BROKER_UPDATE_SOURCE", "\"$brokerUpdationSource\"")
         buildConfigField("String", "WORD_APP_INSTALL_SOURCE", "\"$wordAppInstallationSource\"")
-        buildConfigField("String", "INSTALL_SOURCE_PLAY_STORE", "\"$installSourcePlayStore\"")
-        buildConfigField("String", "INSTALL_SOURCE_LOCAL_APK", "\"$installSourceLocalApk\"")
-        buildConfigField("String", "UPDATE_SOURCE_PLAY_STORE", "\"$updateSourcePlayStore\"")
-        buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$updateSourceLocalApk\"")
+        buildConfigField("String", "INSTALL_SOURCE_PLAY_STORE", "\"$appSourcePlayStore\"")
+        buildConfigField("String", "INSTALL_SOURCE_LOCAL_APK", "\"$appSourceLocalApk\"")
+        buildConfigField("String", "UPDATE_SOURCE_PLAY_STORE", "\"$appSourcePlayStore\"")
+        buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$appSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
 
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -136,18 +136,14 @@ public abstract class App implements IApp {
     }
 
     @Override
-    public void update () {
+    public void update() {
         if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localUpdateApkFileName)) {
             Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
-            updateAppInstaller.installApp(localUpdateApkFileName);
+            AdbShellUtils.updatePackage(packageName, "-t", "-r", "-d");
         } else {
             Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
-            updateAppInstaller.installApp(packageName);
+            ((PlayStore) updateAppInstaller).updateApp(packageName);
         }
-
-        // the app is just installed, first run should be handled
-        // this value can (should) be changed to false by child classes as appropriate
-        shouldHandleFirstRun = true;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -46,7 +46,10 @@ public abstract class App implements IApp {
     private final static String TAG = App.class.getSimpleName();
 
     @Setter
-    private IAppInstaller appInstaller;
+    private final IAppInstaller appInstaller;
+
+    @Setter
+    private final IAppInstaller updateAppInstaller;
 
     private final String packageName;
 
@@ -54,6 +57,7 @@ public abstract class App implements IApp {
     private String appName;
 
     protected String localApkFileName = null;
+    protected String localUpdateApkFileName = null;
 
     /**
      * Indicates whether the first run experience should be handled in the UI. This value can
@@ -66,6 +70,7 @@ public abstract class App implements IApp {
     public App(@NonNull final String packageName) {
         this.packageName = packageName;
         this.appInstaller = new PlayStore();
+        this.updateAppInstaller = new PlayStore();
     }
 
     public App(@NonNull final String packageName, @NonNull final String appName) {
@@ -76,6 +81,8 @@ public abstract class App implements IApp {
     public App(@NonNull final String packageName, @NonNull final IAppInstaller appInstaller) {
         this.appInstaller = appInstaller;
         this.packageName = packageName;
+        // update installer is PlayStore by default
+        this.updateAppInstaller = new PlayStore();
     }
 
     public App(@NonNull final String packageName,
@@ -84,6 +91,18 @@ public abstract class App implements IApp {
         this.appInstaller = appInstaller;
         this.packageName = packageName;
         this.appName = appName;
+        // update installer is PlayStore by default
+        this.updateAppInstaller = new PlayStore();
+    }
+
+    public App(@NonNull final String packageName,
+               @NonNull final String appName,
+               @NonNull final IAppInstaller appInstaller,
+               @NonNull final IAppInstaller updateAppInstaller) {
+        this.appInstaller = appInstaller;
+        this.packageName = packageName;
+        this.appName = appName;
+        this.updateAppInstaller = updateAppInstaller;
     }
 
     @Override
@@ -114,6 +133,21 @@ public abstract class App implements IApp {
     @Override
     public void launch() {
         CommonUtils.launchApp(packageName);
+    }
+
+    @Override
+    public void update () {
+        if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localUpdateApkFileName)) {
+            Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
+            updateAppInstaller.installApp(localUpdateApkFileName);
+        } else {
+            Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
+            updateAppInstaller.installApp(packageName);
+        }
+
+        // the app is just installed, first run should be handled
+        // this value can (should) be changed to false by child classes as appropriate
+        shouldHandleFirstRun = true;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -57,7 +57,7 @@ public abstract class App implements IApp {
     private String appName;
 
     protected String localApkFileName = null;
-    protected String localOldApkFileName = null;
+    protected String localUpdateApkFileName = null;
 
     /**
      * Indicates whether the first run experience should be handled in the UI. This value can
@@ -107,26 +107,14 @@ public abstract class App implements IApp {
 
     @Override
     public void install() {
-        if (localOldApkFileName != null) {
-            // To ensure to install the old apk first in update scenarios
-            if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localOldApkFileName)) {
-                Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
-                appInstaller.installApp(localOldApkFileName);
-            } else {
-                Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
-                appInstaller.installApp(packageName);
-            }
-        }
-        else {
-            //TODO: make it build time configurable to specify the installer that should be used.
-            // Ideally we can specify different installers on app basis
-            if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
-                Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
-                appInstaller.installApp(localApkFileName);
-            } else {
-                Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
-                appInstaller.installApp(packageName);
-            }
+        //TODO: make it build time configurable to specify the installer that should be used.
+        // Ideally we can specify different installers on app basis
+        if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
+            Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
+            appInstaller.installApp(localApkFileName);
+        } else {
+            Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
+            appInstaller.installApp(packageName);
         }
         // the app is just installed, first run should be handled
         // this value can (should) be changed to false by child classes as appropriate
@@ -149,9 +137,9 @@ public abstract class App implements IApp {
     @Override
     public void update() {
         String appHint;
-        if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
+        if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localUpdateApkFileName)) {
             Logger.i(TAG, "Updating the " + this.appName + " from local apk..");
-            appHint = localApkFileName;
+            appHint = localUpdateApkFileName;
         } else {
             Logger.i(TAG, "Updating the " + this.appName + " from Play Store..");
             appHint = packageName;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -70,7 +70,7 @@ public abstract class App implements IApp {
     public App(@NonNull final String packageName) {
         this.packageName = packageName;
         this.appInstaller = new PlayStore();
-        this.updateAppInstaller = new PlayStore();
+        this.updateAppInstaller = new LocalApkInstaller();
     }
 
     public App(@NonNull final String packageName, @NonNull final String appName) {
@@ -82,7 +82,7 @@ public abstract class App implements IApp {
         this.appInstaller = appInstaller;
         this.packageName = packageName;
         // update installer is PlayStore by default
-        this.updateAppInstaller = new PlayStore();
+        this.updateAppInstaller = new LocalApkInstaller();
     }
 
     public App(@NonNull final String packageName,
@@ -92,7 +92,7 @@ public abstract class App implements IApp {
         this.packageName = packageName;
         this.appName = appName;
         // update installer is PlayStore by default
-        this.updateAppInstaller = new PlayStore();
+        this.updateAppInstaller = new LocalApkInstaller();
     }
 
     public App(@NonNull final String packageName,
@@ -148,13 +148,15 @@ public abstract class App implements IApp {
 
     @Override
     public void update() {
+        String appHint;
         if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
             Logger.i(TAG, "Updating the " + this.appName + " from local apk..");
-            AdbShellUtils.updatePackage(LocalApkInstaller.LOCAL_APK_PATH_PREFIX + localApkFileName, "-t", "-r", "-d");
+            appHint = localApkFileName;
         } else {
             Logger.i(TAG, "Updating the " + this.appName + " from Play Store..");
-            ((PlayStore) updateAppInstaller).updateApp(packageName);
+            appHint = packageName;
         }
+        updateAppInstaller.updateApp(appHint);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -107,7 +107,7 @@ public abstract class App implements IApp {
 
     @Override
     public void install() {
-        //TODO: make it build time configurable to specify the installer that should be used.
+        // TODO: make it build time configurable to specify the installer that should be used.
         // Ideally we can specify different installers on app basis
         if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
             Logger.i(TAG, "Installing the " + this.appName + " from local apk..");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -138,10 +138,10 @@ public abstract class App implements IApp {
     @Override
     public void update() {
         if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localUpdateApkFileName)) {
-            Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
-            AdbShellUtils.updatePackage(packageName, "-t", "-r", "-d");
+            Logger.i(TAG, "Updating the " + this.appName + " from local apk..");
+            AdbShellUtils.updatePackage(LocalApkInstaller.LOCAL_APK_PATH_PREFIX + localApkFileName, "-t", "-r", "-d");
         } else {
-            Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
+            Logger.i(TAG, "Updating the " + this.appName + " from Play Store..");
             ((PlayStore) updateAppInstaller).updateApp(packageName);
         }
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -57,7 +57,7 @@ public abstract class App implements IApp {
     private String appName;
 
     protected String localApkFileName = null;
-    protected String localUpdateApkFileName = null;
+    protected String localOldApkFileName = null;
 
     /**
      * Indicates whether the first run experience should be handled in the UI. This value can
@@ -107,16 +107,27 @@ public abstract class App implements IApp {
 
     @Override
     public void install() {
-        //TODO: make it build time configurable to specify the installer that should be used.
-        // Ideally we can specify different installers on app basis
-        if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
-            Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
-            appInstaller.installApp(localApkFileName);
-        } else {
-            Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
-            appInstaller.installApp(packageName);
+        if (localOldApkFileName != null) {
+            // To ensure to install the old apk first in update scenarios
+            if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localOldApkFileName)) {
+                Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
+                appInstaller.installApp(localOldApkFileName);
+            } else {
+                Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
+                appInstaller.installApp(packageName);
+            }
         }
-
+        else {
+            //TODO: make it build time configurable to specify the installer that should be used.
+            // Ideally we can specify different installers on app basis
+            if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
+                Logger.i(TAG, "Installing the " + this.appName + " from local apk..");
+                appInstaller.installApp(localApkFileName);
+            } else {
+                Logger.i(TAG, "Installing the " + this.appName + " from Play Store..");
+                appInstaller.installApp(packageName);
+            }
+        }
         // the app is just installed, first run should be handled
         // this value can (should) be changed to false by child classes as appropriate
         shouldHandleFirstRun = true;
@@ -137,7 +148,7 @@ public abstract class App implements IApp {
 
     @Override
     public void update() {
-        if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localUpdateApkFileName)) {
+        if (updateAppInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {
             Logger.i(TAG, "Updating the " + this.appName + " from local apk..");
             AdbShellUtils.updatePackage(LocalApkInstaller.LOCAL_APK_PATH_PREFIX + localApkFileName, "-t", "-r", "-d");
         } else {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -47,10 +47,12 @@ public class AzureSampleApp extends App {
     private static final String AZURE_SAMPLE_PACKAGE_NAME = "com.azuresamples.msalandroidapp";
     private static final String AZURE_SAMPLE_APP_NAME = "Azure Sample";
     public final static String AZURE_SAMPLE_APK = "AzureSample.apk";
+    public final static String UPDATED_AZURE_SAMPLE_APK = "UpdatedAzureSample.apk";
 
     public AzureSampleApp() {
         super(AZURE_SAMPLE_PACKAGE_NAME, AZURE_SAMPLE_APP_NAME, new LocalApkInstaller());
         localApkFileName = AZURE_SAMPLE_APK;
+        localUpdateApkFileName = UPDATED_AZURE_SAMPLE_APK;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -47,12 +47,19 @@ public class AzureSampleApp extends App {
     private static final String AZURE_SAMPLE_PACKAGE_NAME = "com.azuresamples.msalandroidapp";
     private static final String AZURE_SAMPLE_APP_NAME = "Azure Sample";
     public final static String AZURE_SAMPLE_APK = "AzureSample.apk";
-    public final static String UPDATED_AZURE_SAMPLE_APK = "UpdatedAzureSample.apk";
+    public final static String OLD_AZURE_SAMPLE_APK = "OldAzureSample.apk";
 
     public AzureSampleApp() {
         super(AZURE_SAMPLE_PACKAGE_NAME, AZURE_SAMPLE_APP_NAME, new LocalApkInstaller());
         localApkFileName = AZURE_SAMPLE_APK;
-        localUpdateApkFileName = UPDATED_AZURE_SAMPLE_APK;
+    }
+
+    public AzureSampleApp(final boolean isOldApk) {
+        super(AZURE_SAMPLE_PACKAGE_NAME, AZURE_SAMPLE_APP_NAME, new LocalApkInstaller());
+        localApkFileName = AZURE_SAMPLE_APK;
+        if (isOldApk) {
+            localOldApkFileName = OLD_AZURE_SAMPLE_APK;
+        }
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -54,12 +54,11 @@ public class AzureSampleApp extends App {
         localApkFileName = AZURE_SAMPLE_APK;
     }
 
-    public AzureSampleApp(final boolean isOldApk) {
+    public AzureSampleApp(@NonNull final String azureSampleApk,
+                                        @NonNull final String updatedAzureSampleApk) {
         super(AZURE_SAMPLE_PACKAGE_NAME, AZURE_SAMPLE_APP_NAME, new LocalApkInstaller());
-        localApkFileName = AZURE_SAMPLE_APK;
-        if (isOldApk) {
-            localOldApkFileName = OLD_AZURE_SAMPLE_APK;
-        }
+        localApkFileName = azureSampleApk;
+        localUpdateApkFileName = updatedAzureSampleApk;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -55,10 +55,10 @@ public class AzureSampleApp extends App {
     }
 
     public AzureSampleApp(@NonNull final String azureSampleApk,
-                                        @NonNull final String updatedAzureSampleApk) {
+                                        @NonNull final String updateAzureSampleApk) {
         super(AZURE_SAMPLE_PACKAGE_NAME, AZURE_SAMPLE_APP_NAME, new LocalApkInstaller());
         localApkFileName = azureSampleApk;
-        localUpdateApkFileName = updatedAzureSampleApk;
+        localUpdateApkFileName = updateAzureSampleApk;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
@@ -38,6 +38,11 @@ public interface IApp {
     void launch();
 
     /**
+     * Update this app on the device.
+     */
+    void update();
+
+    /**
      * Clear (storage) associated to this app on the device.
      */
     void clear();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -63,6 +63,9 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
     public final static IAppInstaller DEFAULT_BROKER_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
             .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
+    public final static IAppInstaller DEFAULT_BROKER_APP_UPDATE_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
+            .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
+            ? new LocalApkInstaller() : new PlayStore();
 
     @Override
     public void uninstall() {
@@ -83,13 +86,20 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
 
     public AbstractTestBroker(@NonNull final String packageName,
                               @NonNull final String appName) {
-        super(packageName, appName, DEFAULT_BROKER_APP_INSTALLER);
+        super(packageName, appName, DEFAULT_BROKER_APP_INSTALLER, DEFAULT_BROKER_APP_UPDATE_INSTALLER);
     }
 
     public AbstractTestBroker(@NonNull final String packageName,
                               @NonNull final String appName,
                               @NonNull final IAppInstaller appInstaller) {
-        super(packageName, appName, appInstaller);
+        super(packageName, appName, appInstaller, DEFAULT_BROKER_APP_UPDATE_INSTALLER);
+    }
+
+    public AbstractTestBroker(@NonNull final String packageName,
+                              @NonNull final String appName,
+                              @NonNull final IAppInstaller appInstaller,
+                              @NonNull final IAppInstaller updateAppInstaller) {
+        super(packageName, appName, appInstaller, updateAppInstaller);
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -64,7 +64,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
             .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
     public final static IAppInstaller DEFAULT_BROKER_APP_UPDATE_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
-            .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
+            .equalsIgnoreCase(BuildConfig.BROKER_UPDATE_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/AbstractTestBroker.java
@@ -63,7 +63,7 @@ public abstract class AbstractTestBroker extends App implements ITestBroker {
     public final static IAppInstaller DEFAULT_BROKER_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
             .equalsIgnoreCase(BuildConfig.BROKER_INSTALL_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
-    public final static IAppInstaller DEFAULT_BROKER_APP_UPDATE_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
+    public final static IAppInstaller DEFAULT_BROKER_APP_UPDATE_INSTALLER = BuildConfig.UPDATE_SOURCE_LOCAL_APK
             .equalsIgnoreCase(BuildConfig.BROKER_UPDATE_SOURCE)
             ? new LocalApkInstaller() : new PlayStore();
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -64,17 +64,20 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     public final static String COMPANY_PORTAL_APP_PACKAGE_NAME = "com.microsoft.windowsintune.companyportal";
     public final static String COMPANY_PORTAL_APP_NAME = "Intune Company Portal";
     public final static String COMPANY_PORTAL_APK = "CompanyPortal.apk";
+    public final static String UPDATED_COMPANY_PORTAL_APK = "UpdatedCompanyPortal.apk";
 
     private boolean enrollmentPerformedSuccessfully;
 
     public BrokerCompanyPortal() {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME);
         localApkFileName = COMPANY_PORTAL_APK;
+        localUpdateApkFileName = UPDATED_COMPANY_PORTAL_APK;
     }
 
     public BrokerCompanyPortal(@NonNull final IAppInstaller appInstaller) {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME, appInstaller);
         localApkFileName = COMPANY_PORTAL_APK;
+        localUpdateApkFileName = UPDATED_COMPANY_PORTAL_APK;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -78,12 +78,11 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
         localApkFileName = COMPANY_PORTAL_APK;
     }
 
-    public BrokerCompanyPortal(final boolean isOldApk) {
+    public BrokerCompanyPortal(@NonNull final String companyPortalApkName,
+                                        @NonNull final String updatedCompanyPortalApkName) {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME);
-        localApkFileName = COMPANY_PORTAL_APK;
-        if (isOldApk) {
-            localOldApkFileName = OLD_COMPANY_PORTAL_APK;
-        }
+        localApkFileName = companyPortalApkName;
+        localUpdateApkFileName = updatedCompanyPortalApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -64,20 +64,26 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     public final static String COMPANY_PORTAL_APP_PACKAGE_NAME = "com.microsoft.windowsintune.companyportal";
     public final static String COMPANY_PORTAL_APP_NAME = "Intune Company Portal";
     public final static String COMPANY_PORTAL_APK = "CompanyPortal.apk";
-    public final static String UPDATED_COMPANY_PORTAL_APK = "UpdatedCompanyPortal.apk";
+    public final static String OLD_COMPANY_PORTAL_APK = "OldCompanyPortal.apk";
 
     private boolean enrollmentPerformedSuccessfully;
 
     public BrokerCompanyPortal() {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME);
         localApkFileName = COMPANY_PORTAL_APK;
-        localUpdateApkFileName = UPDATED_COMPANY_PORTAL_APK;
     }
 
     public BrokerCompanyPortal(@NonNull final IAppInstaller appInstaller) {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME, appInstaller);
         localApkFileName = COMPANY_PORTAL_APK;
-        localUpdateApkFileName = UPDATED_COMPANY_PORTAL_APK;
+    }
+
+    public BrokerCompanyPortal(final boolean isOldApk) {
+        super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME);
+        localApkFileName = COMPANY_PORTAL_APK;
+        if (isOldApk) {
+            localOldApkFileName = OLD_COMPANY_PORTAL_APK;
+        }
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -79,10 +79,10 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
     }
 
     public BrokerCompanyPortal(@NonNull final String companyPortalApkName,
-                                        @NonNull final String updatedCompanyPortalApkName) {
+                                        @NonNull final String updateCompanyPortalApkName) {
         super(COMPANY_PORTAL_APP_PACKAGE_NAME, COMPANY_PORTAL_APP_NAME);
         localApkFileName = companyPortalApkName;
-        localUpdateApkFileName = updatedCompanyPortalApkName;
+        localUpdateApkFileName = updateCompanyPortalApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -58,17 +58,20 @@ public class BrokerHost extends AbstractTestBroker {
     public final static String BROKER_HOST_APP_PACKAGE_NAME = "com.microsoft.identity.testuserapp";
     public final static String BROKER_HOST_APP_NAME = "Broker Host App";
     public final static String BROKER_HOST_APK = "BrokerHost.apk";
+    public final static String UPDATED_BROKER_HOST_APK = "UpdatedBrokerHost.apk";
     public final static String BROKER_HOST_APK_PROD = "BrokerHostProd.apk";
     public final static String BROKER_HOST_APK_RC = "BrokerHostRC.apk";
 
     public BrokerHost() {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME, new LocalApkInstaller());
         localApkFileName = BROKER_HOST_APK;
+        localUpdateApkFileName = UPDATED_BROKER_HOST_APK;
     }
 
     public BrokerHost(@NonNull final String brokerHostApkName) {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME, new LocalApkInstaller());
         localApkFileName = brokerHostApkName;
+        localUpdateApkFileName = UPDATED_BROKER_HOST_APK;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -59,7 +59,6 @@ public class BrokerHost extends AbstractTestBroker {
     public final static String BROKER_HOST_APP_NAME = "Broker Host App";
     public final static String BROKER_HOST_APK = "BrokerHost.apk";
     public final static String OLD_BROKER_HOST_APK = "OldBrokerHost.apk";
-    public final static String UPDATED_BROKER_HOST_APK = "UpdatedBrokerHost.apk";
     public final static String BROKER_HOST_APK_PROD = "BrokerHostProd.apk";
     public final static String BROKER_HOST_APK_RC = "BrokerHostRC.apk";
 
@@ -67,23 +66,22 @@ public class BrokerHost extends AbstractTestBroker {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
                 new LocalApkInstaller(), new LocalApkInstaller());
         localApkFileName = BROKER_HOST_APK;
-        localOldApkFileName = null;
+        localUpdateApkFileName = BROKER_HOST_APK;
     }
 
     public BrokerHost(@NonNull final String brokerHostApkName) {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
                 new LocalApkInstaller(), new LocalApkInstaller());
         localApkFileName = brokerHostApkName;
-        localOldApkFileName = null;
+        localUpdateApkFileName = brokerHostApkName;
     }
 
-    public BrokerHost(final boolean isOldApk) {
+    public BrokerHost(@NonNull final String brokerHostApkName,
+                      @NonNull final String updatedBrokerHostApkName) {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
                 new LocalApkInstaller(), new LocalApkInstaller());
-        localApkFileName = BROKER_HOST_APK;
-        if (isOldApk) {
-            localOldApkFileName = OLD_BROKER_HOST_APK;
-        }
+        localApkFileName = brokerHostApkName;
+        localUpdateApkFileName = updatedBrokerHostApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -58,20 +58,32 @@ public class BrokerHost extends AbstractTestBroker {
     public final static String BROKER_HOST_APP_PACKAGE_NAME = "com.microsoft.identity.testuserapp";
     public final static String BROKER_HOST_APP_NAME = "Broker Host App";
     public final static String BROKER_HOST_APK = "BrokerHost.apk";
+    public final static String OLD_BROKER_HOST_APK = "OldBrokerHost.apk";
     public final static String UPDATED_BROKER_HOST_APK = "UpdatedBrokerHost.apk";
     public final static String BROKER_HOST_APK_PROD = "BrokerHostProd.apk";
     public final static String BROKER_HOST_APK_RC = "BrokerHostRC.apk";
 
     public BrokerHost() {
-        super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME, new LocalApkInstaller());
+        super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
+                new LocalApkInstaller(), new LocalApkInstaller());
         localApkFileName = BROKER_HOST_APK;
-        localUpdateApkFileName = UPDATED_BROKER_HOST_APK;
+        localOldApkFileName = null;
     }
 
     public BrokerHost(@NonNull final String brokerHostApkName) {
-        super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME, new LocalApkInstaller());
+        super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
+                new LocalApkInstaller(), new LocalApkInstaller());
         localApkFileName = brokerHostApkName;
-        localUpdateApkFileName = UPDATED_BROKER_HOST_APK;
+        localOldApkFileName = null;
+    }
+
+    public BrokerHost(final boolean isOldApk) {
+        super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
+                new LocalApkInstaller(), new LocalApkInstaller());
+        localApkFileName = BROKER_HOST_APK;
+        if (isOldApk) {
+            localOldApkFileName = OLD_BROKER_HOST_APK;
+        }
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -77,11 +77,11 @@ public class BrokerHost extends AbstractTestBroker {
     }
 
     public BrokerHost(@NonNull final String brokerHostApkName,
-                      @NonNull final String updatedBrokerHostApkName) {
+                      @NonNull final String updateBrokerHostApkName) {
         super(BROKER_HOST_APP_PACKAGE_NAME, BROKER_HOST_APP_NAME,
                 new LocalApkInstaller(), new LocalApkInstaller());
         localApkFileName = brokerHostApkName;
-        localUpdateApkFileName = updatedBrokerHostApkName;
+        localUpdateApkFileName = updateBrokerHostApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -90,12 +90,11 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
         localApkFileName = AUTHENTICATOR_APK;
     }
 
-    public BrokerMicrosoftAuthenticator(final boolean isOldApk) {
+    public BrokerMicrosoftAuthenticator(@NonNull final String authenticatorApkName,
+                                        @NonNull final String updatedAuthenticatorApkName) {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
-        localApkFileName = AUTHENTICATOR_APK;
-        if (isOldApk) {
-            localOldApkFileName = OLD_AUTHENTICATOR_APK;
-        }
+        localApkFileName = authenticatorApkName;
+        localUpdateApkFileName = updatedAuthenticatorApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -61,10 +61,10 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     public final static String AUTHENTICATOR_APP_PACKAGE_NAME = "com.azure.authenticator";
     public final static String AUTHENTICATOR_APP_NAME = "Microsoft Authenticator";
     public final static String AUTHENTICATOR_APK = "Authenticator.apk";
+    public final static String OLD_AUTHENTICATOR_APK = "OldAuthenticator.apk";
+
     private final static String UPDATE_VERSION_NUMBER = "6.2206.3949";
     private final static String OLD_VERSION_NUMBER = "6.2203.1651";
-    public final static String UPDATED_AUTHENTICATOR_APK = "UpdatedAuthenticator.apk";
-
 
     private final static String INCIDENT_MSG = "Broker Automation Incident";
 
@@ -78,13 +78,24 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     public BrokerMicrosoftAuthenticator() {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
         localApkFileName = AUTHENTICATOR_APK;
-        localUpdateApkFileName = UPDATED_AUTHENTICATOR_APK;
     }
 
     public BrokerMicrosoftAuthenticator(@NonNull final IAppInstaller appInstaller) {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME, appInstaller);
         localApkFileName = AUTHENTICATOR_APK;
-        localUpdateApkFileName = UPDATED_AUTHENTICATOR_APK;
+    }
+
+    public BrokerMicrosoftAuthenticator(@NonNull final IAppInstaller appInstaller, @NonNull final IAppInstaller updateAppInstaller) {
+        super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME, appInstaller, updateAppInstaller);
+        localApkFileName = AUTHENTICATOR_APK;
+    }
+
+    public BrokerMicrosoftAuthenticator(final boolean isOldApk) {
+        super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
+        localApkFileName = AUTHENTICATOR_APK;
+        if (isOldApk) {
+            localOldApkFileName = OLD_AUTHENTICATOR_APK;
+        }
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -63,6 +63,8 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     public final static String AUTHENTICATOR_APK = "Authenticator.apk";
     private final static String UPDATE_VERSION_NUMBER = "6.2206.3949";
     private final static String OLD_VERSION_NUMBER = "6.2203.1651";
+    public final static String UPDATED_AUTHENTICATOR_APK = "UpdatedAuthenticator.apk";
+
 
     private final static String INCIDENT_MSG = "Broker Automation Incident";
 
@@ -76,11 +78,13 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     public BrokerMicrosoftAuthenticator() {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
         localApkFileName = AUTHENTICATOR_APK;
+        localUpdateApkFileName = UPDATED_AUTHENTICATOR_APK;
     }
 
     public BrokerMicrosoftAuthenticator(@NonNull final IAppInstaller appInstaller) {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME, appInstaller);
         localApkFileName = AUTHENTICATOR_APK;
+        localUpdateApkFileName = UPDATED_AUTHENTICATOR_APK;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -91,10 +91,10 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
     }
 
     public BrokerMicrosoftAuthenticator(@NonNull final String authenticatorApkName,
-                                        @NonNull final String updatedAuthenticatorApkName) {
+                                        @NonNull final String updateAuthenticatorApkName) {
         super(AUTHENTICATOR_APP_PACKAGE_NAME, AUTHENTICATOR_APP_NAME);
         localApkFileName = authenticatorApkName;
-        localUpdateApkFileName = updatedAuthenticatorApkName;
+        localUpdateApkFileName = updateAuthenticatorApkName;
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/IAppInstaller.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/IAppInstaller.java
@@ -34,4 +34,10 @@ public interface IAppInstaller {
      */
     void installApp(final String appHint);
 
+    /**
+     * Updates the supplied app on the device.
+     *
+     * @param appHint The app name or the package name of the app to update
+     */
+    void updateApp(final String appHint);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/LocalApkInstaller.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/LocalApkInstaller.java
@@ -54,4 +54,12 @@ public class LocalApkInstaller implements IAppInstaller {
         // using -t flag to also allow installation of test only packages
         AdbShellUtils.installPackage(fullPath, "-t");
     }
+
+    @Override
+    public void updateApp(@NonNull final String apkFileName) {
+        final String fullPath = LOCAL_APK_PATH_PREFIX + apkFileName;
+        // adding -r flag will reinstall the apk
+        // -d flag will allow version downgrade as well
+        AdbShellUtils.installPackage(fullPath, "-t", "-r", "-d");
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/PlayStore.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/installer/PlayStore.java
@@ -187,4 +187,49 @@ public class PlayStore implements IAppInstaller {
         installAppFromMarketPage();
     }
 
+    public void updateApp(@NonNull final String searchHint) {
+        if (isStringPackageName(searchHint)) {
+            launchMarketPageForPackage(searchHint);
+        } else {
+            searchAppOnGooglePlay(searchHint);
+            selectGooglePlayAppFromAppName();
+        }
+
+        updateAppFromMarketPage();
+    }
+
+    private void updateAppFromMarketPage() {
+        Logger.i(TAG, "Update App From Market Page..");
+        try {
+            updateAppFromMarketPageInternal();
+        } catch (final UiObjectNotFoundException e) {
+            acceptGooglePlayTermsOfService();
+            try {
+                updateAppFromMarketPageInternal();
+            } catch (UiObjectNotFoundException ex) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+
+    private void updateAppFromMarketPageInternal() throws UiObjectNotFoundException {
+        Logger.i(TAG, "Update App From Market Page Internal..");
+        final UiDevice device = UiDevice.getInstance(getInstrumentation());
+
+        final UiObject updateBtn = device.findObject(
+                new UiSelector().className(Button.class).text("Update").enabled(true)
+        );
+
+        updateBtn.waitForExists(FIND_UI_ELEMENT_TIMEOUT);
+
+        updateBtn.click();
+
+        final UiObject openButton = device.findObject(
+                new UiSelector().className(Button.class).text("Open").enabled(true)
+        );
+
+        // if we see open button, then we know that the update is complete
+        // using same timeout as that used for install
+        openButton.waitForExists(PLAY_STORE_INSTALL_APP_TIMEOUT);
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
@@ -100,6 +100,28 @@ public class AdbShellUtils {
     }
 
     /**
+     * Updates the supplied package on the device with the supplied flags.
+     *
+     * @param packageName the name of the package to update
+     * @param flags       the flags to use during for update of the app
+     */
+    public static void updatePackage(@NonNull final String packageName, @NonNull String... flags) {
+        Logger.i(TAG, "Updates the given package:" + packageName + " on the device with the supplied flags:" + flags);
+        final StringBuilder updateCmdBuilder = new StringBuilder();
+        updateCmdBuilder.append("pm install ");
+
+        for (final String flag : flags) {
+            updateCmdBuilder.append(flag);
+            updateCmdBuilder.append(" ");
+        }
+
+        updateCmdBuilder.append(packageName);
+        final String result = executeShellCommand(updateCmdBuilder.toString());
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Success", result.trim());
+    }
+
+    /**
      * Remove the supplied package name from the device.
      *
      * @param packageName the package name to remove

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
@@ -100,28 +100,6 @@ public class AdbShellUtils {
     }
 
     /**
-     * Updates the supplied package on the device with the supplied flags.
-     *
-     * @param packageName the name of the package to update
-     * @param flags       the flags to use during for update of the app
-     */
-    public static void updatePackage(@NonNull final String packageName, @NonNull String... flags) {
-        Logger.i(TAG, "Updates the given package:" + packageName + " on the device with the supplied flags:" + flags);
-        final StringBuilder updateCmdBuilder = new StringBuilder();
-        updateCmdBuilder.append("pm install ");
-
-        for (final String flag : flags) {
-            updateCmdBuilder.append(flag);
-            updateCmdBuilder.append(" ");
-        }
-
-        updateCmdBuilder.append(packageName);
-        final String result = executeShellCommand(updateCmdBuilder.toString());
-        Assert.assertNotNull(result);
-        Assert.assertEquals("Success", result.trim());
-    }
-
-    /**
      * Remove the supplied package name from the device.
      *
      * @param packageName the package name to remove


### PR DESCRIPTION
**What** : Currently we install the app and perform UI automation testcase run on one particular version of the app. But we do not have testcases that test update scenarios. 
For ex : AcquireToken interactive is called on an app and the next update of the broker app is available. The user updates the app and acquireToken silent is called. To test whether this scenario is successful, I added update support.

**How** : Added update() method to IApp to update with the given installer. By default the app will be updated using the  playstore version if the installer is not explicitly provided.  In each of the broker apps like BrokerMicrosoftAuthentictor, BrokerCompanyPortal, BrokerHost and AzureSampleApp - Added the name of the localApk which will be used for updating the app.

Note : Internally update method added in App.java calls adb install only. But this will still be an app update as adb install -r is the closest you get, that is actually an update as it keeps the database and stored preferences. If you uninstall/re-install both the app database and preferences is deleted. 

**Testing** : Added testcases to test the acquireTokenSilent call after updating the app in https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1640
