### PR TITLE
Add an interface to Broker Token Command Parameters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V.Next
 - [MINOR] Move some storage classes from broker to common4j (#1809)
 - [MINOR] Add a Multi Type separated store (#1810)
 - [MINOR] ESTS Telemetry changes to capture data around FLW and Multiple WPJ (#1799)
+- [MINOR] Add an interface to Broker Token Command Parameters (#1826)
 
 Version 6.0.1
 ----------

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     testFixturesCompileOnly 'com.github.spotbugs:spotbugs-annotations:3.1.12'
     testFixturesCompileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     testFixturesAnnotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
-    resolvableTestFixturesImplementation 'org.robolectric:junit:4.5.1'
+    resolvableTestFixturesImplementation "org.robolectric:junit:$rootProject.ext.robolectricVersion"
 }
 
 sourceCompatibility = "1.8"

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -57,7 +57,7 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     private final String homeAccountId;
     private final String localAccountId;
     private final boolean pKeyAuthHeaderAllowed;
-    private final String tenantIdRequestingBrt;
+    private final String homeTenantId;
 
     @Override
     public void validate() throws ArgumentException {

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -23,9 +23,9 @@
 package com.microsoft.identity.common.java.commands.parameters;
 
 import com.microsoft.identity.common.java.broker.IBrokerAccount;
-import com.microsoft.identity.common.java.request.BrokerRequestType;
 import com.microsoft.identity.common.java.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ArgumentException;
+import com.microsoft.identity.common.java.request.BrokerRequestType;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.util.Map;
@@ -38,7 +38,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCommandParameters
-          implements IHasExtraParameters {
+        implements IHasExtraParameters, IBrokerTokenCommandParameters {
 
     private final String callerPackageName;
     private final int callerUid;
@@ -57,6 +57,7 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     private final String homeAccountId;
     private final String localAccountId;
     private final boolean pKeyAuthHeaderAllowed;
+    private final String tenantIdRequestingBrt;
 
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -59,17 +59,6 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     private final boolean pKeyAuthHeaderAllowed;
     private final String tenantIdRequestingBrt;
 
-
-    /**
-     * Helper method to identify if the request originated from Broker itself or from client libraries.
-     *
-     * @return : true if request is the request is originated from Broker, false otherwise
-     */
-    public boolean isRequestFromBroker() {
-        return requestType == BrokerRequestType.BROKER_RT_REQUEST ||
-                requestType == BrokerRequestType.RESOLVE_INTERRUPT;
-    }
-
     @Override
     public void validate() throws ArgumentException {
         super.validate();

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.java.commands.parameters;
 import com.microsoft.identity.common.java.broker.IBrokerAccount;
 import com.microsoft.identity.common.java.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ArgumentException;
+import com.microsoft.identity.common.java.request.BrokerRequestType;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import lombok.EqualsAndHashCode;
@@ -34,7 +35,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
-public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParameters {
+public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParameters implements IBrokerTokenCommandParameters {
 
     private final String callerPackageName;
     private final int callerUid;
@@ -48,6 +49,9 @@ public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParame
 
     private final String negotiatedBrokerProtocolVersion;
     private final boolean pKeyAuthHeaderAllowed;
+
+    private final BrokerRequestType requestType;
+    private final String tenantIdRequestingBrt;
 
     @Override
     public void validate() throws ArgumentException {

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
@@ -51,7 +51,7 @@ public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParame
     private final boolean pKeyAuthHeaderAllowed;
 
     private final BrokerRequestType requestType;
-    private final String tenantIdRequestingBrt;
+    private final String homeTenantId;
 
     @Override
     public void validate() throws ArgumentException {

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
@@ -81,8 +81,19 @@ public interface IBrokerTokenCommandParameters {
      */
     String getLocalAccountId();
 
+    /**
+     * Get the {@link BrokerRequestType} for the request.
+     *
+     * @return the {@link BrokerRequestType}
+     */
     BrokerRequestType getRequestType();
 
+    /**
+     * Get the tenant id being used for this request. This is particularly tenant id requesting BRT
+     * and this is here for FLW telemetry purposes.
+     *
+     * @return a String representing tenant id
+     */
     @Nullable
     String getTenantIdRequestingBrt();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
@@ -89,13 +89,13 @@ public interface IBrokerTokenCommandParameters {
     BrokerRequestType getRequestType();
 
     /**
-     * Get the tenant id being used for this request. This is particularly tenant id requesting BRT
-     * and this is here for FLW telemetry purposes.
+     * Get the home tenant id being used for this request. This is particularly tenant id
+     * requesting BRT and this is here for FLW telemetry purposes.
      *
      * @return a String representing tenant id
      */
     @Nullable
-    String getTenantIdRequestingBrt();
+    String getHomeTenantId();
 
     /**
      * Helper method to identify if the request originated from Broker itself or from client libraries.

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/IBrokerTokenCommandParameters.java
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.commands.parameters;
+
+import com.microsoft.identity.common.java.broker.IBrokerAccount;
+import com.microsoft.identity.common.java.request.BrokerRequestType;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * An interface that describes token command parameters for broker.
+ */
+public interface IBrokerTokenCommandParameters {
+
+    /**
+     * Get the package name of the calling application.
+     *
+     * @return a String representing caller package name
+     */
+    String getCallerPackageName();
+
+    /**
+     * Get the uid of the calling application.
+     *
+     * @return an int representing caller uid
+     */
+    int getCallerUid();
+
+    /**
+     * Get the app version of the calling application.
+     *
+     * @return a String representing caller app version
+     */
+    String getCallerAppVersion();
+
+    /**
+     * Get the broker version.
+     *
+     * @return a String representing broker version
+     */
+    String getBrokerVersion();
+
+    /**
+     * Get the broker account to use for this request
+     *
+     * @return an {@link IBrokerAccount} to use
+     */
+    IBrokerAccount getBrokerAccount();
+
+    /**
+     * Get the home account id of account to use for the request
+     *
+     * @return a String representing home account id
+     */
+    String getHomeAccountId();
+
+    /**
+     * Get the local account id of account to use for the request
+     *
+     * @return a String representing local account id
+     */
+    String getLocalAccountId();
+
+    BrokerRequestType getRequestType();
+
+    @Nullable
+    String getTenantIdRequestingBrt();
+
+    /**
+     * Helper method to identify if the request originated from Broker itself or from client libraries.
+     *
+     * @return : true if request is the request is originated from Broker, false otherwise
+     */
+    default boolean isRequestFromBroker() {
+        return getRequestType() == BrokerRequestType.BROKER_RT_REQUEST ||
+                getRequestType() == BrokerRequestType.RESOLVE_INTERRUPT;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/InMemoryStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/InMemoryStorage.java
@@ -76,7 +76,13 @@ public class InMemoryStorage<T> implements INameValueStorage<T> {
 
     @Override
     public Iterator<Map.Entry<String, T>> getAllFilteredByKey(Predicate<String> keyFilter) {
-        return null;
+        final Map<String, T> newMap = new HashMap<>();
+        for (final Map.Entry<String, T> entry: mMap.entrySet()) {
+            if (keyFilter.test(entry.getKey())) {
+                newMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return newMap.entrySet().iterator();
     }
 
     public int size() {

--- a/common4j/src/testFixtures/java/com/microsoft/identity/http/HttpRequestMatcher.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/http/HttpRequestMatcher.java
@@ -198,5 +198,15 @@ public class HttpRequestMatcher {
             });
             return this;
         }
+
+        public HttpRequestMatcherBuilder headersContain(Map.Entry<String, String> header) {
+            headers(new Predicate<Map<String, String>>() {
+                @Override
+                public boolean test(Map<String, String> headers) {
+                    return header.getValue().equals(headers.get(header.getKey()));
+                }
+            });
+            return this;
+        }
     }
 }


### PR DESCRIPTION
I've added an interface to broker token command parameters. It was strange they didn't already have one because there were lots of similar functionality in both of them. 

Furthermore, I've added an additional field here on such command parameters that is needed for FLW telemetry purposes.

Related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/1978