### PR TITLE
Added android device type method to get the specific device type

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -22,8 +22,13 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Bundle;
 
+import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.platform.AbstractDeviceMetadata;
 
 import lombok.NonNull;
@@ -34,6 +39,8 @@ import lombok.NonNull;
 public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
 
     private static final String ANDROID_DEVICE_TYPE = "Android";
+    private static final String DEVICE_TYPE = "DeviceType";
+    private static final String TAG = AndroidDeviceMetadata.class.getSimpleName();
 
     @Override
     @NonNull
@@ -63,7 +70,9 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     }
 
     @Override
-    public @NonNull String getOsForMats() { return android.os.Build.VERSION.RELEASE; }
+    public @NonNull String getOsForMats() {
+        return android.os.Build.VERSION.RELEASE;
+    }
 
     @Override
     public @NonNull String getOsForDrs() {
@@ -80,6 +89,29 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     @NonNull
     public String getManufacturer() {
         return Build.MANUFACTURER;
+    }
+
+    /**
+     * Get the android device type, i.e; if it is an nGMS teams device or a mobile device
+     *
+     * @param context {@link Context}
+     * @return device type
+     */
+    public static String getAndroidDeviceTypeFromMetadata(@NonNull final Context context) {
+        final String methodTag = TAG + " :getDeviceType";
+        String defaultDeviceType = "mobileDevice";
+        try {
+            final PackageManager packageManager = context.getPackageManager();
+            final ApplicationInfo appInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            final Bundle metaDataBundle = appInfo.metaData;
+            final String deviceType = metaDataBundle.getString(DEVICE_TYPE, defaultDeviceType);
+            Logger.verbose(methodTag, "Setting the deviceType as " + deviceType);
+            return deviceType;
+        } catch (final PackageManager.NameNotFoundException e) {
+            // Do not throw the exception to break the auth request when getting the app's telemetry
+            Logger.warn(methodTag, "Unable to find the app's package name from PackageManager.");
+        }
+        return defaultDeviceType;
     }
 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -41,6 +41,8 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     private static final String ANDROID_DEVICE_TYPE = "Android";
     private static final String DEVICE_TYPE = "DeviceType";
     private static final String TAG = AndroidDeviceMetadata.class.getSimpleName();
+    private static final String MOBILE_DEVICE = "mobileDevice";
+    private static final String UNKNOWN_DEVICE = "unknown";
 
     @Override
     @NonNull
@@ -99,19 +101,19 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
      */
     public static String getAndroidDeviceTypeFromMetadata(@NonNull final Context context) {
         final String methodTag = TAG + " :getDeviceType";
-        String defaultDeviceType = "mobileDevice";
         try {
             final PackageManager packageManager = context.getPackageManager();
             final ApplicationInfo appInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             final Bundle metaDataBundle = appInfo.metaData;
-            final String deviceType = metaDataBundle.getString(DEVICE_TYPE, defaultDeviceType);
+            // If the deviceType property is not found, default it to mobile device
+            final String deviceType = metaDataBundle.getString(DEVICE_TYPE, MOBILE_DEVICE);
             Logger.verbose(methodTag, "Setting the deviceType as " + deviceType);
             return deviceType;
         } catch (final PackageManager.NameNotFoundException e) {
             // Do not throw the exception to break the auth request when getting the app's telemetry
             Logger.warn(methodTag, "Unable to find the app's package name from PackageManager.");
+            return UNKNOWN_DEVICE;
         }
-        return defaultDeviceType;
     }
 }
 


### PR DESCRIPTION
Added helper method to get android device type from package metadata
Related PR : https://github.com/AzureAD/ad-accounts-for-android/pull/2051
