### PR TITLE
Moving clearClientCertPreferences to onPageLoaded.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ V.Next
 - [MAJOR] Use Java 11 to accomodate android sdk 31 tooling. (#1832)
 - [PATCH] Swallow unbound service exceptions on disconnect. (#1824)
 - [MINOR] Refactored out ClientCertAuthChallengeHandler. (#1833)
-
+- [PATCH] Moved clearClientCertPreferences to onPageLoaded. (#1855)
 
 Version 7.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -102,18 +102,9 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final String methodTag = TAG + ":onCreate";
         final FragmentActivity activity = getActivity();
         if (activity != null) {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
-        }
-        //For CBA, we need to clear the certificate choice cache here so that
-        // the user will be able to login with multiple accounts with CBA
-        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            WebView.clearClientCertPreferences(null);
-        } else {
-            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
         }
     }
 
@@ -182,6 +173,15 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                                 mWebView.loadUrl("javascript:" + javascriptToExecute[0].replace("%", "%25"));
                             }
                         }
+                        //For CBA, we need to clear the certificate choice cache here so that
+                        // if the cert picker is exited (`cancel()`) or the flow has an error,
+                        //the user can still try to login again with a cert.
+                        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            WebView.clearClientCertPreferences(null);
+                        } else {
+                            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+                        }
                     }
                 },
                 mRedirectUri);
@@ -211,15 +211,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         if (mWebView.canGoBack()) {
             mWebView.goBack();
-            //For CBA, we need to clear the certificate choice cache here so that
-            // if the cert picker is exited (`cancel()`) or the flow has an error,
-            //the user can still try to login again with a cert.
-            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                WebView.clearClientCertPreferences(null);
-            } else {
-                Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
-            }
         } else {
             cancelAuthorization(true);
         }


### PR DESCRIPTION
## For Context....
For any sort of CBA via WebView, certificate preferences need to be cleared in order for a user to use CBA again within the same session, whether that's to add another account or simply retry a failed flow. Otherwise, the user's previous choice is remembered and selected again on behalf of the user.
A fix for this behavior was made in [this PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1688), where `Webview.clearClientCertPreferences(null)` was called upon creation of the authorization fragment and when the back button was pressed. Those were the only two times where the call was needed, as a user could only get to the start of CBA again by starting the fragment or clicking the back button.

## The Problem
The server side has made some updates, including one where the user sees a "Certificate validation failed" upon the cancelation of a cert based request (instead of a regular error page). This new page has a link to take the user back to "other ways to sign in", and from there, they can retry CBA. The cert preference hasn't been cleared from our side in this case, so the request will automatically fail and show the "Certificate validation failed" page again.

## The Solution
I moved the `Webview.clearClientCertPreferences(null)` call to the `onPageLoaded` callback defined within `WebViewAuthorizationFragment` for `AzureActiveDirectoryWebViewClient`. This is essentially the very first solution I came up with in the initial PR, and it is the only one I have found to work. Unfortunately, it does call `clearClientCertPreferences` at least 4 times per action. I attempted to filter the urls by "https://certauth", but the urls for the new error page does not contain this prefix, so it did not work. This all being said, I do not see any performance issues thus far while testing.

## Testing
I went through the usual CBA success flows with both smartcard and on-device CBA. I also tested multiple ways to get to the certificate error page and made sure I could still get to the cert picker from there.

## Related PR
 - The first fix: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1688