### PR TITLE
Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set
+- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1781)
 - [MINOR] Add telemetry relay client (#1757)
 - [MINOR] Add telemetry error events (#1768)
 - [MAJOR] Adding YubiKit SDK, which requires Java Version 8 and will thus bump up Java version overall to 8; added keyboard flag to android:configChanges for all activities that could interact with a YubiKey. (#1729)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set
 - [MINOR] Add telemetry relay client (#1757)
 - [MINOR] Add telemetry error events (#1768)
 - [MAJOR] Adding YubiKit SDK, which requires Java Version 8 and will thus bump up Java version overall to 8; added keyboard flag to android:configChanges for all activities that could interact with a YubiKey. (#1729)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -94,6 +94,8 @@ public enum AuthenticationSettings {
 
     private int mReadTimeOut = DEFAULT_READ_CONNECT_TIMEOUT;
 
+    private boolean mIgnoreKeyLoaderNotFoundError = false;
+
     /**
      * Get bytes to derive secretKey to use in encrypt/decrypt.
      *
@@ -408,5 +410,22 @@ public enum AuthenticationSettings {
      */
     public boolean getDisableWebViewHardwareAcceleration() {
         return mEnableHardwareAcceleration;
+    }
+
+    /**
+     * Method to suppress errors where KeyLoader is not found to decrypt the cache content
+     * @param shouldIgnore if true, ignores keyloader not found errors
+     */
+    @SuppressFBWarnings(ME_ENUM_FIELD_SETTER)
+    public void setIgnoreKeyLoaderNotFoundError(boolean shouldIgnore) {
+        mIgnoreKeyLoaderNotFoundError = shouldIgnore;
+    }
+
+    /**
+     * Method to check whether to suppress errors where KeyLoader is not found to decrypt
+     * the cache content.
+     */
+    public boolean shouldIgnoreKeyLoaderNotFoundError() {
+        return mIgnoreKeyLoaderNotFoundError;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/ADALOAuth2TokenCache.java
@@ -175,11 +175,19 @@ public class ADALOAuth2TokenCache
         for (final IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken> sharedSsoCache : mSharedSSOCaches) {
             try {
                 sharedSsoCache.setSingleSignOnState(account, refreshToken);
-            } catch (ClientException e) {
+            } catch (final ClientException e) {
                 Logger.errorPII(TAG,
                         "Exception setting single sign on state for account " + account.getUsername(),
                         e
                 );
+            } catch (final IllegalStateException e) {
+                Logger.errorPII(TAG,
+                        "Exception setting single sign on state for account " + account.getUsername(),
+                        e
+                );
+                if (!AuthenticationSettings.INSTANCE.shouldIgnoreKeyLoaderNotFoundError()) {
+                    throw e;
+                }
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -76,12 +76,17 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
     @Override
     public @NonNull List<AbstractSecretKeyLoader> getKeyLoaderForDecryption(@NonNull byte[] cipherText) {
         final String methodTag = TAG + ":getKeyLoaderForDecryption";
-        if (mPredefinedKeyLoader != null &&
-                isEncryptedByThisKeyIdentifier(cipherText, PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER)) {
-            return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
-        }
 
-        if (isEncryptedByThisKeyIdentifier(cipherText, AndroidWrappedKeyLoader.KEY_IDENTIFIER)) {
+        final String keyIdentifier = getKeyIdentifierFromCipherText(cipherText);
+        if (PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
+            if (mPredefinedKeyLoader != null) {
+                return Collections.<AbstractSecretKeyLoader>singletonList(mPredefinedKeyLoader);
+            } else {
+                throw new IllegalStateException(
+                        "Cipher Text is encrypted by USER_PROVIDED_KEY_IDENTIFIER, " +
+                                "but mPredefinedKeyLoader is null.");
+            }
+        } else if (AndroidWrappedKeyLoader.KEY_IDENTIFIER.equalsIgnoreCase(keyIdentifier)) {
             return Collections.<AbstractSecretKeyLoader>singletonList(mKeyStoreKeyLoader);
         }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
 import static com.microsoft.identity.common.java.crypto.MockData.PREDEFINED_KEY;
@@ -91,6 +92,20 @@ public class StorageEncryptionManagerTest {
                     add(null);
                 }});
         manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_empty_KeyLoader_throws() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, Collections.<AbstractSecretKeyLoader>emptyList());
+        manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
+        Assert.fail("decrypt() should throw an exception but it succeeds.");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDecrypt_null_keyloader_throws() throws ClientException {
+        final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, null, null);
+        final byte[] plainBytes = manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
         Assert.fail("decrypt() should throw an exception but it succeeds.");
     }
 


### PR DESCRIPTION
### What
Merging changes (#1775, #1762) to hotfix office mobile app crash from release/4.2.0-hf2 to dev

### Description
The office mobile app noticed a crash in the latest version (after upgrading to adal 4.1.0, common 4.2.0)
The crash is happening because the [UserDefinedKey](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/457f539c5569e303f5dd714559283a33b27dbb5e/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java#L102) is not set. This results in crash when performing decryption of cache content which were encrypted using UserDefinedKey. The key is set by calling setSecretKey method on AuthenticationSettings.INSTANCE.
From the callstack we see that the crash is happening when trying to update SSO state in unified/msal cache (as the content of that cache is still encrypted using USER_DEFINED_KEY)

java.lang.IllegalStateException: 
  at com.microsoft.identity.common.java.crypto.StorageEncryptionManager.decrypt (SourceFile:19)
  at com.microsoft.identity.common.java.crypto.KeyAccessorStringAdapter.decrypt (SourceFile:2)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.encryptDecryptInternal (SourceFile:3)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.decrypt (SourceFile:1)
  at com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager.getString (SourceFile:6)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:2)
  at com.microsoft.identity.common.internal.util.SharedPrefStringNameValueStorage.get (SourceFile:1)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.getAccount (SourceFile:3)
  at com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache.saveAccount (SourceFile:5)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.saveAccounts (SourceFile:2)
  at com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache.setSingleSignOnState (SourceFile:6)
  at com.microsoft.identity.common.adal.internal.cache.ADALOAuth2TokenCache.save (SourceFile:24)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateTokenCacheUsingCommonCache (SourceFile:19)
  at com.microsoft.aad.adal.TokenCacheAccessor.updateCachedItemWithResult (SourceFile:10)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.acquireTokenWithCachedItem (SourceFile:7)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryFRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryMRRT (SourceFile:8)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.tryRT (SourceFile:15)
  at com.microsoft.aad.adal.AcquireTokenSilentHandler.getAccessToken (SourceFile:9)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilentLocally (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.acquireTokenSilentFlow (SourceFile:4)
  at com.microsoft.aad.adal.AcquireTokenRequest.tryAcquireTokenSilent (SourceFile:3)
  at com.microsoft.aad.adal.AcquireTokenRequest.performAcquireTokenRequest (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest.access$200 (SourceFile:1)
  at com.microsoft.aad.adal.AcquireTokenRequest$1.run (SourceFile:4)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)

To avoid the crash, in this change we are ignoring the exception when updating unified/msal cache in ADAL flow),
This will only be applicable if the flag ignoreKeyLoaderNotFoundError is set to true. Which OfficeMobile application will need to explicitly set. by calling AuthenticationSettings.INSTANCE.SetIgnoreKeyLoaderNotFoundError(true) method

