### PR TITLE
Fix Office SSO when using SharedUserId

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ----------
 - [PATCH] Moved clearClientCertPreferences to onPageLoaded. (#1855)
 - [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1859)
+- [PATCH] Avoid keystore key overwriting for apps using sharedUserId. (#3738)
 
 Version 8.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -206,7 +206,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
             if (wrappedSecretKey == null) {
                 Logger.warn(methodTag, "Key file is empty");
-                deleteSecretKeyFromStorage();
+                FileUtil.deleteFile(getKeyFile());
+                mKeyCache.clear();
                 return null;
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -206,6 +206,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
             if (wrappedSecretKey == null) {
                 Logger.warn(methodTag, "Key file is empty");
+                // Do not delete the KeyStoreKeyPair even if the key file is empty. This caused credential cache
+                // to be deleted in Office because of sharedUserId allowing keystore to be shared amongst apps.
                 FileUtil.deleteFile(getKeyFile());
                 mKeyCache.clear();
                 return null;


### PR DESCRIPTION
Office was experiencing SSO issue where account credential cache was wiped after force-closing Office apps and restarting. Looks like The Keystore KeyPair that is shared when SharedUserId is in use was being overwritten. In this PR, during the check for ADAL-KS file and realizing it is not there, don't delete the KeyStore keypair because that check was passed earlier. In this case, only delete the ADAL-KS file and local memcache.

Validated manually that this fixed the issue