### PR TITLE
NFC Reminder Dialog (CBA)

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/DialogHolder.java
@@ -149,6 +149,17 @@ public class DialogHolder {
     }
 
     /**
+     * Builds and shows a SmartcardDialog that notifies user that NFC is not on for their device.
+     * @param dismissCallback a callback that holds logic to be run upon dismissal of the dialog.
+     */
+    public synchronized void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+        showDialog(new SmartcardNfcReminderDialog(
+                dismissCallback,
+                mActivity
+        ));
+    }
+
+    /**
      * Dismisses current dialog, if one is showing.
      */
     public synchronized void dismissDialog() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardNfcReminderDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardNfcReminderDialog.java
@@ -30,14 +30,22 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.microsoft.identity.common.R;
 
+/**
+ * Builds a dialog that notifies the user to turn on NFC in settings if they want to authenticate via NFC.
+ */
 public class SmartcardNfcReminderDialog extends SmartcardDialog {
 
-    private final PositiveButtonListener mPositiveButtonListener;
+    private final DismissCallback mDismissCallback;
 
-    public SmartcardNfcReminderDialog(@NonNull final PositiveButtonListener positiveButtonListener,
+    /**
+     * Creates new instance of SmartcardNfcReminderDialog.
+     * @param dismissCallback callback containing logic to be run upon dialog dismissal.
+     * @param activity current host activity.
+     */
+    public SmartcardNfcReminderDialog(@NonNull final DismissCallback dismissCallback,
                                       @NonNull final Activity activity) {
         super(activity);
-        mPositiveButtonListener = positiveButtonListener;
+        mDismissCallback = dismissCallback;
         createDialog();
     }
 
@@ -58,7 +66,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                         .setPositiveButton(R.string.smartcard_nfc_reminder_dialog_positive_button, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                mPositiveButtonListener.onClick();
+                                mDismissCallback.onClick();
                             }
                         });
                 final AlertDialog dialog = builder.create();
@@ -69,7 +77,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                 dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        mPositiveButtonListener.onClick();
+                        mDismissCallback.onClick();
                     }
                 });
                 mDialog = dialog;
@@ -86,9 +94,9 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
     }
 
     /**
-     * Listener interface for a positive button click.
+     * Callback interface for a dialog dismissal.
      */
-    public interface PositiveButtonListener {
+    public interface DismissCallback {
         void onClick();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardNfcReminderDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardNfcReminderDialog.java
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.challengehandlers;
+
+import android.app.Activity;
+import android.content.DialogInterface;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+
+import com.microsoft.identity.common.R;
+
+public class SmartcardNfcReminderDialog extends SmartcardDialog {
+
+    private final PositiveButtonListener mPositiveButtonListener;
+
+    public SmartcardNfcReminderDialog(@NonNull final PositiveButtonListener positiveButtonListener,
+                                      @NonNull final Activity activity) {
+        super(activity);
+        mPositiveButtonListener = positiveButtonListener;
+        createDialog();
+    }
+
+    /**
+     * Should build an Android Dialog object and set it to mDialog.
+     * Dialog objects must be built/interacted with on the UI thread.
+     */
+    @Override
+    void createDialog() {
+        mActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final AlertDialog.Builder builder = new AlertDialog.Builder(mActivity, R.style.UserChoiceAlertDialogTheme)
+                        //Sets topmost text of dialog.
+                        .setTitle(R.string.smartcard_nfc_reminder_dialog_title)
+                        //Sets subtext of the title.
+                        .setMessage(R.string.smartcard_nfc_reminder_dialog_message)
+                        .setPositiveButton(R.string.smartcard_nfc_reminder_dialog_positive_button, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                mPositiveButtonListener.onClick();
+                            }
+                        });
+                final AlertDialog dialog = builder.create();
+                //If user touches outside dialog, the default behavior makes the dialog disappear without really doing anything.
+                //Adding this line in disables this default behavior so that the user can only exit by hitting the cancel button.
+                dialog.setCanceledOnTouchOutside(false);
+                //Handle back button the same as the positive button.
+                dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        mPositiveButtonListener.onClick();
+                    }
+                });
+                mDialog = dialog;
+            }
+        });
+    }
+
+    /**
+     * Should dismiss dialog and call the appropriate methods to help cancel the CBA flow.
+     */
+    @Override
+    void onCancelCba() {
+        //This method will never be called on this dialog, so no logic needed.
+    }
+
+    /**
+     * Listener interface for a positive button click.
+     */
+    public interface PositiveButtonListener {
+        void onClick();
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/YubiKitCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/YubiKitCertBasedAuthManager.java
@@ -154,7 +154,7 @@ public class YubiKitCertBasedAuthManager extends AbstractSmartcardCertBasedAuthM
         } catch (@NonNull final NfcNotAvailable e) {
             if (e.isDisabled()) {
                 //User will not be blocked from seeing the regular smartcard prompt,
-                // but appropriate dialog should be shown.
+                // but appropriate reminder dialog should be shown.
                 Logger.info(TAG, "Device has NFC functionality turned off.");
                 return true;
             }


### PR DESCRIPTION
## Summary
This PR builds upon [the main NFC feature PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1896).
When a user is trying CBA for the first time, they may not know that they have NFC turned off, and thus won't be able to authenticate with their smartcard via NFC. 
I added logic to show a reminder dialog when a user is going forth with smartcard CBA, but it is detected that NFC is turned off. The dialog tells them to turn on NFC in settings, then retry the CBA flow. 
When the user dismisses the dialog by either clicking "got it" or pressing the back button, they will be brought to the regular smartcard prompt dialog. This ensures that users wishing to use USB only (and have NFC turned off) won't be blocked from authenticating via USB.

I tested with both msalTestApp and AzureSample by making sure the dialog came up when NFC was turned off and that the regular NFC CBA flow was successful once NFC was turned on again. 