### PR TITLE
ClearClientCertPreferences... part 2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 V.Next
+--------
+
+V.9.0.2
+---------
+- [PATCH] Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed; created off of correct branch. (#TBD)
+
+V.9.0.0
 ----------
 - [MINOR] Add BrokerContentProvider path and IpcStrategy for new device registration API (#1843)
 - [PATCH] Adding cached credential service request id to telemetry (#1866)

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ V.Next
 
 V.9.0.2
 ---------
-- [PATCH] Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed; created off of correct branch. (#TBD)
+- [PATCH] Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed; created off of correct branch. (#1914)
 
 V.9.0.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,10 @@ V.9.0.2
 ---------
 - [PATCH] Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed; created off of correct branch. (#1914)
 
+V.9.0.1
+----------
+- [PATCH] Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed (#1908)
+
 V.9.0.0
 ----------
 - [MINOR] Add BrokerContentProvider path and IpcStrategy for new device registration API (#1843)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -30,7 +30,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 0.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "0.0.+"
+def common4jVersion = "6.0.0"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -40,10 +40,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.AbstractSmartcardCertBasedAuthManager;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.DialogHolder;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.YubiKitCertBasedAuthManager;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
@@ -102,9 +98,18 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        final String methodTag = TAG + ":onCreate";
         final FragmentActivity activity = getActivity();
         if (activity != null) {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
+        }
+        //For CBA, we need to clear the certificate choice cache here so that
+        // the user will be able to login with multiple accounts with CBA
+        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            WebView.clearClientCertPreferences(null);
+        } else {
+            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
         }
     }
 
@@ -173,15 +178,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                                 mWebView.loadUrl("javascript:" + javascriptToExecute[0].replace("%", "%25"));
                             }
                         }
-                        //For CBA, we need to clear the certificate choice cache here so that
-                        // if the cert picker is exited (`cancel()`) or the flow has an error,
-                        //the user can still try to login again with a cert.
-                        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            WebView.clearClientCertPreferences(null);
-                        } else {
-                            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
-                        }
                     }
                 },
                 mRedirectUri);
@@ -211,6 +207,15 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         if (mWebView.canGoBack()) {
             mWebView.goBack();
+            //For CBA, we need to clear the certificate choice cache here so that
+            // if the cert picker is exited (`cancel()`) or the flow has an error,
+            //the user can still try to login again with a cert.
+            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                WebView.clearClientCertPreferences(null);
+            } else {
+                Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+            }
         } else {
             cancelAuthorization(true);
         }

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=8.0.2
+versionName=9.0.2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
## Summary
Last time, this change was branched off of an incorrect branch. This PR is the same as before, but branched off of the v9.0.0 tag this time. 

Proof that changes between melissaahn/ClearPref and 9.0.0 are limited to this PR:  https://github.com/AzureAD/microsoft-authentication-library-common-for-android/compare/v9.0.0...melissaahn/ClearPref2?expand=1
No changes between melissaahn/release/9.0.2 and 9.0.0: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/compare/v9.0.0...melissaahn/release/9.0.2?expand=1
## Related PRs
- [Original PR for melissaahn/release/9.0.1](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1908)