### PR TITLE
Convert crypto operation spans into metrics

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-
+- [MINOR] Convert crypto operation spans into metrics (#1909)
 
 
 V.9.0.0

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -63,4 +63,14 @@ public enum AttributeName {
      * Indicates the request id value for cached credential service (if used) on server side
      */
     ccs_request_id,
+
+    /**
+     * The type of the error. Generally the class name of an exception.
+     */
+    error_type,
+
+    /**
+     * An error code.
+     */
+    error_code
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CryptoFactoryTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CryptoFactoryTelemetryHelper.java
@@ -22,9 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.opentelemetry;
 
-import static com.microsoft.identity.common.java.opentelemetry.AttributeName.crypto_operation;
 import static com.microsoft.identity.common.java.opentelemetry.AttributeName.crypto_controller;
 import static com.microsoft.identity.common.java.opentelemetry.AttributeName.crypto_exception_stack_trace;
+import static com.microsoft.identity.common.java.opentelemetry.AttributeName.crypto_operation;
 
 import com.microsoft.identity.common.java.crypto.ICryptoFactory;
 import com.microsoft.identity.common.java.exception.ClientException;
@@ -42,11 +42,11 @@ public class CryptoFactoryTelemetryHelper {
      * for crypto operation in one place.
      *
      * @param cryptoOperation name of the crypto operation.
-     * @param algorithmName name of the algorithm.
-     * @param cryptoFactory an {@link ICryptoFactory} object.
+     * @param algorithmName   name of the algorithm.
+     * @param cryptoFactory   an {@link ICryptoFactory} object.
      * @param cryptoOperation a callback that wraps around the crypto operation to be performed.
      * @return result of the crypto operation.
-     * */
+     */
     public static <T> T performCryptoOperationAndUploadTelemetry(@NonNull final CryptoObjectName operationName,
                                                                  @NonNull final String algorithmName,
                                                                  @NonNull final ICryptoFactory cryptoFactory,
@@ -74,7 +74,7 @@ public class CryptoFactoryTelemetryHelper {
      * Constructs the telemetry name for {@link AttributeName#crypto_operation}
      */
     private static String getCryptoOperationEventName(@NonNull final CryptoObjectName operationName,
-                                                      @NonNull final String algorithm){
+                                                      @NonNull final String algorithm) {
         return operationName.name() + "_" + algorithm;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -27,6 +27,7 @@ import static com.microsoft.identity.common.java.opentelemetry.AttributeName.par
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -62,6 +63,18 @@ public class OTelUtility {
                 .setDescription(description)
                 .setUnit("count")
                 .build();
+    }
+
+    /**
+     * Get name of the current span, if possible.
+     **/
+    @Nullable
+    public static Attributes getCurrentSpanAttributes() {
+        final Span span = SpanExtension.current();
+        if (span instanceof ReadableSpan) {
+            return ((ReadableSpan) span).toSpanData().getAttributes();
+        }
+        return null;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -27,6 +27,8 @@ import static com.microsoft.identity.common.java.opentelemetry.AttributeName.par
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -46,6 +48,20 @@ public class OTelUtility {
         // Current span is the parent of span just created.
         span.setAttribute(parent_span_name.name(), getCurrentSpanName());
         return span;
+    }
+
+    /**
+     * Creates a span (with shared basic attributes).
+     **/
+    @NonNull
+    public static LongCounter createLongCounter(@NonNull final String name, @NonNull final String description) {
+        final Meter meter = GlobalOpenTelemetry.getMeter(TAG);
+
+        return meter
+                .counterBuilder(name)
+                .setDescription(description)
+                .setUnit("count")
+                .build();
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -81,7 +81,7 @@ public class OTelUtility {
      * Get name of the current span, if possible.
      **/
     @Nullable
-    private static String getCurrentSpanName() {
+    public static String getCurrentSpanName() {
         final Span span = SpanExtension.current();
         if (span instanceof ReadableSpan) {
             return ((ReadableSpan) span).getName();


### PR DESCRIPTION
This PR basically converts the instrumentation for crypto operations from Spans/Traces to Metrics. 

There is a Meter of type LongCounter that will be incremented every time an Exception occurs. 

Rationale is documented here: https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Telemetry/cost_optimization.md&version=GBshahzaibj/optimize-telemetry&_a=preview

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2080