### PR TITLE
Enable signing testFixtureJar for maven release

### DIFF
--- a/azure-pipelines/maven-release/common4j.yml
+++ b/azure-pipelines/maven-release/common4j.yml
@@ -28,3 +28,4 @@ jobs:
     gpgSourcesJar: true
     gpgJavadocJar: true
     gpgJar: true
+    testFixtureJar: true

--- a/azure-pipelines/maven-release/common4j.yml
+++ b/azure-pipelines/maven-release/common4j.yml
@@ -28,4 +28,4 @@ jobs:
     gpgSourcesJar: true
     gpgJavadocJar: true
     gpgJar: true
-    testFixtureJar: true
+    gpgTestFixtureJar: true

--- a/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
+++ b/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
@@ -73,6 +73,18 @@ if [ $JAVADOCJAR == "true" ]; then
     fi
 fi
 
+if [ $TESTFIXUTREJAR == "true" ]; then
+    gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-test-fixtures.jar
+    signed=$?
+    if [ $signed -ne 0 ]; then
+        echo "GPG signing failed with for $PROJECT-$PROJECTVERSION-test-fixtures.jar with error code $signed"
+        exit $signed
+    fi
+    if [ ! -f $PROJECT-$PROJECTVERSION-javadoc.jar.asc ]; then
+        exit "Signature file for $PROJECT-$PROJECTVERSION-test-fixtures.jar not found."
+    fi
+fi
+
 gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
 signed=$?
 

--- a/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
+++ b/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
@@ -73,7 +73,7 @@ if [ $JAVADOCJAR == "true" ]; then
     fi
 fi
 
-if [ $TESTFIXUTREJAR == "true" ]; then
+if [ $TESTFIXTUREJAR == "true" ]; then
     gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION-test-fixtures.jar
     signed=$?
     if [ $signed -ne 0 ]; then

--- a/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
+++ b/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
@@ -36,6 +36,8 @@ parameters:
   default: false
 - name: gpgJavadocJar
   default: false
+- name: gpgTestFixtureJar
+  default: false
 
 
 jobs:
@@ -153,6 +155,7 @@ jobs:
       AAR: ${{ parameters.gpgAar }}
       SOURCESJAR: ${{ parameters.gpgSourcesJar }}
       JAVADOCJAR: ${{ parameters.gpgJavadocJar }}
+      TESTFIXTUREJAR: ${{ parameters.gpgtestFixtureJar }}
   - task: CopyFiles@2
     inputs:
       SourceFolder: $(Build.SourcesDirectory)/$(BuildOutputs)


### PR DESCRIPTION
Enabling the support for signing testfixture jar when creating maven package for publishing.
Currently it's not signed, and it fails verification when releasing to external maven with error "Missing Signature" for the testfixture jar