### PR TITLE
Expose sign() method in PKeyAuth as opposed to the key itself

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Expose sign() method in PKeyAuth as opposed to the key itself (#1846)
 - [MINOR] Wire ICryptoFactory to Signer/Decryptor/SP800108KeyGen (#1845)
 - [MINOR] Add ICryptoFactory to common4j (#1844)
 - [MAJOR] Update target Android targetSdk to API 31/ Android 12

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/IDeviceCertificate.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/IDeviceCertificate.java
@@ -22,12 +22,12 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.challengehandlers;
 
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import com.microsoft.identity.common.java.exception.ClientException;
+
 import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.List;
+
+import lombok.NonNull;
 
 /**
  * Work place join related certificate is required to respond device challenge.
@@ -47,21 +47,8 @@ public interface IDeviceCertificate {
      *
      * @return {@link X509Certificate}
      */
-    X509Certificate getCertificate();
-
-    /**
-     * Gets a private key.
-     *
-     * @return private key
-     */
-    PrivateKey getPrivateKey();
-
-    /**
-     * Gets a public key.
-     *
-     * @return RSA public key.
-     */
-    PublicKey getPublicKey();
+    @NonNull
+    X509Certificate getX509();
 
     /**
      * Gets thumbPrint for certificate.
@@ -69,5 +56,13 @@ public interface IDeviceCertificate {
      * @return thumbPrint for certificate.
      */
     String getThumbPrint();
+
+    /**
+     * Signs a piece of data with the (private key associated to the) certificate.
+     *
+     * @param algorithm         algorithm for signing the data.
+     * @param dataToBeSigned    the data to be signed.
+     */
+    byte[] sign(@NonNull final String algorithm, final byte[] dataToBeSigned) throws ClientException;
 }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallenge.java
@@ -186,27 +186,10 @@ public class PKeyAuthChallenge {
                     );
         }
 
-        final PrivateKey privateKey = deviceCertProxy.getPrivateKey();
-        if (privateKey == null) {
-            throw new ClientException(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION);
-        }
-
-        final PublicKey publicKey = deviceCertProxy.getPublicKey();
-        if (publicKey == null) {
-            throw new ClientException(ErrorStrings.KEY_CHAIN_PUBLIC_KEY_EXCEPTION);
-        }
-
-        final X509Certificate certificate = deviceCertProxy.getCertificate();
-        if (certificate == null) {
-            throw new ClientException(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION);
-        }
-
         final String jwt = mJwsBuilder.generateSignedJWT(
                 mNonce,
                 mSubmitUrl,
-                privateKey,
-                publicKey,
-                certificate);
+                deviceCertProxy);
 
         Logger.info(TAG + methodName, "Generated a signed challenge response.");
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -125,10 +125,10 @@ public class JWSBuilder {
         // two period ('.') characters.
         // Base64 encoding without padding, wrapping and urlsafe.
         final String methodTag = TAG + ":generateSignedJWT";
-        if (nonce.length() == 0) {
+        if (nonce.isEmpty()) {
             throw new IllegalArgumentException("nonce is an empty string.");
         }
-        if (audience.length() == 0) {
+        if (audience.isEmpty()) {
             throw new IllegalArgumentException("audience is an empty string.");
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -138,7 +138,7 @@ public class JWSBuilder {
         claims.mAudience = audience;
         claims.mIssueAt = getCurrentTimeInSeconds();
 
-        JwsHeader header = new JwsHeader();
+        final JwsHeader header = new JwsHeader();
         header.mAlgorithm = JWS_HEADER_ALG;
         header.mType = "JWT"; // recommended UpperCase in JWT Spec
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JWSBuilder.java
@@ -23,35 +23,29 @@
 
 package com.microsoft.identity.common.java.util;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
-
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import com.microsoft.identity.common.java.crypto.DefaultCryptoFactory;
-import com.microsoft.identity.common.java.crypto.ISigner;
-import com.microsoft.identity.common.java.crypto.BasicSigner;
+import com.microsoft.identity.common.java.challengehandlers.IDeviceCertificate;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.logging.Logger;
 
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
-import java.security.cert.X509Certificate;
 
-import cz.msebera.android.httpclient.extras.Base64;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.NonNull;
 
 /**
  * JWS response builder for certificate challenge response.
  */
 public class JWSBuilder {
-    private static final long SECONDS_MS = 1000L;
+    protected static final long SECONDS_MS = 1000L;
 
     /**
      * Algorithm is fixed to RSA PKCS v1.5.
      */
-    private static final String JWS_HEADER_ALG = "RS256";
+    protected static final String JWS_HEADER_ALG = "RS256";
 
     /**
      * Algorithm name for signing.
@@ -60,8 +54,8 @@ public class JWSBuilder {
 
     private static final String TAG = "JWSBuilder";
 
-    // TODO[FIPS] exposes a constructor that takes in an ISigner/ICryptoFactory.
-    private static final ISigner sSigner = new BasicSigner(new DefaultCryptoFactory());
+    public JWSBuilder(){
+    }
 
     /**
      * Payload for JWS.
@@ -83,6 +77,14 @@ public class JWSBuilder {
         @SuppressWarnings("unused")
         private Claims() {
         }
+    }
+
+    protected long getCurrentTimeInSeconds(){
+        return System.currentTimeMillis() / SECONDS_MS;
+    }
+
+    protected String encodeUrlSafeString(final byte[] dataToEncode){
+        return StringUtil.encodeUrlSafeString(dataToEncode);
     }
 
     /**
@@ -110,8 +112,9 @@ public class JWSBuilder {
     /**
      * Generate the signed JWT.
      */
-    public String generateSignedJWT(String nonce, String audience, PrivateKey privateKey,
-                                    PublicKey pubKey, X509Certificate cert) throws ClientException {
+    public String generateSignedJWT(@NonNull final String nonce,
+                                    @NonNull final String audience,
+                                    @NonNull final IDeviceCertificate deviceCert) throws ClientException {
         // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-25
         // In the JWS Compact Serialization, a JWS object is represented as the
         // combination of these three string values,
@@ -121,25 +124,19 @@ public class JWSBuilder {
         // concatenated in that order, with the three strings being separated by
         // two period ('.') characters.
         // Base64 encoding without padding, wrapping and urlsafe.
-        final String methodName = ":generateSignedJWT";
-        if (StringUtil.isNullOrEmpty(nonce)) {
-            throw new IllegalArgumentException("nonce");
+        final String methodTag = TAG + ":generateSignedJWT";
+        if (nonce.length() == 0) {
+            throw new IllegalArgumentException("nonce is an empty string.");
         }
-        if (StringUtil.isNullOrEmpty(audience)) {
-            throw new IllegalArgumentException("audience");
-        }
-        if (privateKey == null) {
-            throw new IllegalArgumentException("privateKey");
-        }
-        if (pubKey == null) {
-            throw new IllegalArgumentException("pubKey");
+        if (audience.length() == 0) {
+            throw new IllegalArgumentException("audience is an empty string.");
         }
 
-        Gson gson = new Gson();
-        Claims claims = new Claims();
+        final Gson gson = new Gson();
+        final Claims claims = new Claims();
         claims.mNonce = nonce;
         claims.mAudience = audience;
-        claims.mIssueAt = System.currentTimeMillis() / SECONDS_MS;
+        claims.mIssueAt = getCurrentTimeInSeconds();
 
         JwsHeader header = new JwsHeader();
         header.mAlgorithm = JWS_HEADER_ALG;
@@ -158,17 +155,17 @@ public class JWSBuilder {
             // to digitally sign the JWS MUST be the first certificate
             // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-27
             header.mCert = new String[1];
-            header.mCert[0] = Base64.encodeToString(cert.getEncoded(), Base64.NO_WRAP);
+            header.mCert[0] = StringUtil.base64Encode(deviceCert.getX509().getEncoded());
 
             // redundant but current ADFS code base is looking for
-            String headerJsonString = gson.toJson(header);
-            String claimsJsonString = gson.toJson(claims);
-            Logger.verbose(TAG + methodName, "Generate client certificate challenge response JWS Header. ");
-            signingInput = StringUtil.encodeUrlSafeString(headerJsonString)
+            final String headerJsonString = gson.toJson(header);
+            final String claimsJsonString = gson.toJson(claims);
+            Logger.verbose(methodTag, "Generate client certificate challenge response JWS Header. ");
+            signingInput = encodeUrlSafeString(StringUtil.toByteArray(headerJsonString))
                     + "."
-                    + StringUtil.encodeUrlSafeString(claimsJsonString);
-            signature = StringUtil.encodeUrlSafeString(
-                    sSigner.sign(privateKey, SIGNING_ALGORITHM, signingInput.getBytes(ENCODING_UTF8)));
+                    + encodeUrlSafeString(StringUtil.toByteArray(claimsJsonString));
+            signature = encodeUrlSafeString(
+                    deviceCert.sign(SIGNING_ALGORITHM, StringUtil.toByteArray(signingInput)));
         } catch (final CertificateEncodingException e) {
             throw new ClientException(ErrorStrings.CERTIFICATE_ENCODING_ERROR,
                     "Certificate encoding error", e);

--- a/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
@@ -436,6 +436,13 @@ public class StringUtil {
     }
 
     /**
+     * Converts the given String into a rawData byte array, and Base64-decode it with the url-safe flag.
+     */
+    public static byte[] base64DecodeUrlSafeString(@NonNull final String encodedString) {
+        return Base64.decode(encodedString, Base64.NO_WRAP | Base64.NO_PADDING | Base64.URL_SAFE);
+    }
+
+    /**
      * This is a reimplementation of String.join for the android platform.  Possibly this should
      * shift into PlatformUtils, which could rely on String.join dependent on the android API level.
      *

--- a/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/MockCertLoader.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/MockCertLoader.java
@@ -39,49 +39,49 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
-@Getter
-@Setter
 @Accessors(prefix = "m")
 public class MockCertLoader implements IDeviceCertificateLoader{
 
     private final String MOCK_CERT_THUMBPRINT = "thumbprint1234";
 
+    @Getter
+    @Setter
     private boolean mValidIssuer = true;
+
+    @Getter
+    @Setter
     private PrivateKey mPrivateKey = mock(PrivateKey.class);
-    private PublicKey mPublicKey = mock(PublicKey.class);
-    private X509Certificate mCert = mock(X509Certificate.class);
+
+    @Getter
+    @Setter
+    private X509Certificate mX509 = mock(X509Certificate.class);
+
+    private final IDeviceCertificate mCert = new IDeviceCertificate() {
+        @Override
+        public boolean isValidIssuer(List<String> certAuthorities) {
+            return mValidIssuer;
+        }
+
+        @Override
+        public @lombok.NonNull X509Certificate getX509() {
+            return mX509;
+        }
+
+        @Override
+        public String getThumbPrint() {
+            return MOCK_CERT_THUMBPRINT;
+        }
+
+        @Override
+        public byte[] sign(@NonNull String algorithm, byte[] dataToBeSigned) throws ClientException {
+            throw new UnsupportedOperationException("Should be mocked!");
+        }
+    };
 
     @Nullable
     @Override
     public IDeviceCertificate loadCertificate(@Nullable String tenantId) {
-        return new IDeviceCertificate() {
-            @Override
-            public boolean isValidIssuer(List<String> certAuthorities) {
-                return mValidIssuer;
-            }
-
-            @Override
-            public X509Certificate getCertificate() {
-                return mCert;
-            }
-
-            @Override
-            public PrivateKey getPrivateKey() {
-                return mPrivateKey;
-
-            }
-
-            @Override
-            public PublicKey getPublicKey() {
-                return mPublicKey;
-
-            }
-
-            @Override
-            public String getThumbPrint() {
-                return MOCK_CERT_THUMBPRINT;
-            }
-        };
+        return mCert;
     }
 
     /**
@@ -95,8 +95,7 @@ public class MockCertLoader implements IDeviceCertificateLoader{
         return nonce + ":" +
                 submitUrl + ":" +
                 mPrivateKey.hashCode() + ":" +
-                mPublicKey.hashCode() + ":" +
-                mCert.hashCode();
+                mX509.hashCode();
     }
 
     /**
@@ -113,8 +112,6 @@ public class MockCertLoader implements IDeviceCertificateLoader{
                 mockJwsBuilder.generateSignedJWT(
                         nonce,
                         submitUrl,
-                        mPrivateKey,
-                        mPublicKey,
                         mCert
                 )
         ).thenReturn(getMockSignedJwt(nonce, submitUrl));

--- a/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeTest.java
@@ -206,60 +206,46 @@ public class PKeyAuthChallengeTest {
     /**
      * Verify correct exception is thrown when certificate is null.
      */
-    @Test
-    public void testGetChallengeResponseNullCertificate() {
+    @Test(expected = NullPointerException.class)
+    public void testGetChallengeResponseNullCertificate() throws Exception {
         final MockCertLoader certLoader = new MockCertLoader();
-        certLoader.setCert(null);
+        certLoader.setX509(null);
         AuthenticationSettings.INSTANCE.setCertificateLoader(certLoader);
 
-        try {
-            getBasicChallengeBuilder()
-                    .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
-                    .build()
-                    .getChallengeHeader();
-            Assert.fail();
-        } catch (final ClientException e) {
-            Assert.assertEquals(ErrorStrings.KEY_CHAIN_CERTIFICATE_EXCEPTION, e.getErrorCode());
-        }
+        getBasicChallengeBuilder()
+                .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
+                .build()
+                .getChallengeHeader();
     }
 
+
     /**
-     * Verify correct exception is thrown when cert's public key is null.
+     * Verify correct exception is thrown when certificate is null.
      */
-    @Test
-    public void testGetChallengeResponseNullPublicKey() {
+    @Test(expected = NullPointerException.class)
+    public void testGetChallengeResponseNullX509Certificate() throws Exception {
         final MockCertLoader certLoader = new MockCertLoader();
-        certLoader.setPublicKey(null);
+        certLoader.setX509(null);
         AuthenticationSettings.INSTANCE.setCertificateLoader(certLoader);
 
-        try {
-            getBasicChallengeBuilder()
-                    .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
-                    .build()
-                    .getChallengeHeader();
-            Assert.fail();
-        } catch (final ClientException e) {
-            Assert.assertEquals(ErrorStrings.KEY_CHAIN_PUBLIC_KEY_EXCEPTION, e.getErrorCode());
-        }
+        getBasicChallengeBuilder()
+                .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
+                .build()
+                .getChallengeHeader();
     }
 
     /**
      * Verify correct exception is thrown when cert's private key is null.
      */
-    @Test
-    public void testGetChallengeResponseNullPrivateKey() {
+    @Test(expected = NullPointerException.class)
+    public void testGetChallengeResponseNullPrivateKey() throws Exception {
         final MockCertLoader certLoader = new MockCertLoader();
         certLoader.setPrivateKey(null);
         AuthenticationSettings.INSTANCE.setCertificateLoader(certLoader);
 
-        try {
-            getBasicChallengeBuilder()
-                    .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
-                    .build()
-                    .getChallengeHeader();
-            Assert.fail();
-        } catch (final ClientException e) {
-            Assert.assertEquals(ErrorStrings.KEY_CHAIN_PRIVATE_KEY_EXCEPTION, e.getErrorCode());
-        }
+        getBasicChallengeBuilder()
+                .certAuthorities(Arrays.asList(PKEYAUTH_CERT_AUTHORITIES))
+                .build()
+                .getChallengeHeader();
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/JwsBuilderTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/JwsBuilderTest.java
@@ -1,0 +1,188 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.identity.common.java.challengehandlers.IDeviceCertificate;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.exception.ErrorStrings;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+@RunWith(JUnit4.class)
+public class JwsBuilderTest {
+
+    private final String MOCK_SIGNATURE = "-signed-";
+    private final String MOCK_NONCE = "nonce_mock";
+    private final String MOCK_AUDIENCE =  "aud_mock";
+    private final String MOCK_ENCODED_CERT_VALUE = "EncodedCertValue";
+    private final long MOCK_TIME = 123456789L;
+
+    @AllArgsConstructor
+    public static class JWSBuilderMock extends JWSBuilder {
+
+        private final long mockTimeInSeconds;
+
+        @Override
+        protected long getCurrentTimeInSeconds() {
+            return mockTimeInSeconds;
+        }
+
+        @Override
+        protected String encodeUrlSafeString(byte[] dataToEncode) {
+            // Do nothing.
+            return StringUtil.fromByteArray(dataToEncode);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateSignedJwt_EmptyNonce() throws Exception {
+        new JWSBuilderMock(MOCK_TIME).generateSignedJWT(
+                "",
+                MOCK_AUDIENCE,
+                getMockCertificate(MOCK_ENCODED_CERT_VALUE, MOCK_SIGNATURE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGenerateSignedJwt_NullNonce() throws Exception {
+        new JWSBuilderMock(MOCK_TIME).generateSignedJWT(
+                null,
+                MOCK_AUDIENCE,
+                getMockCertificate(MOCK_ENCODED_CERT_VALUE, MOCK_SIGNATURE));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGenerateSignedJwt_EmptyAudience() throws Exception {
+        new JWSBuilderMock(MOCK_TIME).generateSignedJWT(
+                MOCK_AUDIENCE,
+                "",
+                getMockCertificate(MOCK_ENCODED_CERT_VALUE, MOCK_SIGNATURE));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGenerateSignedJwt_NullAudience() throws Exception {
+        new JWSBuilderMock(MOCK_TIME).generateSignedJWT(
+                MOCK_AUDIENCE,
+                null,
+                getMockCertificate(MOCK_ENCODED_CERT_VALUE, MOCK_SIGNATURE));
+    }
+
+    @Test
+    public void testGenerateSignedJwt_MalformedCert() throws Exception {
+        final JWSBuilder builder = new JWSBuilderMock(MOCK_TIME);
+
+        final X509Certificate mockX509 = mock(X509Certificate.class);
+        when(
+                mockX509.getEncoded()
+        ).thenThrow(
+                new CertificateEncodingException("Failed to encode cert for some reason.")
+        );
+
+        try {
+            builder.generateSignedJWT(
+                    MOCK_NONCE,
+                    MOCK_AUDIENCE,
+                    getMockCertificate(mockX509, MOCK_SIGNATURE));
+            Assert.fail();
+        } catch (final ClientException e) {
+            Assert.assertEquals(ErrorStrings.CERTIFICATE_ENCODING_ERROR, e.getErrorCode());
+        }
+    }
+
+    @Test
+    public void testGenerateSignedJwt_MockEncoding() throws Exception{
+        final JWSBuilder builder = new JWSBuilderMock(MOCK_TIME);
+        final String result = builder.generateSignedJWT(
+                MOCK_NONCE,
+                MOCK_AUDIENCE,
+                getMockCertificate(MOCK_ENCODED_CERT_VALUE, MOCK_SIGNATURE));
+        Assert.assertEquals(
+                getMockNonEncodedResponse(
+                        MOCK_TIME,
+                        MOCK_NONCE,
+                        MOCK_AUDIENCE,
+                        MOCK_ENCODED_CERT_VALUE,
+                        MOCK_SIGNATURE),
+                result);
+    }
+
+    private static String getMockNonEncodedResponse(final long mockCurrentTime,
+                                                    final String nonce,
+                                                    final String aud,
+                                                    final String encodedCert,
+                                                    final String signature){
+        final String headerJsonString = "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"x5c\":[\"" + encodedCert + "\"]}";
+        final String claimsJsonString = "{\"aud\":\"" + aud + "\",\"iat\":" + mockCurrentTime + ",\"nonce\":\"" + nonce + "\"}";
+        return headerJsonString + "." + claimsJsonString + "." + signature;
+    }
+
+    private static IDeviceCertificate getMockCertificate(@NonNull final String encodedCertValue,
+                                                         @NonNull final String signature) throws Exception{
+        final X509Certificate x509 = mock(X509Certificate.class);
+        when(
+                x509.getEncoded()
+        ).thenReturn(
+                StringUtil.base64Decode(encodedCertValue)
+        );
+
+        return getMockCertificate(x509, signature);
+    }
+
+    private static IDeviceCertificate getMockCertificate(@NonNull final X509Certificate mockX509,
+                                                         @NonNull final String signature) {
+        return new IDeviceCertificate() {
+            @Override
+            public boolean isValidIssuer(List<String> certAuthorities) {
+                return true;
+            }
+
+            @Override
+            public @NonNull X509Certificate getX509() {
+                return mockX509;
+            }
+
+            @Override
+            public String getThumbPrint() {
+                return "mock_thumbprint";
+            }
+
+            @Override
+            public byte[] sign(@NonNull final String algorithm, final byte[] dataToBeSigned) throws ClientException {
+                // Do nothing.
+                return StringUtil.toByteArray(signature);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This will allow the actual signing operation to happen inside the broker - and we'll use ICryptoFactory to generate a provider, essentially allowing us to switch between non-FIPS and FIPS (tbd) mode in PKeyAuth flow.

related: https://github.com/AzureAD/ad-accounts-for-android/pull/2001