### PR TITLE
Melissaahn/cba usb service

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@ V.Next
 
 V.8.0.3
 ----------
-- [PATCH] Add null checks for emulators that do not account for USB_SERVICE. (#1885)
+- [PATCH] Add null checks for devices that do not support USB_SERVICE. (#1885)
 
 V.8.0.2
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,10 @@ V.Next
 - [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1859)
 - [MINOR] Leverage Otel Utility create span method (#1877)
 
+V.8.0.3
+----------
+- [PATCH] Add null checks for emulators that do not account for USB_SERVICE. (#1885)
+
 V.8.0.2
 ----------
 - [PATCH] Remove java.time.* Java8 APIs (#1868)


### PR DESCRIPTION
## Summary
This change is being made to address an issue brought up regarding Android emulators that are not supporting the usb_service system service at the moment. 
In the case described above, `context.getSystemService(Context.USB_SERVICE)` will return null. This is more or less an unusual edge case that YubiKit does not currently handle, so it will cause a NullPointerException upon starting up the authentication WebView (which starts startUsbDiscovery).
It will take some time for Yubico and the emulator company to evaluate changes that may/may not need to be made on their sides, so making some null checks directly in our code to unblock customers.
This change will also be cherry-picked into upcoming releases of Authenticator and Company Portal.

## Testing
Tested on my side by explicitly setting the YubiKitManager variable to null and making sure the app doesn't crash. Service engineer also tested with test version of Authenticator and confirmed the fix.