### PR TITLE
ESTS Telemetry changes to capture data around FLW and Multiple WPJ

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ V.Next
 - [PATCH] Fix APPLICATION_CANCELLED by handling back button press (#1725)
 - [PATCH] Added Base64 encode for the AuthorizationRequest state parameter (#1750)
 - [PATCH] Fix missing authority_url when creating the authority audience (#1753)
+- [MINOR] ESTS Telemetry changes to capture data around FLW and Multiple WPJ (#1799)
 
 Version 5.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/CurrentRequestTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/CurrentRequestTelemetry.java
@@ -58,7 +58,7 @@ class CurrentRequestTelemetry extends RequestTelemetry implements ICurrentTeleme
                 mApiId = value;
                 break;
             case FORCE_REFRESH:
-                mForceRefresh = TelemetryUtils.getBooleanFromSchemaString(value);
+                mForceRefresh = TelemetryUtils.getBooleanFromString(value);
                 break;
             default:
                 putInPlatformTelemetry(key, value);

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/EstsTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/EstsTelemetry.java
@@ -157,7 +157,7 @@ public class EstsTelemetry {
      *
      * @param telemetry a map containing telemetry fields and their values
      */
-    public void emit(final Map<String, String> telemetry) {
+    public void emit(@Nullable final Map<String, String> telemetry) {
         if (telemetry == null) {
             return;
         }
@@ -174,7 +174,7 @@ public class EstsTelemetry {
      * @param key   the key associated to the telemetry field
      * @param value the value associated to the telemetry field
      */
-    public void emit(final String key, final String value) {
+    public void emit(@Nullable final String key, final String value) {
         if (StringUtil.isNullOrEmpty(key)) {
             return;
         }
@@ -196,7 +196,7 @@ public class EstsTelemetry {
      * @param key   the key associated to the telemetry field
      * @param value the value associated to the telemetry field
      */
-    public void emit(final String key, final int value) {
+    public void emit(@Nullable final String key, final int value) {
         emit(key, String.valueOf(value));
     }
 
@@ -207,7 +207,7 @@ public class EstsTelemetry {
      * @param key   the key associated to the telemetry field
      * @param value the value associated to the telemetry field
      */
-    public void emit(final String key, final long value) {
+    public void emit(@Nullable final String key, final long value) {
         emit(key, String.valueOf(value));
     }
 
@@ -218,7 +218,7 @@ public class EstsTelemetry {
      * @param key   the key associated to the telemetry field
      * @param value the value associated to the telemetry field
      */
-    public void emit(final String key, final boolean value) {
+    public void emit(@Nullable final String key, final boolean value) {
         emit(key, TelemetryUtils.getSchemaCompliantStringFromBoolean(value));
     }
 
@@ -228,7 +228,7 @@ public class EstsTelemetry {
      *
      * @param apiId the api id to emit to telemetry
      */
-    public void emitApiId(final String apiId) {
+    public void emitApiId(@Nullable final String apiId) {
         emit(SchemaConstants.Key.API_ID, apiId);
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
@@ -97,7 +97,7 @@ public abstract class RequestTelemetry implements IRequestTelemetry {
 
         if (this instanceof CurrentRequestTelemetry) {
             platformFields = SchemaConstants.getCurrentRequestPlatformFields(
-                    TelemetryUtils.getBooleanFromSchemaString(
+                    TelemetryUtils.getBooleanFromString(
                             mPlatformTelemetry.get(SchemaConstants.Key.IS_SHARED_DEVICE)
                     )
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
@@ -95,6 +95,11 @@ public abstract class RequestTelemetry implements IRequestTelemetry {
     private String getPlatformTelemetryHeaderString() {
         final List<String> platformFields;
 
+        mPlatformTelemetry.putIfAbsent(
+                SchemaConstants.Key.PLATFORM_SCHEMA_VERSION,
+                SchemaConstants.CURRENT_PLATFORM_SCHEMA_VERSION
+        );
+
         if (this instanceof CurrentRequestTelemetry) {
             platformFields = SchemaConstants.getCurrentRequestPlatformFields(
                     TelemetryUtils.getBooleanFromString(

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/RequestTelemetry.java
@@ -26,6 +26,7 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.util.StringUtil;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -92,10 +93,14 @@ public abstract class RequestTelemetry implements IRequestTelemetry {
     }
 
     private String getPlatformTelemetryHeaderString() {
-        final String[] platformFields;
+        final List<String> platformFields;
 
         if (this instanceof CurrentRequestTelemetry) {
-            platformFields = SchemaConstants.getCurrentRequestPlatformFields();
+            platformFields = SchemaConstants.getCurrentRequestPlatformFields(
+                    TelemetryUtils.getBooleanFromSchemaString(
+                            mPlatformTelemetry.get(SchemaConstants.Key.IS_SHARED_DEVICE)
+                    )
+            );
         } else {
             platformFields = SchemaConstants.getLastRequestPlatformFields();
         }
@@ -115,19 +120,19 @@ public abstract class RequestTelemetry implements IRequestTelemetry {
      */
     @NonNull
     // This only being used to compute the platform telemetry header string
-    private String getHeaderStringForFields(final String[] fields, final Map<String, String> telemetry) {
+    private String getHeaderStringForFields(final List<String> fields, final Map<String, String> telemetry) {
         if (fields == null || telemetry == null) {
             return "";
         }
 
         StringBuilder sb = new StringBuilder();
 
-        for (int i = 0; i < fields.length; i++) {
-            final String key = fields[i];
+        for (int i = 0; i < fields.size(); i++) {
+            final String key = fields.get(i);
             final String value = telemetry.get(key);
             final String compliantValueString = TelemetryUtils.getSchemaCompliantString(value);
             sb.append(compliantValueString);
-            if (i != fields.length - 1) {
+            if (i != fields.size() - 1) {
                 sb.append(',');
             }
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
@@ -36,6 +36,9 @@ public class SchemaConstants {
     public static final String SCHEMA_VERSION_KEY = "schema_version";
     public static final String CURRENT_SCHEMA_VERSION = "2";
 
+    // starting from two, as we were sending platform telemetry prior to it being versioned
+    public static final String CURRENT_PLATFORM_SCHEMA_VERSION = "2";
+
     public static final String CURRENT_REQUEST_HEADER_NAME = "x-client-current-telemetry";
     public static final String LAST_REQUEST_HEADER_NAME = "x-client-last-telemetry";
 
@@ -56,6 +59,8 @@ public class SchemaConstants {
         public static final String FRT_STATUS = TelemetryEventStrings.Key.FRT_STATUS;
         public static final String MRRT_STATUS = TelemetryEventStrings.Key.MRRT_STATUS;
         public static final String ALL_TELEMETRY_DATA_SENT = "is_all_telemetry_data_sent";
+
+        public static final String PLATFORM_SCHEMA_VERSION = "platform_schema_version";
 
         // flw and multiple reg fields
         // More details here:
@@ -130,6 +135,7 @@ public class SchemaConstants {
      * Failure do so will break the schema.
      */
     private static final List<String> lastRequestPlatformFields = Arrays.asList(
+            Key.PLATFORM_SCHEMA_VERSION,
             SchemaConstants.Key.ALL_TELEMETRY_DATA_SENT
     );
 
@@ -187,6 +193,8 @@ public class SchemaConstants {
      */
     static List<String> getCurrentRequestPlatformFields(final boolean isSharedDeviceScenario) {
         final List<String> consolidatedPlatformFields = new ArrayList<>();
+
+        consolidatedPlatformFields.add(Key.PLATFORM_SCHEMA_VERSION);
 
         if (isSharedDeviceScenario) {
             consolidatedPlatformFields.addAll(currentRequestSharedFlwPlatformFieldsForAndroidAndiOSBroker);

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
@@ -24,7 +24,9 @@ package com.microsoft.identity.common.java.eststelemetry;
 
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * This class defines the schema for server-side telemetry
@@ -54,6 +56,17 @@ public class SchemaConstants {
         public static final String FRT_STATUS = TelemetryEventStrings.Key.FRT_STATUS;
         public static final String MRRT_STATUS = TelemetryEventStrings.Key.MRRT_STATUS;
         public static final String ALL_TELEMETRY_DATA_SENT = "is_all_telemetry_data_sent";
+
+        // flw and multiple reg fields
+        public static final String IS_SHARED_DEVICE = "isSharedScenario";
+        public static final String REG_TYPE = "reg_type";
+        public static final String REG_SOURCE = "reg_source";
+        public static final String FLW_SIGNOUT_APP = "flw_signout_app";
+        public static final String FLW_SIGNIN_APP = "flw_signin_app";
+        public static final String REG_NUM = "reg_num";
+        public static final String CLOUD_NUM = "cloud_num";
+        public static final String REG_SEQ_NUM = "reg_seq_num";
+        public static final String REQ_PURPOSE = "req_purpose";
     }
 
     public static final class Value {
@@ -64,42 +77,132 @@ public class SchemaConstants {
 
 
     /**
-     * This array defines the platform schema for current request
+     * This array defines the "Android only" platform fields for current request.
      * NOTE: These fields must always be listed in the correct order in this array.
      * Failure do so will break the schema.
      */
-    private static final String[] currentRequestPlatformFields = new String[]{
+    private static final List<String> currentRequestAndroidPlatformFields = Arrays.asList(
+            // Android custom platform fields
             SchemaConstants.Key.ACCOUNT_STATUS,
             SchemaConstants.Key.ID_TOKEN_STATUS,
             SchemaConstants.Key.AT_STATUS,
             SchemaConstants.Key.RT_STATUS,
             SchemaConstants.Key.FRT_STATUS,
             SchemaConstants.Key.MRRT_STATUS
-    };
+    );
+
+    /**
+     * This array defines the "Android and iOS shared" platform fields for current request in the
+     * FLW scenario.
+     * NOTE: These fields must always be listed in the correct order in this array.
+     * Failure do so will break the schema.
+     */
+    private static final List<String> currentRequestSharedFlwPlatformFieldsForAndroidAndiOSBroker = Arrays.asList(
+            // flw shared fields between Android and iOS
+            Key.IS_SHARED_DEVICE,
+            Key.REG_TYPE,
+            Key.REG_SOURCE,
+            Key.FLW_SIGNOUT_APP,
+            Key.FLW_SIGNIN_APP
+    );
+
+    /**
+     * This array defines the "Android and iOS shared" platform fields for current request in the
+     * Multiple Registration scenario.
+     * NOTE: These fields must always be listed in the correct order in this array.
+     * Failure do so will break the schema.
+     */
+    private static final List<String> currentRequestSharedMultipleWpjPlatformFieldsForAndroidAndiOSBroker = Arrays.asList(
+            // Multiple WPJ shared fields between Android and iOS
+            Key.IS_SHARED_DEVICE,
+            Key.REG_NUM,
+            Key.CLOUD_NUM,
+            Key.REG_SEQ_NUM,
+            Key.REQ_PURPOSE,
+            Key.REG_SOURCE
+    );
 
     /**
      * This array defines the platform schema for last request
      * NOTE: These fields must always be listed in the correct order in this array.
      * Failure do so will break the schema.
      */
-    private static final String[] lastRequestPlatformFields = new String[]{
+    private static final List<String> lastRequestPlatformFields = Arrays.asList(
             SchemaConstants.Key.ALL_TELEMETRY_DATA_SENT
-    };
+    );
 
+    /**
+     * This array defines fields for which emitting is allowed outside of a DiagnosticContext.
+     * We have lots of code that is executed outside of a DiagnosticContext i.e.
+     * ThreadLocal is not populated with a correlation Id. Since the current telemetry design is
+     * strictly around DiagnosticContext, therefore we need this supplemental cache to capture these
+     * fields that are emitted in code that is running outside that context.
+     */
+    private static final List<String> allowedFieldsForOfflineEmit = Arrays.asList(
+            Key.FLW_SIGNIN_APP,
+            Key.FLW_SIGNOUT_APP
+    );
+
+    /**
+     * Indicates if the supplied field is part of the platform field schema for current request.
+     *
+     * @param key the key that needs to be checked
+     * @return a boolean indicating if the field if part of current request platform schema
+     */
     static boolean isCurrentPlatformField(final String key) {
-        return Arrays.asList(currentRequestPlatformFields).contains(key);
+        return currentRequestAndroidPlatformFields.contains(key) ||
+                currentRequestSharedFlwPlatformFieldsForAndroidAndiOSBroker.contains(key) ||
+                currentRequestSharedMultipleWpjPlatformFieldsForAndroidAndiOSBroker.contains(key);
     }
 
+    /**
+     * Indicates if the supplied field is part of the platform field schema for last request.
+     *
+     * @param key the key that needs to be checked
+     * @return a boolean indicating if the field if part of last request platform schema
+     */
     static boolean isLastPlatformField(final String key) {
-        return Arrays.asList(lastRequestPlatformFields).contains(key);
+        return lastRequestPlatformFields.contains(key);
     }
 
-
-    static String[] getCurrentRequestPlatformFields() {
-        return currentRequestPlatformFields;
+    /**
+     * Indicates if this field is allowed to be emitted outside of a DiagnosticContext.
+     * We have lots of code that is executed outside of a DiagnosticContext i.e.
+     * ThreadLocal is not populated with a correlation Id. Since the current telemetry design is
+     * strictly around DiagnosticContext, therefore we need this supplemental cache to capture these
+     * fields that are emitted in code that is running outside that context.
+     */
+    static boolean isOfflineEmitAllowedForThisField(final String key) {
+        return allowedFieldsForOfflineEmit.contains(key);
     }
 
-    static String[] getLastRequestPlatformFields() {
+    /**
+     * Get all the "ordered" platform fields for the current request.
+     *
+     * @param isSharedDeviceScenario a boolean that indicates if we're capturing telemetry in shared
+     *                               device scenario
+     * @return a {@link List} of ordered current request platform fields
+     */
+    static List<String> getCurrentRequestPlatformFields(final boolean isSharedDeviceScenario) {
+        final List<String> consolidatedPlatformFields = new ArrayList<>();
+
+        if (isSharedDeviceScenario) {
+            consolidatedPlatformFields.addAll(currentRequestSharedFlwPlatformFieldsForAndroidAndiOSBroker);
+        } else {
+            consolidatedPlatformFields.addAll(currentRequestSharedMultipleWpjPlatformFieldsForAndroidAndiOSBroker);
+        }
+
+        consolidatedPlatformFields.addAll(currentRequestAndroidPlatformFields);
+
+        return consolidatedPlatformFields;
+    }
+
+    /**
+     * Get all the "ordered" platform fields for the last request.
+     *
+     * @return a {@link List} of ordered last request platform fields
+     */
+    static List<String> getLastRequestPlatformFields() {
         return lastRequestPlatformFields;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/SchemaConstants.java
@@ -58,6 +58,8 @@ public class SchemaConstants {
         public static final String ALL_TELEMETRY_DATA_SENT = "is_all_telemetry_data_sent";
 
         // flw and multiple reg fields
+        // More details here:
+        // https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview/pullrequest/5168
         public static final String IS_SHARED_DEVICE = "isSharedScenario";
         public static final String REG_TYPE = "reg_type";
         public static final String REG_SOURCE = "reg_source";

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryUtils.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryUtils.java
@@ -30,7 +30,7 @@ import lombok.NonNull;
 
 public class TelemetryUtils {
 
-    static boolean getBooleanFromSchemaString(@Nullable final String val) {
+    static boolean getBooleanFromString(@Nullable final String val) {
         return val != null && val.equals(SchemaConstants.Value.TRUE);
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryUtils.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/TelemetryUtils.java
@@ -22,15 +22,16 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.eststelemetry;
 
-import lombok.NonNull;
-
-import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.java.util.StringUtil;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.NonNull;
 
 public class TelemetryUtils {
 
-    static boolean getBooleanFromSchemaString(final String val) {
-        return val.equals(SchemaConstants.Value.TRUE);
+    static boolean getBooleanFromSchemaString(@Nullable final String val) {
+        return val != null && val.equals(SchemaConstants.Value.TRUE);
     }
 
     static String getSchemaCompliantStringFromBoolean(final boolean val) {

--- a/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/EstsTelemetryTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/EstsTelemetryTest.java
@@ -119,8 +119,8 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|" + apiId + ",1|,,,,,,1,0,1,1,0,0", headers.get(CURRENT_REQUEST_HEADER_NAME));
-        Assert.assertEquals("2|0|||1", headers.get(LAST_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|" + apiId + ",1|2,,,,,,,1,0,1,1,0,0", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|0|||2,1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class EstsTelemetryTest {
 
         Assert.assertEquals(lastRequestTelemetryMap.size(), 3);
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_SCHEMA_VERSION_CACHE_KEY), "2");
-        Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_HEADER_STRING_CACHE_KEY), "2|1|||");
+        Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_HEADER_STRING_CACHE_KEY), "2|1|||2,");
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_OBJECT_CACHE_KEY),
                 "{\"silent_successful_count\":1,\"failed_requests\":[],\"schema_version\":\"2\",\"platform_telemetry\":{}}");
     }
@@ -227,7 +227,7 @@ public class EstsTelemetryTest {
         Assert.assertEquals(lastRequestTelemetryMap.size(), 3);
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_SCHEMA_VERSION_CACHE_KEY), "2");
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_HEADER_STRING_CACHE_KEY),
-                "2|0|" + apiId + "," + correlationId + "|" + errorCode + "|");
+                "2|0|" + apiId + "," + correlationId + "|" + errorCode + "|2,");
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_OBJECT_CACHE_KEY),
                 "{\"silent_successful_count\":0,\"failed_requests\":[{\"mApiId\":\"" + apiId +
                         "\",\"mCorrelationId\":\"" + correlationId +
@@ -284,7 +284,7 @@ public class EstsTelemetryTest {
         Assert.assertEquals(lastRequestTelemetryMap.size(), 3);
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_SCHEMA_VERSION_CACHE_KEY), "2");
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_HEADER_STRING_CACHE_KEY),
-                "2|0|" + apiId + "," + correlationId + "|" + errorCode + "|");
+                "2|0|" + apiId + "," + correlationId + "|" + errorCode + "|2,");
         Assert.assertEquals(lastRequestTelemetryMap.get(LAST_TELEMETRY_OBJECT_CACHE_KEY),
                 "{\"silent_successful_count\":0,\"failed_requests\":[{\"mApiId\":\"" + apiId +
                         "\",\"mCorrelationId\":\"" + correlationId +
@@ -331,8 +331,8 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|API_ID,0|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
-        Assert.assertEquals("2|0|||1", headers.get(LAST_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|API_ID,0|2,,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|0|||2,1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
     @Test
@@ -359,8 +359,8 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|API_ID,0|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
-        Assert.assertEquals("2|5|API_1,COL_ID_1,API_2,COL_ID_2,API_3,COL_ID_3,API_4,COL_ID_4,API_5,COL_ID_5|ERR_1,ERR_2,ERR_3,ERR_4,ERR_5|1",
+        Assert.assertEquals("2|API_ID,0|2,,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|5|API_1,COL_ID_1,API_2,COL_ID_2,API_3,COL_ID_3,API_4,COL_ID_4,API_5,COL_ID_5|ERR_1,ERR_2,ERR_3,ERR_4,ERR_5|2,1",
                 headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
@@ -424,8 +424,8 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|" + apiId + ",1|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
-        Assert.assertEquals("2|2|||1", headers.get(LAST_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|" + apiId + ",1|2,,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|2|||2,1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
     private void flush(@NonNull ICommand<Boolean> mockCommand,

--- a/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/EstsTelemetryTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/eststelemetry/EstsTelemetryTest.java
@@ -119,7 +119,7 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|" + apiId + ",1|1,0,1,1,0,0", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|" + apiId + ",1|,,,,,,1,0,1,1,0,0", headers.get(CURRENT_REQUEST_HEADER_NAME));
         Assert.assertEquals("2|0|||1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
@@ -331,7 +331,7 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|API_ID,0|,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|API_ID,0|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
         Assert.assertEquals("2|0|||1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 
@@ -359,7 +359,7 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|API_ID,0|,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|API_ID,0|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
         Assert.assertEquals("2|5|API_1,COL_ID_1,API_2,COL_ID_2,API_3,COL_ID_3,API_4,COL_ID_4,API_5,COL_ID_5|ERR_1,ERR_2,ERR_3,ERR_4,ERR_5|1",
                 headers.get(LAST_REQUEST_HEADER_NAME));
     }
@@ -424,7 +424,7 @@ public class EstsTelemetryTest {
         final Map<String, String> headers = telemetry.getTelemetryHeaders();
 
         Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("2|" + apiId + ",1|,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
+        Assert.assertEquals("2|" + apiId + ",1|,,,,,,,,,,,", headers.get(CURRENT_REQUEST_HEADER_NAME));
         Assert.assertEquals("2|2|||1", headers.get(LAST_REQUEST_HEADER_NAME));
     }
 


### PR DESCRIPTION
### What?
Changes to facilitate us to capture header based telemetry around FLW and multiple Workplace Join. This is based on Olga's design PR here: https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview/pullrequest/5168

### How?
Basically, we've separated Android platform fields with shared platform fields we're going to have with Android and iOS.

There are going to be 3 sets of platform fields:

- Android only platform fields
- Android and iOS shared platform fields for FLW
- Android and iOS shared platform fields for Multiple WPJ

Note: The shared platform fields will always come first in the schema and Android only will come second.

Furthermore, we've introduced a new a supplemental cache inside the ESTS Telemetry class (this in addition to the existing ConcurrentMap that maps correlation Ids to telemetry associated to that request). This new supplemental cache will be used to store telemetry that is captured outside of the DiagnosticContext. We have lots of code that is executed outside of a DiagnosticContext i.e. ThreadLocal is not populated with a correlation Id. Since the current telemetry design is strictly around DiagnosticContext, therefore we need this supplemental cache to capture these fields that are emitted in code that is running outside that context. This fields are the ones determined by {SchemaConstants#isOfflineEmitAllowedForThisField(String)}.

Such fields are currently limited to the following as these are the only ones being emitted currently outside DiagnosticContext:

- Apps used for flw sign in (we need to see which app was used to Acquire token first time after shared device registration; sadly we don't have Sign In API in the broker and hence we have to track it via AT/ATS and presence of existing current account or not). 
- Apps used for flw sign out (this is also NOT run on CommandDisptacher)

Note: This PR is part of an effort to break https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1770 into smaller PRs.