### PR TITLE
Add telemetry event for content provider call for getting enrollment id

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 V.Next
 ----------
+- [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Bumped MSAL Broker Protocol version to 9.0, acquireToken/acquireTokenSilent endpoint requires minimum_required_broker_protocol_version of 9.0+ to Send x-ms-PKeyAuth Header to the token endpoint. (#1790)
 
 Version 6.0.0
 ----------
-- [PATCH] Fix msal failing tests due to telemetry context (1788)
+- [PATCH] Fix msal failing tests due to telemetry context (#1788)
 - [MAJOR] Bumped MSAL Broker Protocol version to 8.0, GET_ACCOUNTS endpoint requires minimum_required_broker_protocol_version of 8.0+ to return an account constructed from PRT id token to FOCI apps. (#1771)
 - [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow
 - [MINOR] Add telemetry relay client (#1757)

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ Version 6.0.0
 ----------
 - [PATCH] Fix msal failing tests due to telemetry context (#1788)
 - [MAJOR] Bumped MSAL Broker Protocol version to 8.0, GET_ACCOUNTS endpoint requires minimum_required_broker_protocol_version of 8.0+ to return an account constructed from PRT id token to FOCI apps. (#1771)
-- [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow
+- [MAJOR] [Msal] Remove launching logout endpoint in default browser for shared device mode signout flow (#1783)
 - [MINOR] Add telemetry relay client (#1757)
 - [MINOR] Add telemetry error events (#1768)
 - [MAJOR] Adding YubiKit SDK, which requires Java Version 8 and will thus bump up Java version overall to 8; added keyboard flag to android:configChanges for all activities that could interact with a YubiKey. (#1729)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IntuneMAMEnrollmentIdGateway.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IntuneMAMEnrollmentIdGateway.java
@@ -28,6 +28,10 @@ import android.net.Uri;
 import android.os.SystemClock;
 import android.util.LruCache;
 
+import com.microsoft.identity.common.java.telemetry.Telemetry;
+import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.java.telemetry.events.ContentProviderCallEvent;
+import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
 import lombok.EqualsAndHashCode;
@@ -136,6 +140,7 @@ public class IntuneMAMEnrollmentIdGateway {
 
         final String[] selectionArgs = {packageName, userId};
         final Uri contentURI = Uri.parse(CONTENT_URI);
+        final ContentProviderCallEvent getEnrollmentIdEvent = new ContentProviderCallEvent(CONTENT_URI);
 
         String result = null;
         try {
@@ -157,6 +162,11 @@ public class IntuneMAMEnrollmentIdGateway {
             // case the implementation changes or if there is a bug on the Company Portal side.
             Logger.warn(methodTag, "Unable to query enrollment id: " + e.getMessage());
         }
+
+        getEnrollmentIdEvent.put(TelemetryEventStrings.Key.ENROLLMENT_ID_NULL, String.valueOf(StringUtil.isNullOrEmpty(result)));
+        getEnrollmentIdEvent.put(TelemetryEventStrings.Key.END_TIME, String.valueOf(System.currentTimeMillis()));
+        Telemetry.emit(getEnrollmentIdEvent);
+
         return result;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryEventStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryEventStrings.java
@@ -65,6 +65,8 @@ public class TelemetryEventStrings {
         public static final String BROKER_START_EVENT = "broker_start_event";
         public static final String BROKER_END_EVENT = "broker_end_event";
 
+        public static final String CONTENT_PROVIDER_CALL_EVENT = "content_provider_call_event";
+
         public static final String DEPRECATED_API_USAGE_EVENT = "deprecated_api_usage_event";
     }
 
@@ -76,6 +78,7 @@ public class TelemetryEventStrings {
         public static final String BROKER_EVENT = EVENT_PREFIX + "broker_event";
         public static final String LIBRARY_CONSUMER_EVENT = EVENT_PREFIX + "library_consumer_event";
         public static final String ERROR_EVENT = EVENT_PREFIX + "error_event";
+        public static final String CONTENT_PROVIDER_EVENT = EVENT_PREFIX + "content_provider_event";
     }
 
     public static final class Key {
@@ -174,6 +177,8 @@ public class TelemetryEventStrings {
         public static final String ERROR_LOCATION_LINE_NUMBER = EVENT_PREFIX + "error_location_line_number";
         public static final String IS_WPJ_JOINED = EVENT_PREFIX + "is_wpj_joined";
         public static final String IS_ERROR_EVENT = EVENT_PREFIX + "is_error_event";
+        public static final String CONTENT_PROVIDER_URI = EVENT_PREFIX + "content_provider_uri";
+        public static final String ENROLLMENT_ID_NULL = EVENT_PREFIX + "enrollment_id_null";
     }
 
     public static final class Value {

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.telemetry.events;
+
+import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
+
+import lombok.NonNull;
+
+public class ContentProviderCallEvent extends BaseEvent {
+    public ContentProviderCallEvent(@NonNull final String contentUri){
+        super();
+        types(TelemetryEventStrings.EventType.CONTENT_PROVIDER_EVENT);
+        names(TelemetryEventStrings.Event.CONTENT_PROVIDER_CALL_EVENT);
+        put(TelemetryEventStrings.Key.CONTENT_PROVIDER_URI, contentUri);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
@@ -26,7 +26,14 @@ import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 
 import lombok.NonNull;
 
+/**
+ * Telemetry Event to capture details about a content provider call from broker
+ */
 public class ContentProviderCallEvent extends BaseEvent {
+    /**
+     * Constructor for ContentProviderCallEvent
+     * @param contentUri uri for the content provider call
+     */
     public ContentProviderCallEvent(@NonNull final String contentUri){
         super();
         types(TelemetryEventStrings.EventType.CONTENT_PROVIDER_EVENT);


### PR DESCRIPTION
### What
Add telemetry event for content provider call for getting enrollment id

### Why
Need a way to measure if company portal was called to get enrollment id and how much time it took. 

### How
Added a new TelemetryEventType for ContentProviderCall, and emitting it when we make a call to Company portal for getting enrollment id

## Testing
Verified locally that the event is getting added to the event map