### PR TITLE
Support 2 new UI Test Cases, fix update scenario in Play Store

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -104,13 +104,6 @@ public class AzureSampleApp extends App {
                 new MicrosoftStsPromptHandler(promptHandlerParameters);
 
         microsoftStsPromptHandler.handlePrompt(username, password);
-
-        // sleep as it can take a bit for UPN to appear in Azure Sample app
-        try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-        } catch (InterruptedException e){
-            e.printStackTrace();
-        }
     }
 
     /**
@@ -132,13 +125,6 @@ public class AzureSampleApp extends App {
             // handle browser first run as applicable
             ((IApp) browser).handleFirstRun();
         }
-
-        // sleep as it can take a bit for UPN to appear in Azure Sample app
-        try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-        } catch (InterruptedException e){
-            e.printStackTrace();
-        }
     }
 
     /**
@@ -157,13 +143,16 @@ public class AzureSampleApp extends App {
      */
     public void confirmSignedIn(@NonNull final String username) {
         Logger.i(TAG, "Confirming account with supplied username is signed in..");
+
+        final UiObject signedInUser = UiAutomatorUtils.obtainUiObjectWithResourceId("com.azuresamples.msalandroidapp:id/current_user");
+
+        // Sometimes need some time for upn to appear
         try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(10));
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
 
-        final UiObject signedInUser = UiAutomatorUtils.obtainUiObjectWithResourceId("com.azuresamples.msalandroidapp:id/current_user");
         try {
             Assert.assertEquals("User is signed into Azure Sample App", username, signedInUser.getText());
         } catch (final UiObjectNotFoundException e) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 
+import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.browser.IBrowser;
 import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
@@ -103,6 +104,34 @@ public class AzureSampleApp extends App {
                 new MicrosoftStsPromptHandler(promptHandlerParameters);
 
         microsoftStsPromptHandler.handlePrompt(username, password);
+
+        // sleep as it can take a bit for UPN to appear in Azure Sample app
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        } catch (InterruptedException e){
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Sign in into the Azure Sample App. Please note that this method performs sign in into the
+     * Single Account Mode Fragment in the Sample App.
+     *
+     * @param browser                     the browser that is expected to be used during sign in flow
+     * @param broker                      the broker used in the test case
+     * @param shouldHandleBrowserFirstRun whether this is the first time the browser being run
+     */
+    public void signInSilentlyWithSingleAccountFragment(@Nullable final IBrowser browser,
+                                                        @NonNull final ITestBroker broker,
+                                                        final boolean shouldHandleBrowserFirstRun) {
+        Logger.i(TAG, "Signing in into Azure Sample App with Single Account Mode Fragment..");
+        // Click Sign In in Single Account Fragment
+        UiAutomatorUtils.handleButtonClick("com.azuresamples.msalandroidapp:id/btn_signIn");
+
+        if (broker == null && browser != null && shouldHandleBrowserFirstRun) {
+            // handle browser first run as applicable
+            ((IApp) browser).handleFirstRun();
+        }
 
         // sleep as it can take a bit for UPN to appear in Azure Sample app
         try {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/AzureSampleApp.java
@@ -144,19 +144,8 @@ public class AzureSampleApp extends App {
     public void confirmSignedIn(@NonNull final String username) {
         Logger.i(TAG, "Confirming account with supplied username is signed in..");
 
-        final UiObject signedInUser = UiAutomatorUtils.obtainUiObjectWithResourceId("com.azuresamples.msalandroidapp:id/current_user");
+        final UiObject signedInUser = UiAutomatorUtils.obtainEnabledUiObjectWithExactText(username);
 
-        // Sometimes need some time for upn to appear
-        try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(10));
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-
-        try {
-            Assert.assertEquals("User is signed into Azure Sample App", username, signedInUser.getText());
-        } catch (final UiObjectNotFoundException e) {
-            throw new AssertionError(e);
-        }
+        Assert.assertTrue("User is signed into Azure Sample App", signedInUser.exists());
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
@@ -28,6 +28,11 @@ package com.microsoft.identity.client.ui.automation.app;
 public interface IApp {
 
     /**
+     * Returns the package name of the broker.
+     */
+    String getPackageName();
+
+    /**
      * Install this app on the device.
      */
     void install();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/IApp.java
@@ -28,7 +28,7 @@ package com.microsoft.identity.client.ui.automation.app;
 public interface IApp {
 
     /**
-     * Returns the package name of the broker.
+     * Returns the package name of the app.
      */
     String getPackageName();
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserEdge.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/browser/BrowserEdge.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client.ui.automation.browser;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
@@ -34,10 +35,6 @@ import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadP
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
-import org.junit.Assert;
-
-import static org.junit.Assert.fail;
-
 /**
  * A model for interacting with the Microsoft Edge Browser App during UI Test.
  */
@@ -46,6 +43,7 @@ public class BrowserEdge extends App implements IBrowser {
     private final static String TAG = BrowserEdge.class.getSimpleName();
     private static final String EDGE_PACKAGE_NAME = "com.microsoft.emmx";
     private static final String EDGE_APP_NAME = "Microsoft Edge";
+    private boolean shouldHandleFirstRun = true;
 
     public BrowserEdge() {
         super(EDGE_PACKAGE_NAME, EDGE_APP_NAME);
@@ -53,19 +51,22 @@ public class BrowserEdge extends App implements IBrowser {
 
     @Override
     public void handleFirstRun() {
-        Logger.i(TAG, "Handle First Run of Browser..");
-        // cancel sync in Edge
-        UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/not_now");
-        sleep(); // need to use sleep due to Edge animations
-        // cancel sharing data
-        UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/not_now");
-        sleep(); // need to use sleep due to Edge animations
-        // cancel personalization
-        UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/fre_share_not_now");
-        sleep();// need to use sleep due to Edge animations
-        // avoid setting default
-        UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/no");
-        sleep();// need to use sleep due to Edge animations
+        if (shouldHandleFirstRun) {
+            Logger.i(TAG, "Handle First Run of Browser..");
+            // cancel sync in Edge
+            UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/not_now");
+            sleep(); // need to use sleep due to Edge animations
+            // cancel sharing data
+            UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/not_now");
+            sleep(); // need to use sleep due to Edge animations
+            // cancel personalization
+            UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/fre_share_not_now");
+            sleep();// need to use sleep due to Edge animations
+            // avoid setting default
+            UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/no");
+            sleep();// need to use sleep due to Edge animations
+            shouldHandleFirstRun = false;
+        }
     }
 
     @Override
@@ -166,5 +167,26 @@ public class BrowserEdge extends App implements IBrowser {
         aadPromptHandler.handlePrompt(username, password);
 
         handleFirstRun();
+    }
+
+    public boolean confirmSignedIn(@Nullable final String username) {
+        Logger.i(TAG, "Checking if account " + username + "is signed in to Edge.");
+        launch();
+
+        // Depending on when edge was opened and when account was signed out, we might see this
+        if (username == null && UiAutomatorUtils.obtainUiObjectWithText("Add account").exists()){
+            return true;
+        }
+
+        UiAutomatorUtils.handleButtonClick("com.microsoft.emmx:id/edge_account_image_view");
+
+        // If we're checking that no account is signed in, we can check for specific text suggesting that the user sign in
+        if (username == null) {
+            final UiObject signInToSyncObject = UiAutomatorUtils.obtainUiObjectWithText("sign in to sync");
+            return signInToSyncObject.exists();
+        }
+
+        final UiObject usernameObject = UiAutomatorUtils.obtainUiObjectWithExactText(username);
+        return usernameObject.exists();
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/GoogleSettings.java
@@ -41,6 +41,7 @@ import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT_LONG;
+import static com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils.handleButtonClick;
 import static com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils.obtainUiObjectWithExactText;
 
 /**
@@ -344,5 +345,22 @@ public class GoogleSettings extends BaseSettings {
         }
     }
 
+    @Override
+    public void disableAppThroughSettings(@NonNull final String packageName) {
+        Logger.i(TAG, "Disabling app through settings: " + packageName);
+        launchAppInfoPage(packageName);
+        // This is the id for the disable button
+        handleButtonClick("com.android.settings:id/button2");
+        // Confirm disabling app
+        handleButtonClick("android:id/button1");
+    }
+
+    @Override
+    public void enableAppThroughSettings(@NonNull final String packageName) {
+        Logger.i(TAG, "Enabling app through settings");
+        launchAppInfoPage(packageName);
+        // This is the id for the enable button
+        handleButtonClick("com.android.settings:id/button2");
+    }
 }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/ISettings.java
@@ -130,4 +130,15 @@ public interface ISettings {
      */
     void launchAppInfoPage(String packageName);
 
+    /**
+     * Disable an app through the device's settings page instead of shell command.
+     * @param packageName name of package to be disabled
+     */
+    public void disableAppThroughSettings(@NonNull final String packageName);
+
+    /**
+     * Enable an app through the device's settings page instead of shell command.
+     * @param packageName name of package to be enabled
+     */
+    public void enableAppThroughSettings(@NonNull final String packageName);
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -218,14 +218,15 @@ public class SamsungSettings extends BaseSettings {
         //TODO: implement removing PIN for SAMSUNG device.
     }
 
-
     @Override
     public void disableAppThroughSettings(@NonNull final String packageName) {
         //TODO: implement disabling app through settings
+        throw new UnsupportedOperationException("We do not support disabling apps through Settings Page on samsung devices");
     }
 
     @Override
     public void enableAppThroughSettings(@NonNull final String packageName) {
         //TODO: implement enabling app through settings
+        throw new UnsupportedOperationException("We do not support enabling apps through Settings Page on samsung devices");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/device/settings/SamsungSettings.java
@@ -217,4 +217,15 @@ public class SamsungSettings extends BaseSettings {
     public void removePinFromDevice(String pin) {
         //TODO: implement removing PIN for SAMSUNG device.
     }
+
+
+    @Override
+    public void disableAppThroughSettings(@NonNull final String packageName) {
+        //TODO: implement disabling app through settings
+    }
+
+    @Override
+    public void enableAppThroughSettings(@NonNull final String packageName) {
+        //TODO: implement enabling app through settings
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -123,6 +123,12 @@ public class PromptHandlerParameters {
     private final boolean staySignedInPageExpected;
 
     /**
+     * Denotes whether or not the Verify Your Identity page is expected to appear during an interactive
+     * token request
+     */
+    private final boolean verifyYourIdentityPageExpected;
+
+    /**
      * Denotes the way in which we want to respond to the enroll page for this request.
      */
     @Builder.Default

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -36,7 +36,6 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import org.junit.Assert;
 
 import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
-import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT_LONG;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
@@ -109,7 +108,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         final UiObject consentScreen = getConsentScreen();
         Assert.assertTrue(
                 "Consent screen does not appear",
-                consentScreen.waitForExists(FIND_UI_ELEMENT_TIMEOUT)
+                consentScreen.exists()
         );
     }
 
@@ -135,7 +134,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         // Confirm On Speed Bump Screen
         final UiObject speedBump = UiAutomatorUtils.obtainUiObjectWithResourceId("appConfirmTitle");
 
-        if (!speedBump.waitForExists(FIND_UI_ELEMENT_TIMEOUT_LONG)) {
+        if (!speedBump.exists()) {
             fail("Speed Bump screen did not show up");
         }
 
@@ -182,5 +181,16 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         } else {
             handleBackButton();
         }
+    }
+
+    @Override
+    public void handleVerifyYourIdentity() {
+        Logger.i(TAG, "Handle Verify Your Identity Page..");
+
+        final UiObject verifyYourIdentity = UiAutomatorUtils.obtainUiObjectWithResourceId("idDiv_SAOTCS_Title");
+        if (!verifyYourIdentity.exists()) {
+            fail("Verify your identity page did not show up");
+        }
+        UiAutomatorUtils.handleButtonClickForObjectWithText("Call +X XXXXXXXX21");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
@@ -61,4 +61,10 @@ public interface IMicrosoftStsLoginComponentHandler extends IOAuth2LoginComponen
      * @param staySignedInResponse denotes whether to accept or decline the staySignedIn prompt.
      */
     void handleStaySignedIn(UiResponse staySignedInResponse);
+
+    /**
+     * Clicks the call option in the verify your identity page to allow auto mfa account to proceed with
+     * interactive request.
+     */
+    void handleVerifyYourIdentity();
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -80,6 +80,13 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
             loginComponentHandler.handlePasswordField(password);
         }
 
+        final IMicrosoftStsLoginComponentHandler aadLoginComponentHandler =
+                (IMicrosoftStsLoginComponentHandler) loginComponentHandler;
+
+        if (parameters.isVerifyYourIdentityPageExpected()) {
+            aadLoginComponentHandler.handleVerifyYourIdentity();
+        }
+
         if (parameters.isConsentPageExpected() || parameters.getPrompt() == PromptParameter.CONSENT) {
             final UiResponse consentPageResponse = parameters.getConsentPageResponse();
             if (consentPageResponse == UiResponse.ACCEPT) {
@@ -88,9 +95,6 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
                 loginComponentHandler.declineConsent();
             }
         }
-
-        final IMicrosoftStsLoginComponentHandler aadLoginComponentHandler =
-                (IMicrosoftStsLoginComponentHandler) loginComponentHandler;
 
         if (parameters.isStaySignedInPageExpected()) {
             aadLoginComponentHandler.handleStaySignedIn(parameters.getStaySignedInResponse());

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -96,6 +96,9 @@ public class RulesHelper {
         Log.i(TAG, "Adding RemoveBrokersBeforeTestRule");
         ruleChain = ruleChain.around(new RemoveBrokersBeforeTestRule());
 
+        Log.i(TAG, "Adding RemoveFirstPartyAppsTestRule");
+        ruleChain = ruleChain.around(new RemoveFirstPartyAppsTestRule());
+
         if (broker != null) {
             Log.i(TAG, "Adding BrokerSupportRule");
             ruleChain = ruleChain.around(new BrokerSupportRule(broker));


### PR DESCRIPTION
**What:**
This common PR supports 2 new UI Test cases in MSAL and Broker. Also, fixes checks for the update scenario in Play Store, this was causing issues where the test would finish while the app was still installing, which would cause some unpredictable behavior during rules and specifically broker installation

MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1731
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2068

**Why:**
Increase UI Automation coverage, fix playstore check to make sure installation is complete before proceeding.

**How**
Update Ui in playstore to check for different buttons in install/update scenarios.

**Testing**
Test included in MSAL and Broker PRs