### PR TITLE
Add opt-in flag to skip expensive SecretKey invalidation steps

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add opt-in flag to skip expensive SecretKey invalidation steps (#1837)
 - [MINOR] Storage performance improvements (#1852)
 - [PATCH] More fields exposed for GSON based logging for Broker Token Parameters (#1849)
 - [MINOR] Logging performance speedup, removal of IDetailedLoggerCallback/logDiscarded (#1836)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -65,6 +65,11 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     private static final String TAG = AndroidWrappedKeyLoader.class.getSimpleName() + "#";
 
     /**
+     * Should KeyStore and key file check for validity before every key load be skipped.
+     */
+    public static boolean sSkipKeyInvalidationCheck = false;
+
+    /**
      * Alias for this type of key.
      */
     /* package */ static final String KEYSTORE_KEY_ALIAS = "KEYSTORE_KEY";
@@ -99,7 +104,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     private final CachedData<SecretKey> mKeyCache = new CachedData<SecretKey>() {
         @Override
         public SecretKey getData() {
-            if (!AndroidKeyStoreUtil.canLoadKey(mAlias) || !getKeyFile().exists()) {
+            if (!sSkipKeyInvalidationCheck &&
+                    (!AndroidKeyStoreUtil.canLoadKey(mAlias) || !getKeyFile().exists())) {
                 this.clear();
             }
             return super.getData();

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -52,6 +52,7 @@ import javax.crypto.SecretKey;
 import javax.security.auth.x500.X500Principal;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.NonNull;
 
 /**
@@ -67,6 +68,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     /**
      * Should KeyStore and key file check for validity before every key load be skipped.
      */
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
     public static boolean sSkipKeyInvalidationCheck = false;
 
     /**


### PR DESCRIPTION
20-25% of CPU time in the storageWrite path for OneAuth is spent doing the very expensive `AndroidKeyStoreUtil.canLoadKey` check down to the hardware to then invalidate the in-memory copy of the key and generate a new one.  This change currently removes the check altogether, although if useful it could potentially be added more explicitly once per API call from the user for a smaller penalty.

I expect significant improvements in all paths that touch encryption/decryption, particularly in a loop like `getAllAccounts`/`getAllCredentials`.  The time spent checking the hardware for this key (and to a smaller extent, the filesystem for the on-disk file) is significantly more than is spent actually doing encryption/decryption operations with it.