### PR TITLE
[IGNORE] Storage perf improvements

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/StringUtil.java
@@ -212,6 +212,7 @@ public final class StringUtil {
      */
     @SuppressFBWarnings(value = "ES_COMPARING_PARAMETER_STRING_WITH_EQ",
                         justification = "This is actually a reference comparison")
+    @SuppressWarnings("PMD.UseEqualsToCompareStrings")
     public static boolean equalsIgnoreCase(@Nullable final String one, @Nullable final String two) {
         return one == two || (one != null && one.equalsIgnoreCase(two));
     }

--- a/common/src/test/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -393,7 +393,6 @@ public class MsalCppOAuth2TokenCacheTest {
         mCppCache.saveAccountRecord(generatedAccount);
 
         mCppCache.saveCredentials(
-                generatedAccount,
                 mTestBundle.mGeneratedAccessToken,
                 mTestBundle.mGeneratedIdToken,
                 mTestBundle.mGeneratedRefreshToken
@@ -429,7 +428,6 @@ public class MsalCppOAuth2TokenCacheTest {
         mCppCache.saveAccountRecord(generatedAccount);
 
         mCppCache.saveCredentials(
-                generatedAccount,
                 mTestBundle.mGeneratedAccessToken,
                 mTestBundle.mGeneratedIdToken,
                 mTestBundle.mGeneratedRefreshToken,

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -1268,7 +1268,8 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 REALM,
                 null,
                 BEARER_AUTHENTICATION_SCHEME.getName(),
-                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}"
+                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}",
+                mSharedPreferencesAccountCredentialCache.getCredentials()
         );
         assertEquals(1, credentials.size());
     }
@@ -1320,7 +1321,8 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 REALM,
                 null,
                 BEARER_AUTHENTICATION_SCHEME.getName(),
-                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}"
+                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}",
+                mSharedPreferencesAccountCredentialCache.getCredentials()
         );
         assertEquals(1, credentials.size());
         assertEquals("SecretB", credentials.get(0).getSecret());

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
@@ -157,7 +157,8 @@ public interface IAccountCredentialCache {
             final String realm,
             final String target,
             final String authScheme,
-            final String requestedClaims
+            final String requestedClaims,
+            final List<Credential> inputCredentials
     );
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -117,8 +117,7 @@ public class MsalCppOAuth2TokenCache
      * @param credentials   : list of Credential which can include AccessTokenRecord, IdTokenRecord and RefreshTokenRecord.
      * @throws ClientException : If the supplied Account or Credential are null or schema invalid.
      */
-    public synchronized void saveCredentials(@Nullable final AccountRecord accountRecord,
-                                             @NonNull final Credential... credentials) throws ClientException {
+    public synchronized void saveCredentials(@NonNull final Credential... credentials) throws ClientException {
         if (credentials.length == 0) {
             throw new ClientException("Credential array passed in is null or empty");
         }
@@ -137,13 +136,6 @@ public class MsalCppOAuth2TokenCache
                         "AT is missing a required property."
                 );
             }
-        }
-
-        if (accountRecord != null && refreshTokenRecord != null) {
-            // MSAL C++ writes credentials first and then the account.
-            // For a new account, this will not be true as the accountRecord will be null.
-            // For existing accounts, we would remove the old refresh token if present.
-            removeRefreshTokenIfNeeded(accountRecord, refreshTokenRecord);
         }
 
         saveCredentialsInternal(credentials);

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1661,7 +1661,8 @@ public class MsalOAuth2TokenCache
                 referenceToken.getRealm(),
                 null, // Wildcard (*)
                 referenceToken.getAccessTokenType(),
-                referenceToken.getRequestedClaims()
+                referenceToken.getRequestedClaims(),
+                mAccountCredentialCache.getCredentials()
         );
 
         Logger.verbose(

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -380,10 +380,9 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             @Nullable final String realm,
             @Nullable final String target,
             @Nullable final String authScheme,
-            @Nullable final String requestedClaims) {
+            @Nullable final String requestedClaims,
+            @Nullable final List<Credential> inputCredentials) {
         Logger.verbose(TAG, "getCredentialsFilteredBy()");
-
-        final List<Credential> allCredentials = getCredentials();
 
         final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
                 homeAccountId,
@@ -394,7 +393,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                 target,
                 authScheme,
                 requestedClaims,
-                allCredentials
+                inputCredentials
         );
 
         Logger.verbose(TAG, "Found [" + matchingCredentials.size() + "] matching Credentials...");
@@ -440,18 +439,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             throw new IllegalArgumentException("Param [accountToRemove] cannot be null.");
         }
 
-        final Map<String, AccountRecord> accounts = getAccountsWithKeys();
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToRemove);
 
         boolean accountRemoved = false;
-        for (final Map.Entry<String, AccountRecord> entry : accounts.entrySet()) {
-            Logger.verbosePII(TAG, "Inspecting: [" + entry.getKey() + "]");
-            final IAccountRecord currentAccount = entry.getValue();
-
-            if (currentAccount.equals(accountToRemove)) {
-                mSharedPreferencesFileManager.remove(entry.getKey());
-                accountRemoved = true;
-                break;
-            }
+        if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
+        {
+            mSharedPreferencesFileManager.remove(cacheKey);
+            accountRemoved = true;
         }
 
         Logger.info(TAG, "Account was removed? [" + accountRemoved + "]");
@@ -467,18 +461,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             throw new IllegalArgumentException("Param [credentialToRemove] cannot be null.");
         }
 
-        final Map<String, Credential> credentials = getCredentialsWithKeys();
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToRemove);
 
         boolean credentialRemoved = false;
-        for (final Map.Entry<String, Credential> entry : credentials.entrySet()) {
-            Logger.verbosePII(TAG, "Inspecting: [" + entry.getKey() + "]");
-            final Credential currentCredential = entry.getValue();
-
-            if (currentCredential.equals(credentialToRemove)) {
-                mSharedPreferencesFileManager.remove(entry.getKey());
-                credentialRemoved = true;
-                break;
-            }
+        if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
+        {
+            mSharedPreferencesFileManager.remove(cacheKey);
+            credentialRemoved = true;
         }
 
         Logger.info(TAG, "Credential was removed? [" + credentialRemoved + "]");


### PR DESCRIPTION
Many of the AccountCredentialCache operations involve a database scan + deserialization because they begin with 'getCredentials' or 'getAccounts'.  Higher level operations in the TokenCache classes that call these operations can then involve several full scans and deserializations of every Credential/Account in the database.

This change is being combined with changes in MsalCpp to make sure that only a single DB scan + deserialization happens per top-level request.

Additionally removeCredential/removeAccount no longer involve a full scan + deserialization and operate on keys only.  This was particularly problematic for operations that did full scans to filter to a set of credentials, and then another full scan for each credential that was eventually deleted.