### PR TITLE
Fix for failing foci scenarios

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -865,6 +865,10 @@ public abstract class BaseController {
         return targetAccount;
     }
 
+    /**
+     * Lookup in app-specific cache.
+     */
+    @Nullable
     private AccountRecord getCachedAccountRecordFromCallingAppCache(
             @NonNull final SilentTokenCommandParameters parameters) {
         final boolean isB2CAuthority = B2C.equalsIgnoreCase(
@@ -909,6 +913,7 @@ public abstract class BaseController {
     /**
      * Lookup in ALL the caches including the foci cache.
      */
+    @Nullable
     protected AccountRecord getCachedAccountRecordFromAllCaches(
             @NonNull final SilentTokenCommandParameters parameters) throws ClientException {
         // TO-DO https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1999531/

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -907,7 +907,7 @@ public abstract class BaseController {
     }
 
     /**
-     * Lookup in ALL the caches including the foci cache
+     * Lookup in ALL the caches including the foci cache.
      */
     protected AccountRecord getCachedAccountRecordFromAllCaches(
             @NonNull final SilentTokenCommandParameters parameters) throws ClientException {


### PR DESCRIPTION
**What?** : AcquireTokenSilent is failing to fetch a token in foci scenarios. During the broker 5.0.0 bug bash, it was found that the FOCI tests are failing. Here's one of the FOCI tests: https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833519

**Why was it failing?**
It was failing at step 6. Word was not getting SSO from the user having already signed into Outlook (another FOCI app).

**Why was it happening?**
Use of TSL has verified foci membership and getAccounts, however, the following acquire token silent request fails with an account_not_found error because no matching account and/or credential is found in the cache. The reason is that [broker verifies that the account supplied for ATS is actually part of the cache](https://github.com/AzureAD/ad-accounts-for-android/blob/dev/broker4j/src/main/com/microsoft/identity/client/BrokerLocalController.java#L135). [The caching layer will see if there is an existing token cache for this client application](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/dev/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java#L904). When TSL is used then there is NO existing token cache for client because the client hasn't got any tokens yet. So that part fails (it succeeds using ESTS request because that request seeds the token into the cache and so it creates an entry in the ApplicationMetadataCache). But the flow does not make an ESTS request because there is a check to verify if the cache instance is of type MsalOauth2TokenCache, which is not the case. It is actually BrokerOauth2TokenCache that is used. _Why did we add this  https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/32156ad74515e300394ee3997754b33e95713e83/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java#L865 condition? Can we safely remove it?_ If we can remove it.. Then we would be making use of this fallback i.e to make a service call to confirm the client is a FOCI app and the account is returned successfully.
**_Answer** :_  _The purpose of this instanceOf MsalOAuth2TokenCache check may be to protect it from being called for AdalOAuth2Cache. This was written during initial broker refactor, so this must have been added without taking into consideration that this flow is applicable for BrokerOAuth2Cache as well._ _I have not changed it to avoid any regressions._https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1999531/

Also, even if there is no existing cache for this particular client,  it should still work by virtue of having a dedicated foci cache, however,  even that doesn't work because we fall down here to look into the foci cache, but [we seem to be doing a look-up that requires a hard match on clientId](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/dev/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java#L924) i.e. the look-up will only return credentials that were issued to that particular client id. This defeats the purpose of having the foci cache if we're doing a hard look-up on a specific client Id. 

**What is the fix?**
I made a change to make break the getCachedAccountRecords in BaseController into 2 parts
 1. To get accounts using localAccountId and clientId
 2. To get accounts from all caches including the FOCI cache - In baseController, I have not added anything in this function other than what was there earlier. But in a seperate PR I did an override of this method and   used the BrokerUtil.getCacheRecordListFromBrokerCache() method which internally verifies if calling app is eligible to get FOCI accounts. These override changes are in https://github.com/AzureAD/ad-accounts-for-android/pull/1951


**Testing my fix**
Tested my fix on Pixel 3 phone by building Authenticator app with my changes. 
Feel free to test the scenario with the following Authenticator build :  https://msazure.visualstudio.com/One/_build/results?buildId=58053075&view=artifacts&pathAsName=false&type=publishedArtifacts
