### PR TITLE
Otel for CertBasedAuth

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.PackageHelper;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CertBasedAuthFactory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ICertBasedAuthChallengeHandler;
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
@@ -461,6 +462,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (mCertBasedAuthChallengeHandler != null) {
             mCertBasedAuthChallengeHandler.cleanUp();
         }
+        CertBasedAuthTelemetryHelper helper = new CertBasedAuthTelemetryHelper();
         mCertBasedAuthChallengeHandler = mCertBasedAuthFactory.createCertBasedAuthChallengeHandler();
         mCertBasedAuthChallengeHandler.processChallenge(clientCertRequest);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -42,7 +42,6 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.PackageHelper;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CertBasedAuthFactory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ICertBasedAuthChallengeHandler;
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
@@ -462,7 +461,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (mCertBasedAuthChallengeHandler != null) {
             mCertBasedAuthChallengeHandler.cleanUp();
         }
-        CertBasedAuthTelemetryHelper helper = new CertBasedAuthTelemetryHelper();
         mCertBasedAuthChallengeHandler = mCertBasedAuthFactory.createCertBasedAuthChallengeHandler();
         mCertBasedAuthChallengeHandler.processChallenge(clientCertRequest);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/AbstractSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/AbstractSmartcardCertBasedAuthManager.java
@@ -26,6 +26,8 @@ import android.app.Activity;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
@@ -84,8 +86,9 @@ public abstract class AbstractSmartcardCertBasedAuthManager {
 
     /**
      * Runs implementation specific processes that may need to occur just before calling {@link android.webkit.ClientCertRequest#proceed(PrivateKey, X509Certificate[])}.
+     * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
-    abstract void initBeforeProceedingWithRequest();
+    abstract void initBeforeProceedingWithRequest(@NonNull final CertBasedAuthTelemetryHelper telemetryHelper);
 
     /**
      * Cleanup to be done upon host activity being destroyed.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CertBasedAuthFactory.java
@@ -41,6 +41,7 @@ public class CertBasedAuthFactory {
     private static final String USER_CANCEL_MESSAGE = "User canceled smartcard CBA flow.";
     private static final String ON_DEVICE_CHOICE = "on-device";
     private static final String SMARTCARD_CHOICE = "smartcard";
+    private static final String NON_APPLICABLE = "N/A";
     private final Activity mActivity;
     private final AbstractSmartcardCertBasedAuthManager mSmartcardCertBasedAuthManager;
     private final DialogHolder mDialogHolder;
@@ -77,8 +78,8 @@ public class CertBasedAuthFactory {
      */
     public void createCertBasedAuthChallengeHandler(@NonNull final CertBasedAuthChallengeHandlerCallback callback) {
         final CertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
-        telemetryHelper.setUserChoice(null);
-        telemetryHelper.setCertBasedAuthChallengeHandler(null);
+        telemetryHelper.setUserChoice(NON_APPLICABLE);
+        telemetryHelper.setCertBasedAuthChallengeHandler(NON_APPLICABLE);
         if (mSmartcardCertBasedAuthManager == null) {
             //Smartcard CBA is not available, so default to on-device.
             callback.onReceived(new OnDeviceCertBasedAuthChallengeHandler(

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CertBasedAuthFactory.java
@@ -26,6 +26,7 @@ import android.app.Activity;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 
 /**
@@ -70,12 +71,23 @@ public class CertBasedAuthFactory {
     public ICertBasedAuthChallengeHandler createCertBasedAuthChallengeHandler() {
         if (mSmartcardCertBasedAuthManager == null) {
             //Smartcard CBA is not available, so default to on-device.
-            return new OnDeviceCertBasedAuthChallengeHandler(mActivity);
+            return new OnDeviceCertBasedAuthChallengeHandler(
+                    mActivity,
+                    new CertBasedAuthTelemetryHelper());
         }
         else if (mSmartcardCertBasedAuthManager.isUsbDeviceConnected()) {
-            return new SmartcardCertBasedAuthChallengeHandler(mActivity, mSmartcardCertBasedAuthManager, new DialogHolder(mActivity), false);
+            return new SmartcardCertBasedAuthChallengeHandler(
+                    mActivity,
+                    mSmartcardCertBasedAuthManager,
+                    new DialogHolder(mActivity),
+                    new CertBasedAuthTelemetryHelper(),
+                    false);
         }
-        return new UserChoiceCertBasedAuthChallengeHandler(mActivity, mSmartcardCertBasedAuthManager, new DialogHolder(mActivity));
+        return new UserChoiceCertBasedAuthChallengeHandler(
+                mActivity,
+                mSmartcardCertBasedAuthManager,
+                new DialogHolder(mActivity),
+                new CertBasedAuthTelemetryHelper());
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SmartcardCertBasedAuthChallengeHandler.java
@@ -82,6 +82,7 @@ public class SmartcardCertBasedAuthChallengeHandler implements ICertBasedAuthCha
         mTelemetryHelper = telemetryHelper;
         mTelemetryHelper.setCertBasedAuthChallengeHandler(TAG);
         mProceedWithNfc = proceedWithNfc;
+        mTelemetryHelper.setSmartcardConnectionType(proceedWithNfc ? "NFC" : "USB");
         mSmartcardCertBasedAuthManager.setConnectionCallback(new AbstractSmartcardCertBasedAuthManager.IConnectionCallback() {
             @Override
             public void onCreateConnection(final boolean isNfc) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/UserChoiceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/UserChoiceCertBasedAuthChallengeHandler.java
@@ -29,6 +29,7 @@ import android.webkit.ClientCertRequest;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 
 /**
@@ -37,9 +38,11 @@ import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
  */
 public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthChallengeHandler {
     private static final String TAG = UserChoiceCertBasedAuthChallengeHandler.class.getSimpleName();
+    private static final String USER_CANCEL_MESSAGE = "User canceled smartcard CBA flow.";
     private final Activity mActivity;
     protected final AbstractSmartcardCertBasedAuthManager mSmartcardCertBasedAuthManager;
     private final DialogHolder mDialogHolder;
+    private final CertBasedAuthTelemetryHelper mTelemetryHelper;
     private ICertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
 
     /**
@@ -47,13 +50,17 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
      * @param activity current host activity.
      * @param smartcardCertBasedAuthManager AbstractSmartcardCertBasedAuthManager instance.
      * @param dialogHolder DialogHolder instance.
+     * @param telemetryHelper CertBasedAuthTelemetryHelder instance.
      */
     public UserChoiceCertBasedAuthChallengeHandler(@NonNull final Activity activity,
                                                    @NonNull final AbstractSmartcardCertBasedAuthManager smartcardCertBasedAuthManager,
-                                                   @NonNull final DialogHolder dialogHolder) {
+                                                   @NonNull final DialogHolder dialogHolder,
+                                                   @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
         mActivity = activity;
         mSmartcardCertBasedAuthManager = smartcardCertBasedAuthManager;
         mDialogHolder = dialogHolder;
+        mTelemetryHelper = telemetryHelper;
+        mTelemetryHelper.setCertBasedAuthChallengeHandler(TAG);
     }
 
 
@@ -66,9 +73,7 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
     public void emitTelemetryForCertBasedAuthResults(@NonNull RawAuthorizationResult response) {
         if (mCertBasedAuthChallengeHandler != null) {
             mCertBasedAuthChallengeHandler.emitTelemetryForCertBasedAuthResults(response);
-            return;
         }
-        //TODO: Handle any local error telemetry here.
     }
 
     /**
@@ -101,7 +106,7 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
                 //Position 1 -> Smartcard
                 if (checkedPosition == 0) {
                     mDialogHolder.dismissDialog();
-                    mCertBasedAuthChallengeHandler = new OnDeviceCertBasedAuthChallengeHandler(mActivity);
+                    mCertBasedAuthChallengeHandler = new OnDeviceCertBasedAuthChallengeHandler(mActivity, mTelemetryHelper);
                     mCertBasedAuthChallengeHandler.processChallenge(request);
                 } else {
                     setUpForSmartcardCertBasedAuth(request);
@@ -112,6 +117,7 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
             @Override
             public void onCancel() {
                 mDialogHolder.dismissDialog();
+                mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
                 request.cancel();
             }
         });
@@ -140,6 +146,7 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
             @Override
             public void onCancel() {
                 mDialogHolder.dismissDialog();
+                mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
                 request.cancel();
             }
         });
@@ -172,6 +179,7 @@ public class UserChoiceCertBasedAuthChallengeHandler implements ICertBasedAuthCh
                 mActivity,
                 mSmartcardCertBasedAuthManager,
                 mDialogHolder,
+                mTelemetryHelper,
                 isNfc);
         mCertBasedAuthChallengeHandler.processChallenge(request);
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -78,5 +78,10 @@ public enum AttributeName {
     /**
      * Indicates which CBA flow the user intended to select.
      */
-    cert_based_auth_user_choice
+    cert_based_auth_user_choice,
+
+    /**
+     * Indicates if user with smartcard connected via USB or NFC.
+     */
+    cert_based_auth_smartcard_connection_type
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -63,4 +63,20 @@ public enum AttributeName {
      * Indicates the request id value for cached credential service (if used) on server side
      */
     ccs_request_id,
+
+    /**
+     * Indicates which CertBasedAuthChallengeHandler was handling the CBA flow.
+     */
+    cert_based_auth_challenge_handler,
+
+    /**
+     * Indicates if PivProvider (part of YubiKit) was already present in the
+     *  Security static list prior to adding a new PivProvider.
+     */
+    cert_based_auth_existing_piv_provider_present,
+
+    /**
+     * Indicates which CBA flow the user intended to select.
+     */
+    cert_based_auth_user_choice
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
@@ -76,11 +76,7 @@ public class CertBasedAuthTelemetryHelper {
      * @param message descriptive cause of failure message.
      */
     public void setResultFailure(@NonNull final String message) {
-        //setting the error_message attribute manually since there's no exception to record.
-        mSpan.setAttribute(
-                "error_message",
-                message);
-        mSpan.setStatus(StatusCode.ERROR);
+        mSpan.setStatus(StatusCode.ERROR, message);
         mSpan.end();
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.opentelemetry;
 
+import javax.annotation.Nullable;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import lombok.NonNull;
@@ -100,5 +102,16 @@ public class CertBasedAuthTelemetryHelper {
         mSpan.setAttribute(
                 AttributeName.cert_based_auth_user_choice.name(),
                 choice);
+    }
+
+    /**
+     * Sets attribute that indicates if a user selecting smartcard CBA connected via USB or NFC.
+     * @param connectionType string indicating "USB" or "NFC".
+     */
+    public void setSmartcardConnectionType(@NonNull final String connectionType) {
+        mSpan.setAttribute(
+                AttributeName.cert_based_auth_smartcard_connection_type.name(),
+                connectionType
+        );
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import lombok.NonNull;
+
+/**
+ * Assists classes associated with Certificate Based Authentication (CBA) with
+ *  telemetry-related tasks.
+ */
+public class CertBasedAuthTelemetryHelper {
+
+    private final Span mSpan;
+
+    public CertBasedAuthTelemetryHelper() {
+        mSpan = OTelUtility.createSpan(SpanName.CertBasedAuth.name());
+    }
+
+    /**
+     * Sets attribute that indicates the ICertBasedAuthChallengeHandler handling the current CBA flow.
+     * @param challengeHandlerName name of the ICertBasedAuthChallengeHandler class.
+     */
+    public void setCertBasedAuthChallengeHandler(@NonNull final String challengeHandlerName) {
+        mSpan.setAttribute(
+                AttributeName.cert_based_auth_challenge_handler.name(),
+                challengeHandlerName);
+    }
+
+    /**
+     * Sets attribute that indicates if a PivProvider instance is already present in the
+     *  Java Security static list upon adding a new instance.
+     * @param present true if PivProvider instance present; false otherwise.
+     */
+    public void setExistingPivProviderPresent(final boolean present) {
+        mSpan.setAttribute(
+                AttributeName.cert_based_auth_existing_piv_provider_present.name(),
+                present);
+    }
+
+    /**
+     * Indicates on the Span that CBA was successful and then ends current Span.
+     */
+    public void setResultSuccess() {
+        mSpan.setStatus(StatusCode.OK);
+        mSpan.end();
+    }
+
+    /**
+     * Indicates on the Span that CBA failed and then ends current Span.
+     * This method should mainly be used for cases without an exception,
+     *  such as user cancellation, no certificates on smartcard, etc.
+     * @param message descriptive cause of failure message.
+     */
+    public void setResultFailure(@NonNull final String message) {
+        //setting the error_message attribute manually since there's no exception to record.
+        mSpan.setAttribute(
+                "error_message",
+                message);
+        mSpan.setStatus(StatusCode.ERROR);
+        mSpan.end();
+    }
+
+    /**
+     * Indicates on the Span that CBA failed and then ends current Span.
+     * @param exception exception thrown upon error.
+     */
+    public void setResultFailure(@NonNull final Exception exception) {
+        mSpan.recordException(exception);
+        mSpan.setStatus(StatusCode.ERROR);
+        mSpan.end();
+    }
+
+    /**
+     * Sets attribute that indicates the user's intended choice for CBA (smartcard or on-device).
+     * @param choice string indicating user's choice for CBA.
+     */
+    public void setUserChoice(@NonNull final String choice) {
+        mSpan.setAttribute(
+                AttributeName.cert_based_auth_user_choice.name(),
+                choice);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
@@ -22,8 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.opentelemetry;
 
-import javax.annotation.Nullable;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import lombok.NonNull;
@@ -44,7 +43,7 @@ public class CertBasedAuthTelemetryHelper {
      * Sets attribute that indicates the ICertBasedAuthChallengeHandler handling the current CBA flow.
      * @param challengeHandlerName name of the ICertBasedAuthChallengeHandler class.
      */
-    public void setCertBasedAuthChallengeHandler(@Nullable final String challengeHandlerName) {
+    public void setCertBasedAuthChallengeHandler(@NonNull final String challengeHandlerName) {
         mSpan.setAttribute(
                 AttributeName.cert_based_auth_challenge_handler.name(),
                 challengeHandlerName);
@@ -64,6 +63,8 @@ public class CertBasedAuthTelemetryHelper {
     /**
      * Indicates on the Span that CBA was successful and then ends current Span.
      */
+    //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
+    @SuppressFBWarnings
     public void setResultSuccess() {
         mSpan.setStatus(StatusCode.OK);
         mSpan.end();
@@ -75,6 +76,8 @@ public class CertBasedAuthTelemetryHelper {
      *  such as user cancellation, no certificates on smartcard, etc.
      * @param message descriptive cause of failure message.
      */
+    //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
+    @SuppressFBWarnings
     public void setResultFailure(@NonNull final String message) {
         mSpan.setStatus(StatusCode.ERROR, message);
         mSpan.end();
@@ -84,6 +87,8 @@ public class CertBasedAuthTelemetryHelper {
      * Indicates on the Span that CBA failed and then ends current Span.
      * @param exception exception thrown upon error.
      */
+    //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
+    @SuppressFBWarnings
     public void setResultFailure(@NonNull final Exception exception) {
         mSpan.recordException(exception);
         mSpan.setStatus(StatusCode.ERROR);
@@ -94,7 +99,7 @@ public class CertBasedAuthTelemetryHelper {
      * Sets attribute that indicates the user's intended choice for CBA (smartcard or on-device).
      * @param choice string indicating user's intended choice for CBA.
      */
-    public void setUserChoice(@Nullable final String choice) {
+    public void setUserChoice(@NonNull final String choice) {
         mSpan.setAttribute(
                 AttributeName.cert_based_auth_user_choice.name(),
                 choice);

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -35,5 +35,6 @@ public enum SpanName {
     WorkplaceJoin,
     DoDiscovery,
     WorkplaceLeave,
-    DeviceState
+    DeviceState,
+    CertBasedAuth
 }


### PR DESCRIPTION
## Summary
This PR adds OTel to the latest CBA feature currently in review. 
Due to the asynchronous nature of CBA, `CertBasedAuthTelemetryHelper` was created to keep track of a Span object that can collect attributes for the duration of a CBA flow. This Span is never set as "current", as an instance of `CertBasedAuthTelemetryHelper` is passed along as a parameter instead.
Telemetry details:
Span name: CertBasedAuth
Attributes:
- `cert_based_auth_challenge_handler` (string):  Indicates which CertBasedAuthChallengeHandler was handling the CBA flow. ( can be null)
- `cert_based_auth_existing_piv_provider_present` (boolean): Indicates if PivProvider (part of YubiKit) was already present in the Security static list prior to adding a new PivProvider.
-  `cert_based_auth_user_choice` (string): Indicates which CBA flow the user intended to select. (smartcard, on-device, null)

An OK status will have no message attached, while an ERROR status will either have an exception or error message attached.
Note that because the CBA feature is housed in common, the attribute names are in `AttributeNames` located in common4j, but they also need to be in broker4j (this will be released as a PR once the updated CBA feature is ready to be merged into dev).

I've made sure that the spans and attributes are being propagated into Aria via the Aria live events as well as via Kustos queries.

[Link to NFC Feature draft PR (main feature branch)](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1896)