### PR TITLE
Bumping MSAL_TO_BROKER_PROTOCOL_VERSION_CODE to 10.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 V.Next
 ----------
 - [MINOR] Add implementation for clearAll method to BrokerOAuth2TokenCache to clear all the credentials and metadata (#1823)
-- [MAJOR] Adding smartcard certificate based authentication (CBA) feature. (#1814)
+- [MAJOR] Adding smartcard certificate based authentication (CBA) feature. Bumped MSAL Broker Protocol Version to 10.0. (#1814, #1829)
 - [PATCH] Fix an issue where incorrect authority url is returned after cloud discovery is set. (#1820)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 V.Next
 ----------
+- [MINOR] Bumped MSAL Broker Protocol Version to 10.0. (#1829)
 - [MINOR] Add implementation for clearAll method to BrokerOAuth2TokenCache to clear all the credentials and metadata (#1823)
-- [MAJOR] Adding smartcard certificate based authentication (CBA) feature. Bumped MSAL Broker Protocol Version to 10.0. (#1814, #1829)
+- [MAJOR] Adding smartcard certificate based authentication (CBA) feature.  (#1814)
 - [PATCH] Fix an issue where incorrect authority url is returned after cloud discovery is set. (#1820)
 - [PATCH] Add telemetry event for content provider call for getting enrollment id (#1801)
 - [MINOR] Move some storage classes from broker to common4j (#1809)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -597,7 +597,7 @@ public final class AuthenticationConstants {
          * The newest Msal-To-Broker protocol version.
          * @see <a href="ttps://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md">Android Auth Broker Protocol Versions</a>
          */
-        public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "9.0";
+        public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "10.0";
 
         /**
          * A client id for requesting the SSO token.


### PR DESCRIPTION
## Summary
Updating max MSAL to Broker protocol version from 9.0 to 10.0. 10.0 includes authentication via YubiKey CBA. 
I also updated [broker_protocol_versions.md](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md&version=GBdev&_a=preview).

I tested by generating brokerhost with the variable set to 9.0; bumped the variable to 10.0 and set the min broker version entry in the default config to 10.0; and then generated msaltestapp. I got the correct exception upon attempting to acquire a token. (Setting min broker version in default config to 9.0 and rest to 10.0 works as well)

I'm updating my existing changelog entry to include this PR number.