### PR TITLE
Adding cached credential service request id to telemetry

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Adding cached credential service request id to telemetry (#1866)
 - [MAJOR] Add support for client/application managed key in pop flow (#1854)
 - [PATCH] Avoid keystore key overwriting for apps using sharedUserId. (#1864)
 - [PATCH] Moved clearClientCertPreferences to onPageLoaded. (#1855)

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpConstants.java
@@ -48,6 +48,11 @@ public final class HttpConstants {
          * Header used to track SPE Ring for telemetry.
          */
         public static final String X_MS_CLITELEM = "x-ms-clitelem";
+
+        /**
+         * Header to track if Cached Credential Service (CCS) was used
+         */
+        public static final String XMS_CCS_REQUEST_ID = "xms-ccs-requestid";
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
@@ -101,7 +101,7 @@ public class HttpResponse {
         }
 
         final List<String> list = mResponseHeaders.get(key);
-        if (list == null){
+        if (list == null || list.size() <= index){
             return null;
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
@@ -94,7 +94,11 @@ public class HttpResponse {
     }
 
     /**
-     * Returns: element "index" of the header list associated to the provided key.
+     * Gets the value from the response header list associated to the provided key at a given index.
+     * @param key   header key for look up.
+     * @param index index of the element to get
+     * @return      element at given index of the header list associated to the provided key.
+     *              if element is not found returns null.
      */
     @Nullable
     public String getHeaderValue(@NonNull final String key, final int index){

--- a/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/HttpResponse.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.net;
 
+import com.microsoft.identity.common.java.util.StringUtil;
+
 import net.jcip.annotations.Immutable;
 
 import java.util.Date;
@@ -96,7 +98,7 @@ public class HttpResponse {
      */
     @Nullable
     public String getHeaderValue(@NonNull final String key, final int index){
-        if (mResponseHeaders == null){
+        if (mResponseHeaders == null || index < 0 || StringUtil.isNullOrEmpty(key)){
             return null;
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -37,5 +37,10 @@ public enum AttributeName {
     /**
      * Indicates the algorithm for the JWE returned by eSTS.
      */
-    jwt_alg
+    jwt_alg,
+
+    /**
+     * Indicates the request id value for cached credential service (if used) on server side
+     */
+    ccs_request_id
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -28,6 +28,7 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2Scopes.CLAIMS_UPDATE_RESOURCE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
+import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.XMS_CCS_REQUEST_ID;
 import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.X_MS_CLITELEM;
 import static com.microsoft.identity.common.java.providers.oauth2.TokenRequest.GrantTypes.CLIENT_CREDENTIALS;
 
@@ -41,20 +42,6 @@ import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
 import com.microsoft.identity.common.java.commands.parameters.RopcTokenCommandParameters;
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
-import com.microsoft.identity.common.java.opentelemetry.AttributeName;
-import com.microsoft.identity.common.java.platform.Device;
-import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationResponse;
-import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErrorResponse;
-import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
-import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResultFactory;
-import com.microsoft.identity.common.java.providers.oauth2.IAuthorizationStrategy;
-import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
-import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import lombok.NonNull;
-import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.dto.IAccountRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
@@ -65,6 +52,7 @@ import com.microsoft.identity.common.java.net.HttpClient;
 import com.microsoft.identity.common.java.net.HttpConstants;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationResponse;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErrorResponse;
@@ -87,8 +75,6 @@ import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.ResultUtil;
 import com.microsoft.identity.common.java.util.StringUtil;
 
-import io.opentelemetry.api.trace.Span;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
@@ -100,17 +86,9 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP_PACKAGE_NAME;
-import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP_VERSION;
-import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.CHALLENGE_REQUEST_HEADER;
-import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2Scopes.CLAIMS_UPDATE_RESOURCE;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
-import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.XMS_CCS_REQUEST_ID;
-import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.X_MS_CLITELEM;
-import static com.microsoft.identity.common.java.providers.oauth2.TokenRequest.GrantTypes.CLIENT_CREDENTIALS;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.opentelemetry.api.trace.Span;
 import lombok.NonNull;
 
 // Suppressing rawtype warnings due to the generic type AuthorizationStrategy, AuthorizationResult, AuthorizationResultFactory and MicrosoftAuthorizationRequest

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -619,11 +619,9 @@ public class MicrosoftStsOAuth2Strategy
                 }
             }
 
-            if (null != responseHeaders.get(XMS_CCS_REQUEST_ID)) {
-                Span.current().setAttribute(
-                        AttributeName.ccs_request_id.name(),
-                        response.getHeaderValue(XMS_CCS_REQUEST_ID, 0));
-            }
+            Span.current().setAttribute(
+                    AttributeName.ccs_request_id.name(),
+                    response.getHeaderValue(XMS_CCS_REQUEST_ID, 0));
         }
 
         return result;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -615,7 +615,7 @@ public class MicrosoftStsOAuth2Strategy
             if (null != responseHeaders.get(XMS_CCS_REQUEST_ID)) {
                 Span.current().setAttribute(
                         AttributeName.ccs_request_id.name(),
-                        responseHeaders.get(XMS_CCS_REQUEST_ID).get(0));
+                        response.getHeaderValue(XMS_CCS_REQUEST_ID, 0));
             }
         }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
@@ -26,8 +26,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Tests for {@link HttpResponse}.
@@ -58,5 +61,16 @@ public final class HttpResponseTests {
         final HttpResponse response = new HttpResponse(HttpURLConnection.HTTP_OK, RESPONSE_BODY, null);
         Assert.assertTrue(response.getBody().equals(RESPONSE_BODY));
         Assert.assertNull(response.getHeaders());
+    }
+
+    @Test
+    public void testGetHeaderValue() {
+        final String requestId = UUID.randomUUID().toString();
+        HashMap responseHeaders = new HashMap<>();
+        responseHeaders.put("xms-ccs-requestid", new ArrayList<>((Collections.singleton(requestId))));
+        final HttpResponse response = new HttpResponse(HttpURLConnection.HTTP_OK, RESPONSE_BODY, responseHeaders);
+        Assert.assertEquals(requestId, response.getHeaderValue("xms-ccs-requestid", 0));
+        Assert.assertNull(response.getHeaderValue("xms-ccs-requestid", 1));
+        Assert.assertNull(response.getHeaderValue("invalid", 1));
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * Tests for {@link HttpResponse}.
  */
-public final class HttpResponseBodyTest {
+public final class HttpResponseTests {
 
     private static final String RESPONSE_BODY = "test response body";
 

--- a/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/HttpResponseTests.java
@@ -72,5 +72,7 @@ public final class HttpResponseTests {
         Assert.assertEquals(requestId, response.getHeaderValue("xms-ccs-requestid", 0));
         Assert.assertNull(response.getHeaderValue("xms-ccs-requestid", 1));
         Assert.assertNull(response.getHeaderValue("invalid", 1));
+        Assert.assertNull(response.getHeaderValue("xms-ccs-requestid", -3));
+        Assert.assertNull(response.getHeaderValue("", 0));
     }
 }


### PR DESCRIPTION
### What
Adding cached credential service request id to telemetry

### Why
This change is part of the ADO workitem
[Android broker should add telemetry indicating whether CCS was used to serve a token](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2018515/)

### How
Adding the attribute ccs_requestid to current span when parsing token response.

### Testing
Added UTs for getting header value if present
