### PR TITLE
Fixes MSAL Issue #1715

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.Next
 - [MINOR] Leverage Otel Utility create span method (#1877)
 - [MINOR] Add Open Telemetry explicitly in common as transitive is set to false (#1882)
 - [MINOR] Add open telemetry to consumer rules (#1883)
+- [PATCH] Fixes MSAL Issue #1715 (#1894)
 
 V.8.0.3
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
@@ -51,7 +51,42 @@ public class NoopSpan implements Span {
     private final SpanContext spanContext;
 
     @Override
+    public Span setAttribute(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public Span setAttribute(String key, long value) {
+        return this;
+    }
+
+    @Override
+    public Span setAttribute(String key, double value) {
+        return this;
+    }
+
+    @Override
+    public Span setAttribute(String key, boolean value) {
+        return this;
+    }
+
+    @Override
     public <T> Span setAttribute(AttributeKey<T> key, T value) {
+        return this;
+    }
+
+    @Override
+    public Span setAllAttributes(Attributes attributes) {
+        return this;
+    }
+
+    @Override
+    public Span addEvent(String name) {
+        return this;
+    }
+
+    @Override
+    public Span addEvent(String name, long timestamp, TimeUnit unit) {
         return this;
     }
 
@@ -66,7 +101,17 @@ public class NoopSpan implements Span {
     }
 
     @Override
+    public Span setStatus(StatusCode statusCode) {
+        return this;
+    }
+
+    @Override
     public Span setStatus(StatusCode statusCode, String description) {
+        return this;
+    }
+
+    @Override
+    public Span recordException(Throwable exception) {
         return this;
     }
 
@@ -81,14 +126,10 @@ public class NoopSpan implements Span {
     }
 
     @Override
-    public void end() {
-
-    }
+    public void end() {}
 
     @Override
-    public void end(long timestamp, TimeUnit unit) {
-
-    }
+    public void end(long timestamp, TimeUnit unit) {}
 
     @Override
     public SpanContext getSpanContext() {
@@ -98,5 +139,10 @@ public class NoopSpan implements Span {
     @Override
     public boolean isRecording() {
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NoopSpan{" + spanContext + '}';
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import java.util.concurrent.TimeUnit;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.StatusCode;
+import lombok.AllArgsConstructor;
+
+/**
+ * A custom noop implementation of {@link Span} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+@AllArgsConstructor
+public class NoopSpan implements Span {
+
+    private final SpanContext spanContext;
+
+    @Override
+    public <T> Span setAttribute(AttributeKey<T> key, T value) {
+        return this;
+    }
+
+    @Override
+    public Span addEvent(String name, Attributes attributes) {
+        return this;
+    }
+
+    @Override
+    public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
+        return this;
+    }
+
+    @Override
+    public Span setStatus(StatusCode statusCode, String description) {
+        return this;
+    }
+
+    @Override
+    public Span recordException(Throwable exception, Attributes additionalAttributes) {
+        return this;
+    }
+
+    @Override
+    public Span updateName(String name) {
+        return this;
+    }
+
+    @Override
+    public void end() {
+
+    }
+
+    @Override
+    public void end(long timestamp, TimeUnit unit) {
+
+    }
+
+    @Override
+    public SpanContext getSpanContext() {
+        return spanContext;
+    }
+
+    @Override
+    public boolean isRecording() {
+        return false;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
@@ -1,0 +1,56 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import io.opentelemetry.api.trace.TraceFlags;
+
+/**
+ * A custom noop implementation of {@link io.opentelemetry.api.trace.TraceFlags} to be used in MSAL
+ * for scenarios where minSdkVersion of calling application < 24. The reason for this is because the
+ * default no-op implementation uses "static interface methods" and these get left out of the APK
+ * for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because the
+ * consumers-rules are NOT honored when minification is disabled and R8 applies some default
+ * proguard rules that leaves static interface methods out of the APK. This causes a
+ * "NoSuchMethodError" when such methods are invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopTraceFlags implements TraceFlags {
+    @Override
+    public boolean isSampled() {
+        return false;
+    }
+
+    @Override
+    public String asHex() {
+        return null;
+    }
+
+    @Override
+    public byte asByte() {
+        return 0;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceState.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceState.java
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import javax.annotation.Nullable;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+import lombok.Builder;
+
+
+/**
+ * A custom noop implementation of {@link TraceState} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+@Builder
+public class NoopTraceState implements TraceState {
+
+    private static final Map<String, String> EMPTY = Collections.emptyMap();
+
+    @Nullable
+    @Override
+    public String get(String key) {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public void forEach(BiConsumer<String, String> consumer) {
+
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+        return EMPTY;
+    }
+
+    @Override
+    public TraceStateBuilder toBuilder() {
+        return new com.microsoft.identity.common.java.opentelemetry.NoopTraceStateBuilder();
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceStateBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceStateBuilder.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+
+/**
+ * A custom noop implementation of {@link TraceStateBuilder} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopTraceStateBuilder implements TraceStateBuilder {
+    @Override
+    public TraceStateBuilder put(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public TraceStateBuilder remove(String key) {
+        return this;
+    }
+
+    @Override
+    public TraceState build() {
+        return new NoopTraceState();
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -23,23 +23,40 @@
 package com.microsoft.identity.common.java.opentelemetry;
 
 import static com.microsoft.identity.common.java.opentelemetry.AttributeName.parent_span_name;
+import static io.opentelemetry.api.trace.TraceFlags.fromByte;
+
+import com.microsoft.identity.common.java.logging.Logger;
 
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.internal.ImmutableSpanContext;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import lombok.NonNull;
 
 public class OTelUtility {
     private static final String TAG = OTelUtility.class.getSimpleName();
-    
+
+    private static final SpanContext INVALID =
+            ImmutableSpanContext.create(
+                    TraceId.getInvalid(),
+                    SpanId.getInvalid(),
+                    fromByte((byte) 0x00),
+                    new NoopTraceState(),
+                    /* remote= */ false,
+                    /* valid= */ false
+            );
+
     /**
      * Creates a span (with shared basic attributes).
      **/
     @NonNull
-    public static Span createSpan(@NonNull final String name){
+    public static Span createSpan(@NonNull final String name) {
         final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
         final Span span = tracer.spanBuilder(name).startSpan();
 
@@ -48,11 +65,20 @@ public class OTelUtility {
         return span;
     }
 
+    public static Span getCurrentSpan() {
+        try {
+            return Span.current();
+        } catch (final NoSuchMethodError error) {
+            Logger.error(TAG + ":getCurrentSpan", error.getMessage(), error);
+            return new NoopSpan(INVALID);
+        }
+    }
+
     /**
      * Get name of the current span, if possible.
      **/
     @Nullable
-    private static String getCurrentSpanName(){
+    private static String getCurrentSpanName() {
         final Span span = Span.current();
         if (span instanceof ReadableSpan) {
             return ((ReadableSpan) span).getName();

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -23,34 +23,17 @@
 package com.microsoft.identity.common.java.opentelemetry;
 
 import static com.microsoft.identity.common.java.opentelemetry.AttributeName.parent_span_name;
-import static io.opentelemetry.api.trace.TraceFlags.fromByte;
-
-import com.microsoft.identity.common.java.logging.Logger;
 
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.internal.ImmutableSpanContext;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.SpanId;
-import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import lombok.NonNull;
 
 public class OTelUtility {
     private static final String TAG = OTelUtility.class.getSimpleName();
-
-    private static final SpanContext INVALID =
-            ImmutableSpanContext.create(
-                    TraceId.getInvalid(),
-                    SpanId.getInvalid(),
-                    fromByte((byte) 0x00),
-                    new NoopTraceState(),
-                    /* remote= */ false,
-                    /* valid= */ false
-            );
 
     /**
      * Creates a span (with shared basic attributes).
@@ -65,21 +48,12 @@ public class OTelUtility {
         return span;
     }
 
-    public static Span getCurrentSpan() {
-        try {
-            return Span.current();
-        } catch (final NoSuchMethodError error) {
-            Logger.error(TAG + ":getCurrentSpan", error.getMessage(), error);
-            return new NoopSpan(INVALID);
-        }
-    }
-
     /**
      * Get name of the current span, if possible.
      **/
     @Nullable
     private static String getCurrentSpanName() {
-        final Span span = Span.current();
+        final Span span = SpanExtension.current();
         if (span instanceof ReadableSpan) {
             return ((ReadableSpan) span).getName();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CO
+package com.microsoft.identity.common.java.opentelemetry;
+
+import static io.opentelemetry.api.trace.TraceFlags.fromByte;
+
+import com.microsoft.identity.common.java.logging.Logger;
+
+import io.opentelemetry.api.internal.ImmutableSpanContext;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
+
+/**
+ * Extension methods for {@link Span}.
+ * <p>
+ * This basically provides a custom, safe implementation of {@link Span#current()} to be used in
+ * MSAL for scenarios where minSdkVersion of calling application < 24. The reason for this is
+ * because the default no-op implementation uses "static interface methods" and these get left out
+ * of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because
+ * the consumers-rules are NOT honored when minification is disabled and R8 applies some default
+ * proguard rules that leaves static interface methods out of the APK. This causes a
+ * "NoSuchMethodError" when such methods are invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class SpanExtension {
+
+    private static final String TAG = SpanExtension.class.getSimpleName();
+
+    private static final SpanContext INVALID =
+            ImmutableSpanContext.create(
+                    TraceId.getInvalid(),
+                    SpanId.getInvalid(),
+                    fromByte((byte) 0x00),
+                    new NoopTraceState(),
+                    /* remote= */ false,
+                    /* valid= */ false
+            );
+
+    public static Span current() {
+        try {
+            return Span.current();
+        } catch (final NoSuchMethodError error) {
+            Logger.error(TAG + ":getCurrentSpan", error.getMessage(), error);
+            return new NoopSpan(INVALID);
+        }
+    }
+
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -21,8 +21,6 @@
 // OUT OF OR IN CO
 package com.microsoft.identity.common.java.opentelemetry;
 
-import static io.opentelemetry.api.trace.TraceFlags.fromByte;
-
 import com.microsoft.identity.common.java.logging.Logger;
 
 import io.opentelemetry.api.internal.ImmutableSpanContext;
@@ -55,7 +53,7 @@ public class SpanExtension {
             ImmutableSpanContext.create(
                     TraceId.getInvalid(),
                     SpanId.getInvalid(),
-                    fromByte((byte) 0x00),
+                    new NoopTraceFlags(),
                     new NoopTraceState(),
                     /* remote= */ false,
                     /* valid= */ false

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/JweResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/JweResponse.java
@@ -24,6 +24,7 @@
 package com.microsoft.identity.common.java.platform;
 
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import org.json.JSONException;
@@ -97,7 +98,7 @@ public class JweResponse {
     }
 
     public static JweResponse parseJwe(String jwe) throws JSONException {
-        final Span span = Span.current();
+        final Span span = SpanExtension.current();
         JweResponse response = new JweResponse();
 
         String[] split = jwe.split("\\.");

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -53,6 +53,7 @@ import com.microsoft.identity.common.java.net.HttpConstants;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationResponse;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErrorResponse;
@@ -619,7 +620,7 @@ public class MicrosoftStsOAuth2Strategy
                 }
             }
 
-            Span.current().setAttribute(
+            SpanExtension.current().setAttribute(
                     AttributeName.ccs_request_id.name(),
                     response.getHeaderValue(XMS_CCS_REQUEST_ID, 0));
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/HashMapExtensions.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/HashMapExtensions.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.java.util;
 
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -59,7 +60,7 @@ public class HashMapExtensions {
      */
     public static HashMap<String, String> getJsonResponseFromResponseBody(String responseBody) throws JSONException {
         final HashMap<String, String> response = new HashMap<>();
-        final Span span = Span.current();
+        final Span span = SpanExtension.current();
         span.setAttribute(AttributeName.response_body_length.name(), responseBody.length());
         if (!StringUtil.isNullOrEmpty(responseBody)) {
             final JSONObject jsonObject = new JSONObject(responseBody);

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -21,4 +21,10 @@
     <!-- This warns when a field is never read. -->
     <Bug pattern="URF_UNREAD_FIELD" />
 </Match>
+<Match>
+    <!-- Return value of method without side effect is ignored. -->
+    <!-- Adding this primarily for CryptoFactoryTelemetryHelper where this shows up -->
+    <Class name="com.microsoft.identity.common.java.opentelemetry.CryptoFactoryTelemetryHelper" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+</Match>
 </FindBugsFilter>


### PR DESCRIPTION
Fix https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1715

This basically provides a custom, safe implementation of `Span.current()` method to be used in MSAL for scenarios where minSdkVersion of calling application < 24. The reason for this is because the default no-op implementation uses "static interface methods" and these get left out of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT honored when minification is disabled and R8 applies some default proguard rules that leaves static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are invoked.

We are just catching the exception and return the Noop based on that because there isn't a way to know about application's minSdk AND their minification settings. 

This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24. The issue only arises for the some MSAL consumers falling into the above situation. Tracing is disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its own Noop implementations, however, here we are just providing our own that DON'T use static interface methods.

Related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2047