### PR TITLE
Swallow unbound service exceptions on disconnect

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Swallow unbound service exceptions on disconnect. (#1824)
 - [PATCH] Fix an issue where incorrect authority url is returned after cloud discovery is set. (#1820)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
@@ -167,7 +167,7 @@ public abstract class BoundServiceClient<T extends IInterface> {
         if (mHasStartedBinding) {
             try {
                 mContext.unbindService(mConnection);
-            } catch (IllegalArgumentException e) {
+            } catch (final IllegalArgumentException e) {
                 final String errorDescription = "Error occurred while unbinding bound Service with " + getClass().getSimpleName();
                 Logger.error(methodTag, errorDescription, e);
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
@@ -163,8 +163,14 @@ public abstract class BoundServiceClient<T extends IInterface> {
      * Disconnects (unbinds) from the service.
      */
     public void disconnect() {
+        final String methodTag = TAG + ":disconnect";
         if (mHasStartedBinding) {
-            mContext.unbindService(mConnection);
+            try {
+                mContext.unbindService(mConnection);
+            } catch (IllegalArgumentException e) {
+                final String errorDescription = "Error occurred while unbinding bound Service with " + getClass().getSimpleName();
+                Logger.error(methodTag, errorDescription, e);
+            }
             mHasStartedBinding = false;
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BoundServiceClient.java
@@ -168,6 +168,9 @@ public abstract class BoundServiceClient<T extends IInterface> {
             try {
                 mContext.unbindService(mConnection);
             } catch (final IllegalArgumentException e) {
+                // This is coming from LoadedApk framework code when there is some error unbinding the service,
+                // possibly due to it not having been registered correctly in the first place, or already unregistered.
+                // Since this is the cleanup path, just handle log this and move on.
                 final String errorDescription = "Error occurred while unbinding bound Service with " + getClass().getSimpleName();
                 Logger.error(methodTag, errorDescription, e);
             }


### PR DESCRIPTION
Errors during cleanup of a broker call were surfacing rather than the results of the operation itself.