### PR TITLE
Leverage Otel Utility create span method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V.Next
 - [PATCH] Avoid keystore key overwriting for apps using sharedUserId. (#1864)
 - [PATCH] Moved clearClientCertPreferences to onPageLoaded. (#1855)
 - [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1859)
+- [MINOR] Leverage Otel Utility create span method (#1877)
 
 Version 8.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
@@ -17,9 +17,9 @@
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- // THE SOFTWARE.
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.java.foci;
 
 import static com.microsoft.identity.common.java.authorities.AllAccounts.ALL_ACCOUNTS_TENANT_ID;
@@ -34,6 +34,8 @@ import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
@@ -42,8 +44,8 @@ import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.Micro
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
-import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.CommonURIBuilder;
+import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.ObjectUtils;
 
 import java.io.IOException;
@@ -52,9 +54,7 @@ import java.net.URL;
 import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import lombok.NonNull;
 
@@ -132,13 +132,12 @@ public class FociQueryUtilities {
         //       for every FoCI apps (and hardcode it here).
         //       https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1222002
         if (ObjectUtils.equals(clientId, "87749df4-7ccf-48f8-aa87-704bad0e0e16")) {
-            final Span span = GlobalOpenTelemetry.getTracer(TAG).spanBuilder("setScopeForDMAgentForFoci").startSpan();
+            final Span span = OTelUtility.createSpan(SpanName.SetScopeForDMAgentForFoci.name());
             try (final Scope scope = span.makeCurrent()) {
                 scopes = "https://devicemgmt.teams.microsoft.com/.default " + BaseController.getDelimitedDefaultScopeString();
                 Logger.info(TAG + methodName,
                         "Teams agent client ID - making a test request with teams agent resource.");
-            }
-            finally {
+            } finally {
                 span.end();
             }
         } else {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -28,5 +28,6 @@ public enum SpanName {
     AcquireAtUsingPrt,
     AcquireTokenInteractive,
     AcquireTokenSilent,
-    CryptoFactoryEvent
+    CryptoFactoryEvent,
+    SetScopeForDMAgentForFoci
 }


### PR DESCRIPTION
Leverage OtelUtility creatSpan method for creating spans everywhere. 

This helper method populates each Span with the parent span name.

@somalaya I also moved the foci span name into the SpanName enum and followed the same casing as other span names.