### PR TITLE
Bundling multiple credential saves in a single SharedPreferences transaction

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
+++ b/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
@@ -295,7 +295,7 @@ public class AndroidPlatformComponents implements IPlatformComponents {
                 SharedPreferences.Editor editor = sharedPreferences.edit();
 
                 for (Map.Entry<String, Long> keyValuePair : keyValuePairs.entrySet()) {
-                    editor.putLong(keyValuePair.getKey(), keyValuePair.getValue());
+                    editor.putString(keyValuePair.getKey(), keyValuePair.getValue().toString());
                 }
 
                 editor.apply();

--- a/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
+++ b/common/src/main/java/com/microsoft/identity/common/AndroidPlatformComponents.java
@@ -270,6 +270,17 @@ public class AndroidPlatformComponents implements IPlatformComponents {
         final SharedPreferences sharedPreferences = mContext.getSharedPreferences(storeName, Context.MODE_MULTI_PROCESS);
         return new SharedPrefStringNameValueStorage(new IMultiTypeNameValueStorage() {
             @Override
+            public void putStrings(Map<String, String> keyValuePairs) {
+                SharedPreferences.Editor editor = sharedPreferences.edit();
+
+                for (Map.Entry<String, String> keyValuePair : keyValuePairs.entrySet()) {
+                    editor.putString(keyValuePair.getKey(), keyValuePair.getValue());
+                }
+
+                editor.apply();
+            }
+
+            @Override
             public void putString(String key, String value) {
                 sharedPreferences.edit().putString(key, value).apply();
             }
@@ -277,6 +288,17 @@ public class AndroidPlatformComponents implements IPlatformComponents {
             @Override
             public String getString(String key) {
                 return sharedPreferences.getString(key, null);
+            }
+
+            @Override
+            public void putLongs(Map<String, Long> keyValuePairs) {
+                SharedPreferences.Editor editor = sharedPreferences.edit();
+
+                for (Map.Entry<String, Long> keyValuePair : keyValuePairs.entrySet()) {
+                    editor.putLong(keyValuePair.getKey(), keyValuePair.getValue());
+                }
+
+                editor.apply();
             }
 
             @Override

--- a/common/src/main/java/com/microsoft/identity/common/SharedPreferenceStringStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/SharedPreferenceStringStorage.java
@@ -70,4 +70,9 @@ public class SharedPreferenceStringStorage extends AbstractSharedPrefNameValueSt
     public void put(@NonNull String name, @Nullable String value) {
         mManager.putString(name, value);
     }
+
+    @Override
+    public void put(Map<String, String> keyValuePairs) {
+        mManager.putStrings(keyValuePairs);
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefStringNameValueStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPrefStringNameValueStorage.java
@@ -54,6 +54,11 @@ public class SharedPrefStringNameValueStorage extends AbstractSharedPrefNameValu
     }
 
     @Override
+    public void put(Map<String, String> keyValuePairs) {
+        mManager.putStrings(keyValuePairs);
+    }
+
+    @Override
     public Iterator<Map.Entry<String, String>> getAllFilteredByKey(Predicate<String> keyFilter) {
         return mManager.getAllFilteredByKey(keyFilter);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPreferenceLongStorage.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/SharedPreferenceLongStorage.java
@@ -71,6 +71,11 @@ public class SharedPreferenceLongStorage extends AbstractSharedPrefNameValueStor
     }
 
     @Override
+    public void put(Map<String, Long> keyValuePairs) {
+        mManager.putLongs(keyValuePairs);
+    }
+
+    @Override
     public Iterator<Map.Entry<String, Long>> getAllFilteredByKey(final @NonNull Predicate<String> keyFilter) {
         return new Iterator<Map.Entry<String, Long>>() {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
@@ -49,6 +49,13 @@ public interface IAccountCredentialCache {
     void saveCredential(final Credential credential);
 
     /**
+     * Saves the supplied Credential's in the cache.
+     *
+     * @param credential The Credential's to save.
+     */
+    void saveCredentials(final Credential... credentials);
+
+    /**
      * Gets the Account saved for the supplied cache key.
      *
      * @param cacheKey The cache key to use when consulting the cache.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IMultiTypeNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IMultiTypeNameValueStorage.java
@@ -32,6 +32,8 @@ import java.util.Map;
  * Shared Preferences.
  */
 public interface IMultiTypeNameValueStorage {
+    void putStrings(Map<String, String> keyValuePairs);
+
     /**
      * Associates a {@link String} value with a key in the named resource that this represents.
      *
@@ -47,6 +49,8 @@ public interface IMultiTypeNameValueStorage {
      * @return The string value associated with this key or null if no value could be found.
      */
     String getString(String key);
+
+    void putLongs(Map<String, Long> keyValuePairs);
 
     /**
      * Persists a long value to the named resource.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MapBackedPreferencesManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MapBackedPreferencesManager.java
@@ -46,6 +46,9 @@ public class MapBackedPreferencesManager implements IMultiTypeNameValueStorage {
     private final Map<String, String> mBackingStore = new HashMap<>();
 
     @Override
+    public void putStrings(Map<String, String> keyValuePairs) { mBackingStore.putAll(keyValuePairs); }
+
+    @Override
     public void putString(String key, String value) {
         mBackingStore.put(key, value);
     }
@@ -53,6 +56,13 @@ public class MapBackedPreferencesManager implements IMultiTypeNameValueStorage {
     @Override
     public String getString(String key) {
         return mBackingStore.get(key);
+    }
+
+    @Override
+    public void putLongs(Map<String, Long> keyValuePairs) {
+        for (Map.Entry<String, Long> entry : keyValuePairs.entrySet()) {
+            putLong(entry.getKey(), entry.getValue());
+        }
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1586,9 +1586,9 @@ public class MsalOAuth2TokenCache
             if (credential instanceof AccessTokenRecord) {
                 deleteAccessTokensWithIntersectingScopes((AccessTokenRecord) credential);
             }
-
-            mAccountCredentialCache.saveCredential(credential);
         }
+
+        mAccountCredentialCache.saveCredentials(credentials);
     }
 
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -149,6 +149,11 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
         for (Credential cred : credentials)
         {
+            if (cred == null)
+            {
+                continue;
+            }
+
             final String cacheKey = mCacheValueDelegate.generateCacheKey(cred);
             Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -141,6 +141,33 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     }
 
     @Override
+    public synchronized void saveCredentials(final Credential... credentials)
+    {
+        Logger.verbose(TAG, "Saving bulk credentials...");
+
+        Map<String, String> cacheKeyValuePairs = new HashMap<>();
+
+        for (Credential cred : credentials)
+        {
+            final String cacheKey = mCacheValueDelegate.generateCacheKey(cred);
+            Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
+
+            // Perform any necessary field merging on the Credential to save...
+            final Credential existingCredential = getCredential(cacheKey);
+
+            if (null != existingCredential) {
+                cred.mergeAdditionalFields(existingCredential);
+            }
+
+            final String cacheValue = mCacheValueDelegate.generateCacheValue(cred);
+
+            cacheKeyValuePairs.put(cacheKey, cacheValue);
+        }
+
+        mSharedPreferencesFileManager.put(cacheKeyValuePairs);
+    }
+
+    @Override
     public synchronized AccountRecord getAccount(@NonNull final String cacheKey) {
         Logger.verbose(TAG, "Loading Account by key...");
         AccountRecord account = mCacheValueDelegate.fromCacheValue(

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/INameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/INameValueStorage.java
@@ -57,6 +57,8 @@ public interface INameValueStorage<T> {
      */
     void put(@NonNull String name, @Nullable T value);
 
+    void put(Map<String, T> keyValuePairs);
+
     /**
      * Removes a value from the storage.
      * [

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/InMemoryStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/InMemoryStorage.java
@@ -49,6 +49,9 @@ public class InMemoryStorage<T> implements INameValueStorage<T> {
         return mMap;
     }
 
+    @Override
+    public void put(Map<String, T> nameValuePairs) { mMap.putAll(nameValuePairs); }
+
     public void put(@NonNull final String key,
                     @Nullable final T value) {
         if (value == null) {


### PR DESCRIPTION
The abstractions on top of SharedPreferences currently only allow a single key-value pair to be edited, each resulting in a locking/synchronous copying of the in-memory map, followed by a scheduled asynchronous disk write for the transaction to be committed back to disk.

This change gives the abstraction support for editing multiple key-value pairs and comitting in a single transaction.  We expect this to improve performance, especially in cases where we could be writing up to four credentials serially.  These each resulted in deep copies of the entirety of the SharedPreferences in-memory representation.  For apps popping an Activity after authentication is complete, Activity.onPause() also synchronously waits for all the background writes to be finished.  Waiting for one to finish instead of four should be faster.

One other notable change her was removing the LRU cache and lock.  This layer is not needed as the implementation of SharedPreferences in Android is itself keeping the totality of data in a Map<String, Object> at all times.  That layer is itself threadsafe and supports transactions, so it can be safely read directly.

I'm still measuring and testing here.  If time allows, I'm going to try to funnel some performance/timing information back from these code paths to the calling library/application.  We need this to help further understand where slow StorageRead/Write times are coming from for OneAuth customer applications if this change does not get to parity with ADAL.