### PR TITLE
Remove SSLContext From HttpClient signature

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/net/AbstractHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/AbstractHttpClient.java
@@ -41,75 +41,65 @@ public abstract class AbstractHttpClient implements HttpClient {
     public HttpResponse method(@NonNull final String httpMethod,
                                @NonNull final URL requestUrl,
                                @NonNull final Map<String, String> requestHeaders,
-                               @Nullable final byte[] requestContent,
-                               @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.validateAndNormalizeMethod(httpMethod), requestUrl, requestHeaders, requestContent, sslContext);
+                               @Nullable final byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.validateAndNormalizeMethod(httpMethod), requestUrl, requestHeaders, requestContent);
     }
 
     @Override
     public abstract HttpResponse method(@NonNull final HttpMethod httpMethod,
                                         @NonNull final URL requestUrl,
                                         @NonNull final Map<String, String> requestHeaders,
-                                        @Nullable final byte[] requestContent,
-                                        @Nullable final SSLContext sslContext) throws IOException;
+                                        @Nullable final byte[] requestContent) throws IOException;
 
     @Override
     public HttpResponse put(@NonNull final URL requestUrl,
                             @NonNull final Map<String, String> requestHeaders,
-                            @Nullable final byte[] requestContent,
-                            @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.PUT, requestUrl, requestHeaders, requestContent, sslContext);
+                            @Nullable final byte[] requestContent) throws IOException {
+        return method(HttpMethod.PUT, requestUrl, requestHeaders, requestContent);
     }
 
     @Override
     public HttpResponse patch(@NonNull final URL requestUrl,
                               @NonNull final Map<String, String> requestHeaders,
-                              @Nullable final byte[] requestContent,
-                              @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.PATCH, requestUrl, requestHeaders, requestContent, sslContext);
+                              @Nullable final byte[] requestContent) throws IOException {
+        return method(HttpMethod.PATCH, requestUrl, requestHeaders, requestContent);
     }
 
     @Override
     public HttpResponse options(@NonNull final URL requestUrl,
-                                @NonNull final Map<String, String> requestHeaders,
-                                @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.OPTIONS, requestUrl, requestHeaders, null, sslContext);
+                                @NonNull final Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.OPTIONS, requestUrl, requestHeaders, null);
     }
 
     @Override
     public HttpResponse post(@NonNull final URL requestUrl,
                              @NonNull final Map<String, String> requestHeaders,
-                             @Nullable final byte[] requestContent,
-                             @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.POST, requestUrl, requestHeaders, requestContent, sslContext);
+                             @Nullable final byte[] requestContent) throws IOException {
+        return method(HttpMethod.POST, requestUrl, requestHeaders, requestContent);
     }
 
     @Override
     public HttpResponse delete(@NonNull final URL requestUrl,
                                @NonNull final Map<String, String> requestHeaders,
-                               @Nullable final byte[] requestContent,
-                               @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.DELETE, requestUrl, requestHeaders, requestContent, sslContext);
+                               @Nullable final byte[] requestContent) throws IOException {
+        return method(HttpMethod.DELETE, requestUrl, requestHeaders, requestContent);
     }
 
     @Override
     public HttpResponse get(@NonNull final URL requestUrl,
-                            @NonNull final Map<String, String> requestHeaders,
-                            @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.GET, requestUrl, requestHeaders, null, sslContext);
+                            @NonNull final Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.GET, requestUrl, requestHeaders, null);
     }
 
     @Override
     public HttpResponse head(@NonNull final URL requestUrl,
-                             @NonNull final Map<String, String> requestHeaders,
-                             @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.HEAD, requestUrl, requestHeaders, null, sslContext);
+                             @NonNull final Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.HEAD, requestUrl, requestHeaders, null);
     }
 
     @Override
     public HttpResponse trace(@NonNull final URL requestUrl,
-                              @NonNull final Map<String, String> requestHeaders,
-                              @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpMethod.TRACE, requestUrl, requestHeaders, null, sslContext);
+                              @NonNull final Map<String, String> requestHeaders) throws IOException {
+        return method(HttpMethod.TRACE, requestUrl, requestHeaders, null);
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpClient.java
@@ -46,15 +46,13 @@ public interface HttpClient {
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
     HttpResponse method(@NonNull String httpMethod,
                         @NonNull URL requestUrl,
                         @NonNull Map<String, String> requestHeaders,
-                        byte[] requestContent,
-                        SSLContext sslContext) throws IOException;
+                        byte[] requestContent) throws IOException;
 
     /**
      * Execute an arbitrary method.
@@ -62,119 +60,101 @@ public interface HttpClient {
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
     HttpResponse method(@NonNull HttpMethod httpMethod,
                         @NonNull URL requestUrl,
                         @NonNull Map<String, String> requestHeaders,
-                        byte[] requestContent,
-                        SSLContext sslContext) throws IOException;
+                        byte[] requestContent) throws IOException;
 
     /**
      * Execute an HTTP PUT request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
     HttpResponse put(@NonNull URL requestUrl,
                      @NonNull Map<String, String> requestHeaders,
-                     byte[] requestContent,
-                     SSLContext sslContext) throws IOException;
+                     byte[] requestContent) throws IOException;
 
     /**
      * Execute an HTTP PATCH request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
     HttpResponse patch(@NonNull URL requestUrl,
                        @NonNull Map<String, String> requestHeaders,
-                       byte[] requestContent,
-                       SSLContext sslContext) throws IOException;
+                       byte[] requestContent) throws IOException;
 
     /**
      * Execute an HTTP OPTIONS request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
-    HttpResponse options(@NonNull URL requestUrl,
-                         @NonNull Map<String, String> requestHeaders,
-                         SSLContext sslContext) throws IOException;
+    HttpResponse options(@NonNull final URL requestUrl,
+                         @NonNull final Map<String, String> requestHeaders) throws IOException;
 
     /**
      * Execute an HTTP POST request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
     HttpResponse post(@NonNull URL requestUrl,
                       @NonNull Map<String, String> requestHeaders,
-                      byte[] requestContent,
-                      SSLContext sslContext) throws IOException;
+                      byte[] requestContent) throws IOException;
 
     /**
      * Execute an HTTP PATCH request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
      * @param requestContent the body content of the request, if applicable.  May be null.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
-    HttpResponse delete(@NonNull URL requestUrl,
-                        @NonNull Map<String, String> requestHeaders,
-                        byte[] requestContent,
-                        SSLContext sslContext) throws IOException;
+    HttpResponse delete(@NonNull final URL requestUrl,
+                        @NonNull final Map<String, String> requestHeaders,
+                        byte[] requestContent) throws IOException;
 
     /**
      * Execute an HTTP GET request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
-    HttpResponse get(@NonNull URL requestUrl,
-                     @NonNull Map<String, String> requestHeaders,
-                     SSLContext sslContext) throws IOException;
+    HttpResponse get(@NonNull final URL requestUrl,
+                     @NonNull final Map<String, String> requestHeaders) throws IOException;
 
     /**
      * Execute an HTTP HEAD request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
-    HttpResponse head(@NonNull URL requestUrl,
-                      @NonNull Map<String, String> requestHeaders,
-                      SSLContext sslContext) throws IOException;
+    HttpResponse head(@NonNull final URL requestUrl,
+                      @NonNull final Map<String, String> requestHeaders) throws IOException;
 
     /**
      * Execute an HTTP TRACE request.
      * @param requestUrl the URL of the resource to operate on.
      * @param requestHeaders the headers for the request.
-     * @param sslContext an optional {@link SSLContext} object.
      * @return an HttpResponse with the result of the call.
      * @throws IOException if there was a communication problem.
      */
-    HttpResponse trace(@NonNull URL requestUrl,
-                       @NonNull Map<String, String> requestHeaders,
-                       SSLContext sslContext) throws IOException;
+    HttpResponse trace(@NonNull final URL requestUrl,
+                       @NonNull final Map<String, String> requestHeaders) throws IOException;
 
     /**
      * An enumeration of the HTTP verbs supported by this client interface.

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpRequest.java
@@ -64,10 +64,6 @@ public class HttpRequest {
     @Accessors(prefix = "m")
     private final String mRequestMethod;
 
-    @Getter
-    @Accessors(prefix = "m")
-    public SSLContext mSslContext;
-
     private final Map<String, String> mRequestHeaders = new HashMap<>();
 
     Map<String, String> getRequestHeaders() {
@@ -82,20 +78,17 @@ public class HttpRequest {
      * @param requestHeaders     Headers used to send the http request.
      * @param requestContent     Post message sent in the post request.
      * @param requestContentType Request content type.
-     * @param sslContext         an optional {@link SSLContext} object.
      */
     public HttpRequest(@NonNull final URL requestUrl,
                        @NonNull final Map<String, String> requestHeaders,
                        @NonNull final String requestMethod,
                        final byte[] requestContent,
-                       final String requestContentType,
-                       final SSLContext sslContext) {
+                       final String requestContentType) {
         mRequestUrl = requestUrl;
         mRequestHeaders.put(HOST, requestUrl.getAuthority());
         mRequestHeaders.putAll(requestHeaders);
         mRequestMethod = requestMethod;
         mRequestContent = requestContent != null ? Arrays.copyOf(requestContent, requestContent.length) : null;
         mRequestContentType = requestContentType;
-        mSslContext = sslContext;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -32,7 +32,6 @@ import com.microsoft.identity.common.java.util.ported.Consumer;
 import com.microsoft.identity.common.java.util.ported.Function;
 import com.microsoft.identity.common.java.util.ported.Supplier;
 
-import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
 import java.io.BufferedReader;
@@ -52,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -75,44 +75,92 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.CLI
  * TODO: add telemetry for exceptions/intermediary failures in this class.
  */
 @AllArgsConstructor
-@Builder
 @ThreadSafe
 public class UrlConnectionHttpClient extends AbstractHttpClient {
-
     private static final Object TAG = UrlConnectionHttpClient.class.getName();
 
     protected static final int RETRY_TIME_WAITING_PERIOD_MSEC = 1000;
-    protected static final int STREAM_BUFFER_SIZE_BYTES = 1024;
     public static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;
     public static final int DEFAULT_READ_TIME_OUT_MS = 30000;
-    public static final int DEFAULT_STREAM_BUFFER_SIZE = 1024;
-
-    @Builder.Default
-    private final IRetryPolicy<HttpResponse> retryPolicy = new NoRetryPolicy();
-    @Builder.Default
-    private final int connectTimeoutMs = DEFAULT_CONNECT_TIME_OUT_MS;
-    @Builder.Default
-    private final int readTimeoutMs = DEFAULT_READ_TIME_OUT_MS;
-    @Builder.Default
-    private final Supplier<Integer> connectTimeoutMsSupplier = null;
-    @Builder.Default
-    private final Supplier<Integer> readTimeoutMsSupplier = null;
-    @Builder.Default
-    private final int streamBufferSize = DEFAULT_STREAM_BUFFER_SIZE;
-    @Builder.Default
-    private final List<String> supportedSslProtocol = SSLSocketFactoryWrapper.SUPPORTED_SSL_PROTOCOLS;
-
-
-    private SSLSocketFactoryWrapper sDefault;
-
-    private synchronized SSLSocketFactoryWrapper getDefaultWrapper(){
-        if (sDefault == null){
-            sDefault = new SSLSocketFactoryWrapper((SSLSocketFactory) SSLSocketFactory.getDefault(), supportedSslProtocol);
-        }
-        return sDefault;
-    }
+    public static final int DEFAULT_STREAM_BUFFER_SIZE_BYTE = 1024;
 
     private static final transient AtomicReference<UrlConnectionHttpClient> defaultReference = new AtomicReference<>(null);
+
+    /**
+     * Retry policy of this HttpClient. Default is {@link NoRetryPolicy}.
+     */
+    private final IRetryPolicy<HttpResponse> retryPolicy;
+
+    /**
+     * Retry policy of this HttpClient. Default is {@link NoRetryPolicy}.
+     */
+    private final int streamBufferSize;
+
+    /**
+     * To be set in {@link java.net.URLConnection#setConnectTimeout(int)}.
+     * If {@link UrlConnectionHttpClient#connectTimeoutMsSupplier} is provided, the value will be loaded from there instead.
+     * Default is {@link UrlConnectionHttpClient#DEFAULT_CONNECT_TIME_OUT_MS}.
+     */
+    private final int connectTimeoutMs;
+
+    /**
+     * To be set in {@link java.net.URLConnection#setReadTimeout(int)}.
+     * If {@link UrlConnectionHttpClient#readTimeoutMsSupplier} is provided, the value will be loaded from there instead.
+     * Default is {@link UrlConnectionHttpClient#DEFAULT_READ_TIME_OUT_MS}.
+     */
+    private final int readTimeoutMs;
+
+    /**
+     * A provider for loading values to be set in {@link java.net.URLConnection#setConnectTimeout(int)}.
+     */
+    private final Supplier<Integer> connectTimeoutMsSupplier;
+
+    /**
+     * A provider for loading values to be set in {@link java.net.URLConnection#setReadTimeout(int)}.
+     */
+    private final Supplier<Integer> readTimeoutMsSupplier;
+
+    /**
+     * A socket factory for creating the connection's {@link javax.net.ssl.SSLSocket} objects.
+     */
+    private final SSLSocketFactoryWrapper sslSocketFactory;
+
+    /**
+     * Default Constructor, for constructing Lombok's Builder only. Do not expose.
+     */
+    @Builder
+    private UrlConnectionHttpClient(@Nullable final IRetryPolicy<HttpResponse> retryPolicy,
+                                    @Nullable final Integer streamBufferSize,
+                                    @Nullable final Integer connectTimeoutMs,
+                                    @Nullable final Integer readTimeoutMs,
+                                    @Nullable final Supplier<Integer> connectTimeoutMsSupplier,
+                                    @Nullable final Supplier<Integer> readTimeoutMsSupplier,
+                                    @Nullable final List<String> supportedSslProtocol,
+                                    @Nullable final SSLContext sslContext) {
+
+        this.retryPolicy = retryPolicy != null ?
+                retryPolicy : new NoRetryPolicy();
+        this.streamBufferSize = streamBufferSize != null ?
+                streamBufferSize : DEFAULT_STREAM_BUFFER_SIZE_BYTE;
+        this.connectTimeoutMs = connectTimeoutMs != null ?
+                connectTimeoutMs : DEFAULT_CONNECT_TIME_OUT_MS;
+        this.readTimeoutMs = readTimeoutMs != null ?
+                readTimeoutMs : DEFAULT_READ_TIME_OUT_MS;
+        this.connectTimeoutMsSupplier = connectTimeoutMsSupplier;
+        this.readTimeoutMsSupplier = readTimeoutMsSupplier;
+
+        final List<String> protocol = supportedSslProtocol != null ?
+                supportedSslProtocol : SSLSocketFactoryWrapper.SUPPORTED_SSL_PROTOCOLS;
+
+        if (sslContext == null) {
+            // TODO: Build the default SSLContext ourselves with the defined JSSE provider.
+            this.sslSocketFactory = new SSLSocketFactoryWrapper((SSLSocketFactory) SSLSocketFactory.getDefault(),
+                    protocol);
+        } else {
+            this.sslSocketFactory = new SSLSocketFactoryWrapper(sslContext.getSocketFactory(),
+                    protocol);
+        }
+    }
 
     /**
      * Obtain a static default instance of the HTTP Client class.
@@ -123,7 +171,6 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
         UrlConnectionHttpClient reference = defaultReference.get();
         if (reference == null) {
             defaultReference.compareAndSet(null, UrlConnectionHttpClient.builder()
-                    .streamBufferSize(STREAM_BUFFER_SIZE_BYTES)
                     .retryPolicy(StatusCodeAndExceptionRetry.builder()
                             .number(1)
                             .extensionFactor(2)
@@ -187,7 +234,6 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
      * @param requestUrl     The recipient {@link URL}.
      * @param requestHeaders Headers used to send the http request.
      * @param requestContent Optional request body, if applicable.
-     * @param sslContext     an optional {@link SSLContext} object.
      * @return HttpResponse  The response for this request.
      * @throws IOException If an error is encountered while servicing this request.
      */
@@ -195,10 +241,9 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     public HttpResponse method(@NonNull final HttpClient.HttpMethod httpMethod,
                                @NonNull final URL requestUrl,
                                @NonNull final Map<String, String> requestHeaders,
-                               final byte[] requestContent,
-                               final SSLContext sslContext) throws IOException {
+                               final byte[] requestContent) throws IOException {
         recordHttpTelemetryEventStart(httpMethod.name(), requestUrl, requestHeaders.get(CLIENT_REQUEST_ID));
-        final HttpRequest request = constructHttpRequest(httpMethod, requestUrl, requestHeaders, requestContent, sslContext);
+        final HttpRequest request = constructHttpRequest(httpMethod, requestUrl, requestHeaders, requestContent);
         return retryPolicy.attempt(new Callable<HttpResponse>() {
             public HttpResponse call() throws IOException {
                 return executeHttpSend(request, new Consumer<HttpResponse>() {
@@ -214,8 +259,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     private static HttpRequest constructHttpRequest(@NonNull HttpClient.HttpMethod httpMethod,
                                                     @NonNull URL requestUrl,
                                                     @NonNull Map<String, String> requestHeaders,
-                                                    byte[] requestContent,
-                                                    final SSLContext sslContext) {
+                                                    byte[] requestContent) {
 
         // Apply special backcompat behaviors for PATCH, if reqd
         if (HttpClient.HttpMethod.PATCH == httpMethod) {
@@ -233,8 +277,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
                 requestHeaders,
                 httpMethod.name(), // HttpURLConnection doesn't natively support PATCH
                 requestContent,
-                null,
-                sslContext
+                null
         );
     }
 
@@ -335,11 +378,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
         }
 
         if (urlConnection instanceof HttpsURLConnection) {
-            final SSLSocketFactory factory =
-                    request.getSslContext() != null ?
-                            new SSLSocketFactoryWrapper(request.getSslContext().getSocketFactory(), supportedSslProtocol) :
-                            getDefaultWrapper();
-            ((HttpsURLConnection) urlConnection).setSSLSocketFactory(factory);
+            ((HttpsURLConnection) urlConnection).setSSLSocketFactory(sslSocketFactory);
         } else if ("https".equalsIgnoreCase(request.getRequestUrl().getProtocol())) {
             throw new IllegalStateException("Trying to initiate a HTTPS request, but didn't get back HttpsURLConnection");
         } else if ("http".equalsIgnoreCase(request.getRequestUrl().getProtocol())) {

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -135,7 +135,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
                                     @Nullable final Integer readTimeoutMs,
                                     @Nullable final Supplier<Integer> connectTimeoutMsSupplier,
                                     @Nullable final Supplier<Integer> readTimeoutMsSupplier,
-                                    @Nullable final List<String> supportedSslProtocol,
+                                    @Nullable final List<String> supportedSslProtocols,
                                     @Nullable final SSLContext sslContext) {
 
         this.retryPolicy = retryPolicy != null ?

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -92,7 +92,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     private final IRetryPolicy<HttpResponse> retryPolicy;
 
     /**
-     * Retry policy of this HttpClient. Default is {@link NoRetryPolicy}.
+     * Size of the stream buffer.
      */
     private final int streamBufferSize;
 
@@ -149,8 +149,8 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
         this.connectTimeoutMsSupplier = connectTimeoutMsSupplier;
         this.readTimeoutMsSupplier = readTimeoutMsSupplier;
 
-        final List<String> protocol = supportedSslProtocol != null ?
-                supportedSslProtocol : SSLSocketFactoryWrapper.SUPPORTED_SSL_PROTOCOLS;
+        final List<String> protocol = supportedSslProtocols != null ?
+                supportedSslProtocols : SSLSocketFactoryWrapper.SUPPORTED_SSL_PROTOCOLS;
 
         if (sslContext == null) {
             // TODO: Build the default SSLContext ourselves with the defined JSSE provider.

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -80,9 +80,9 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     private static final Object TAG = UrlConnectionHttpClient.class.getName();
 
     protected static final int RETRY_TIME_WAITING_PERIOD_MSEC = 1000;
-    public static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;
-    public static final int DEFAULT_READ_TIME_OUT_MS = 30000;
-    public static final int DEFAULT_STREAM_BUFFER_SIZE_BYTE = 1024;
+    protected static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;
+    protected static final int DEFAULT_READ_TIME_OUT_MS = 30000;
+    protected static final int DEFAULT_STREAM_BUFFER_SIZE_BYTE = 1024;
 
     private static final transient AtomicReference<UrlConnectionHttpClient> defaultReference = new AtomicReference<>(null);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -191,8 +191,7 @@ public class AzureActiveDirectory
 
         final HttpResponse response =
                 httpClient.get(new URL(instanceDiscoveryRequestUri.toString()),
-                        new HashMap<String, String>(),
-                        null);
+                        new HashMap<String, String>());
 
         if (response.getStatusCode() >= HttpURLConnection.HTTP_BAD_REQUEST) {
             Logger.warn(TAG + methodName, "Error getting cloud information");

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -540,8 +540,7 @@ public class MicrosoftStsOAuth2Strategy
             return httpClient.post(
                     authority,
                     headers,
-                    requestBody.getBytes(ObjectMapper.ENCODING_SCHEME),
-                    null
+                    requestBody.getBytes(ObjectMapper.ENCODING_SCHEME)
             );
         } catch (final UnsupportedEncodingException exception) {
             throw new ClientException(ErrorStrings.UNSUPPORTED_ENCODING,

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -231,8 +231,7 @@ public abstract class OAuth2Strategy
         final HttpResponse response = httpClient.post(
                 requestUrl,
                 headers,
-                requestBody.getBytes(ObjectMapper.ENCODING_SCHEME),
-                null
+                requestBody.getBytes(ObjectMapper.ENCODING_SCHEME)
         );
 
         // Record the clock skew between *this device* and EVO...
@@ -304,8 +303,7 @@ public abstract class OAuth2Strategy
         final HttpResponse response = httpClient.post(
                 ((MicrosoftStsOAuth2Configuration) mConfig).getDeviceAuthorizationEndpoint(),
                 headers,
-                requestBody.getBytes(ObjectMapper.ENCODING_SCHEME),
-                null
+                requestBody.getBytes(ObjectMapper.ENCODING_SCHEME)
         );
 
         // Create the authorization result

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -143,8 +143,7 @@ public class OpenIdProviderConfigurationClient {
             );
 
             final HttpResponse providerConfigResponse = httpClient.get(configUrl.toURL(),
-                    new HashMap<String, String>(),
-                    null);
+                    new HashMap<String, String>());
 
             final int statusCode = providerConfigResponse.getStatusCode();
 

--- a/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
@@ -1211,7 +1211,7 @@ public final class UrlConnectionHttpClientTest {
     @Test(expected = SSLHandshakeException.class)
     public void testConnectingToTLS13ServerWhileEnforcing12OnClientSide() throws IOException {
         final UrlConnectionHttpClient client = UrlConnectionHttpClient.builder()
-                .supportedSslProtocol(Arrays.asList("TLSv1.3"))
+                .supportedSslProtocols(Arrays.asList("TLSv1.3"))
                 .build();
 
         final HttpResponse response = client.method(
@@ -1227,7 +1227,7 @@ public final class UrlConnectionHttpClientTest {
     @Test
     public void testSpecifyingSupportedSSLVersion() throws IOException {
         final UrlConnectionHttpClient client = UrlConnectionHttpClient.builder()
-                .supportedSslProtocol(Arrays.asList("TLSv1.2"))
+                .supportedSslProtocols(Arrays.asList("TLSv1.2"))
                 .build();
 
         // Microsoft.com supports TLS 1.3

--- a/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
@@ -23,6 +23,11 @@
 
 package com.microsoft.identity.common.java.net;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.microsoft.identity.common.java.net.util.MockConnection;
 import com.microsoft.identity.common.java.net.util.ResponseBody;
 
@@ -44,7 +49,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -53,11 +57,6 @@ import java.util.UUID;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLHandshakeException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link UrlConnectionHttpClient}.
@@ -88,12 +87,12 @@ public final class UrlConnectionHttpClientTest {
      */
     @Test(expected = NullPointerException.class)
     public void testNullRequestUrl() throws IOException {
-        sNoRetryClient.get(null, Collections.<String, String>emptyMap(), null);
+        sNoRetryClient.get(null, Collections.<String, String>emptyMap());
     }
 
     /**
      * Verify that HTTP GET succeed
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -103,7 +102,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP GET succeed
-     * - via {@link UrlConnectionHttpClient#get(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#get(URL, Map)}
      * - with retry logic.
      */
     @Test
@@ -113,7 +112,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP GET succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -123,7 +122,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP GET succeed
-     * - via {@link UrlConnectionHttpClient#get(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#get(URL, Map)}
      * - without retry logic.
      */
     @Test
@@ -133,7 +132,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP POST succeed
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -143,7 +142,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP POST succeed
-     * - via {@link UrlConnectionHttpClient#post(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#post(URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -153,7 +152,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP POST succeed
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -163,7 +162,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP POST succeed
-     * - via {@link UrlConnectionHttpClient#post(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#post(URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -173,7 +172,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP HEAD succeed
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -183,7 +182,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP HEAD succeed
-     * - via {@link UrlConnectionHttpClient#head(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#head(URL, Map)}
      * - with retry logic.
      */
     @Test
@@ -193,7 +192,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP HEAD succeed
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -203,7 +202,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP HEAD succeed
-     * - via {@link UrlConnectionHttpClient#head(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#head(URL, Map)}
      * - without retry logic.
      */
     @Test
@@ -213,7 +212,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PUT succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -223,7 +222,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PUT succeeds
-     * - via {@link UrlConnectionHttpClient#put(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#put(URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -233,7 +232,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PUT succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -243,7 +242,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PUT succeeds
-     * - via {@link UrlConnectionHttpClient#put(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#put(URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -253,7 +252,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP DELETE succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -263,7 +262,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP DELETE succeeds
-     * - via {@link UrlConnectionHttpClient#delete(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#delete(URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -273,7 +272,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP DELETE succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -283,7 +282,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP DELETE succeeds
-     * - via {@link UrlConnectionHttpClient#delete(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#delete(URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -293,7 +292,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP TRACE succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -303,7 +302,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP TRACE succeeds
-     * - via {@link UrlConnectionHttpClient#trace(URL, Map, SSLContext))}
+     * - via {@link UrlConnectionHttpClient#trace(URL, Map))}
      * - with retry logic.
      */
     @Test
@@ -313,7 +312,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP TRACE succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -323,7 +322,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP TRACE succeeds
-     * - via {@link UrlConnectionHttpClient#trace(URL, Map, SSLContext))}
+     * - via {@link UrlConnectionHttpClient#trace(URL, Map))}
      * - without retry logic.
      */
     @Test
@@ -333,7 +332,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP OPTIONS succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -343,7 +342,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP OPTIONS succeeds
-     * - via {@link UrlConnectionHttpClient#options(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#options(URL, Map)}
      * - with retry logic.
      */
     @Test
@@ -353,7 +352,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP OPTIONS succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -363,7 +362,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP OPTIONS succeeds
-     * - via {@link UrlConnectionHttpClient#options(URL, Map, SSLContext)}
+     * - via {@link UrlConnectionHttpClient#options(URL, Map)}
      * - without retry logic.
      */
     @Test
@@ -373,7 +372,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PATCH succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - with retry logic.
      */
     @Test
@@ -383,7 +382,7 @@ public final class UrlConnectionHttpClientTest {
     
     /**
      * Verify that HTTP PATCH succeeds
-     * - via {@link UrlConnectionHttpClient#patch(URL, Map, byte[], SSLContext)}}
+     * - via {@link UrlConnectionHttpClient#patch(URL, Map, byte[])}}
      * - with retry logic.
      */
     @Test
@@ -393,7 +392,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PATCH succeeds
-     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#method(String, URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -403,7 +402,7 @@ public final class UrlConnectionHttpClientTest {
 
     /**
      * Verify that HTTP PATCH succeeds
-     * - via {@link UrlConnectionHttpClient#patch(URL, Map, byte[], SSLContext)}
+     * - via {@link UrlConnectionHttpClient#patch(URL, Map, byte[])}
      * - without retry logic.
      */
     @Test
@@ -958,11 +957,11 @@ public final class UrlConnectionHttpClientTest {
             }
 
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().get(url, headers, null);
+                return UrlConnectionHttpClient.getDefaultInstance().get(url, headers);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.get(url, headers, null);
+                return sNoRetryClient.get(url, headers);
             }
         },
         HEAD {
@@ -971,38 +970,38 @@ public final class UrlConnectionHttpClientTest {
             }
 
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().head(url, headers, null);
+                return UrlConnectionHttpClient.getDefaultInstance().head(url, headers);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.head(url, headers, null);
+                return sNoRetryClient.head(url, headers);
             }
         },
         PUT {
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().put(url, headers, body, null);
+                return UrlConnectionHttpClient.getDefaultInstance().put(url, headers, body);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.put(url, headers, body, null);
+                return sNoRetryClient.put(url, headers, body);
             }
         },
         POST {
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().post(url, headers, body, null);
+                return UrlConnectionHttpClient.getDefaultInstance().post(url, headers, body);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.post(url, headers, body, null);
+                return sNoRetryClient.post(url, headers, body);
             }
         },
         OPTIONS {
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().options(url, headers, null);
+                return UrlConnectionHttpClient.getDefaultInstance().options(url, headers);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.options(url, headers, null);
+                return sNoRetryClient.options(url, headers);
             }
         },
         TRACE {
@@ -1011,29 +1010,29 @@ public final class UrlConnectionHttpClientTest {
             }
 
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().trace(url, headers, null);
+                return UrlConnectionHttpClient.getDefaultInstance().trace(url, headers);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.trace(url, headers, null);
+                return sNoRetryClient.trace(url, headers);
             }
         },
         PATCH {
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().patch(url, headers, body, null);
+                return UrlConnectionHttpClient.getDefaultInstance().patch(url, headers, body);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.patch(url, headers, body, null);
+                return sNoRetryClient.patch(url, headers, body);
             }
         },
         DELETE {
             HttpResponse specific(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return UrlConnectionHttpClient.getDefaultInstance().delete(url, headers, body, null);
+                return UrlConnectionHttpClient.getDefaultInstance().delete(url, headers, body);
             }
 
             HttpResponse specificNoRetry(URL url, Map<String, String> headers, byte[] body) throws Exception {
-                return sNoRetryClient.delete(url, headers, body, null);
+                return sNoRetryClient.delete(url, headers, body);
             }
         };
 
@@ -1084,8 +1083,7 @@ public final class UrlConnectionHttpClientTest {
                 method.name(),
                 validRequestUrl,
                 method.canHaveBody() ? Collections.singletonMap(CONTENT_TYPE_KEY, CONTENT_TYPE_VALUE) : Collections.<String, String>emptyMap(),
-                method.canHaveBody() ? UUID.nameUUIDFromBytes((validRequestUrl.toString() + method).getBytes(UTF8)).toString().getBytes(UTF8) : null,
-                null
+                method.canHaveBody() ? UUID.nameUUIDFromBytes((validRequestUrl.toString() + method).getBytes(UTF8)).toString().getBytes(UTF8) : null
         );
     }
 
@@ -1095,8 +1093,7 @@ public final class UrlConnectionHttpClientTest {
                 method.name(),
                 validRequestUrl,
                 method.canHaveBody() ? Collections.singletonMap(CONTENT_TYPE_KEY, CONTENT_TYPE_VALUE) : Collections.<String, String>emptyMap(),
-                method.canHaveBody() ? UUID.nameUUIDFromBytes((validRequestUrl.toString() + method).getBytes(UTF8)).toString().getBytes(UTF8) : null,
-                null
+                method.canHaveBody() ? UUID.nameUUIDFromBytes((validRequestUrl.toString() + method).getBytes(UTF8)).toString().getBytes(UTF8) : null
         );
     }
 
@@ -1121,7 +1118,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("http://http.badssl.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1136,7 +1132,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://tls-v1-0.badssl.com:1010/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1151,7 +1146,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://tls-v1-1.badssl.com:1011/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1165,7 +1159,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://tls-v1-2.badssl.com:1012/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1178,14 +1171,18 @@ public final class UrlConnectionHttpClientTest {
         final SSLContext context = SSLContext.getInstance("TLSv1.1");
         context.init(null, null, new SecureRandom());
 
+        final HttpClient client = UrlConnectionHttpClient.builder()
+                .retryPolicy(new NoRetryPolicy())
+                .sslContext(context)
+                .build();
+
         // Microsoft.com supports TLS 1.3
         // https://www.ssllabs.com/ssltest/analyze.html?d=www.microsoft.com&s=2600%3a1406%3a1400%3a69d%3a0%3a0%3a0%3a356e&hideResults=on&ignoreMismatch=on
-        final HttpResponse response = sNoRetryClient.method(
+        final HttpResponse response = client.method(
                 HttpClient.HttpMethod.GET,
                 new URL("https://www.microsoft.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
-                context
+                null
         );
 
         Assert.assertEquals(200, response.getStatusCode());
@@ -1204,7 +1201,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://www.microsoft.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1222,7 +1218,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://tls-v1-2.badssl.com:1012/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1241,7 +1236,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://www.microsoft.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1256,7 +1250,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("https://www.microsoft.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 
@@ -1270,7 +1263,6 @@ public final class UrlConnectionHttpClientTest {
                 HttpClient.HttpMethod.GET,
                 new URL("http://www.somewebsite.com/"),
                 new LinkedHashMap<String, String>(),
-                null,
                 null
         );
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/InterceptedHttpClient.java
@@ -53,11 +53,10 @@ public class InterceptedHttpClient extends AbstractHttpClient {
     public HttpResponse method(@NonNull final HttpMethod httpMethod,
                                @NonNull final URL requestUrl,
                                @NonNull final Map<String, String> requestHeaders,
-                               @Nullable final byte[] requestContent,
-                               @Nullable final SSLContext sslContext) throws IOException {
+                               @Nullable final byte[] requestContent) throws IOException {
         final HttpRequestInterceptor interceptor = MockHttpClient.getInterceptor(httpMethod, requestUrl, requestHeaders, requestContent);
         if (interceptor == null) {
-            return mClient.method(httpMethod, requestUrl, requestHeaders, requestContent, sslContext);
+            return mClient.method(httpMethod, requestUrl, requestHeaders, requestContent);
         } else {
             return interceptor.performIntercept(httpMethod, requestUrl, requestHeaders, requestContent);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockHttpClient.java
@@ -125,7 +125,7 @@ public class MockHttpClient {
                     @Override
                     public HttpResponse performIntercept(@NonNull HttpClient.HttpMethod httpMethod, @NonNull  URL requestUrl, @NonNull Map<String, String> requestHeaders, @Nullable byte[] requestContent) throws IOException {
                         if (sSaveRequests.get()) {
-                            sInterceptedRequests.add(new HttpRequest(url, requestHeaders, method.name(), requestContent, null, null));
+                            sInterceptedRequests.add(new HttpRequest(url, requestHeaders, method.name(), requestContent, null));
                         }
                         return httpRequestInterceptor.performIntercept(httpMethod, requestUrl, requestHeaders, requestContent);
                     }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/shadows/ShadowHttpClient.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/shadows/ShadowHttpClient.java
@@ -47,7 +47,7 @@ import javax.net.ssl.SSLContext;
  * <p>
  * We need to shadow the {@link AbstractHttpClient} because we are using an instance of the
  * {@link UrlConnectionHttpClient} in the method here
- * {@link ShadowHttpClient#intercept(HttpClient.HttpMethod, URL, Map, byte[], SSLContext)} therefore using the
+ * {@link HttpRequestInterceptor#performIntercept(HttpClient.HttpMethod, URL, Map, byte[])} therefore using the
  * {@link UrlConnectionHttpClient} as the shadow would prevent us from making an actual http request
  * when there are no interceptors defined for the request.
  *
@@ -59,11 +59,10 @@ public class ShadowHttpClient {
     public HttpResponse method(@NonNull HttpClient.HttpMethod httpMethod,
                                   @NonNull URL requestUrl,
                                   @NonNull Map<String, String> requestHeaders,
-                                  @Nullable byte[] requestContent,
-                                  @Nullable final SSLContext sslContext) throws IOException {
+                                  @Nullable byte[] requestContent) throws IOException {
         final HttpRequestInterceptor interceptor = MockHttpClient.getInterceptor(httpMethod, requestUrl, requestHeaders, requestContent);
         if (interceptor == null) {
-            return UrlConnectionHttpClient.getDefaultInstance().method(httpMethod, requestUrl, requestHeaders, requestContent, sslContext);
+            return UrlConnectionHttpClient.getDefaultInstance().method(httpMethod, requestUrl, requestHeaders, requestContent);
         } else {
             return interceptor.performIntercept(httpMethod, requestUrl, requestHeaders, requestContent);
         }
@@ -72,60 +71,52 @@ public class ShadowHttpClient {
     @Implementation
     public HttpResponse put(@NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,
-                            @Nullable byte[] requestContent,
-                            @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.PUT, requestUrl, requestHeaders, requestContent, sslContext);
+                            @Nullable byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.PUT, requestUrl, requestHeaders, requestContent);
     }
 
     @Implementation
     public HttpResponse patch(@NonNull URL requestUrl,
                               @NonNull Map<String, String> requestHeaders,
-                              @Nullable byte[] requestContent,
-                              @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.PATCH, requestUrl, requestHeaders, requestContent, sslContext);
+                              @Nullable byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.PATCH, requestUrl, requestHeaders, requestContent);
     }
 
     @Implementation
     public HttpResponse options(@NonNull URL requestUrl,
-                                @NonNull Map<String, String> requestHeaders,
-                                @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.OPTIONS, requestUrl, requestHeaders, null, sslContext);
+                                @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpClient.HttpMethod.OPTIONS, requestUrl, requestHeaders, null);
     }
 
     @Implementation
     protected HttpResponse post(@NonNull URL requestUrl,
                                 @NonNull Map<String, String> requestHeaders,
-                                @Nullable byte[] requestContent,
-                                @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.POST, requestUrl, requestHeaders, requestContent, sslContext);
+                                @Nullable byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.POST, requestUrl, requestHeaders, requestContent);
     }
 
     @Implementation
     public HttpResponse delete(@NonNull URL requestUrl,
                                @NonNull Map<String, String> requestHeaders,
-                               @Nullable byte[] requestContent,
-                               @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.DELETE, requestUrl, requestHeaders, requestContent, sslContext);
+                               @Nullable byte[] requestContent) throws IOException {
+        return method(HttpClient.HttpMethod.DELETE, requestUrl, requestHeaders, requestContent);
     }
 
     @Implementation
     public HttpResponse get(@NonNull URL requestUrl,
-                            @NonNull Map<String, String> requestHeaders,
-                            @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.GET, requestUrl, requestHeaders, null, sslContext);
+                            @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpClient.HttpMethod.GET, requestUrl, requestHeaders, null);
     }
 
     @Implementation
     public HttpResponse head(@NonNull URL requestUrl,
-                             @NonNull Map<String, String> requestHeaders,
-                             @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.HEAD, requestUrl, requestHeaders, null, sslContext);
+                             @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpClient.HttpMethod.HEAD, requestUrl, requestHeaders, null);
     }
 
     @Implementation
     public HttpResponse trace(@NonNull URL requestUrl,
-                              @NonNull Map<String, String> requestHeaders,
-                              @Nullable final SSLContext sslContext) throws IOException {
-        return method(HttpClient.HttpMethod.TRACE, requestUrl, requestHeaders, null, sslContext);
+                              @NonNull Map<String, String> requestHeaders) throws IOException {
+        return method(HttpClient.HttpMethod.TRACE, requestUrl, requestHeaders, null);
     }
 }


### PR DESCRIPTION
This is to make way for an HttpClient instance in Linux Broker that will act as a proxy to the Device Broker, to make a request with Device Private Key (for Client TLS challenge) there.

The idea is that 
1. we'll remove the SSLContext object from HttpClient signature.
2. For non-proxy HttpClient object (UrlConnectionHttpClient), SSLContext will be constructed - or loaded - via its constructor/builder.
3. For proxy HttpClient object, we'll take whatever it requires (i.e. key entry, certificate), route the request to Linux Broker, and then use it to construct an SSLContext over there.

This is a breaking change for broker.. so the broker test will fail.
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1926

Validated with WPJ's getDeviceState() - as part of https://github.com/AzureAD/ad-accounts-for-android/pull/1928