### PR TITLE
Remove java.time.* Java8 APIs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Remove java.time.* Java8 APIs (#1868)
 - [MAJOR] Add support for client/application managed key in pop flow (#1854)
 - [PATCH] Avoid keystore key overwriting for apps using sharedUserId. (#1864)
 - [PATCH] Moved clearClientCertPreferences to onPageLoaded. (#1855)

--- a/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
@@ -25,13 +25,12 @@ package com.microsoft.identity.common.java.logging;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ThrowableUtil;
 
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
-import java.time.ZoneOffset;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -69,7 +68,11 @@ public class Logger {
 
     private static final Map<String, ILoggerCallback> sLoggers = new HashMap<>();
 
-    private static final DateTimeFormatter sDateTimeFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT).withZone(ZoneOffset.UTC);
+    private static final SimpleDateFormat sDateTimeFormatter;
+    static {
+        sDateTimeFormatter = new SimpleDateFormat(DATE_FORMAT, Locale.getDefault());
+        sDateTimeFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
 
     /**
      * Set the platform string to be used when generating logs.
@@ -379,7 +382,7 @@ public class Logger {
             return;
         }
 
-        final Instant now = Instant.now();
+        final Date now = new Date();
 
         sLogExecutor.execute(new Runnable() {
             @Override


### PR DESCRIPTION
Java 8 APIs are only available default on min-sdk >= 26.  Desugaring allows using language features that are compiled correctly even for lower min-sdk levels. There is also a feature to make [Java 8 APIs](https://developer.android.com/studio/write/java8-support#library-desugaring) available, but it requires the including *app* to opt-in to library desugaring.  Since common only controls its own library, it cannot transitively push these requirements on to the app.  Until min-sdk level is moved up to 26+, it will not be safe to use Java 8+ APIs in common.

This swap back to the original time APIs should be nearly as fast.  The main benefit from changing to Instant was the more clear time API surface, and some multithreading usage of the formatter that isn't actually needed given the Executor is the only thread using it.  The primary benefits of not formatting before checking logLevel and only creating one formatter will still be in place.

Validations:
* Checked all my PRs, these are the only Java 8 APIs introduced
* Validated that we crashed before this PR on API 24, and now fixed
* Validated that log format is the same