### PR TITLE
[pipeline] update gradle commands for oneauth build and test

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -250,7 +250,7 @@ stages:
       - task: MavenAuthenticate@0
         displayName: Authenticate to the Intune_App_SDK feed
         inputs:
-          MavenServiceConnections: Intune_App_SDK
+          MavenServiceConnections: AndroidBroker-CI
 
       - task: Bash@3
         displayName: Install ninja

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -247,6 +247,11 @@ stages:
         inputs:
           MavenServiceConnections: IdentityDivision
 
+      - task: MavenAuthenticate@0
+          displayName: Authenticate to the Intune_App_SDK feed
+          inputs:
+            MavenServiceConnections: Intune_App_SDK
+
       - task: Bash@3
         displayName: Install ninja
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -248,7 +248,7 @@ stages:
           MavenServiceConnections: IdentityDivision
 
       - task: MavenAuthenticate@0
-          displayName: Authenticate to the Intune_App_SDK feed
+        displayName: Authenticate to the Intune_App_SDK feed
         inputs:
           MavenServiceConnections: Intune_App_SDK
 

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -250,7 +250,7 @@ stages:
       - task: MavenAuthenticate@0
         displayName: Authenticate to the Intune_App_SDK feed
         inputs:
-          MavenServiceConnections: AndroidBroker-CI
+          MavenServiceConnections: Intune_App_SDK
 
       - task: Bash@3
         displayName: Install ninja

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -249,8 +249,8 @@ stages:
 
       - task: MavenAuthenticate@0
           displayName: Authenticate to the Intune_App_SDK feed
-          inputs:
-            MavenServiceConnections: Intune_App_SDK
+        inputs:
+          MavenServiceConnections: Intune_App_SDK
 
       - task: Bash@3
         displayName: Install ninja

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -264,10 +264,10 @@ stages:
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
           gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
-          tasks: clean assembleOneAuth
+          tasks: clean OneAuth:assembleLocalDebug
       - task: Gradle@2
         displayName: Run OneAuth Unit tests
         inputs:
           cwd: $(Agent.BuildDirectory)/s/
           gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
-          tasks: runOneAuthTests
+          tasks: OneAuth:testLocalDebugUnitTest


### PR DESCRIPTION
### What
Updating gradle tasks to run for OneAuth build and test as part of consumers of common pipeline

### Why
Need to update the gradle tasks to run from oneauth project to be able to cosnume local common. The previous composite build (includeBuild) does not work as expected.

### Testing
Verified running the command locally to ensure that it is able to build local common and oneauth

