### PR TITLE
Add filter for broker telemetry event fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Version 6.0.0
 - [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)
 - [PATCH] Added Base64 encode for the AuthorizationRequest state parameter (#1750)
 - [PATCH] Fix missing authority_url when creating the authority audience (#1753)
+- [PATCH] Add filter for broker telemetry event fields.
 
 Version 5.0.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,7 +13,7 @@ Version 6.0.0
 - [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)
 - [PATCH] Added Base64 encode for the AuthorizationRequest state parameter (#1750)
 - [PATCH] Fix missing authority_url when creating the authority audience (#1753)
-- [PATCH] Add filter for broker telemetry event fields.
+- [PATCH] Add filter for broker telemetry event fields. (#1793)
 
 Version 5.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
@@ -25,9 +25,6 @@ package com.microsoft.identity.common.java.telemetry.relay;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.telemetry.observers.ITelemetryObserver;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.NonNull;
 
 /**
@@ -39,33 +36,33 @@ import lombok.NonNull;
 public abstract class AbstractTelemetryRelayClient<T> implements ITelemetryObserver<T> {
 
     private static final String TAG = AbstractTelemetryRelayClient.class.getSimpleName();
-    // Filters to apply on the events captured.
-    // This basically performs an AND operation on the filters to determine whether the event will be relayed.
-    private final List<ITelemetryEventFilter<T>> eventFilters = new ArrayList<>();
+    // Filter to apply on the events captured.
+    private ITelemetryEventFilter<T> mEventFilter = null;
 
     @Override
     public synchronized void onReceived(T telemetryData) {
         final String methodTag = TAG + ":onReceived";
 
-        for (final ITelemetryEventFilter<T> filter : eventFilters) {
-            // Prevent event relay if any of the filters returns false.
-            if (!filter.shouldRelay(telemetryData)) {
-                return;
-            }
+        T filteredData = telemetryData;
+
+        if (mEventFilter != null) {
+            filteredData = mEventFilter.apply(telemetryData);
         }
 
-        try {
-            relayEvent(telemetryData);
-        } catch (TelemetryRelayException e) {
-            Logger.error(methodTag, "Error relaying telemetry data", e);
+        if (filteredData != null) {
+            try {
+                relayEvent(filteredData);
+            } catch (TelemetryRelayException e) {
+                Logger.error(methodTag, "Error relaying telemetry data", e);
+            }
         }
     }
 
     /**
-     * Add an event filter to the list of filters
+     * Add an event filter
      */
-    public void addFilter(ITelemetryEventFilter<T> filter) {
-        this.eventFilters.add(filter);
+    public void setFilter(ITelemetryEventFilter<T> filter) {
+        this.mEventFilter = filter;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
@@ -59,7 +59,7 @@ public abstract class AbstractTelemetryRelayClient<T> implements ITelemetryObser
     }
 
     /**
-     * Add an event filter
+     * Add an event filter.
      */
     public void setFilter(ITelemetryEventFilter<T> filter) {
         this.mEventFilter = filter;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
@@ -40,7 +40,7 @@ public abstract class AbstractTelemetryRelayClient<T> implements ITelemetryObser
     private ITelemetryEventFilter<T> mEventFilter = null;
 
     @Override
-    public synchronized void onReceived(T telemetryData) {
+    public void onReceived(T telemetryData) {
         final String methodTag = TAG + ":onReceived";
 
         T filteredData = telemetryData;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
@@ -31,7 +31,7 @@ public interface ITelemetryEventFilter<T> {
      * Invoked when a new event is captured by the telemetry.
      * @param telemetryEvent the telemetry event data
      *
-     * @return a boolean representing whether the event should be relayed.
+     * @return an event with filtered fields. Return null if the event is to be ignored completely.
      */
-    boolean shouldRelay(T telemetryEvent);
+    T apply(T telemetryEvent);
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
@@ -21,6 +21,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.telemetry.relay;
 
+import javax.annotation.Nullable;
+
+import lombok.NonNull;
+
 /**
  * An interface that describes an event filter for a telemetry relay client {@link AbstractTelemetryRelayClient}
  * @param <T> the event data
@@ -33,5 +37,6 @@ public interface ITelemetryEventFilter<T> {
      *
      * @return an event with filtered fields. Return null if the event is to be ignored completely.
      */
-    T apply(T telemetryEvent);
+    @Nullable
+    T apply(@NonNull final T telemetryEvent);
 }


### PR DESCRIPTION
## Why 
Since we need to do the privacy review for telemetry, for now, we should add a filter to NOT upload anything for which we aren’t sure whether that is PII or OII. 

## How
Add a filter that only allows specific fields to be published to a telemetry relay client

## Broker PR
Here is the related broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1931