### PR TITLE
Add implementation for clearAll method to BrokerOAuth2TokenCache to clear all the credentials and metadata

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add implementation for clearAll method to BrokerOAuth2TokenCache to clear all the credentials and metadata (#1823)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -1300,9 +1300,28 @@ public class BrokerOAuth2TokenCache
         throw new UnsupportedOperationException(OAuth2TokenCache.ERR_UNSUPPORTED_OPERATION);
     }
 
+    /**
+     * Removes all entries from broker cache for all clients in applications metadata cache.
+     * Removes all entries from broker Foci cache
+     * Removes all entries from broker applications metadata cache
+     */
     @Override
     public void clearAll() {
-        throw new UnsupportedOperationException(OAuth2TokenCache.ERR_UNSUPPORTED_OPERATION);
+        final List<BrokerApplicationMetadata> allClientsMetadata = mApplicationMetadataCache.getAll();
+        for (final BrokerApplicationMetadata clientMetadata : allClientsMetadata) {
+            final OAuth2TokenCache clientTokenCache = getTokenCacheForClient(
+                    clientMetadata.getClientId(),
+                    clientMetadata.getEnvironment(),
+                    clientMetadata.getUid()
+            );
+
+            if (clientTokenCache != null) {
+                clientTokenCache.clearAll();
+            }
+        }
+
+        this.mFociCache.clearAll();
+        this.mApplicationMetadataCache.clear();
     }
 
     /**


### PR DESCRIPTION
### What
Adding implemetation for clearAll method in BrokerOAuth2TokenCache to clear all credentials and metadata

### Why
This method will be called from Shared Device Mode SignOut flow. Currently we are removing each credential separately during SDM sign-out, which is not efficient and also leads to not be able to clean up all FOCI credentials if multiple FOCI apps credentials are present.

### How
Cleaning up individual app caches for all apps in the metadata cache, Foci cache and the app metadata cache in the clearAll method implementation

### Testing
Corresponding Broker PR where this method is used in SDM signOut Flow (https://github.com/AzureAD/ad-accounts-for-android/pull/1974). 
Also verified that this change fixes the bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1980471/
The issue in the bug was that current SignOut form SDM wasn't clearing the FOCI cache properly, it was only clearing the token credentials corresponding to only one client-id, and token credentials corresponding to other client-ids were not cleared.
This led to Edge receiving multiple accounts entry later as it uses multiple client ids (an issue to follow up with Edge). 
After this change we clear all entries in FOCI cache and on the next launch only one account is returned to Edge and it is able to perform SSO.