### PR TITLE
Add UI test for "is_remote_login_required=true" showing DCF option (Common)

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -531,4 +531,47 @@ public class BrokerHost extends AbstractTestBroker {
             UiAutomatorUtils.handleButtonClick("android:id/button1");
         }
     }
+
+    /**
+     * Check if the Device Code Flow option shows up in sign in flow.
+     * @param tenantId tenant ID to use in Join Tenant
+     * @throws UiObjectNotFoundException
+     */
+    public void checkForDcfOption(@Nullable final String tenantId){
+        final String tenantIdToUse;
+
+        // If no tenant ID is specified, default to microsoft tenant
+        if (tenantId == null) {
+            tenantIdToUse = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+        } else {
+            tenantIdToUse = tenantId;
+        }
+
+        final String joinTenantButtonId = "com.microsoft.identity.testuserapp:id/buttonJoinTenant";
+        final String joinTenantEditTestId = "com.microsoft.identity.testuserapp:id/editTextTenantId";
+
+        launch();
+
+        UiAutomatorUtils.handleInput(joinTenantEditTestId, tenantIdToUse);
+
+        UiAutomatorUtils.handleButtonClick(joinTenantButtonId);
+
+        // Apparently, there are two UI objects with exact test "Sign-in options", one is a button the other is a view
+        // Have to specify the search to button class
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        final UiObject optionsObject = device.findObject(new UiSelector()
+                .text("Sign-in options").className("android.widget.Button"));
+
+        try {
+            optionsObject.click();
+        } catch (UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+        UiAutomatorUtils.handleButtonClickForObjectWithText("Sign in from another device");
+
+        // Doesn't look like the page with the device code is readable to the UI automation,
+        // this is a sufficient stopping point
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerHost.java
@@ -556,7 +556,7 @@ public class BrokerHost extends AbstractTestBroker {
 
         UiAutomatorUtils.handleButtonClick(joinTenantButtonId);
 
-        // Apparently, there are two UI objects with exact test "Sign-in options", one is a button the other is a view
+        // Apparently, there are two UI objects with exact text "Sign-in options", one is a button the other is a view
         // Have to specify the search to button class
         final UiDevice device =
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());


### PR DESCRIPTION
Work Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2096386

I created this Test Case: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2110359

Work to create an automated UI test to check that the "Sign in from another device" option shows up when we call acquire token with "is_remote_login_required=true" parameter.

Common PR is for adding a new method in BrokerHost Automation to enter tenant id, click "Join Tenant" button, and check for the UI elements shown "Sign from another device" option.

Related PRs
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1704
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2023