### PR TITLE
Send PKeyAuth Header to token endpoint for required msal-broker protocol version 9.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MAJOR] Bumped MSAL Broker Protocol version to 9.0, acquireToken/acquireTokenSilent endpoint requires minimum_required_broker_protocol_version of 9.0+ to Send x-ms-PKeyAuth Header to the token endpoint. (#1790)
 - [MAJOR] Bumped MSAL Broker Protocol version to 8.0, GET_ACCOUNTS endpoint requires minimum_required_broker_protocol_version of 8.0+ to return an account constructed from PRT id token to FOCI apps. (#1771)
 - [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow
 - [PATCH] [Adal] Ignore failure in updating unified/msal cache if ignoreKeyLoaderNotFoundError flag is set (#1781)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [MAJOR] Bumped MSAL Broker Protocol version to 9.0, acquireToken/acquireTokenSilent endpoint requires minimum_required_broker_protocol_version of 9.0+ to Send x-ms-PKeyAuth Header to the token endpoint. (#1790)
+- [MINOR] Bumped MSAL Broker Protocol version to 9.0, acquireToken/acquireTokenSilent endpoint requires minimum_required_broker_protocol_version of 9.0+ to Send x-ms-PKeyAuth Header to the token endpoint. (#1790)
 - [PATCH] Fix msal failing tests due to telemetry context (1788)
 - [MAJOR] Bumped MSAL Broker Protocol version to 8.0, GET_ACCOUNTS endpoint requires minimum_required_broker_protocol_version of 8.0+ to return an account constructed from PRT id token to FOCI apps. (#1771)
 - [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1160,6 +1160,11 @@ public final class AuthenticationConstants {
         public static final String BROKER_REQUEST_V2_SUCCESS = "broker_request_v2_success";
 
         /**
+         * String to send true if the request should send the PkeyAuth header to the token endpoint, false otherwise.
+         */
+        public static final String SHOULD_SEND_PKEYAUTH_HEADER_TO_THE_TOKEN_ENDPOINT = "should.send.pkeyauth.header";
+
+        /**
          * String for ssl prefix.
          */
         public static final String REDIRECT_SSL_PREFIX = "https://";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -597,7 +597,7 @@ public final class AuthenticationConstants {
          * The newest Msal-To-Broker protocol version.
          * @see <a href="ttps://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md">Android Auth Broker Protocol Versions</a>
          */
-        public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "8.0";
+        public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "9.0";
 
         /**
          * A client id for requesting the SSO token.

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -37,6 +37,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.REQUEST_AUTHORITY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.SHOULD_SEND_PKEYAUTH_HEADER_TO_THE_TOKEN_ENDPOINT;
 import static com.microsoft.identity.common.internal.util.GzipUtil.compressString;
 
 import android.content.Context;
@@ -203,7 +204,11 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     public Bundle getRequestBundleForAcquireTokenInteractive(@NonNull final InteractiveTokenCommandParameters parameters,
                                                              @Nullable final String negotiatedBrokerProtocolVersion) {
         final BrokerRequest brokerRequest = brokerRequestFromAcquireTokenParameters(parameters);
-        return getRequestBundleFromBrokerRequest(brokerRequest, negotiatedBrokerProtocolVersion);
+        return getRequestBundleFromBrokerRequest(
+                brokerRequest,
+                negotiatedBrokerProtocolVersion,
+                parameters.getRequiredBrokerProtocolVersion()
+        );
     }
 
     /**
@@ -224,7 +229,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
         final Bundle requestBundle = getRequestBundleFromBrokerRequest(
                 brokerRequest,
-                negotiatedBrokerProtocolVersion
+                negotiatedBrokerProtocolVersion,
+                parameters.getRequiredBrokerProtocolVersion()
         );
 
         requestBundle.putInt(
@@ -236,7 +242,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     }
 
     private Bundle getRequestBundleFromBrokerRequest(@NonNull BrokerRequest brokerRequest,
-                                                     @Nullable String negotiatedBrokerProtocolVersion) {
+                                                     @Nullable String negotiatedBrokerProtocolVersion,
+                                                     @Nullable String requiredBrokerProtocolVersion) {
         final String methodTag = TAG + ":getRequestBundleFromBrokerRequest";
         final Bundle requestBundle = new Bundle();
 
@@ -265,6 +272,10 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
             );
         }
         requestBundle.putString(NEGOTIATED_BP_VERSION_KEY, negotiatedBrokerProtocolVersion);
+        requestBundle.putBoolean(
+                SHOULD_SEND_PKEYAUTH_HEADER_TO_THE_TOKEN_ENDPOINT,
+                BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint(requiredBrokerProtocolVersion)
+        );
         return requestBundle;
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -56,6 +56,7 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     private final IBrokerAccount brokerAccount;
     private final String homeAccountId;
     private final String localAccountId;
+    private final boolean pKeyAuthHeaderAllowed;
 
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
@@ -47,6 +47,7 @@ public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParame
     private final int sleepTimeBeforePrtAcquisition;
 
     private final String negotiatedBrokerProtocolVersion;
+    private final boolean pKeyAuthHeaderAllowed;
 
     @Override
     public void validate() throws ArgumentException {

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -386,7 +386,6 @@ public abstract class BaseController {
         if (tokenRequest instanceof MicrosoftTokenRequest) {
             ((MicrosoftTokenRequest) tokenRequest).setClientAppName(parameters.getApplicationName());
             ((MicrosoftTokenRequest) tokenRequest).setClientAppVersion(parameters.getApplicationVersion());
-            //((MicrosoftTokenRequest) tokenRequest).setNegotiatedProtocolVersion(parameters.getRequiredBrokerProtocolVersion());
         }
 
         if (parameters instanceof IHasExtraParameters) {

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -386,6 +386,7 @@ public abstract class BaseController {
         if (tokenRequest instanceof MicrosoftTokenRequest) {
             ((MicrosoftTokenRequest) tokenRequest).setClientAppName(parameters.getApplicationName());
             ((MicrosoftTokenRequest) tokenRequest).setClientAppVersion(parameters.getApplicationVersion());
+            //((MicrosoftTokenRequest) tokenRequest).setNegotiatedProtocolVersion(parameters.getRequiredBrokerProtocolVersion());
         }
 
         if (parameters instanceof IHasExtraParameters) {
@@ -734,18 +735,22 @@ public abstract class BaseController {
             ((MicrosoftTokenRequest) refreshTokenRequest).setClaims(parameters.getClaimsRequestJson());
             ((MicrosoftTokenRequest) refreshTokenRequest).setClientAppName(parameters.getApplicationName());
             ((MicrosoftTokenRequest) refreshTokenRequest).setClientAppVersion(parameters.getApplicationVersion());
-        }
 
-        //NOTE: this should be moved to the strategy; however requires a larger refactor
-        if (parameters.getSdkType() == SdkType.ADAL) {
-            ((MicrosoftTokenRequest) refreshTokenRequest).setIdTokenVersion("1");
-        }
+            //NOTE: this should be moved to the strategy; however requires a larger refactor
+            if (parameters.getSdkType() == SdkType.ADAL) {
+                ((MicrosoftTokenRequest) refreshTokenRequest).setIdTokenVersion("1");
+            }
 
-        // Set Broker version to Token Request if it's a brokered request.
-        if (parameters instanceof BrokerSilentTokenCommandParameters) {
-            ((MicrosoftTokenRequest) refreshTokenRequest).setBrokerVersion(
-                    ((BrokerSilentTokenCommandParameters) parameters).getBrokerVersion()
-            );
+            if (parameters instanceof BrokerSilentTokenCommandParameters) {
+                // Set Broker version to Token Request if it's a brokered request.
+                ((MicrosoftTokenRequest) refreshTokenRequest).setBrokerVersion(
+                        ((BrokerSilentTokenCommandParameters) parameters).getBrokerVersion()
+                );
+                // Set PKeyAuth Header for token endpoint.
+                ((MicrosoftTokenRequest) refreshTokenRequest).setPKeyAuthHeaderAllowed(
+                        ((BrokerSilentTokenCommandParameters) parameters).isPKeyAuthHeaderAllowed()
+                );
+            }
         }
 
         if (!StringUtil.isNullOrEmpty(refreshTokenRequest.getScope())) {

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenRequest.java
@@ -30,6 +30,9 @@ import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 public class MicrosoftTokenRequest extends TokenRequest implements IHasExtraParameters {
 
@@ -96,6 +99,11 @@ public class MicrosoftTokenRequest extends TokenRequest implements IHasExtraPara
 
     // Sent as part of headers if available, so marking it transient.
     private transient String mBrokerVersion;
+
+    @Getter
+    @Setter
+    @Accessors(prefix = "m")
+    private boolean mPKeyAuthHeaderAllowed;
 
     public String getCodeVerifier() {
         return this.mCodeVerifier;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenRequest.java
@@ -100,6 +100,7 @@ public class MicrosoftTokenRequest extends TokenRequest implements IHasExtraPara
     // Sent as part of headers if available, so marking it transient.
     private transient String mBrokerVersion;
 
+    // Send PKeyAuth Header to token endpoint for required msal-broker protocol version 9.0.
     @Getter
     @Setter
     @Accessors(prefix = "m")

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -213,8 +213,6 @@ public abstract class OAuth2Strategy
         headers.put(AuthenticationConstants.SdkPlatformFields.VERSION, Device.getProductVersion());
         headers.putAll(EstsTelemetry.getInstance().getTelemetryHeaders());
         headers.put(HttpConstants.HeaderField.CONTENT_TYPE, TOKEN_REQUEST_CONTENT_TYPE);
-        // ADO:TODO:1934500 - Reverting this change as this is considered a "breaking change" fix.
-        //headers.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
         if (request instanceof MicrosoftTokenRequest) {
             headers.put(
@@ -225,6 +223,9 @@ public abstract class OAuth2Strategy
                     AuthenticationConstants.AAD.APP_VERSION,
                     ((MicrosoftTokenRequest) request).getClientAppVersion()
             );
+            if (((MicrosoftTokenRequest) request).isPKeyAuthHeaderAllowed()) {
+                headers.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
+            }
         }
 
         final URL requestUrl = new URL(getTokenEndpoint());

--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -35,7 +35,7 @@ public class BrokerProtocolVersionUtil {
 
     public static final String MSAL_TO_BROKER_PROTOCOL_COMPRESSION_CHANGES_MINIMUM_VERSION = "5.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION = "8.0";
-    public static final String MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION = "8.0";
+    public static final String MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION = "9.0";
 
     /**
      * Verifies if negotiated broker protocol version allows to decompressing/compressing broker payloads.
@@ -66,7 +66,7 @@ public class BrokerProtocolVersionUtil {
     /**
      * Verifies if client required broker protocol version allows FOCI apps to construct accounts from PRT Id token.
      *
-     * @param clientAppProtocolVersion broker protocol version of the calling app.
+     * @param clientRequiredBrokerProtocolVersion broker protocol version of the calling app.
      * @return true if the broker protocol version of the calling app is larger or equal than
      * the {@link BrokerProtocolVersionUtil#MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION}.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -35,6 +35,7 @@ public class BrokerProtocolVersionUtil {
 
     public static final String MSAL_TO_BROKER_PROTOCOL_COMPRESSION_CHANGES_MINIMUM_VERSION = "5.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION = "8.0";
+    public static final String MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION = "8.0";
 
     /**
      * Verifies if negotiated broker protocol version allows to decompressing/compressing broker payloads.
@@ -44,41 +45,53 @@ public class BrokerProtocolVersionUtil {
      * the {@link BrokerProtocolVersionUtil#MSAL_TO_BROKER_PROTOCOL_COMPRESSION_CHANGES_MINIMUM_VERSION}.
      */
     public static final boolean canCompressBrokerPayloads(@Nullable String negotiatedBrokerProtocol) {
-        return isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+        return isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                 negotiatedBrokerProtocol,
                 MSAL_TO_BROKER_PROTOCOL_COMPRESSION_CHANGES_MINIMUM_VERSION);
     }
 
     /**
-     * Verifies if negotiated broker protocol version allows FOCI apps to construct accounts from PRT Id token.
+     * Verifies if client required broker protocol version allows FOCI apps to construct accounts from PRT Id token.
      *
      * @param clientRequiredBrokerProtocolVersion client protocol version.
      * @return true if the client protocol version is larger or equal than
      * the {@link BrokerProtocolVersionUtil#MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION}.
      */
     public static final boolean canFociAppsConstructAccountsFromPrtIdTokens(@Nullable String clientRequiredBrokerProtocolVersion) {
-        return isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+        return isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                 clientRequiredBrokerProtocolVersion,
                 MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION);
     }
 
     /**
-     * Verify if the negotiated broker protocol id larger or equal that the requiredBrokerProtocol.
+     * Verifies if client required broker protocol version allows FOCI apps to construct accounts from PRT Id token.
      *
-     * @param negotiatedBrokerProtocol negotiated protocol version, result of hello handshake
-     * @param requiredBrokerProtocol   minimun required protocol version for the feature.
-     * @return true if the negotiated broker protocol larger or equal than required broker protocol,
-     * false otherwise.
+     * @param clientAppProtocolVersion broker protocol version of the calling app.
+     * @return true if the broker protocol version of the calling app is larger or equal than
+     * the {@link BrokerProtocolVersionUtil#MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION}.
      */
-    protected static final boolean isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
-            @Nullable final String negotiatedBrokerProtocol,
+    public static boolean canSendPKeyAuthHeaderToTheTokenEndpoint(@Nullable String clientRequiredBrokerProtocolVersion) {
+        return isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+                clientRequiredBrokerProtocolVersion,
+                MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION);
+    }
+
+    /**
+     * Verifies if the provided broker protocol is larger or equal than the required protocol.
+     *
+     * @param providedBrokerProtocol provided protocol version.
+     * @param requiredBrokerProtocol minimum required protocol version for the feature.
+     * @return true if the provided protocol is larger or equal than required protocol, false otherwise.
+     */
+    protected static final boolean isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+            @Nullable final String providedBrokerProtocol,
             @NonNull final String requiredBrokerProtocol) {
 
-        if (StringUtil.isNullOrEmpty(negotiatedBrokerProtocol)) {
+        if (StringUtil.isNullOrEmpty(providedBrokerProtocol)) {
             return false;
         }
         return isFirstVersionLargerOrEqual(
-                negotiatedBrokerProtocol,
+                providedBrokerProtocol,
                 requiredBrokerProtocol);
     }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
@@ -142,4 +142,32 @@ public class BrokerProtocolVersionUtilTest {
                 BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens(null)
         );
     }
+
+    @Test
+    public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedLargerThanRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint("10.0")
+        );
+    }
+
+    @Test
+    public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedEqualToRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens("9.0")
+        );
+    }
+
+    @Test
+    public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedSmallerThanRequired(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens("8.0")
+        );
+    }
+
+    @Test
+    public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedNull(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens(null)
+        );
+    }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
@@ -45,7 +45,7 @@ public class BrokerProtocolVersionUtilTest {
         final String requiredBrokerProtocol = "5.0";
         Assert.assertTrue(
                 BrokerProtocolVersionUtil
-                        .isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+                        .isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                                 negotiatedBrokerProtocol,
                                 requiredBrokerProtocol)
         );
@@ -57,7 +57,7 @@ public class BrokerProtocolVersionUtilTest {
         final String requiredBrokerProtocol = "10.0";
         Assert.assertFalse(
                 BrokerProtocolVersionUtil
-                        .isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+                        .isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                                 negotiatedBrokerProtocol,
                                 requiredBrokerProtocol)
         );
@@ -69,7 +69,7 @@ public class BrokerProtocolVersionUtilTest {
         final String requiredBrokerProtocol = "10.0";
         Assert.assertTrue(
                 BrokerProtocolVersionUtil
-                        .isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+                        .isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                                 negotiatedBrokerProtocol,
                                 requiredBrokerProtocol)
         );
@@ -81,7 +81,7 @@ public class BrokerProtocolVersionUtilTest {
         final String requiredBrokerProtocol = "10.0";
         Assert.assertFalse(
                 BrokerProtocolVersionUtil
-                        .isNegotiatedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+                        .isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
                                 negotiatedBrokerProtocol,
                                 requiredBrokerProtocol)
         );

--- a/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
@@ -153,21 +153,21 @@ public class BrokerProtocolVersionUtilTest {
     @Test
     public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedEqualToRequired(){
         Assert.assertTrue(
-                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens("9.0")
+                BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint("9.0")
         );
     }
 
     @Test
     public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedSmallerThanRequired(){
         Assert.assertFalse(
-                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens("8.0")
+                BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint("8.0")
         );
     }
 
     @Test
     public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedNull(){
         Assert.assertFalse(
-                BrokerProtocolVersionUtil.canFociAppsConstructAccountsFromPrtIdTokens(null)
+                BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint(null)
         );
     }
 }


### PR DESCRIPTION
### Why
On #1687 we started sending x-ms-PKeyAuth in both interactive and silent flow, fixing the silent flow pkeyauth. 
This change broke a client whose misconfiguration relied on the old flow (see related ICM: [31201066](https://portal.microsofticm.com/imp/v3/incidents/details/312010665/home)).
So, we stopped sending the pkeyauth header to the token endpoint on #1755.
We are bringing back this fix in secure way adding a version lock to avoid breaking customers.
Sending the pkeyauth header to the token endpoint only to clients who configure the minimum_required_broker_protocol_version to version 9.0.  

[Android Auth Broker Protocol Versions](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md&version=GBdev&_a=preview)
Related PR: [broker#1927](https://github.com/AzureAD/ad-accounts-for-android/pull/1927)

### What change

* Added a boolean value to the acquire token Interactive/silent request bundle that determines if we should send the pkeauth header to the token endpoint.
* On minimum_required_broker_protocol_version to version 9.0 or higher we set this boolean value to true, otherwise false.
*  propagate the flag to OAuth2Strategy using  Broker[Silent,Interactive]TokenCommandParameters and MicrosoftTokenRequest

