### PR TITLE
Added span names for get and remove accounts

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -29,5 +29,7 @@ public enum SpanName {
     AcquireTokenInteractive,
     AcquireTokenSilent,
     CryptoFactoryEvent,
-    SetScopeForDMAgentForFoci
+    SetScopeForDMAgentForFoci,
+    GetAccounts,
+    RemoveAccounts
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -31,5 +31,5 @@ public enum SpanName {
     CryptoFactoryEvent,
     SetScopeForDMAgentForFoci,
     GetAccounts,
-    RemoveAccounts
+    RemoveAccount
 }


### PR DESCRIPTION
Added new span names for GetAccounts and RemoveAccounts flows in broker for adding open telemetry.

The span names are used in this PR -> https://github.com/AzureAD/ad-accounts-for-android/pull/2028