### PR TITLE
set lab secret in env.file for Instrumented test

### DIFF
--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -21,6 +21,9 @@ steps:
 - script: echo "${{ parameters.EnvVstsMvnAccount }}=$(mvnAccessToken)" >> env.list
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
+- script: echo "LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
+  condition: ne(variables['AndroidAutomationRunnerAppSecret'], '')
+  displayName: set lab secret in env.file
 - script: docker --version
   displayName: Docker Version
 - script: |

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -21,10 +21,8 @@ steps:
 - script: echo "${{ parameters.EnvVstsMvnAccount }}=$(mvnAccessToken)" >> env.list
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
-- script: echo LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
+- script: echo "LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
   displayName: set labsecret in env.file
-- script: echo "$(AndroidAuthClient-Internal-Maven-Username)"
-- script: echo "$(AndroidAutomationRunnerAppSecret)"
 - script: docker --version
   displayName: Docker Version
 - script: |

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -22,8 +22,9 @@ steps:
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
 - script: echo LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
-  condition: ne('${{ variables.AndroidAutomationRunnerAppSecret }}', '')
   displayName: set labsecret in env.file
+- script: echo "$(AndroidAuthClient-Internal-Maven-Username)"
+- script: echo "$(AndroidAutomationRunnerAppSecret)"
 - script: docker --version
   displayName: Docker Version
 - script: |

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -22,7 +22,8 @@ steps:
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
 - script: echo "LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
-  displayName: set labsecret in env.file
+  condition: ne("$(AndroidAutomationRunnerAppSecret)", "")
+  displayName: set lab secret in env.file
 - script: docker --version
   displayName: Docker Version
 - script: |

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -22,7 +22,7 @@ steps:
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
 - script: echo "LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
-  condition: ne("$(AndroidAutomationRunnerAppSecret)", "")
+  condition: ne(variables['AndroidAutomationRunnerAppSecret'], '')
   displayName: set lab secret in env.file
 - script: docker --version
   displayName: Docker Version

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -9,9 +9,6 @@ parameters:
 - name: EnvVstsMvnAccount
   default: ''
 
-variables:
-  - group: AndroidAuthClientSecrets
-
 steps:
 - task: PostBuildCleanup@3
   condition: always()
@@ -25,6 +22,7 @@ steps:
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
 - script: echo LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
+  condition: ne('${{ variables.AndroidAutomationRunnerAppSecret }}', '')
   displayName: set labsecret in env.file
 - script: docker --version
   displayName: Docker Version

--- a/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
+++ b/azure-pipelines/templates/steps/auth-client/docker-tasks.yml
@@ -9,6 +9,9 @@ parameters:
 - name: EnvVstsMvnAccount
   default: ''
 
+variables:
+  - group: AndroidAuthClientSecrets
+
 steps:
 - task: PostBuildCleanup@3
   condition: always()
@@ -21,6 +24,8 @@ steps:
 - script: echo "${{ parameters.EnvVstsMvnAccount }}=$(mvnAccessToken)" >> env.list
   condition: ne('${{ parameters.EnvVstsMvnAccount }}', '')
   displayName: set mvnAccessToken in env.file
+- script: echo LAB_SECRET=$(AndroidAutomationRunnerAppSecret)" >> env.list
+  displayName: set labsecret in env.file
 - script: docker --version
   displayName: Docker Version
 - script: |


### PR DESCRIPTION
new network tests added to the broker Instrumented test pipeline needed the lab secret, so we are providing it here.
https://github.com/AzureAD/ad-accounts-for-android/pull/1935

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=957491