### PR TITLE
Add homeAccountId to BaseException

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Add homeAccountId to BaseException (#1822)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -75,6 +75,10 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     @Nullable
     private String mUsername;
 
+    // The home account id of the account that owns the flow.
+    @Nullable
+    private String mHomeAccountId;
+
     private final List<Map<String, String>> mTelemetry = new ArrayList<>();
 
     /**
@@ -205,6 +209,15 @@ public class BaseException extends Exception implements IErrorInformation, ITele
 
     public void setUsername(@NonNull final String username) {
         this.mUsername = username;
+    }
+
+    @Nullable
+    public String getHomeAccountId() {
+        return mHomeAccountId;
+    }
+
+    public void setHomeAccountId(@NonNull final String homeAccountId) {
+        this.mHomeAccountId = homeAccountId;
     }
 
     public String getExceptionName() {


### PR DESCRIPTION
### What
Adding homeAccountId field in BaseException class to pass the homeAccountId information to errorHandler

### Why
The interactive requests do not have the homeAccountId field populated to begin with. But this field is required to be returned back to application when we return IntuneAppProtecttionPolicyRequiredException. Otherwise applicaiton failed to do MAM registration.

### How
Adding homeAccountId field in BaseException, and exposing a method to set it.

### Testing
This change is part of fixing the bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1998929/
Verified the scenario where Teams app could not sign in if user (with MAM and MFA policies) sign out once or if user tries to sign in after device registration
The changes to setHomeAccountId fields are in this Broker PR https://github.com/AzureAD/ad-accounts-for-android/pull/1975