### PR TITLE
Add new exception type for broker protocol not supported exception during msal-broker handshake

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1859)
 - [MINOR] Add opt-in flag to skip expensive SecretKey invalidation steps (#1837)
 - [MINOR] Storage performance improvements (#1852)
 - [PATCH] More fields exposed for GSON based logging for Broker Token Parameters (#1849)
@@ -13,11 +14,9 @@ V.Next
 - [PATCH] Swallow unbound service exceptions on disconnect. (#1824)
 - [MINOR] Refactored out ClientCertAuthChallengeHandler. (#1833)
 
-
 Version 7.0.1
 ----------
 - [Minor] Bumped Common to 7.0.1 to fix publishing bug.
-
 
 Version 7.0.0
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -126,8 +126,6 @@ android {
 }
 
 dependencies {
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.3'
-
     //Java 8 - Desugaring - Enabled/Disabled via plugin
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -666,6 +666,16 @@ public final class AuthenticationConstants {
         public static final String NEGOTIATED_BP_VERSION_KEY = "common.broker.protocol.version.name";
 
         /**
+         * Code of the error that occurs as a result of MSAL-Broker protocol handshake (hello()).
+         */
+        public static final String HELLO_ERROR_CODE = "error";
+
+        /**
+         * Description of the error that occurs as a result of MSAL-Broker protocol handshake (hello()).
+         */
+        public static final String HELLO_ERROR_MESSAGE = "error_description";
+
+        /**
          * The Boolean to send when FOCI apps are allowed to construct accounts from PRT id token in getAccounts.
          */
         public static final String CAN_FOCI_APPS_CONSTRUCT_ACCOUNTS_FROM_PRT_ID_TOKEN_KEY = "can.construct.accounts.from.prt.id.token";

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
@@ -57,8 +57,8 @@ public class ContentProviderStrategy implements IIpcStrategy {
     }
 
     @Override
-    public @Nullable
-    Bundle communicateToBroker(final @NonNull BrokerOperationBundle brokerOperationBundle)
+    @Nullable
+    public Bundle communicateToBroker(final @NonNull BrokerOperationBundle brokerOperationBundle)
             throws BrokerCommunicationException {
         final String methodTag = TAG + ":communicateToBroker";
         final String operationName = brokerOperationBundle.getOperation().name();

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -169,9 +169,8 @@ public class BrokerMsalController extends BaseController {
      * Order of objects in the list will reflects the order of strategies that will be used.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    protected @NonNull
-    List<IIpcStrategy> getIpcStrategies(final Context applicationContext,
-                                        final String activeBrokerPackageName) {
+    @NonNull
+    protected List<IIpcStrategy> getIpcStrategies(final Context applicationContext, final String activeBrokerPackageName) {
         final String methodTag = TAG + ":getIpcStrategies";
         final List<IIpcStrategy> strategies = new ArrayList<>();
         final StringBuilder sb = new StringBuilder(100);
@@ -237,6 +236,7 @@ public class BrokerMsalController extends BaseController {
                 bundle);
 
         final String negotiatedProtocolVersion = mResultAdapter.verifyHelloFromResultBundle(
+                mActiveBrokerPackageName,
                 strategy.communicateToBroker(helloBundle)
         );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -538,13 +538,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (resultObject instanceof BrokerResult) {
             // for the back compatibility purpose to version 3.0.4 and 3.0.6.
             final BrokerResult brokerResult = (BrokerResult) resultObject;
-            if (StringUtil.isNullOrEmpty(brokerResult.getErrorCode())){
-                throw new UnsupportedBrokerException(
-                        activeBrokerPackageName,
-                        brokerResult.getErrorCode(),
-                        brokerResult.getErrorMessage());
-            }
+            throw new ClientException(brokerResult.getErrorCode(), brokerResult.getErrorMessage());
         }
+        
         // This means that the Broker doesn't support hello().
         Logger.warn(methodTag, "The result bundle is not in a recognizable format.");
         throw new UnsupportedBrokerException(activeBrokerPackageName);

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -528,7 +528,6 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         // Actual handshake error.
-        // We shouldn't be using OAuth2.Error... but changing this would break backcompat...
         if (!StringUtil.isNullOrEmpty(bundle.getString(HELLO_ERROR_CODE))) {
             final String errorCode = bundle.getString(HELLO_ERROR_CODE);
             final String errorMessage = bundle.getString(HELLO_ERROR_MESSAGE);

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -86,7 +86,7 @@ import java.util.List;
  */
 public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
-    private static final String TAG = MsalBrokerResultAdapter.class.getName();
+    private static final String TAG = MsalBrokerResultAdapter.class.getSimpleName();
     public static final Gson GSON = new Gson();
 
     @NonNull
@@ -540,7 +540,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             final BrokerResult brokerResult = (BrokerResult) resultObject;
             throw new ClientException(brokerResult.getErrorCode(), brokerResult.getErrorMessage());
         }
-        
+
         // This means that the Broker doesn't support hello().
         Logger.warn(methodTag, "The result bundle is not in a recognizable format.");
         throw new UnsupportedBrokerException(activeBrokerPackageName);

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/UnsupportedBrokerException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/UnsupportedBrokerException.java
@@ -1,0 +1,53 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.exception;
+
+import javax.annotation.Nullable;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Representing all exceptions that occur due to unsupported/incompatible broker.
+ */
+@Getter
+@Accessors(prefix = "m")
+public class UnsupportedBrokerException extends BaseException {
+
+    @NonNull
+    private final String mActiveBrokerPackageName;
+
+    public UnsupportedBrokerException(@NonNull final String activeBrokerPackageName){
+        this(activeBrokerPackageName,
+                ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE,
+                ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_MESSAGE);
+    }
+
+    public UnsupportedBrokerException(@NonNull final String activeBrokerPackageName,
+                                      @NonNull final String errorCode,
+                                      @Nullable final String errorMessage){
+        super(errorCode, errorMessage);
+        mActiveBrokerPackageName = activeBrokerPackageName;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -90,24 +90,24 @@ public class BrokerProtocolVersionUtil {
         if (StringUtil.isNullOrEmpty(providedBrokerProtocol)) {
             return false;
         }
-        return isFirstVersionLargerOrEqual(
+        return isFirstVersionNewerOrEqual(
                 providedBrokerProtocol,
                 requiredBrokerProtocol);
     }
 
     /**
-     * Returns true if the first semantic version is smaller or equal to the second version.
+     * Returns true if the first semantic version is smaller (older) or equal to the second version.
      */
-    public static final boolean isFirstVersionSmallerOrEqual(@NonNull final String first,
-                                                             @Nullable final String second) {
+    public static boolean isFirstVersionOlderOrEqual(@NonNull final String first,
+                                                     @Nullable final String second) {
         return compareSemanticVersion(first, second) <= 0;
     }
 
     /**
-     * Returns true if the first semantic version is larger or equal to the second version.
+     * Returns true if the first semantic version is larger (newer) or equal to the second version.
      */
-    public static final boolean isFirstVersionLargerOrEqual(@NonNull final String first,
-                                                            @Nullable final String second) {
+    public static boolean isFirstVersionNewerOrEqual(@NonNull final String first,
+                                                     @Nullable final String second) {
         return compareSemanticVersion(first, second) >= 0;
     }
 


### PR DESCRIPTION
see https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1703, https://github.com/AzureAD/ad-accounts-for-android/pull/2015

When MSAL initialization fails due to a protocol handshake error, we will be returning an exception with enough info for the client app to show an actionable prompt to the customer. (i.e. update app XXXX)