### PR TITLE
Expose more fields in broker token parameters for logging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Expose more fields of Broker Token Parameters for better logging (#1849)
 - [MINOR] Add ICryptoFactory to common4j (#1844)
 - [MAJOR] Update target Android targetSdk to API 31/ Android 12
 - [MINOR] Use Java 11 in Spotbugs Check

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.commands.parameters;
 
+import com.google.gson.annotations.Expose;
 import com.microsoft.identity.common.java.broker.IBrokerAccount;
 import com.microsoft.identity.common.java.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ArgumentException;
@@ -40,14 +41,27 @@ import lombok.experimental.SuperBuilder;
 public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCommandParameters
         implements IHasExtraParameters, IBrokerTokenCommandParameters {
 
+    @Expose
     private final String callerPackageName;
+
+    @Expose
     private final int callerUid;
+
+    @Expose
     private final String callerAppVersion;
+
+    @Expose
     private final String brokerVersion;
 
+    @Expose
     private final boolean shouldResolveInterrupt;
+
+    @Expose
     private final BrokerRequestType requestType;
+
+    @Expose
     private final String negotiatedBrokerProtocolVersion;
+
     private final Iterable<Map.Entry<String, String>> extraParameters;
 
     private final String enrollmentId;
@@ -59,7 +73,10 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
 
     // If this flag is true, we will send the x-ms-PKeyAuth Header to the token endpoint.
     // Note: this flag is transferred to a MicrosoftTokenRequest in BaseController.
+    @Expose
     private final boolean pKeyAuthHeaderAllowed;
+
+    @Expose
     private final String homeTenantId;
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerSilentTokenCommandParameters.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.commands.parameters;
 
+import com.google.gson.annotations.Expose;
 import com.microsoft.identity.common.java.broker.IBrokerAccount;
 import com.microsoft.identity.common.java.cache.BrokerOAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ArgumentException;
@@ -37,9 +38,16 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParameters implements IBrokerTokenCommandParameters {
 
+    @Expose
     private final String callerPackageName;
+
+    @Expose
     private final int callerUid;
+
+    @Expose
     private final String callerAppVersion;
+
+    @Expose
     private final String brokerVersion;
 
     private final IBrokerAccount brokerAccount;
@@ -47,13 +55,18 @@ public class BrokerSilentTokenCommandParameters extends SilentTokenCommandParame
     private final String localAccountId;
     private final int sleepTimeBeforePrtAcquisition;
 
+    @Expose
     private final String negotiatedBrokerProtocolVersion;
 
     // If this flag is true, we will send the x-ms-PKeyAuth Header to the token endpoint.
     // Note: this flag is transferred to a MicrosoftTokenRequest in BaseController.
+    @Expose
     private final boolean pKeyAuthHeaderAllowed;
 
+    @Expose
     private final BrokerRequestType requestType;
+
+    @Expose
     private final String homeTenantId;
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
@@ -64,6 +64,7 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
 
     private final List<Map.Entry<String, String>> extraQueryStringParameters;
 
+    @Expose()
     private final List<String> extraScopesToConsent;
 
     public boolean getHandleNullTaskAffinity(){


### PR DESCRIPTION
**What**
Improve broker/PRT flow logging

**How**
This change adds Expose attribute to certain token parameters which are logged in acquire token flows as part of [logParameters](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/057313dac8d781440220eb2abddda1f205bc62db/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java#L693) method. We log a few but there are other fields which would be helpful if logged. Added expose attribute to them enabling them in logs.

**Tests**

Before
{
    "authorizationAgent": "WEBVIEW",
    "handleNullTaskAffinity": false,
    "isWebViewZoomControlsEnabled": false,
    "isWebViewZoomEnabled": false,
    "prompt": "UNSET",
    "authenticationScheme": {},
    "authority": {},
    "forceRefresh": false,
    "scopes": [
        "urn:ms-drs:enterpriseregistration.windows.net/.default"
    ],
    "clientId": "29d9ed98-a469-4536-ade2-f981bc1d605e",
    "correlationId": "11ea7e0b-43e4-4991-8eb0-f4cf5142d720",
    "powerOptCheckEnabled": false,
    "redirectUri": "msauth://Microsoft.AAD.BrokerPlugin",
    "sdkType": "ADAL"
}

After
{
    "callerAppVersion": "1.0-local",
    "callerPackageName": "com.msft.identity.client.sample.local",
    "callerUid": 10305,
    "negotiatedBrokerProtocolVersion": "10.0",
    "pKeyAuthHeaderAllowed": false,
    "shouldResolveInterrupt": false,
    "authorizationAgent": "WEBVIEW",
    "handleNullTaskAffinity": false,
    "isWebViewZoomControlsEnabled": false,
    "isWebViewZoomEnabled": false,
    "prompt": "LOGIN",
    "authenticationScheme": {},
    "authority": {},
    "claimsRequestJson": "{}",
    "forceRefresh": false,
    "scopes": [
        "user.read"
    ],
    "applicationName": "com.msft.identity.client.sample.local",
    "applicationVersion": "1.0-local",
    "clientId": "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
    "correlationId": "489140b2-0d31-4b1f-b32f-70ba7db346db",
    "powerOptCheckEnabled": true,
    "redirectUri": "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
    "sdkType": "MSAL",
    "sdkVersion": "4.0.1"
}
