### PR TITLE
Cherry-pick CBA fix for 7.0.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 V.Next
 ----------
 
+Version 7.0.2
+----------
+- [PATCH] Add null checks for devices that do not support USB_SERVICE. (#1885, #1888)
+
 Version 7.0.1
 ----------
 - [Minor] Bumped Common to 7.0.1 to fix publishing bug.

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -30,7 +30,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 0.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "0.0.+"
+def common4jVersion = "4.0.0"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=7.0.1
+versionName=7.0.2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
Cherry-pick the change @melissaahn made for 7.0.1.

The fix addressed the same issue in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1885, but the code was refactored in dev, hence the difference.