### PR TITLE
[Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 4.2.0-hf2
+----------
+- [PATCH] Ignore predefined key not set error if shouldIgnorePredefinedKeyLoaderNotFoundError flag is set (#1775)
+
 Version 4.2.0-hf1
 ----------
 - [PATCH] Add additional logging/exception to identify root cause for office union app crash (#1762)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 Version 4.2.0-hf2
 ----------
-- [PATCH] Ignore predefined key not set error if shouldIgnorePredefinedKeyLoaderNotFoundError flag is set (#1775)
+- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1775)
 
 Version 4.2.0-hf1
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "1.2.0-hf1"
+def common4jVersion = "1.2.0-hf2"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -424,7 +424,7 @@ public enum AuthenticationSettings {
      * Method to check whether to suppress errors where KeyLoader is not found to decrypt
      * the cache content.
      */
-    public boolean getIgnoreKeyLoaderNotFoundError() {
+    public boolean shouldIgnoreKeyLoaderNotFoundError() {
         return mIgnoreKeyLoaderNotFoundError;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -416,6 +416,7 @@ public enum AuthenticationSettings {
      * Method to suppress errors where KeyLoader is not found to decrypt the cache content
      * @param shouldIgnore if true, ignores keyloader not found errors
      */
+    @SuppressFBWarnings(ME_ENUM_FIELD_SETTER)
     public void setIgnoreKeyLoaderNotFoundError(boolean shouldIgnore) {
         mIgnoreKeyLoaderNotFoundError = shouldIgnore;
     }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -94,7 +94,7 @@ public enum AuthenticationSettings {
 
     private int mReadTimeOut = DEFAULT_READ_CONNECT_TIMEOUT;
 
-    private boolean mShouldIgnorePredefinedKeyLoaderNotFoundError = false;
+    private boolean mIgnoreKeyLoaderNotFoundError = false;
 
     /**
      * Get bytes to derive secretKey to use in encrypt/decrypt.
@@ -413,18 +413,18 @@ public enum AuthenticationSettings {
     }
 
     /**
-     * Method to suppress errors where predefinedKeyLoader is not found to decrypt the cache content
-     * @param shouldIgnorePredefinedKeyLoaderNotFoundError if true, suppresses the error
+     * Method to suppress errors where KeyLoader is not found to decrypt the cache content
+     * @param shouldIgnore if true, ignores keyloader not found errors
      */
-    public void setShouldIgnorePredefinedKeyLoaderNotFoundError(boolean shouldIgnorePredefinedKeyLoaderNotFoundError) {
-        mShouldIgnorePredefinedKeyLoaderNotFoundError = shouldIgnorePredefinedKeyLoaderNotFoundError;
+    public void setIgnoreKeyLoaderNotFoundError(boolean shouldIgnore) {
+        mIgnoreKeyLoaderNotFoundError = shouldIgnore;
     }
 
     /**
-     * Method to check whether to suppress errors where predefinedKeyLoader is not found to decrypt
+     * Method to check whether to suppress errors where KeyLoader is not found to decrypt
      * the cache content.
      */
-    public boolean getShouldIgnorePredefinedKeyLoaderNotFoundError() {
-        return mShouldIgnorePredefinedKeyLoaderNotFoundError;
+    public boolean getIgnoreKeyLoaderNotFoundError() {
+        return mIgnoreKeyLoaderNotFoundError;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -94,6 +94,8 @@ public enum AuthenticationSettings {
 
     private int mReadTimeOut = DEFAULT_READ_CONNECT_TIMEOUT;
 
+    private boolean mShouldIgnorePredefinedKeyLoaderNotFoundError = false;
+
     /**
      * Get bytes to derive secretKey to use in encrypt/decrypt.
      *
@@ -408,5 +410,21 @@ public enum AuthenticationSettings {
      */
     public boolean getDisableWebViewHardwareAcceleration() {
         return mEnableHardwareAcceleration;
+    }
+
+    /**
+     * Method to suppress errors where predefinedKeyLoader is not found to decrypt the cache content
+     * @param shouldIgnorePredefinedKeyLoaderNotFoundError if true, suppresses the error
+     */
+    public void setShouldIgnorePredefinedKeyLoaderNotFoundError(boolean shouldIgnorePredefinedKeyLoaderNotFoundError) {
+        mShouldIgnorePredefinedKeyLoaderNotFoundError = shouldIgnorePredefinedKeyLoaderNotFoundError;
+    }
+
+    /**
+     * Method to check whether to suppress errors where predefinedKeyLoader is not found to decrypt
+     * the cache content.
+     */
+    public boolean getShouldIgnorePredefinedKeyLoaderNotFoundError() {
+        return mShouldIgnorePredefinedKeyLoaderNotFoundError;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
@@ -175,7 +175,7 @@ public class ADALOAuth2TokenCache
         for (final IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken> sharedSsoCache : mSharedSSOCaches) {
             try {
                 sharedSsoCache.setSingleSignOnState(account, refreshToken);
-            } catch (ClientException e) {
+            } catch (final ClientException | IllegalStateException e) {
                 Logger.errorPII(TAG,
                         "Exception setting single sign on state for account " + account.getUsername(),
                         e

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
@@ -185,7 +185,7 @@ public class ADALOAuth2TokenCache
                         "Exception setting single sign on state for account " + account.getUsername(),
                         e
                 );
-                if (!AuthenticationSettings.INSTANCE.getIgnoreKeyLoaderNotFoundError()) {
+                if (!AuthenticationSettings.INSTANCE.shouldIgnoreKeyLoaderNotFoundError()) {
                     throw e;
                 }
             }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
@@ -175,11 +175,19 @@ public class ADALOAuth2TokenCache
         for (final IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken> sharedSsoCache : mSharedSSOCaches) {
             try {
                 sharedSsoCache.setSingleSignOnState(account, refreshToken);
-            } catch (final ClientException | IllegalStateException e) {
+            } catch (final ClientException e) {
                 Logger.errorPII(TAG,
                         "Exception setting single sign on state for account " + account.getUsername(),
                         e
                 );
+            } catch (final IllegalStateException e) {
+                Logger.errorPII(TAG,
+                        "Exception setting single sign on state for account " + account.getUsername(),
+                        e
+                );
+                if (!AuthenticationSettings.INSTANCE.getIgnoreKeyLoaderNotFoundError()) {
+                    throw e;
+                }
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -81,8 +81,6 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
         if (PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
             if (mPredefinedKeyLoader != null) {
                 return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
-            } else if (AuthenticationSettings.INSTANCE.getShouldIgnorePredefinedKeyLoaderNotFoundError()) {
-                return null;
             } else {
                 throw new IllegalStateException(
                         "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, " +
@@ -93,6 +91,10 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
         }
 
         Logger.warn(methodTag, "Cannot find a matching key to decrypt the given blob");
+        if (AuthenticationSettings.INSTANCE.getIgnoreKeyLoaderNotFoundError()) {
+            return null;
+        }
+
         throw new IllegalStateException("Unknown keyIdentifier for cipher text: " + keyIdentifier);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -81,6 +81,8 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
         if (PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
             if (mPredefinedKeyLoader != null) {
                 return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
+            } else if (AuthenticationSettings.INSTANCE.getShouldIgnorePredefinedKeyLoaderNotFoundError()) {
+                return null;
             } else {
                 throw new IllegalStateException(
                         "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, " +

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -91,10 +91,6 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
         }
 
         Logger.warn(methodTag, "Cannot find a matching key to decrypt the given blob");
-        if (AuthenticationSettings.INSTANCE.getIgnoreKeyLoaderNotFoundError()) {
-            return null;
-        }
-
-        throw new IllegalStateException("Unknown keyIdentifier for cipher text: " + keyIdentifier);
+        return Collections.emptyList();
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
@@ -121,6 +121,22 @@ public class AndroidAuthSdkStorageEncryptionManagerTest {
         }
     }
 
+    @Test
+    public void testGetDecryptionKey_ForDataEncryptedWithPreDefinedKey_PredefinedKeyNotProvided_returns_null_When_shouldIgnorePredefinedKeyLoaderNotFoundError_is_true() {
+        AuthenticationSettings.INSTANCE.setShouldIgnorePredefinedKeyLoaderNotFoundError(true);
+        final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
+        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.assertNull(keyLoaderList);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGetDecryptionKey_ForDataEncryptedWithPreDefinedKey_PredefinedKeyNotProvided_throws_When_shouldIgnorePredefinedKeyLoaderNotFoundError_is_false() {
+        AuthenticationSettings.INSTANCE.setShouldIgnorePredefinedKeyLoaderNotFoundError(false);
+        final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
+        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("Expected IllegalStateException to be thrown");
+    }
+
     /**
      * Given a data encrypted with the predefined key,
      * try getting a decryption key when a predefined key is provided.

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
@@ -122,20 +122,11 @@ public class AndroidAuthSdkStorageEncryptionManagerTest {
         }
     }
 
-    @Test
-    public void testGetDecryptionKey_ForUnencryptedText_returns_null_When_ignoreKeyLoaderNotFoundError_is_true() {
-        AuthenticationSettings.INSTANCE.setIgnoreKeyLoaderNotFoundError(true);
-        final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
-        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption("Unencrypted".getBytes(ENCODING_UTF8));
-        Assert.assertNull(keyLoaderList);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testGetDecryptionKey_ForUnencryptedText_throws_When_ignoreKeyLoaderNotFoundError_is_false() {
+    public void testGetDecryptionKey_ForUnencryptedText_returns_empty_keyloader() {
         AuthenticationSettings.INSTANCE.setIgnoreKeyLoaderNotFoundError(false);
         final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
         final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption("Unencrypted".getBytes(ENCODING_UTF8));
-        Assert.fail("Expected IllegalStateException to be thrown");
+        Assert.assertEquals(0, keyLoaderList.size());
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManagerTest.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.crypto;
 import static com.microsoft.identity.common.crypto.MockData.PREDEFINED_KEY;
 import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_ANDROID_WRAPPED_KEY;
 import static com.microsoft.identity.common.crypto.MockData.TEXT_ENCRYPTED_BY_PREDEFINED_KEY;
+import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
 
 import android.content.Context;
 
@@ -122,18 +123,18 @@ public class AndroidAuthSdkStorageEncryptionManagerTest {
     }
 
     @Test
-    public void testGetDecryptionKey_ForDataEncryptedWithPreDefinedKey_PredefinedKeyNotProvided_returns_null_When_shouldIgnorePredefinedKeyLoaderNotFoundError_is_true() {
-        AuthenticationSettings.INSTANCE.setShouldIgnorePredefinedKeyLoaderNotFoundError(true);
+    public void testGetDecryptionKey_ForUnencryptedText_returns_null_When_ignoreKeyLoaderNotFoundError_is_true() {
+        AuthenticationSettings.INSTANCE.setIgnoreKeyLoaderNotFoundError(true);
         final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
-        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption("Unencrypted".getBytes(ENCODING_UTF8));
         Assert.assertNull(keyLoaderList);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testGetDecryptionKey_ForDataEncryptedWithPreDefinedKey_PredefinedKeyNotProvided_throws_When_shouldIgnorePredefinedKeyLoaderNotFoundError_is_false() {
-        AuthenticationSettings.INSTANCE.setShouldIgnorePredefinedKeyLoaderNotFoundError(false);
+    public void testGetDecryptionKey_ForUnencryptedText_throws_When_ignoreKeyLoaderNotFoundError_is_false() {
+        AuthenticationSettings.INSTANCE.setIgnoreKeyLoaderNotFoundError(false);
         final AndroidAuthSdkStorageEncryptionManager manager = new AndroidAuthSdkStorageEncryptionManager(context, null);
-        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        final List<AbstractSecretKeyLoader> keyLoaderList = manager.getKeyLoaderForDecryption("Unencrypted".getBytes(ENCODING_UTF8));
         Assert.fail("Expected IllegalStateException to be thrown");
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -199,14 +199,8 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         }
 
         final List<AbstractSecretKeyLoader> keysForDecryption = getKeyLoaderForDecryption(cipherText);
-        if (keysForDecryption == null) {
-            Logger.warn(TAG + methodName,
-                    "No key found to decrypt the cipher text. returning the cipher text as-is");
-            return cipherText;
-        }
-
-        if (keysForDecryption.size() == 0) {
-            throw new IllegalStateException("KeyLoader list must not be empty.");
+        if (keysForDecryption == null || keysForDecryption.size() == 0) {
+            throw new IllegalStateException("KeyLoader list must not be null or empty.");
         }
 
         final ClientException exceptionToThrowIfAllFails = new ClientException(ErrorStrings.DECRYPTION_FAILED,

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -199,8 +199,14 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         }
 
         final List<AbstractSecretKeyLoader> keysForDecryption = getKeyLoaderForDecryption(cipherText);
-        if (keysForDecryption == null || keysForDecryption.size() == 0) {
-            throw new IllegalStateException("KeyLoader list must not be null or empty.");
+        if (keysForDecryption == null) {
+            Logger.warn(TAG + methodName,
+                    "No key found to decrypt the cipher text. returning the cipher text as-is");
+            return cipherText;
+        }
+
+        if (keysForDecryption.size() == 0) {
+            throw new IllegalStateException("KeyLoader list must not be empty.");
         }
 
         final ClientException exceptionToThrowIfAllFails = new ClientException(ErrorStrings.DECRYPTION_FAILED,

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -103,7 +103,7 @@ public class StorageEncryptionManagerTest {
     }
 
     @Test
-    public void testDecrypt_returns_cipherText_if_keyloader_is_null() throws ClientException {
+    public void testDecrypt_null_keyloader_returns_cipherText() throws ClientException {
         final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, null);
         final byte[] plainBytes = manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
         Assert.assertEquals(TEXT_ENCRYPTED_BY_PREDEFINED_KEY, plainBytes);

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
 import static com.microsoft.identity.common.java.crypto.MockData.PREDEFINED_KEY;
@@ -92,6 +93,20 @@ public class StorageEncryptionManagerTest {
                 }});
         manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
         Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_empty_KeyLoader_throws() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, Collections.<AbstractSecretKeyLoader>emptyList());
+        manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test
+    public void testDecrypt_returns_cipherText_if_keyloader_is_null() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, null);
+        final byte[] plainBytes = manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.assertEquals(TEXT_ENCRYPTED_BY_PREDEFINED_KEY, plainBytes);
     }
 
     @Test(expected = ClientException.class)

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -102,11 +102,11 @@ public class StorageEncryptionManagerTest {
         Assert.fail("decrypt() should throw an exception but it succeeds.");
     }
 
-    @Test
-    public void testDecrypt_null_keyloader_returns_cipherText() throws ClientException {
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_null_keyloader_throws() throws ClientException {
         final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, null);
         final byte[] plainBytes = manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
-        Assert.assertEquals(TEXT_ENCRYPTED_BY_PREDEFINED_KEY, plainBytes);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
     }
 
     @Test(expected = ClientException.class)

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=1.2.0-hf1
+versionName=1.2.0-hf2
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=4.2.0-hf1
+versionName=4.2.0-hf2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
The office mobile app is noticing a crash in the latest version (after upgrading to adal 4.1.0, common 4.2.0)
We provided a hotfix build of common (4.2.0-hf1) with additional logging. Which revealed that the crash is happening because the [UserDefinedKey](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/457f539c5569e303f5dd714559283a33b27dbb5e/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java#L102) is not set. This results in crash when performing decryption of cache content which were encrypted using UserDefinedKey. The key is set by calling setSecretKey method on AuthenticationSettings.INSTANCE.
From the callstack we see that the crash is happening when trying to update SSO state in unified/msal cache (as the content of that cache is still encrypted using USER_DEFINED_KEY)

```java
java.lang.IllegalStateException: 
  at com.microsoft.identity.common.java.crypto.StorageEncryptionManager.decrypt (SourceFile:19)
  at com.microsoft.identity.common.java.crypto.KeyAccessorStringAdapter.decrypt (SourceFile:2)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.encryptDecryptInternal (SourceFile:3)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.decrypt (SourceFile:1)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.getString (SourceFile:6)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:2)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:1)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.getAccount (SourceFile:3)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.saveAccount (SourceFile:5)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.saveAccounts (SourceFile:2)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.setSingleSignOnState (SourceFile:6)
  at com.microsoft.identity.common.adal.internal.cache.ADALOAuth2TokenCache.save (SourceFile:24)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateTokenCacheUsingCommonCache (SourceFile:19)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateCachedItemWithResult (SourceFile:10)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.acquireTokenWithCachedItem (SourceFile:7)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryFRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryMRRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryRT (SourceFile:15)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.getAccessToken (SourceFile:9)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilentLocally (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.acquireTokenSilentFlow (SourceFile:4)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilent (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.performAcquireTokenRequest (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest.access$200 (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest$1.run (SourceFile:4)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)
```


The root cause of why the user defined key is not set is not yet known and is still under investigation
To avoid the crash, in this change we are ignoring the exception when updating unified/msal cache in ADAL flow), 
This will only be applicable if the flag ignoreKeyLoaderNotFoundError is set to true. Which OfficeMobile application will need to explicitly set. by calling `AuthenticationSettings.INSTANCE.SetIgnoreKeyLoaderNotFoundError(true)` method 


Related PR: [#1762](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1762)
Bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1944140