### PR TITLE
Create new common release @5.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,17 @@
+Version 5.0.1
+----------
+- [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)
+
 Version 5.0.0
 ----------
 - [MAJOR] Move IKeyStoreKeyManager and IDevicePopManager to common4j (#1683)
+- [MINOR] Added support for broadcasting to applications installed on the device.
+
+Version 4.2.0
+----------
 - [PATCH] Add exception handling in Content Provider strategy, for broker communication (#1722)
 - [MINOR] Support TenantID value from eSTS in PKeyAuth flows (#1712)
 - [MINOR] Implement cert loader for both multiple and legacy WPJ data store in PKeyAuth (#1711)
-- [MINOR] Added support for broadcasting to applications installed on the device.
 
 Version 4.1.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 5.0.1
 ----------
+- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1781)
 - [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)
 
 Version 5.0.0

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "2.0.0"
+def common4jVersion = "2.0.1-RC1"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "2.0.1-RC1"
+def common4jVersion = "2.0.1"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -94,6 +94,8 @@ public enum AuthenticationSettings {
 
     private int mReadTimeOut = DEFAULT_READ_CONNECT_TIMEOUT;
 
+    private boolean mIgnoreKeyLoaderNotFoundError = false;
+
     /**
      * Get bytes to derive secretKey to use in encrypt/decrypt.
      *
@@ -408,5 +410,22 @@ public enum AuthenticationSettings {
      */
     public boolean getDisableWebViewHardwareAcceleration() {
         return mEnableHardwareAcceleration;
+    }
+
+    /**
+     * Method to suppress errors where KeyLoader is not found to decrypt the cache content
+     * @param shouldIgnore if true, ignores keyloader not found errors
+     */
+    @SuppressFBWarnings(ME_ENUM_FIELD_SETTER)
+    public void setIgnoreKeyLoaderNotFoundError(boolean shouldIgnore) {
+        mIgnoreKeyLoaderNotFoundError = shouldIgnore;
+    }
+
+    /**
+     * Method to check whether to suppress errors where KeyLoader is not found to decrypt
+     * the cache content.
+     */
+    public boolean shouldIgnoreKeyLoaderNotFoundError() {
+        return mIgnoreKeyLoaderNotFoundError;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
@@ -175,11 +175,19 @@ public class ADALOAuth2TokenCache
         for (final IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken> sharedSsoCache : mSharedSSOCaches) {
             try {
                 sharedSsoCache.setSingleSignOnState(account, refreshToken);
-            } catch (ClientException e) {
+            } catch (final ClientException e) {
                 Logger.errorPII(TAG,
                         "Exception setting single sign on state for account " + account.getUsername(),
                         e
                 );
+            } catch (final IllegalStateException e) {
+                Logger.errorPII(TAG,
+                        "Exception setting single sign on state for account " + account.getUsername(),
+                        e
+                );
+                if (!AuthenticationSettings.INSTANCE.shouldIgnoreKeyLoaderNotFoundError()) {
+                    throw e;
+                }
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -76,12 +76,17 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
     @Override
     public @NonNull List<AbstractSecretKeyLoader> getKeyLoaderForDecryption(@NonNull byte[] cipherText) {
         final String methodTag = TAG + ":getKeyLoaderForDecryption";
-        if (mPredefinedKeyLoader != null &&
-                isEncryptedByThisKeyIdentifier(cipherText, PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER)) {
-            return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
-        }
 
-        if (isEncryptedByThisKeyIdentifier(cipherText, AndroidWrappedKeyLoader.KEY_IDENTIFIER)) {
+        final String keyIdentifier = getKeyIdentifierFromCipherText(cipherText);
+        if (PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
+            if (mPredefinedKeyLoader != null) {
+                return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
+            } else {
+                throw new IllegalStateException(
+                        "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, " +
+                                "but mPredefinedKeyLoader is null.");
+            }
+        } else if (AndroidWrappedKeyLoader.KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
             return Collections.<AbstractSecretKeyLoader>singletonList(mKeyStoreKeyLoader);
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
@@ -51,11 +51,4 @@ public class AuthorizationActivity extends DualScreenActivity {
         }
         setFragment(mFragment);
     }
-
-    @Override
-    public void onBackPressed() {
-        if (!mFragment.onBackPressed()) {
-            super.onBackPressed();
-        }
-    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -23,7 +23,9 @@
 package com.microsoft.identity.common.internal.providers.oauth2;
 
 import android.os.Bundle;
+import android.view.View;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -103,9 +105,21 @@ public abstract class AuthorizationFragment extends Fragment {
         }
     }
 
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        requireActivity().getOnBackPressedDispatcher().addCallback(getViewLifecycleOwner(), new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBackButtonPressed();
+            }
+        });
+    }
+
     void finish() {
         final String methodName = "#finish";
         LocalBroadcaster.INSTANCE.unregisterCallback(CANCEL_AUTHORIZATION_REQUEST);
+
         final FragmentActivity activity = getActivity();
         if (activity instanceof AuthorizationActivity) {
             activity.finish();
@@ -189,12 +203,8 @@ public abstract class AuthorizationFragment extends Fragment {
         super.onDestroy();
     }
 
-    /**
-     * NOTE: Fragment-only mode will not support this, as we don't own the activity.
-     * This must be invoked by AuthorizationActivity.onBackPressed().
-     */
-    public boolean onBackPressed() {
-        return false;
+    public void handleBackButtonPressed() {
+        cancelAuthorization(true);
     }
 
     void sendResult(final RawAuthorizationResult.ResultCode resultCode) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
@@ -115,13 +115,6 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
         }
     }
 
-    @Override
-    public void onBackPressed() {
-        if (!mFragment.onBackPressed()) {
-            super.onBackPressed();
-        }
-    }
-
     /**
      * This is invoked when an existing activity is re-used and provided with a new intent with additional information
      * NOTE: It's important that you use setIntent to update the intent associated with the activity.  Otherwise subsequent calls to

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -200,13 +200,9 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         return view;
     }
 
-    /**
-     * NOTE: Fragment-only mode will not support this, as we don't own the activity.
-     * This must be invoked by AuthorizationActivity.onBackPressed().
-     */
     @Override
-    public boolean onBackPressed() {
-        final String methodTag = TAG + ":onBackPressed";
+    public void handleBackButtonPressed() {
+        final String methodTag = TAG + ":handleBackButtonPressed";
         Logger.info(methodTag, "Back button is pressed");
 
         if (mWebView.canGoBack()) {
@@ -223,8 +219,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         } else {
             cancelAuthorization(true);
         }
-
-        return true;
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
 import static com.microsoft.identity.common.java.crypto.MockData.PREDEFINED_KEY;
@@ -91,6 +92,20 @@ public class StorageEncryptionManagerTest {
                     add(null);
                 }});
         manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_empty_KeyLoader_throws() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, Collections.<AbstractSecretKeyLoader>emptyList());
+        manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_null_keyloader_throws() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, null);
+        final byte[] plainBytes = manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
         Assert.fail("decrypt() should throw an exception but it succeeds.");
     }
 

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=2.0.1-RC1
+versionName=2.0.1
 versionCode=1
 latestPatchVersion=227

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=2.0.0
+versionName=2.0.1-RC1
 versionCode=1
 latestPatchVersion=227

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -21,7 +21,7 @@ ext {
     androidxTestCoreVersion = "1.2.0"
     androidxJunitVersion = "1.1.1"
     annotationVersion = "1.0.0"
-    appCompatVersion = "1.0.2"
+    appCompatVersion = "1.1.0"
     browserVersion = "1.0.0"
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=5.0.1-RC1
+versionName=5.0.1
 versionCode=1
 latestPatchVersion=234

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=5.0.0
+versionName=5.0.1-RC1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
Changes to create a new common release to be included in the next OneAuth release.
The payload contains below fix for One Auth, which resolve issues for outlook, office mobile apps 

### Payload
- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1781)
- [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)

### Version
- 5.0.1

### Release branch 
- `release/5.0.1`,  base branch `release/5.0.0`