### PR TITLE
Use Java 11 in Spotbugs Check

### DIFF
--- a/azure-pipelines/pull-request-validation/common4j.yml
+++ b/azure-pipelines/pull-request-validation/common4j.yml
@@ -1,5 +1,6 @@
 # File: azure-pipelines\pull-request-validation\common4j.yml
 # Description: Run test in common4j
+# Uses Java 11
 name: $(date:yyyyMMdd)$(rev:.r)
 
 trigger: none

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -12,9 +12,12 @@ parameters:
   default: $(Build.SourcesDirectory)
 
 steps:
-- task: Gradle@2
+- task: Gradle@3
   displayName: 'Run Spotbugs'
   inputs:
+    javaHomeSelection: JDKVersion
+    jdkVersionOption: "1.11"
+    jdkArchitecture: x64
     cwd: ${{ parameters.cwd }}
     tasks: ${{ parameters.project }}:${{ parameters.spotbugsCommand }}
     publishJUnitResults: false

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Use Java 11 in Spotbugs Check
 - [MAJOR] Use Java 11 to accomodate android sdk 31 tooling. (#1832)
 - [PATCH] Swallow unbound service exceptions on disconnect. (#1824)
 - [MINOR] Bumped MSAL Broker Protocol Version to 10.0. (#1829)


### PR DESCRIPTION
Similar to #1834, this PR is meant to utilize the use of JAVA 11 in the build process following the upgrade to android targetSdk 31.

Successful Build Id: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=988353&view=logs&j=6f26e4aa-3eaf-5d24-2c84-463275687676&t=6f26e4aa-3eaf-5d24-2c84-463275687676