### PR TITLE
Remove factory reset rule as no longer needed

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -93,9 +93,6 @@ public class RulesHelper {
             ));
         }
 
-        Log.i(TAG, "Adding FactoryResetChromeRule");
-        ruleChain = ruleChain.around(new FactoryResetChromeRule());
-
         Log.i(TAG, "Adding RemoveBrokersBeforeTestRule");
         ruleChain = ruleChain.around(new RemoveBrokersBeforeTestRule());
 


### PR DESCRIPTION
ESTS has made change that enables our automation to work on newer versions of Chrome or more simply put newer Android devices, and therefore this change to downgrade Chrome to factory default is no longer needed, and hence removed.