### PR TITLE
Move some storage classes from broker to common4j

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.Next
 ----------
 - [MINOR] Bumped MSAL Broker Protocol version to 9.0, acquireToken/acquireTokenSilent endpoint requires minimum_required_broker_protocol_version of 9.0+ to Send x-ms-PKeyAuth Header to the token endpoint. (#1790)
+- [MINOR] Move some storage classes from broker to common4j (#1809)
 
 Version 6.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.storage;
+
+import com.microsoft.identity.common.java.crypto.IKeyAccessor;
+import com.microsoft.identity.common.java.crypto.KeyAccessorStringAdapter;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
+import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.ported.Predicate;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.NonNull;
+
+/**
+ * An encrypted implementation of a {@link INameValueStorage}. Each value stored in this storage is
+ * encrypted using the encryption manager provided to this storage via its constructor.
+ * <p>
+ * Please note that internal raw storage here is backed by a String based {@link INameValueStorage}
+ * that is provided to the constructor here. Any value that we intend to put into the
+ * {@link EncryptedNameValueStorage} based on the type parameter T is first adapted into a String
+ * based on the provided {@link IGenericTypeStringAdapter} for that type and then the String is
+ * encrypted and persisted into the raw String based name value storage.
+ * <p>
+ * Doing the above gives us a design very similar to the SharedPreferencesFileManager that we have
+ * in the Android Broker (that one actually only supports Strings and Long...this one should
+ * support any type).
+ *
+ * @param <T> the type parameter denoting the Type of data that we intend to store
+ */
+public class EncryptedNameValueStorage<T> implements INameValueStorage<T> {
+
+    private static final String TAG = EncryptedNameValueStorage.class.getSimpleName();
+
+    @NonNull
+    private final INameValueStorage<String> mRawNameValueStorage;
+
+    @NonNull
+    private final KeyAccessorStringAdapter mEncryptionManager;
+
+    @NonNull
+    private final IGenericTypeStringAdapter<T> mStringAdapter;
+
+    /**
+     * Creates an instance of an {@link EncryptedNameValueStorage}.
+     *
+     * @param rawNameValueStringStorage the raw String based {@link INameValueStorage} where the
+     *                                  encrypted data is stored
+     * @param encryptionManager         the {@link IKeyAccessor} responsible for encrypting the data
+     * @param stringAdapter             the {@link IGenericTypeStringAdapter} that will be used to
+     *                                  adapt the values to their String representation before
+     *                                  encrypting and persisting them
+     */
+    public EncryptedNameValueStorage(@NonNull final INameValueStorage<String> rawNameValueStringStorage,
+                                     @NonNull final IKeyAccessor encryptionManager,
+                                     @NonNull final IGenericTypeStringAdapter<T> stringAdapter) {
+        this.mRawNameValueStorage = rawNameValueStringStorage;
+        this.mEncryptionManager = new KeyAccessorStringAdapter(encryptionManager);
+        this.mStringAdapter = stringAdapter;
+    }
+
+    @Nullable
+    @Override
+    public T get(@NonNull final String name) {
+        final String encryptedString = mRawNameValueStorage.get(name);
+
+        if (StringUtil.isNullOrEmpty(encryptedString)) {
+            return null;
+        }
+
+        final String decryptedString = decrypt(encryptedString);
+
+        if (StringUtil.isNullOrEmpty(decryptedString)) {
+            // This is what the Android Broker's SharedPreferencesFileManager does right now
+            logWarningAndRemoveKey(name);
+            return null;
+        }
+
+        return mStringAdapter.adapt(decryptedString);
+    }
+
+    @Override
+    public @NonNull Map<String, T> getAll() {
+        final Map<String, String> stringEntries = mRawNameValueStorage.getAll();
+        final Map<String, T> decryptedEntries = new HashMap<>();
+
+        for (final Map.Entry<String, String> entry : stringEntries.entrySet()) {
+            final T decryptedValue = get(entry.getKey());
+
+            if (decryptedValue != null) {
+                decryptedEntries.put(entry.getKey(), decryptedValue);
+            }
+        }
+
+        return decryptedEntries;
+    }
+
+    @Override
+    public void put(@NonNull final String name, @Nullable final T value) {
+        if (value == null) {
+            mRawNameValueStorage.put(name, null);
+            return;
+        }
+
+        final String adaptedValue = mStringAdapter.adapt(value);
+
+        if (StringUtil.isNullOrEmpty(adaptedValue)) {
+            mRawNameValueStorage.put(name, adaptedValue);
+            return;
+        }
+
+        final String encryptedValue = encrypt(adaptedValue);
+        mRawNameValueStorage.put(name, encryptedValue);
+    }
+
+    @Override
+    public void remove(@NonNull final String name) {
+        mRawNameValueStorage.remove(name);
+    }
+
+    @Override
+    public void clear() {
+        mRawNameValueStorage.clear();
+    }
+
+    @Override
+    public @NonNull Set<String> keySet() {
+        return mRawNameValueStorage.keySet();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, T>> getAllFilteredByKey(@NonNull final Predicate<String> keyFilter) {
+        final Map<String, T> newMap = new HashMap<>();
+        for (final Map.Entry<String, T> entry : getAll().entrySet()) {
+            if (keyFilter.test(entry.getKey())) {
+                newMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newMap.entrySet().iterator();
+    }
+
+    @Nullable
+    private String encrypt(@NonNull final String clearText) {
+        return encryptDecryptInternal(clearText, true);
+    }
+
+    @Nullable
+    private String decrypt(@NonNull final String encryptedBlob) {
+        return encryptDecryptInternal(encryptedBlob, false);
+    }
+
+    @Nullable
+    private String encryptDecryptInternal(
+            @NonNull final String inputText,
+            final boolean encrypt) {
+        final String methodName = "encryptDecryptInternal";
+
+        try {
+            return encrypt
+                    ? mEncryptionManager.encrypt(inputText)
+                    : mEncryptionManager.decrypt(inputText);
+        } catch (final ClientException e) {
+            Logger.error(
+                    TAG + ":" + methodName,
+                    "Failed to " + (encrypt ? "encrypt" : "decrypt") + " value",
+                    encrypt
+                            ? null // If we failed to encrypt, don't log the error as it may contain a token
+                            : e // If we failed to decrypt, we couldn't see that secret value so log the error
+            );
+            return null;
+        }
+    }
+
+    private void logWarningAndRemoveKey(@NonNull final String key) {
+        Logger.warn(
+                TAG,
+                "Failed to decrypt value! "
+                        + "This usually signals an issue with KeyStore or the provided SecretKeys."
+        );
+
+        remove(key);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/IGenericTypeStringAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/IGenericTypeStringAdapter.java
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.storage;
+
+import lombok.NonNull;
+
+/**
+ * Describes an adapter that can take the value of an Object as specified by the type parameter, and
+ * convert it into its String representation as well as vice versa.
+ *
+ * @param <T> the type parameter that denotes the {@link java.lang.reflect.Type} of the Object that
+ *            needs to be adapted
+ */
+public interface IGenericTypeStringAdapter<T> {
+
+    /**
+     * Adapt the given value into a String representation.
+     *
+     * @param value the value that needs to be adapted
+     * @return a String representation of the value
+     */
+    String adapt(T value);
+
+    /**
+     * Adapt the given String into a the Java Object specified by the type parameter.
+     *
+     * @param value the String that needs to be adapted
+     * @return the adapted value
+     */
+    T adapt(String value);
+
+    /**
+     * An {@link IGenericTypeStringAdapter} for {@link Long}.
+     */
+    IGenericTypeStringAdapter<Long> LongStringAdapter = new IGenericTypeStringAdapter<Long>() {
+        @NonNull
+        @Override
+        public String adapt(@NonNull final Long value) {
+            return String.valueOf(value);
+        }
+
+        @NonNull
+        @Override
+        public Long adapt(@NonNull final String value) throws NumberFormatException {
+            return Long.parseLong(value);
+        }
+    };
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/MultiTypeNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/MultiTypeNameValueStorage.java
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.storage;
+
+import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
+import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.ported.Predicate;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+/**
+ * An implementation of {@link IMultiTypeNameValueStorage}.
+ * <p>
+ * The internal implementation here is backed by an implementation of a {@link INameValueStorage<String>}.
+ * Strings are dropped directly into the storage, whereas Long values are adapted into a String
+ * using the {@link IGenericTypeStringAdapter#LongStringAdapter}.
+ * <p>
+ * This entire class should be functionally equivalent to the SharedPreferencesFileManager in the
+ * Android Broker which does the exact things.
+ * <p>
+ * Any data stored in this {@link MultiTypeNameValueStorage} can also be encrypted by simply
+ * supplying an encrypted variant of the {@link INameValueStorage} as the raw storage here. For
+ * instance, you may choose to supply an {@link EncryptedNameValueStorage} to the constructor here
+ * if you wish to store encrypted data in this {@link MultiTypeNameValueStorage}.
+ */
+@AllArgsConstructor
+public class MultiTypeNameValueStorage implements IMultiTypeNameValueStorage {
+
+    private final INameValueStorage<String> mNameValueStringStorage;
+
+    @Override
+    public void putString(@NonNull final String key, @Nullable final String value) {
+        mNameValueStringStorage.put(key, value);
+    }
+
+    @Override
+    public String getString(@NonNull final String key) {
+        return mNameValueStringStorage.get(key);
+    }
+
+    @Override
+    public void putLong(@NonNull final String key, final long value) {
+        mNameValueStringStorage.put(key, IGenericTypeStringAdapter.LongStringAdapter.adapt(value));
+    }
+
+    @Override
+    public long getLong(@NonNull final String key) {
+        final String val = mNameValueStringStorage.get(key);
+
+        if (StringUtil.isNullOrEmpty(val)) {
+            return 0;
+        }
+
+        return IGenericTypeStringAdapter.LongStringAdapter.adapt(val);
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return mNameValueStringStorage.getAll();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> getAllFilteredByKey(@NonNull final Predicate<String> keyFilter) {
+        return mNameValueStringStorage.getAllFilteredByKey(keyFilter);
+    }
+
+    @Override
+    public boolean contains(@NonNull final String key) {
+        return !StringUtil.isNullOrEmpty(getString(key));
+    }
+
+    @Override
+    public void clear() {
+        mNameValueStringStorage.clear();
+    }
+
+    @Override
+    public void remove(@NonNull final String key) {
+        mNameValueStringStorage.remove(key);
+    }
+}


### PR DESCRIPTION
Related: https://github.com/AzureAD/ad-accounts-for-android/pull/1959

Note: This only moves classes as indicated in the title. This PR does NOT contain any new code.

This is to facilitate some work I've been doing in the telemetry and also allow ourselves to use these classes more broadly if needed.

I didn't move the accompanying tests to common4j as part of this PR. I can do that later probably by moving them to testFixtures and write multi-platform tests for them.