### PR TITLE
Add open telemetry to consumer rules

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ V.Next
 - [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1859)
 - [MINOR] Leverage Otel Utility create span method (#1877)
 - [MINOR] Add Open Telemetry explicitly in common as transitive is set to false (#1882)
+- [MINOR] Add open telemetry to consumer rules (#1883)
 
 V.8.0.3
 ----------

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -47,6 +47,9 @@
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
 
+# keep everything in this package from being removed or renamed
+-keep class io.opentelemetry.** { *; }
+
 # Prevent R8 from leaving Data object members always null
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;


### PR DESCRIPTION
To ensure Open Telemetry methods are not removed during minification process of the APK for MSAL consumers.