### PR TITLE
Bump YubiKit version to public 2.1.0 release

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     //For Executive Order work
     implementation "com.yubico.yubikit:android:$rootProject.ext.yubikitAndroidVersion"
-    implementation "com.yubico.yubikit:piv:$rootProject.ext.yubikitAndroidVersion"
+    implementation "com.yubico.yubikit:piv:$rootProject.ext.yubikitPivVersion"
 
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.3.0'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,7 +43,8 @@ ext {
     uiAutomatorVersion = "2.2.0"
     msal4jVersion = "1.10.0"
     mseberaApacheHttpClientVersion = "4.5.8"
-    yubikitAndroidVersion = "2.1.0-alpha.1"
+    yubikitAndroidVersion = "2.1.0"
+    yubikitPivVersion = "2.1.0"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"


### PR DESCRIPTION
## Summary 
Yubico recently released their [final version of 2.1.0 for YubiKit Android and YubiKit PIV](https://github.com/Yubico/yubikit-android/releases/tag/2.1.0), the two dependencies needed for smartcard CBA.

I bumped up the versions within Common. No breaking changes were made from alpha to the final release. I also added a separate version variable for YubiKit PIV, in case its version ever deviates from Android.

Later, I'll release PRs for MSAL, broker, ADAL, and Android-Complete for bumping up the versions. 

## Testing
Built MSALTestApp, and then MSALTestApp + BrokerHost. Regular success and error scenarios passed manual tests.
