### PR TITLE
Fix Build Issue that arose from targeting sdk 31 

### DIFF
--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,14 +28,15 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
-  - task: Gradle@1
-    name: Gradle1
+  - task: Gradle@3
+    name: Gradle1    
     displayName: Assemble Release
     inputs:
+      jdkVersionOption: "1.11"
       tasks: clean common:assembleLocal
       publishJUnitResults: false
       jdkArchitecture: x86
-      sqAnalysisBreakBuildIfQualityGateFailed: false
+      sqAnalysisEnabled: false
   - template: ../templates/steps/spotbugs.yml
     parameters:
       project: common

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,6 +28,11 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11' 
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
   - task: Gradle@2
     name: Gradle2   
     displayName: Assemble Release

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -32,7 +32,7 @@ jobs:
     inputs:
       versionSpec: '11' 
       jdkArchitectureOption: 'x86'
-      jdkSourceOption: 'PreInstalled'
+      jdkSourceOption: 'AzureStorage'
   - task: Gradle@2
     name: Gradle2   
     displayName: Assemble Release

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,10 +28,11 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
-  - task: Gradle@3
-    name: Gradle1    
+  - task: Gradle@2
+    name: Gradle2   
     displayName: Assemble Release
     inputs:
+      javaHomeSelection: JDKVersion
       jdkVersionOption: "1.11"
       tasks: clean common:assembleLocal
       publishJUnitResults: false
@@ -43,5 +44,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
+      javaHomeSelection: JDKVersion
+      jdkVersionOption: "1.11"
       tasks: common:testLocalDebugUnitTest
 ...

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,13 +28,13 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
-  - task: JavaToolInstaller@0
-    inputs:
-      versionSpec: '11' 
-      jdkArchitectureOption: 'x86'
-      jdkSourceOption: 'AzureStorage'
-  - task: Gradle@2
-    name: Gradle2   
+  # - task: JavaToolInstaller@0
+  #   inputs:
+  #     versionSpec: '11' 
+  #     jdkArchitectureOption: 'x86'
+  #     jdkSourceOption: 'AzureStorage'
+  - task: Gradle@3
+    name: Gradle3   
     displayName: Assemble Release
     inputs:
       javaHomeSelection: JDKVersion

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,11 +28,6 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
-  # - task: JavaToolInstaller@0
-  #   inputs:
-  #     versionSpec: '11' 
-  #     jdkArchitectureOption: 'x86'
-  #     jdkSourceOption: 'AzureStorage'
   - task: Gradle@3
     name: Gradle3   
     displayName: Assemble Release

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -31,7 +31,7 @@ jobs:
   - task: JavaToolInstaller@0
     inputs:
       versionSpec: '11' 
-      jdkArchitectureOption: 'x64'
+      jdkArchitectureOption: 'x86'
       jdkSourceOption: 'PreInstalled'
   - task: Gradle@2
     name: Gradle2   

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -41,7 +41,7 @@ jobs:
       jdkVersionOption: "1.11"
       tasks: clean common:assembleLocal
       publishJUnitResults: false
-      jdkArchitecture: x86
+      jdkArchitecture: x64
       sqAnalysisEnabled: false
   - template: ../templates/steps/spotbugs.yml
     parameters:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MAJOR] Use Java 11 to accomodate android sdk 31 tooling. (#1832)
 - [PATCH] Swallow unbound service exceptions on disconnect. (#1824)
 - [MINOR] Bumped MSAL Broker Protocol Version to 10.0. (#1829)
 - [MINOR] Add implementation for clearAll method to BrokerOAuth2TokenCache to clear all the credentials and metadata (#1823)


### PR DESCRIPTION
Common Build & Test pipeline only ran successfully after the upgrade after using Java 11.

Initially I was getting this exception while running the assemble tasks that used java 8
![image](https://user-images.githubusercontent.com/1685221/189459733-bc108a44-f570-45d6-8b75-b87bbaf79a3a.png)

The Official documentation does not say much about this bug but on searching for other instances of the bug this is predominantly what I found 

https://developercommunity.visualstudio.com/t/some-android-apps-require-java-11-as-sdk/1549184

Upgrading to Java 11 fixed the build issues. 

