### PR TITLE
Added more precautions when handling PIN

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ClientCertAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ClientCertAuthChallengeHandler.java
@@ -548,7 +548,7 @@ public final class ClientCertAuthChallengeHandler implements IChallengeHandler<C
     }
 
     /**
-     * Sets all chars in the PIN array to null.
+     * Sets all chars in the PIN array to 0.
      * @param pin char array containing PIN.
      */
     private void clearPin(@NonNull final char[] pin) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardPinDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardPinDialog.java
@@ -152,7 +152,10 @@ public class SmartcardPinDialog extends SmartcardDialog {
                 ((AlertDialog)mDialog).getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        mPositiveButtonListener.onClick(pinEditText.getText().toString());
+                        //Avoiding the use of strings for pin.
+                        char[] pin = new char[pinEditText.length()];
+                        pinEditText.getText().getChars(0, pinEditText.length(), pin, 0);
+                        mPositiveButtonListener.onClick(pin);
                     }
                 });
             }
@@ -199,7 +202,7 @@ public class SmartcardPinDialog extends SmartcardDialog {
      * Listener interface for a positive button click.
      */
     public interface PositiveButtonListener {
-        void onClick(@NonNull final String pin);
+        void onClick(@NonNull final char[] pin);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardPinDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardPinDialog.java
@@ -153,7 +153,7 @@ public class SmartcardPinDialog extends SmartcardDialog {
                     @Override
                     public void onClick(View v) {
                         //Avoiding the use of strings for pin.
-                        char[] pin = new char[pinEditText.length()];
+                        final char[] pin = new char[pinEditText.length()];
                         pinEditText.getText().getChars(0, pinEditText.length(), pin, 0);
                         mPositiveButtonListener.onClick(pin);
                     }


### PR DESCRIPTION
## Summary
It's generally not great to use Strings to store passwords/pins because they are immutable (and for other reasons [explained here](https://www.geeksforgeeks.org/use-char-array-string-storing-passwords-java/)). 

I removed logic that sets the PIN grabbed from the EditText to a string, replacing it with logic that turns it into a char array. The parameter declarations in which a string was passed were changed to char array. 

I also added a small method, `clearPin`, which sets the characters in the provided char array to 0. I call it in the success scenario after the PivPrivateKey is created (the constructor of PivPrivateKey creates a copy of the char array, which I have no control over) and in the failure scenario when an incorrect PIN attempt is made.

Of course, these changes aren't necessarily going to prevent an experienced hacker from finding the PIN somehow, but it does reduce the area of code in which the PIN is present from our side.

## Testing
I stepped through the code to make sure that the PIN array was being cleared without affecting the existing functionalities. 