### PR TITLE
Update common to 6.0.0-RC2

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,7 +28,7 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-def common4jVersion = "3.0.0-RC1"
+def common4jVersion = "3.0.0-RC2"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=3.0.0-RC1
+versionName=3.0.0-RC2
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=6.0.0-RC1
+versionName=6.0.0-RC2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
Update Common to 6.0.0-RC2
Update Common4j to 3.0.0-RC2

Contains following
- [MAJOR] Bumped MSAL Broker Protocol version to 8.0, GET_ACCOUNTS endpoint requires minimum_required_broker_protocol_version of 8.0+ to return an account constructed from PRT id token to FOCI apps. (#1771)
- [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow (#1783)
- [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1781)