### PR TITLE
Enable JDK 11 for common-ci pipeline

### DIFF
--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -39,6 +39,8 @@ steps:
 - task: Gradle@2
   displayName: Run unit tests
   inputs:
+    javaHomeSelection: JDKVersion
+    jdkVersionOption: "1.11"
     tasks: '${{ parameters.project }}:test${{ parameters.variant }} ${{ parameters.testArguments }}'
 - task: Gradle@2
   displayName: Publish

--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -45,6 +45,8 @@ steps:
 - task: Gradle@2
   displayName: Publish
   inputs:
+    javaHomeSelection: JDKVersion
+    jdkVersionOption: "1.11"
     tasks: '${{ parameters.project }}:publish${{ parameters.variant }} ${{ parameters.buildArguments }}'
 - ${{ if ne(parameters.artifactFolder, '') }}:
   - task: CopyFiles@2

--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -33,6 +33,8 @@ steps:
 - task: Gradle@2
   displayName: Assemble ${{ parameters.project }} ${{ parameters.variant }}
   inputs:
+    javaHomeSelection: JDKVersion
+    jdkVersionOption: "1.11"
     tasks: '${{ parameters.project }}:clean ${{ parameters.project }}:assemble${{ parameters.variant }} ${{ parameters.buildArguments }}'
 - task: Gradle@2
   displayName: Run unit tests


### PR DESCRIPTION
### What
Enable JDK 11 for common-ci pipeline

### Why
The common-ci pipeline has been falling since Oct. Thus we don't have new published libraries for testUtils and other common test libraries with our latest code. These published libs are consumed by OneAuth.

#### How
With the move to target SDK 31 we need to use JDK 11 for the gradle tasks in our pipelines
This work has already been done for other pipelines (PR:1834) but was missing from the common-ci pipeline, which is covered in this change 

### Testing
A successful run with these changes: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1016073&view=results