### PR TITLE
Fix an issue where incorrect authority url is returned after cloud discovery is set.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Fix an issue where incorrect authority url is returned after cloud discovery is set. (#1820)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -371,7 +371,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
     private boolean getMultipleCloudsSupported(@NonNull final TokenCommandParameters parameters) {
         if (parameters.getAuthority() instanceof AzureActiveDirectoryAuthority) {
             final AzureActiveDirectoryAuthority authority = (AzureActiveDirectoryAuthority) parameters.getAuthority();
-            return authority.getMultipleCloudsSupported();
+            return authority.isMultipleCloudsSupported();
         } else {
             return false;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -22,7 +22,11 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.authorities;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -46,45 +50,46 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+@Accessors(prefix = "m")
 public class AzureActiveDirectoryAuthority extends Authority {
 
     private static transient final String TAG = AzureActiveDirectoryAuthority.class.getSimpleName();
 
+    @Getter
     @SerializedName("audience")
     public AzureActiveDirectoryAudience mAudience;
 
     @SerializedName("flight_parameters")
     public Map<String, String> mFlightParameters;
 
-    public boolean mMultipleCloudsSupported = false;
+    @Getter
+    @Setter
+    private boolean mMultipleCloudsSupported = false;
 
-    private AzureActiveDirectoryCloud mAzureActiveDirectoryCloud;
-
-    private AzureActiveDirectoryCloud getAzureActiveDirectoryCloud() {
+    /** Gets {@link AzureActiveDirectoryCloud}, if the cloud metadata is already initialized. */
+    @Nullable
+    private static synchronized AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(
+            @NonNull final AzureActiveDirectoryAudience audience) {
         final String methodName = ":getAzureActiveDirectoryCloud";
-        AzureActiveDirectoryCloud cloud = null;
 
         try {
-            cloud = AzureActiveDirectory.getAzureActiveDirectoryCloud(new URL(mAudience.getCloudUrl()));
-            mKnownToMicrosoft = true;
+            return AzureActiveDirectory.getAzureActiveDirectoryCloud(new URL(audience.getCloudUrl()));
         } catch (MalformedURLException e) {
             Logger.errorPII(
                     TAG + methodName,
                     "AAD cloud URL was malformed.",
                     e
             );
-            cloud = null;
-            mKnownToMicrosoft = false;
         }
 
-        return cloud;
+        return null;
     }
 
     public AzureActiveDirectoryAuthority(AzureActiveDirectoryAudience signInAudience) {
         mAudience = signInAudience;
         mAuthorityTypeString = "AAD";
-        mAzureActiveDirectoryCloud = getAzureActiveDirectoryCloud();
     }
 
     public AzureActiveDirectoryAuthority() {
@@ -92,41 +97,18 @@ public class AzureActiveDirectoryAuthority extends Authority {
         mAudience = new AllAccounts();
         mAuthorityTypeString = "AAD";
         mMultipleCloudsSupported = false;
-        mAzureActiveDirectoryCloud = getAzureActiveDirectoryCloud();
-    }
-
-    /**
-     * Gets the {@link AzureActiveDirectoryCloud} associated to this Authority.
-     *
-     * @return The {@link AzureActiveDirectoryCloud} or null, if the provided URL is not associated
-     * with any cloud.
-     */
-    public AzureActiveDirectoryCloud getCloud() {
-        return mAzureActiveDirectoryCloud;
-    }
-
-    public Map<String, String> getFlightParameters() {
-        return this.mFlightParameters;
-    }
-
-    public void setMultipleCloudsSupported(boolean supported) {
-        mMultipleCloudsSupported = supported;
-    }
-
-    public boolean getMultipleCloudsSupported() {
-        return mMultipleCloudsSupported;
     }
 
     @Override
     public URI getAuthorityUri() {
         try {
-            getAzureActiveDirectoryCloud();
+            final AzureActiveDirectoryCloud cloud = getAzureActiveDirectoryCloud(mAudience);
             CommonURIBuilder issuer;
 
-            if (mAzureActiveDirectoryCloud == null) {
+            if (cloud == null) {
                 issuer = new CommonURIBuilder(mAudience.getCloudUrl());
             } else {
-                issuer = new CommonURIBuilder("https://" + mAzureActiveDirectoryCloud.getPreferredNetworkHostName());
+                issuer = new CommonURIBuilder("https://" + cloud.getPreferredNetworkHostName());
             }
 
             if (!StringUtil.isNullOrEmpty(mAudience.getTenantId())) {
@@ -185,10 +167,6 @@ public class AzureActiveDirectoryAuthority extends Authority {
         return new MicrosoftStsOAuth2Strategy(config, parameters);
     }
 
-    public AzureActiveDirectoryAudience getAudience() {
-        return mAudience;
-    }
-
     /**
      * Checks if current authority belongs to same cloud as the passed in authority.
      *
@@ -198,11 +176,14 @@ public class AzureActiveDirectoryAuthority extends Authority {
     //@WorkerThread
     public synchronized boolean isSameCloudAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck)
             throws IOException, URISyntaxException {
-        if (!AzureActiveDirectory.isInitialized()) {
-            // Cloud discovery is needed in order to make sure that we have a preferred_network_host_name to cloud aliases mappings
-            AzureActiveDirectory.performCloudDiscovery();
+        final AzureActiveDirectoryCloud cloudOfThisAuthority = getAzureActiveDirectoryCloud(mAudience);
+        final AzureActiveDirectoryCloud cloudOfAuthorityToCheck = getAzureActiveDirectoryCloud(authorityToCheck.getAudience());
+
+        // Can't verify, return false.
+        if (cloudOfThisAuthority == null && cloudOfAuthorityToCheck == null) {
+            return false;
         }
 
-        return getAzureActiveDirectoryCloud().equals(authorityToCheck.getAzureActiveDirectoryCloud());
+        return Objects.equals(cloudOfThisAuthority, cloudOfAuthorityToCheck);
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -176,6 +176,11 @@ public class AzureActiveDirectoryAuthority extends Authority {
     //@WorkerThread
     public synchronized boolean isSameCloudAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck)
             throws IOException, URISyntaxException {
+        if (!AzureActiveDirectory.isInitialized()) {
+            // Cloud discovery is needed in order to make sure that we have a preferred_network_host_name to cloud aliases mappings
+            AzureActiveDirectory.performCloudDiscovery();
+        }
+
         final AzureActiveDirectoryCloud cloudOfThisAuthority = getAzureActiveDirectoryCloud(mAudience);
         final AzureActiveDirectoryCloud cloudOfAuthorityToCheck = getAzureActiveDirectoryCloud(authorityToCheck.getAudience());
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -280,7 +280,7 @@ public abstract class BaseController {
                     final AzureActiveDirectoryAuthority requestAuthority = (AzureActiveDirectoryAuthority) interactiveTokenCommandParameters.getAuthority();
                     ((MicrosoftStsAuthorizationRequest.Builder) builder)
                             .setAuthority(requestAuthority.getAuthorityURL())
-                            .setMultipleCloudAware(requestAuthority.mMultipleCloudsSupported)
+                            .setMultipleCloudAware(requestAuthority.isMultipleCloudsSupported())
                             .setState(interactiveTokenCommandParameters.getPlatformComponents().getStateGenerator().generate())
                             .setSlice(requestAuthority.mSlice);
                 }

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityDeserializerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityDeserializerTest.java
@@ -24,10 +24,14 @@ package com.microsoft.identity.common.java.authorities;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class AuthorityDeserializerTest {
 
@@ -63,6 +67,21 @@ public class AuthorityDeserializerTest {
     public void testDeserializeAAD() {
         final Authority authority = gson.fromJson(AAD_AUTHORITY, Authority.class);
 
+        Assert.assertTrue(authority instanceof AzureActiveDirectoryAuthority);
+
+        Assert.assertEquals("https://login.microsoftonline.us", ((AzureActiveDirectoryAuthority) authority).mAudience.getCloudUrl());
+        Assert.assertEquals("common", ((AzureActiveDirectoryAuthority) authority).mAudience.getTenantId());
+
+        Assert.assertEquals("https://login.microsoftonline.us/common", authority.getAuthorityUri().toString());
+    }
+
+    // AzureActiveDirectoryAuthority.getAuthorityUri() relies on results from cloud metadata.
+    // We should make sure that the result are valid after cloud discovery is done.
+    @Test
+    public void testDeserializeAfterGettingCloudMetadata() throws Exception {
+        AzureActiveDirectory.performCloudDiscovery();
+
+        final Authority authority = gson.fromJson(AAD_AUTHORITY, Authority.class);
         Assert.assertTrue(authority instanceof AzureActiveDirectoryAuthority);
 
         Assert.assertEquals("https://login.microsoftonline.us", ((AzureActiveDirectoryAuthority) authority).mAudience.getCloudUrl());


### PR DESCRIPTION
## What happened
There is a bug in the deserialization process of Authority (see AuthoritySerializer.java).
1. We [deserialize the object with the default constructor](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/516c219d12a5ba089db4032b2112daa623ce3059/common4j/src/main/com/microsoft/identity/common/java/authorities/AuthorityDeserializer.java#L59)
2. In the default constructor, we [construct `AzureActiveDirectoryCloud`](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/516c219d12a5ba089db4032b2112daa623ce3059/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java#L69) [with the "Default" audience.](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/516c219d12a5ba089db4032b2112daa623ce3059/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java#L92) 
 3. The default audience is pointing to worldwide cloud, so you ended up having this variable set to worldwide.
4. We then [try to set audience from the URI](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/516c219d12a5ba089db4032b2112daa623ce3059/common4j/src/main/com/microsoft/identity/common/java/authorities/AuthorityDeserializer.java#L69), well.. it's too late now. `AzureActiveDirectoryCloud` was already initialized in the constructor.
5. Whenever someone invokes getAuthorityUri(), [The url from `AzureActiveDirectoryCloud` will be used](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/516c219d12a5ba089db4032b2112daa623ce3059/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java#L129)
      -  If I don't perform metadata discovery, then AzureActiveDirectoryAuthority.getAzureActiveDirectoryCloud() will return null, and we'll load the url from the actual audience object we set in step 4. instead.

This means that if I perform metadata discovery first, then i will ALWAYS get a worldwide authority, regardless of what i passed into the configuration file.

Meaning.... that this will only repro **_AFTER_** you've made a token request/ DCF request, because those request will trigger the discovery. (i.e. Create (PublicClientApplication) PCA-A, use PCA-A to acquire token, Create PCA-B. PCA-B will run into this issue).

## What I did
1. Remove the `mAzureActiveDirectoryCloud` class parameter. We will load the value from the cache when we need to.
      -  There is no reason to cache this value as a class variable. IMO, the amount of class variables should be kept to the minimum. Given that this value has a 1-1 relationship with mAudience (and we're retrieving it from a _cache_), then we can just keep mAudience.
2. Also removed the unused mKnownToMicrosoft and mKnownToDeveloper from the Authority class. They're not used. (The method Authority.isKnownAuthority() does not use them).
3. Add a test in AuthorityDeserializer test, and [in MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1674/commits/0a342434829bc109b3e20dbb710954a92cb798b0)

## What I also/actually want to do
This issue is tricky to repro because there are 2 **GLOBAL** states
- the metadata cache is empty (before invoking DCF or any token requests)
- the metadata cache is filled (after invoking DCF or any token requests)

Ideally, we should be moving toward making MSAL stateless. One way to do this is to make sure the cache is always initialized before use. We can do that by either put the discovery logic in the static block of the class, or turn this cache as part of the immutable configuration/parameter that we inject at the very beginning of the flow.

Given that this involves a network request, and the logic is also used by adal, it's a considerably big change (primarily due to threading), so I decided not to do it now as part of this fix.