### PR TITLE
Move clearClientCertPreferences to onCreateView only

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.Next
 ----------
 - [MINOR] Convert crypto operation spans into metrics (#1909)
+- [PATCH] Move clearClientCertPreferences to onCreateView only (#1915)
 
 V.9.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -98,18 +98,9 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final String methodTag = TAG + ":onCreate";
         final FragmentActivity activity = getActivity();
         if (activity != null) {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
-        }
-        //For CBA, we need to clear the certificate choice cache here so that
-        // the user will be able to login with multiple accounts with CBA
-        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            WebView.clearClientCertPreferences(null);
-        } else {
-            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
         }
     }
 
@@ -182,21 +173,20 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 },
                 mRedirectUri);
         setUpWebView(view, mAADWebViewClient);
-
-        mWebView.post(new Runnable() {
-            @Override
-            public void run() {
-                Logger.info(methodTag, "Launching embedded WebView for acquiring auth code.");
-                Logger.infoPII(methodTag, "The start url is " + mAuthorizationRequestUrl);
-                mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
-
-                // The first page load could take time, and we do not want to just show a blank page.
-                // Therefore, we'll show a spinner here, and hides it when mAuthorizationRequestUrl is successfully loaded.
-                // After that, progress bar will be displayed by MSA/AAD.
-                mProgressBar.setVisibility(View.VISIBLE);
-            }
-        });
-
+        //For CBA, we need to clear the certificate choice cache here so that
+        // the user will be able to login with multiple accounts with CBA
+        //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            WebView.clearClientCertPreferences(new Runnable() {
+                @Override
+                public void run() {
+                    launchWebView();
+                }
+            });
+        } else {
+            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+            launchWebView();
+        }
         return view;
     }
 
@@ -206,20 +196,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         Logger.info(methodTag, "Back button is pressed");
 
         if (mWebView.canGoBack()) {
-            //For CBA, we need to clear the certificate choice cache here so that
-            // if the cert picker is exited (`cancel()`) or the flow has an error,
-            //the user can still try to login again with a cert.
-            //addressing on-device CBA bug: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1776683
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                WebView.clearClientCertPreferences(new Runnable() {
-                    @Override
-                    public void run() {
-                        mWebView.goBack();
-                    }
-                });
-                return;
-            }
-            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
             mWebView.goBack();
         } else {
             cancelAuthorization(true);
@@ -263,6 +239,26 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mWebView.getSettings().setSupportZoom(webViewZoomEnabled);
         mWebView.setVisibility(View.INVISIBLE);
         mWebView.setWebViewClient(webViewClient);
+    }
+
+    /**
+     * Loads starting authorization request url into WebView.
+     */
+    private void launchWebView() {
+        final String methodTag = TAG + ":launchWebView";
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                Logger.info(methodTag, "Launching embedded WebView for acquiring auth code.");
+                Logger.infoPII(methodTag, "The start url is " + mAuthorizationRequestUrl);
+                mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
+
+                // The first page load could take time, and we do not want to just show a blank page.
+                // Therefore, we'll show a spinner here, and hides it when mAuthorizationRequestUrl is successfully loaded.
+                // After that, progress bar will be displayed by MSA/AAD.
+                mProgressBar.setVisibility(View.VISIBLE);
+            }
+        });
     }
 
     // For CertBasedAuthChallengeHandler within AADWebViewClient,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -26,7 +26,6 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -41,10 +40,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.AbstractSmartcardCertBasedAuthManager;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.DialogHolder;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.YubiKitCertBasedAuthManager;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;


### PR DESCRIPTION
## Background
OneAuth engineers have alerted us to increased rates of ERR_CERT_DATABASE_CHANGED in their telemetry starting around the time that `clearClientCertPreferences` method calls were added to common. We need to investigate if there are other ways to place and handle the calls of `clearClientCertPreferences` in order to reduce the amount of ERR_CERT_DATABASE_CHANGED from Chromium on their side. 
For more context, please see the PR [Moving ClearClientCertPreferences back to onCreate and handleBackButtonPressed](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1908).

## Investigation
Two things we discussed were removing the call completely from `handleOnBackPressed` and ensuring that the cert preferences would be cleared before any navigation within the WebView.

To address the first thing, TL;DR I think it's a good idea.
I tried to do some more investigation into what actually occurs in `clearClientCertPreferences`. Nick from CPP found [this implementation of the method](https://chromium.googlesource.com/chromium/src/+/fd0e8caa5cfe6316a3de3d181d7feb448359f125/android_webview/native/aw_contents_statics.cc). I found it interesting that it not only notifies listeners that certs were cleared, but it also calls this method `NotifyClientCertificatesChanged`... which brought me to [`cert_database_android.cc`](https://chromium.googlesource.com/chromium/src/+/refs/tags/65.0.3315.0/net/cert/cert_database_android.cc), and there to [`cert_database.cc`](https://source.chromium.org/chromium/chromium/src/+/main:net/cert/cert_database.cc;bpv=1;bpt=1), which seems to notify `observers` via the method `OnCertDBChanged`. I wasn't able to find which `observers` were in the observer list variable, however.
There is this class though called [`ssl_client_socket.cc`](https://source.chromium.org/chromium/chromium/src/+/main:net/socket/ssl_client_socket.cc;l=71;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29) that has `OnCertDBChanged`, and it passes a `is_cert_database_change` parameter value of `true` to `observers` of `onSSLConfigChanged`. when I searched for this method, one of the classes was [`TransportClientSocketPool`, which calls `FlushWithError` with... ERR_CERT_DATABASE_CHANGED](https://source.chromium.org/chromium/chromium/src/+/main:net/socket/transport_client_socket_pool.cc;l=810;drc=38321ee39cd73ac2d9d4400c56b90613dee5fe29;bpv=1;bpt=1?q=onsslconfigchanged&ss=chromium%2Fchromium%2Fsrc) (dun dun dun).
Totally possible that I have a misstep along the way, but what I think I can generally conclude from this is that the less we call `clearClientCertPreferences`, the less ERR_CERT_DATABASE_CHANGED may appear. 
Therefore, I'm proposing that we get rid of the `clearClientCertPreferences` call in `handleOnBackPressed`, which should greatly decrease the number of current calls, and see in a month of that will lessen the number of errors the CPP team sees.

For the second thing, I moved the one `clearClientCertPreferences` call from `onCreate` to `onCreateView` so that I could ensure that the first `loadUrl` call on the `WebView` occurred within the callback runnable of `clearClientCertPreferences`. The `mWebView.post` logic is now in a method `launchWebView`. 

## Note
With this PR, users using CBA that either cancel or fail out of the flow the first time will now need to either exit out of the WebView somehow or restart the app in order to try CBA again (as opposed to pressing the back button once).

## Testing
I made sure that the `clearClientCertPreferences` call was on the UI thread, and I have also gone through both regular cloud account and CBA authentication testing scenarios without issue.
I am going to request the CPP team to see if this branch can be run on their OneAuth UI automation pipeline to ensure that this change won't cause any other cert related issues.
Please let me know if I should try any other scenarios or tests.  