### PR TITLE
Add support to reset broadcast Executor service

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.Next
 - [MINOR] Add Open Telemetry explicitly in common as transitive is set to false (#1882)
 - [MINOR] Add open telemetry to consumer rules (#1883)
 - [PATCH] Fixes MSAL Issue #1715 (#1894)
+- [MINOR] Add support to reset broadcast Executor service (#1895)
 
 V.8.0.3
 ----------
@@ -123,7 +124,7 @@ Version 4.0.3
 
 Version 4.0.2
 ----------
-- [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689, #1690) 
+- [PATCH] Port #1662 into the new common4j class - since StorageHelper is no longer used (#1689, #1690)
 
 Version 4.0.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -82,6 +82,9 @@ public enum LocalBroadcaster {
         });
     }
 
+    /**
+     * Resets the broadcast executor service.
+     */
     public void resetBroadcast() {
         shutdownAndAwaitTerminationForBroadcasterService();
         sBroadcastExecutor = Executors.newSingleThreadExecutor();

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -27,6 +27,7 @@ import com.microsoft.identity.common.java.logging.Logger;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import lombok.NonNull;
 
@@ -34,7 +35,7 @@ public enum LocalBroadcaster {
     INSTANCE;
 
     private static final String TAG = LocalBroadcaster.class.getSimpleName();
-    private static final ExecutorService sBroadcastExecutor = Executors.newSingleThreadExecutor();
+    private static ExecutorService sBroadcastExecutor = Executors.newSingleThreadExecutor();
 
     public interface IReceiverCallback {
         void onReceive(@NonNull final PropertyBag propertyBag);
@@ -79,5 +80,26 @@ public enum LocalBroadcaster {
                 }
             }
         });
+    }
+
+    public void resetBroadcast() {
+        shutdownAndAwaitTerminationForBroadcasterService();
+        sBroadcastExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    void shutdownAndAwaitTerminationForBroadcasterService() {
+        final String methodName = ":shutdownAndAwaitTerminationForBroadcasterService";
+        sBroadcastExecutor.shutdown();
+        try {
+            if (!sBroadcastExecutor.awaitTermination(20, TimeUnit.SECONDS)) {
+                sBroadcastExecutor.shutdownNow();
+                if (!sBroadcastExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    Logger.info(TAG + methodName, "broadcastExecutor did not terminate");
+                }
+            }
+        } catch (InterruptedException ex) {
+            sBroadcastExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -85,12 +85,12 @@ public enum LocalBroadcaster {
     /**
      * Resets the broadcast executor service.
      */
-    public void resetBroadcast() {
+    public static void resetBroadcast() {
         shutdownAndAwaitTerminationForBroadcasterService();
         sBroadcastExecutor = Executors.newSingleThreadExecutor();
     }
 
-    private void shutdownAndAwaitTerminationForBroadcasterService() {
+    private static void shutdownAndAwaitTerminationForBroadcasterService() {
         final String methodName = ":shutdownAndAwaitTerminationForBroadcasterService";
         sBroadcastExecutor.shutdown();
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -90,7 +90,7 @@ public enum LocalBroadcaster {
         sBroadcastExecutor = Executors.newSingleThreadExecutor();
     }
 
-    void shutdownAndAwaitTerminationForBroadcasterService() {
+    private void shutdownAndAwaitTerminationForBroadcasterService() {
         final String methodName = ":shutdownAndAwaitTerminationForBroadcasterService";
         sBroadcastExecutor.shutdown();
         try {


### PR DESCRIPTION
Currently there is no way of synchronizing between MSAL CPP code and Android common broadcast service. 
We have seen MSAL Android nightly tests fail when the broadcast to cancel a web flow is delayed and in the meantime another test starts executing.
The cancel broadcast is triggered after the first test has ended and the second test starts executing resulting in the second test failing.
Logs for this case can be found here: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1990045

So, with the proposed change we intend to call the resetBroadcast() method before starting a new test to make sure that the stale broadcast does not interfere with the new test.