### PR TITLE
Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -211,15 +211,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         if (mWebView.canGoBack()) {
             mWebView.goBack();
-            //For CBA, we need to clear the certificate choice cache here so that
-            // if the cert picker is exited (`cancel()`) or the flow has an error,
-            //the user can still try to login again with a cert.
-            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                WebView.clearClientCertPreferences(null);
-            } else {
-                Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
-            }
         } else {
             cancelAuthorization(true);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -102,9 +102,18 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        final String methodTag = TAG + ":onCreate";
         final FragmentActivity activity = getActivity();
         if (activity != null) {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
+        }
+        //For CBA, we need to clear the certificate choice cache here so that
+        // the user will be able to login with multiple accounts with CBA
+        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            WebView.clearClientCertPreferences(null);
+        } else {
+            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
         }
     }
 
@@ -173,15 +182,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                                 mWebView.loadUrl("javascript:" + javascriptToExecute[0].replace("%", "%25"));
                             }
                         }
-                        //For CBA, we need to clear the certificate choice cache here so that
-                        // if the cert picker is exited (`cancel()`) or the flow has an error,
-                        //the user can still try to login again with a cert.
-                        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            WebView.clearClientCertPreferences(null);
-                        } else {
-                            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
-                        }
                     }
                 },
                 mRedirectUri);
@@ -211,6 +211,15 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         if (mWebView.canGoBack()) {
             mWebView.goBack();
+            //For CBA, we need to clear the certificate choice cache here so that
+            // if the cert picker is exited (`cancel()`) or the flow has an error,
+            //the user can still try to login again with a cert.
+            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                WebView.clearClientCertPreferences(null);
+            } else {
+                Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+            }
         } else {
             cancelAuthorization(true);
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -211,6 +211,15 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         if (mWebView.canGoBack()) {
             mWebView.goBack();
+            //For CBA, we need to clear the certificate choice cache here so that
+            // if the cert picker is exited (`cancel()`) or the flow has an error,
+            //the user can still try to login again with a cert.
+            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                WebView.clearClientCertPreferences(null);
+            } else {
+                Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+            }
         } else {
             cancelAuthorization(true);
         }


### PR DESCRIPTION
## Context
The most recent PR I made regarding ClearClientCertPreferences, which has been included in common version 9.0.0, has been bringing up a spike of "ERR_CERT_DATABASE_CHANGED" errors in the OneAuth UI automation pipeline. 
This PR moves ClearClientCertPreferences back to OnCreate and handleBackButtonPressed so that ClearClientCertPreferences is only called once upon WebView creation and for every back button press, instead of multiple times per page reload, which I believe is the cause of the issue here. 

With this change, the user will not be able to do CBA via the "Other ways to sign in" link on the "Certificate validation failed" page. I've let one of the CBA PMs know that eSTS will need to change their UI so that the user is not prompted to try other ways to login when they see the "Certificate validation failed" page. 

I'm also thinking about not putting ClearClientCertPreferences back into the OnBackPressed method. I'm wondering if having ClearClientCertPreferences there is causing the few "ERR_CERT_DATABASE_CHANGED" errors that OnAuth has been reporting to see for a while now. But this would mean that upon CBA cancel or failure, the user will need to close the WebView in some way before trying to authenticate via CBA again.

## Related PR
- [Moving clearClientCertPreferences to onPageLoaded](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1855) 