### PR TITLE
Updating localized string resource files

### DIFF
--- a/common/src/main/res/values-ar/strings.xml
+++ b/common/src/main/res/values-ar/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">إلغاء</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">مطلوب اختيار شهادة بطاقة ذكية لتسجيل الدخول</string>
+    <string name="smartcard_cert_dialog_title">حدد الشهادة لتسجيل الدخول</string>
     <string name="smartcard_cert_dialog_positive_button">متابعة</string>
     <string name="smartcard_cert_dialog_negative_button">إلغاء الأمر</string>
 
-    <string name="smartcard_pin_dialog_title">فتح قفل البطاقة الذكية</string>
+    <string name="smartcard_pin_dialog_title">إلغاء تأمين البطاقة الذكية</string>
     <string name="smartcard_pin_dialog_message">أدخل رقم التعريف الشخصي (PIN) للبطاقة الذكية للوصول إلى الشهادة وتسجيل الدخول</string>
     <string name="smartcard_pin_dialog_positive_button">فتح القفل</string>
     <string name="smartcard_pin_dialog_negative_button">إلغاء الأمر</string>
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">تمت إزالة جهاز البطاقة الذكية. الرجاء إعادة إدخال الجهاز قبل محاولة تسجيل الدخول مجدداً.</string>
 
     <string name="smartcard_no_cert_dialog_title">ما من شهادات قابلة للتطبيق موجودة.</string>
-    <string name="smartcard_no_cert_dialog_message">الرجاء تأكيد أن شهادتك مزودة بالخدمة بشكل صحيح على جهاز البطاقة الذكية.</string>
+    <string name="smartcard_no_cert_dialog_message">تأكيد أن شهادتك مزودة بالخدمة بشكل صحيح على جهاز البطاقة الذكية.</string>
 
     <string name="smartcard_general_error_dialog_title">حاول مجدداً لاحقاً</string>
     <string name="smartcard_general_error_dialog_message">حدث خطأ غير متوقع. الرجاء إعادة المحاولة لاحقًا.</string>
+
+    <string name="user_choice_dialog_title">كيف ترغب في الإعداد؟</string>
+    <string name="user_choice_dialog_on_device_name">الشهادة على جهازك</string>
+    <string name="user_choice_dialog_smartcard_name">بطاقة ذكية فعلية</string>
+    <string name="user_choice_dialog_positive_button">متابعة</string>
+    <string name="user_choice_dialog_negative_button">إلغاء الأمر</string>
+
+    <string name="smartcard_prompt_dialog_title">إعداد بطاقتك الذكية</string>
+    <string name="smartcard_prompt_dialog_message">قم بتوصيل بطاقة ذكية أو الاحتفاظ بها في الجزء الخلفي من هاتفك.</string>
+    <string name="smartcard_prompt_dialog_negative_button">إلغاء الأمر</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">قراءة بطاقتك الذكية</string>
+    <string name="smartcard_nfc_loading_dialog_message">احتفظ ببطاقتك الذكية في مكانها.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">إعداد بطاقتك الذكية</string>
+    <string name="smartcard_nfc_prompt_dialog_message">ضع بطاقة ذكية في الجزء الخلفي من هاتفك.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">إلغاء الأمر</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">تشغيل NFC في إعدادات الجهاز</string>
+    <string name="smartcard_nfc_reminder_dialog_message">لتسجيل الدخول باستخدام NFC، قم بتشغيل NFC في إعدادات جهازك. ثم قم بتسجيل الدخول مرة أخرى.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">فهمت</string>
 </resources>

--- a/common/src/main/res/values-b+sr+Latn/strings.xml
+++ b/common/src/main/res/values-b+sr+Latn/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Otkaži</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Odaberite certifikat pametne kartice za prijavljivanje</string>
+    <string name="smartcard_cert_dialog_title">Izaberite certifikat za prijavljivanje</string>
     <string name="smartcard_cert_dialog_positive_button">Nastavi</string>
     <string name="smartcard_cert_dialog_negative_button">Otkaži</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Pokušajte ponovo kasnije</string>
     <string name="smartcard_general_error_dialog_message">Došlo je do neočekivane greške. Pokušajte ponovo kasnije.</string>
+
+    <string name="user_choice_dialog_title">Kako želite da se prijavite?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikat na uređaju</string>
+    <string name="user_choice_dialog_smartcard_name">Fizička pametna kartica</string>
+    <string name="user_choice_dialog_positive_button">Nastavi</string>
+    <string name="user_choice_dialog_negative_button">Otkaži</string>
+
+    <string name="smartcard_prompt_dialog_title">Pripremite pametnu karticu</string>
+    <string name="smartcard_prompt_dialog_message">Priključite ili držite pametnu karticu na zadnjoj strani telefona.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Otkaži</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Čitanje pametne kartice</string>
+    <string name="smartcard_nfc_loading_dialog_message">Držite pametnu karticu na mestu.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Pripremite pametnu karticu</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Držite pametnu karticu na zadnjoj strani telefona.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Otkaži</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Uključi NFC u postavkama uređaja</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Da biste se prijavili pomoću NFC-a, uključite NFC u postavkama uređaja. Zatim se ponovo prijavite.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Razumem</string>
 </resources>

--- a/common/src/main/res/values-bg/strings.xml
+++ b/common/src/main/res/values-bg/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Отказ</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Избиране на сертификат за смарт карта за влизане</string>
+    <string name="smartcard_cert_dialog_title">Изберете сертификат за влизане</string>
     <string name="smartcard_cert_dialog_positive_button">Продължи</string>
     <string name="smartcard_cert_dialog_negative_button">Отказ</string>
 
-    <string name="smartcard_pin_dialog_title">Отключване на смарт карта</string>
+    <string name="smartcard_pin_dialog_title">Отключване на смарт картата</string>
     <string name="smartcard_pin_dialog_message">Въведете ПИН кода на смарт картата, за да получите достъп до сертификата и да влезете</string>
     <string name="smartcard_pin_dialog_positive_button">Отключване</string>
     <string name="smartcard_pin_dialog_negative_button">Отказ</string>
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Устройството със смарт карта е премахнато. Поставете повторно устройството, преди да се опитате да влезете отново.</string>
 
     <string name="smartcard_no_cert_dialog_title">Не са намерени приложими сертификати.</string>
-    <string name="smartcard_no_cert_dialog_message">Потвърдете, че вашият сертификат е бил правилно инсталиран на устройството ви със смарт карта.</string>
+    <string name="smartcard_no_cert_dialog_message">Потвърдете, че вашият сертификат е бил правилно осигурен на устройството ви със смарт карта.</string>
 
     <string name="smartcard_general_error_dialog_title">Опитайте отново по-късно</string>
     <string name="smartcard_general_error_dialog_message">Възникна неочаквана грешка. Опитайте отново по-късно.</string>
+
+    <string name="user_choice_dialog_title">Как бихте искали да влезете?</string>
+    <string name="user_choice_dialog_on_device_name">Сертификат на вашето устройство</string>
+    <string name="user_choice_dialog_smartcard_name">Физическа смарт карта</string>
+    <string name="user_choice_dialog_positive_button">Продължаване</string>
+    <string name="user_choice_dialog_negative_button">Отказ</string>
+
+    <string name="smartcard_prompt_dialog_title">Подготовка на вашата смарт карта</string>
+    <string name="smartcard_prompt_dialog_message">Включете или задръжте смарт карта до задната страна на телефона.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Отказ</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Четене на вашата смарт карта</string>
+    <string name="smartcard_nfc_loading_dialog_message">Съхранявайте смарт картата на място.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Подготовка на вашата смарт карта</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Задръжте смарт карта до задната страна на телефона.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Отказ</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Включете NFC в настройките на устройството</string>
+    <string name="smartcard_nfc_reminder_dialog_message">За да влезете с NFC, включете NFC в настройките на устройството си. След това влезте отново.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Разбрах</string>
 </resources>

--- a/common/src/main/res/values-ca/strings.xml
+++ b/common/src/main/res/values-ca/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Cancel·la</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Trieu un certificat de targeta intel·ligent per iniciar la sessió</string>
+    <string name="smartcard_cert_dialog_title">Seleccioneu un certificat per iniciar la sessió</string>
     <string name="smartcard_cert_dialog_positive_button">Continua</string>
     <string name="smartcard_cert_dialog_negative_button">Cancel·la</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Torneu-ho a provar més tard.</string>
     <string name="smartcard_general_error_dialog_message">S\'ha produït un error inesperat. Torneu-ho a provar més tard.</string>
+
+    <string name="user_choice_dialog_title">Com t\'agradaria iniciar sessió?</string>
+    <string name="user_choice_dialog_on_device_name">Certificat al dispositiu</string>
+    <string name="user_choice_dialog_smartcard_name">Targeta intel·ligent física</string>
+    <string name="user_choice_dialog_positive_button">Continua</string>
+    <string name="user_choice_dialog_negative_button">Cancel·la</string>
+
+    <string name="smartcard_prompt_dialog_title">Prepara la targeta intel·ligent</string>
+    <string name="smartcard_prompt_dialog_message">Connecta o mantén premuda una targeta intel·ligent a la part posterior del telèfon.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Cancel·la</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">S\'està llegint la targeta intel·ligent</string>
+    <string name="smartcard_nfc_loading_dialog_message">Manteniu la targeta intel·ligent al lloc.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Prepara la targeta intel·ligent</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Mantén premuda una targeta intel·ligent a la part posterior del telèfon.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Cancel·la</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Activa l\'NFC a la configuració del dispositiu</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Per iniciar la sessió amb l\'NFC, activeu l\'NFC a la configuració del dispositiu. A continuació, torneu a iniciar la sessió.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Entesos</string>
 </resources>

--- a/common/src/main/res/values-cs/strings.xml
+++ b/common/src/main/res/values-cs/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Zrušit</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Zvolte certifikát čipové karty pro přihlášení</string>
+    <string name="smartcard_cert_dialog_title">Vyberte certifikát, který se má použít k přihlášení</string>
     <string name="smartcard_cert_dialog_positive_button">Pokračovat</string>
     <string name="smartcard_cert_dialog_negative_button">Zrušit</string>
 
     <string name="smartcard_pin_dialog_title">Odemknout čipovou kartu</string>
-    <string name="smartcard_pin_dialog_message">Zadejte PIN kód čipové karty pro přístup k certifikátu a přihlaste se</string>
+    <string name="smartcard_pin_dialog_message">Zadejte PIN kód čipové karty pro přístup k certifikátu a přihlaste se.</string>
     <string name="smartcard_pin_dialog_positive_button">Odemknout</string>
     <string name="smartcard_pin_dialog_negative_button">Zrušit</string>
     <string name="smartcard_pin_dialog_error_message">Pin kód, který jste zadali, byl nesprávný</string>
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Zařízení čipové karty se odebralo. Než se znovu pokusíte přihlásit, znovu vložte zařízení.</string>
 
     <string name="smartcard_no_cert_dialog_title">Nenašly se žádné použitelné certifikáty.</string>
-    <string name="smartcard_no_cert_dialog_message">Ověřte prosím, že se váš certifikát správně zřídil na zařízení s čipovou kartou.</string>
+    <string name="smartcard_no_cert_dialog_message">Ověřte, že se váš certifikát správně zřídil na zařízení s čipovou kartou.</string>
 
     <string name="smartcard_general_error_dialog_title">Zkuste to znovu později</string>
     <string name="smartcard_general_error_dialog_message">Je nám líto, ale objevila se nečekaná chyba. Zkuste to prosím znovu později.</string>
+
+    <string name="user_choice_dialog_title">Jak se chcete přihlásit?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikát na vašem zařízení</string>
+    <string name="user_choice_dialog_smartcard_name">Fyzická čipová karta</string>
+    <string name="user_choice_dialog_positive_button">Pokračovat</string>
+    <string name="user_choice_dialog_negative_button">Zrušit</string>
+
+    <string name="smartcard_prompt_dialog_title">Příprava čipové karty</string>
+    <string name="smartcard_prompt_dialog_message">Připojte nebo podržte čipovou kartu na zadní straně telefonu.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Zrušit</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Čtení čipové karty</string>
+    <string name="smartcard_nfc_loading_dialog_message">Udržujte čipovou kartu na místě.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Příprava čipové karty</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Podržte čipovou kartu na zadní straně telefonu.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Zrušit</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Zapnutí NFC v nastavení zařízení</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Pokud se chcete přihlásit pomocí NFC, zapněte v nastavení zařízení možnost NFC. Pak se znovu přihlaste.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumím</string>
 </resources>

--- a/common/src/main/res/values-da/strings.xml
+++ b/common/src/main/res/values-da/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Annuller</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Vælg et chipkort-certifikat for at logge på</string>
+    <string name="smartcard_cert_dialog_title">Vælg et certifikat for at logge på</string>
     <string name="smartcard_cert_dialog_positive_button">Fortsæt</string>
     <string name="smartcard_cert_dialog_negative_button">Annuller</string>
 
-    <string name="smartcard_pin_dialog_title">Lås chipkort op</string>
-    <string name="smartcard_pin_dialog_message">Angiv chipkort-pinkoden for at få adgang til certifikatet og logge på</string>
+    <string name="smartcard_pin_dialog_title">Lås chipkortet op</string>
+    <string name="smartcard_pin_dialog_message">Angiv pinkoden til chipkortet for at få adgang til certifikatet og logge på</string>
     <string name="smartcard_pin_dialog_positive_button">Lås op</string>
     <string name="smartcard_pin_dialog_negative_button">Annuller</string>
     <string name="smartcard_pin_dialog_error_message">Den pinkode, du har angivet, var forkert</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Der er for mange mislykkede forsøg. Prøv igen senere.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Prøv igen</string>
-    <string name="smartcard_early_unplug_dialog_message">Chipkort-enheden blev fjernet. Indsæt enheden igen, før du forsøger at logge på igen.</string>
+    <string name="smartcard_early_unplug_dialog_message">Chipkortenheden blev fjernet. Indsæt enheden igen, før du forsøger at logge på igen.</string>
 
     <string name="smartcard_no_cert_dialog_title">Der blev ikke fundet nogen relevante certifikater.</string>
-    <string name="smartcard_no_cert_dialog_message">Bekræft, at dit certifikat er blevet klargjort korrekt på din chipkort-enhed.</string>
+    <string name="smartcard_no_cert_dialog_message">Bekræft, at dit certifikat er blevet klargjort korrekt på din chipkortenhed.</string>
 
     <string name="smartcard_general_error_dialog_title">Prøv igen senere</string>
     <string name="smartcard_general_error_dialog_message">Der opstod en uventet fejl. Prøv igen senere.</string>
+
+    <string name="user_choice_dialog_title">Hvordan vil du logge på?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikat på din enhed</string>
+    <string name="user_choice_dialog_smartcard_name">Fysisk chipkort</string>
+    <string name="user_choice_dialog_positive_button">Fortsæt</string>
+    <string name="user_choice_dialog_negative_button">Annuller</string>
+
+    <string name="smartcard_prompt_dialog_title">Forbered dit chipkort</string>
+    <string name="smartcard_prompt_dialog_message">Tilslut eller hold et chipkort på bagsiden af telefonen.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Annuller</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Læser dit chipkort</string>
+    <string name="smartcard_nfc_loading_dialog_message">Sørg for, at chipkortet er på plads.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Forbered dit chipkort</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Hold et chipkort på bagsiden af telefonen.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Annuller</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Slå NFC til i enhedsindstillinger</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Hvis du vil logge på med NFC, skal du slå NFC til i dine enhedsindstillinger. Log derefter på igen.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Forstået</string>
 </resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Abbrechen</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Ein Smartcard Zertifikat für die Anmeldung auswählen</string>
+    <string name="smartcard_cert_dialog_title">Zertifikat für die Anmeldung auswählen</string>
     <string name="smartcard_cert_dialog_positive_button">Weiter</string>
     <string name="smartcard_cert_dialog_negative_button">Abbrechen</string>
 
     <string name="smartcard_pin_dialog_title">Smartcard entsperren</string>
-    <string name="smartcard_pin_dialog_message">Die Smartcard-PIN eingeben, um auf das Zertifikat zuzugreifen und sich anzumelden</string>
+    <string name="smartcard_pin_dialog_message">Geben Sie die Smartcard-PIN ein, um auf das Zertifikat zuzugreifen und sich anzumelden.</string>
     <string name="smartcard_pin_dialog_positive_button">Entsperren</string>
     <string name="smartcard_pin_dialog_negative_button">Abbrechen</string>
     <string name="smartcard_pin_dialog_error_message">Die eingegebene PIN war falsch</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Zu viele Fehlversuche, später erneut versuchen.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Erneut versuchen</string>
-    <string name="smartcard_early_unplug_dialog_message">Smartcard Gerät wurde entfernt. Bitte stecken das Gerät erneut ein, bevor Sie versuchen, sich erneut anzumelden.</string>
+    <string name="smartcard_early_unplug_dialog_message">Smartcard-Gerät wurde entfernt. Bitte stecken das Gerät wieder ein, bevor Sie versuchen, sich erneut anzumelden.</string>
 
     <string name="smartcard_no_cert_dialog_title">Keine zutreffenden Zertifikate gefunden.</string>
-    <string name="smartcard_no_cert_dialog_message">Bitte bestätigen Sie, dass Ihr Zertifikat korrekt auf Ihrem Smartcard-Gerät bereitgestellt wurde.</string>
+    <string name="smartcard_no_cert_dialog_message">Bestätigen Sie, dass Ihr Zertifikat korrekt auf Ihrem Smartcard-Gerät bereitgestellt wurde.</string>
 
     <string name="smartcard_general_error_dialog_title">Später noch mal versuchen</string>
     <string name="smartcard_general_error_dialog_message">Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später noch einmal.</string>
+
+    <string name="user_choice_dialog_title">Wie möchten Sie sich anmelden?</string>
+    <string name="user_choice_dialog_on_device_name">Zertifikat auf Ihrem Gerät</string>
+    <string name="user_choice_dialog_smartcard_name">Physische Smartcard</string>
+    <string name="user_choice_dialog_positive_button">Weiter</string>
+    <string name="user_choice_dialog_negative_button">Abbrechen</string>
+
+    <string name="smartcard_prompt_dialog_title">Smartcard vorbereiten</string>
+    <string name="smartcard_prompt_dialog_message">Schließen Sie eine Smartcard an die Rückseite Ihres Smartphones an, oder halten Sie sie dagegen.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Abbrechen</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Smartcard wird gelesen</string>
+    <string name="smartcard_nfc_loading_dialog_message">Halten Sie Ihre Smartcard bereit.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Smartcard vorbereiten</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Halten Sie eine Smartcard an die Rückseite Ihres Smartphones.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Abbrechen</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">NFC in den Geräteeinstellungen aktivieren</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Um sich mit NFC anzumelden, aktivieren Sie NFC in ihren Geräteeinstellungen. Melden Sie sich dann erneut an.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-el/strings.xml
+++ b/common/src/main/res/values-el/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Άκυρο</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Επιλέξτε ένα πιστοποιητικό έξυπνης κάρτας για είσοδο</string>
+    <string name="smartcard_cert_dialog_title">Επιλέξτε ένα πιστοποιητικό για να εισέλθετε</string>
     <string name="smartcard_cert_dialog_positive_button">Συνέχεια</string>
     <string name="smartcard_cert_dialog_negative_button">Άκυρο</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Πάρα πολλές αποτυχημένες προσπάθειες, δοκιμάστε ξανά αργότερα.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Επανάληψη</string>
-    <string name="smartcard_early_unplug_dialog_message">Η συσκευή έξυπνης κάρτας καταργήθηκε. Τοποθετήστε ξανά τη συσκευή πριν επιχειρήσετε να συνδεθείτε ξανά.</string>
+    <string name="smartcard_early_unplug_dialog_message">Καταργήθηκε η συσκευή έξυπνης κάρτας. Τοποθετήστε ξανά τη συσκευή πριν επιχειρήσετε να συνδεθείτε ξανά.</string>
 
     <string name="smartcard_no_cert_dialog_title">Δεν βρέθηκαν ισχύοντα πιστοποιητικά.</string>
-    <string name="smartcard_no_cert_dialog_message">Επιβεβαιώστε ότι το πιστοποιητικό σας έχει παραχθεί σωστά στη συσκευή έξυπνης κάρτας σας.</string>
+    <string name="smartcard_no_cert_dialog_message">Επιβεβαιώστε ότι το πιστοποιητικό σας έχει εκχωρηθεί σωστά στη συσκευή έξυπνης κάρτας σας.</string>
 
     <string name="smartcard_general_error_dialog_title">Δοκιμάστε ξανά αργότερα</string>
     <string name="smartcard_general_error_dialog_message">Δυστυχώς, παρουσιάστηκε ένα απρόσμενο σφάλμα. Δοκιμάστε ξανά αργότερα.</string>
+
+    <string name="user_choice_dialog_title">Πώς θέλετε να εισέλθετε;</string>
+    <string name="user_choice_dialog_on_device_name">Πιστοποιητικό στη συσκευή σας</string>
+    <string name="user_choice_dialog_smartcard_name">Φυσική έξυπνη κάρτα</string>
+    <string name="user_choice_dialog_positive_button">Συνέχεια</string>
+    <string name="user_choice_dialog_negative_button">Άκυρο</string>
+
+    <string name="smartcard_prompt_dialog_title">Προετοιμασία της έξυπνης κάρτας σας</string>
+    <string name="smartcard_prompt_dialog_message">Συνδέστε ή κρατήστε μια έξυπνη κάρτα στο πίσω μέρος του τηλεφώνου σας.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Άκυρο</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Ανάγνωση της έξυπνης κάρτας σας</string>
+    <string name="smartcard_nfc_loading_dialog_message">Διατηρήστε την έξυπνη κάρτα σας στη θέση της.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Προετοιμασία της έξυπνης κάρτας σας</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Κρατήστε μια έξυπνη κάρτα στο πίσω μέρος του τηλεφώνου σας.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Άκυρο</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Ενεργοποίηση NFC στις ρυθμίσεις συσκευής</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Για να εισέλθετε με NFC, ενεργοποιήστε το NFC στις ρυθμίσεις της συσκευής σας. Στη συνέχεια, εισέλθετε ξανά.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Το κατάλαβα</string>
 </resources>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Cancelar</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Elegir un certificado de tarjeta inteligente para iniciar sesión</string>
+    <string name="smartcard_cert_dialog_title">Seleccionar un certificado con el que iniciar sesión</string>
     <string name="smartcard_cert_dialog_positive_button">Continuar</string>
     <string name="smartcard_cert_dialog_negative_button">Cancelar</string>
 
     <string name="smartcard_pin_dialog_title">Desbloquear tarjeta inteligente</string>
-    <string name="smartcard_pin_dialog_message">Escriba el PIN de la tarjeta inteligente para acceder al certificado e iniciar sesión</string>
+    <string name="smartcard_pin_dialog_message">Escribir el PIN de la tarjeta inteligente para acceder al certificado e iniciar sesión</string>
     <string name="smartcard_pin_dialog_positive_button">Desbloquear</string>
     <string name="smartcard_pin_dialog_negative_button">Cancelar</string>
     <string name="smartcard_pin_dialog_error_message">El PIN que introdujo no es correcto</string>
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Volver a intentarlo más tarde</string>
     <string name="smartcard_general_error_dialog_message">Ha ocurrido un error inesperado. Inténtalo de nuevo más tarde.</string>
+
+    <string name="user_choice_dialog_title">¿Cómo desea iniciar sesión?</string>
+    <string name="user_choice_dialog_on_device_name">Certificado en el dispositivo</string>
+    <string name="user_choice_dialog_smartcard_name">Tarjeta inteligente física</string>
+    <string name="user_choice_dialog_positive_button">Continuar</string>
+    <string name="user_choice_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_prompt_dialog_title">Preparar la tarjeta inteligente</string>
+    <string name="smartcard_prompt_dialog_message">Conecte o mantenga presionada una tarjeta inteligente en la parte posterior del teléfono.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Leyendo la tarjeta inteligente</string>
+    <string name="smartcard_nfc_loading_dialog_message">Mantenga la tarjeta inteligente en su lugar.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Preparar la tarjeta inteligente</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Mantenga una tarjeta inteligente en la parte posterior del teléfono.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Activar NFC en la configuración del dispositivo</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Para iniciar sesión con NFC, active NFC en la configuración del dispositivo. Después, vuelva a iniciar sesión.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Entendido</string>
 </resources>

--- a/common/src/main/res/values-et/strings.xml
+++ b/common/src/main/res/values-et/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Loobu</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Sisselogimiseks valige kiipkaardi sert</string>
+    <string name="smartcard_cert_dialog_title">Sisselogimiseks valige sert</string>
     <string name="smartcard_cert_dialog_positive_button">Jätka</string>
     <string name="smartcard_cert_dialog_negative_button">Loobu</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Proovige hiljem uuesti</string>
     <string name="smartcard_general_error_dialog_message">Ilmnes ootamatu tõrge. Proovige hiljem uuesti.</string>
+
+    <string name="user_choice_dialog_title">Kuidas soovite sisse logida?</string>
+    <string name="user_choice_dialog_on_device_name">Teie seadme sert</string>
+    <string name="user_choice_dialog_smartcard_name">Füüsiline kiipkaart</string>
+    <string name="user_choice_dialog_positive_button">Jätka</string>
+    <string name="user_choice_dialog_negative_button">Loobu</string>
+
+    <string name="smartcard_prompt_dialog_title">Kiipkaardi ettevalmistamine</string>
+    <string name="smartcard_prompt_dialog_message">Sisestage kiipkaart või hoidke seda vastu telefoni tagakülge.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Loobu</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Kiipkaardi lugemine</string>
+    <string name="smartcard_nfc_loading_dialog_message">Hoidke kiipkaarti paigal.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Kiipkaardi ettevalmistamine</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Hoidke kiipkaarti vastu telefoni tagakülge.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Loobu</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Lülitage NFC seadme sätetes sisse</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC abil sisselogimiseks lülitage NFC oma seadme sätetes sisse. Seejärel logige uuesti sisse.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Sain aru</string>
 </resources>

--- a/common/src/main/res/values-eu/strings.xml
+++ b/common/src/main/res/values-eu/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Utzi</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Aukeratu saioa hasteko txartel adimendunaren ziurtagiri bat</string>
+    <string name="smartcard_cert_dialog_title">Hautatu ziurtagiri bat saioa hasteko</string>
     <string name="smartcard_cert_dialog_positive_button">Jarraitu</string>
     <string name="smartcard_cert_dialog_negative_button">Utzi</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Saiatu berriro geroago</string>
     <string name="smartcard_general_error_dialog_message">Ustekabeko errore bat gertatu da. Saiatu berriro geroago.</string>
+
+    <string name="user_choice_dialog_title">Nola hasi nahi duzu saioa?</string>
+    <string name="user_choice_dialog_on_device_name">Gailuko ziurtagiria</string>
+    <string name="user_choice_dialog_smartcard_name">Txartel adimendun fisikoa</string>
+    <string name="user_choice_dialog_positive_button">Jarraitu</string>
+    <string name="user_choice_dialog_negative_button">Utzi</string>
+
+    <string name="smartcard_prompt_dialog_title">Prestatu txartel adimenduna</string>
+    <string name="smartcard_prompt_dialog_message">Konektatu edo jarri txartel adimenduna mugikorraren atzealdean.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Utzi</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Txartel adimenduna irakurtzen</string>
+    <string name="smartcard_nfc_loading_dialog_message">Mantendu txartel adimenduna bere lekuan.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Prestatu txartel adimenduna</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Jarri txartel adimenduna mugikorraren atzealdean.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Utzi</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Aktibatu NFC gailuaren ezarpenetan</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFCrekin saioa hasteko, aktibatu NFC gailuaren ezarpenetan. Ondoren, hasi saioa berriro.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Ados</string>
 </resources>

--- a/common/src/main/res/values-fi/strings.xml
+++ b/common/src/main/res/values-fi/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Peruuta</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Valitse älykorttivarmenne sisäänkirjautumista varten</string>
+    <string name="smartcard_cert_dialog_title">Valitse varmenne sisäänkirjautumista varten</string>
     <string name="smartcard_cert_dialog_positive_button">Jatka</string>
     <string name="smartcard_cert_dialog_negative_button">Peruuta</string>
 
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Älykorttilaite poistettiin. Aseta laite uudelleen, ennen kuin yrität kirjautua uudelleen sisään.</string>
 
     <string name="smartcard_no_cert_dialog_title">Soveltuvia varmenteita ei löytynyt.</string>
-    <string name="smartcard_no_cert_dialog_message">Vahvista, että varmenne on valmisteltu älykorttilaitteeseen oikein.</string>
+    <string name="smartcard_no_cert_dialog_message">Varmista, että varmenne on valmisteltu älykorttilaitteeseen oikein.</string>
 
     <string name="smartcard_general_error_dialog_title">Yritä myöhemmin uudelleen</string>
     <string name="smartcard_general_error_dialog_message">Tapahtui odottamaton virhe. Yritä myöhemmin uudelleen.</string>
+
+    <string name="user_choice_dialog_title">Miten haluat kirjautua sisään?</string>
+    <string name="user_choice_dialog_on_device_name">Varmenne laitteessasi</string>
+    <string name="user_choice_dialog_smartcard_name">Fyysinen älykortti</string>
+    <string name="user_choice_dialog_positive_button">Jatka</string>
+    <string name="user_choice_dialog_negative_button">Peruuta</string>
+
+    <string name="smartcard_prompt_dialog_title">Älykortin valmisteleminen</string>
+    <string name="smartcard_prompt_dialog_message">Kytke älykortti puhelimen takaosaan tai pidä sitä painettuna.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Peruuta</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Älykortin lukeminen</string>
+    <string name="smartcard_nfc_loading_dialog_message">Pidä älykorttia paikallaan.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Älykortin valmisteleminen</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Pidä älykorttia puhelimen takaosassa.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Peruuta</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">NFC:n ottaminen käyttöön laitteen asetuksissa</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Jos haluat kirjautua sisään NFC:llä, ota NFC käyttöön laitteesi asetuksissa. Kirjaudu sitten uudelleen sisään.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Selvä juttu</string>
 </resources>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Annuler</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Choisir un certificat de carte à puce pour se connecter</string>
+    <string name="smartcard_cert_dialog_title">Sélectionner un certificat avec la connexion</string>
     <string name="smartcard_cert_dialog_positive_button">Continuer</string>
     <string name="smartcard_cert_dialog_negative_button">Annuler</string>
 
-    <string name="smartcard_pin_dialog_title">Déverrouiller la carte à puce</string>
+    <string name="smartcard_pin_dialog_title">Déverrouiller une carte à puce</string>
     <string name="smartcard_pin_dialog_message">Entrez le code PIN de la carte à puce pour accéder au certificat et vous connecter</string>
     <string name="smartcard_pin_dialog_positive_button">Déverrouiller</string>
     <string name="smartcard_pin_dialog_negative_button">Annuler</string>
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Le périphérique de carte à puce a été supprimé. Réinsérez l’appareil avant de tenter de vous reconnecter.</string>
 
     <string name="smartcard_no_cert_dialog_title">Aucun certificat applicable trouvé.</string>
-    <string name="smartcard_no_cert_dialog_message">Vérifiez que votre certificat a été correctement configuré sur votre appareil de carte à puce.</string>
+    <string name="smartcard_no_cert_dialog_message">Vérifiez que votre certificat a été correctement configuré sur votre périphérique de carte à puce.</string>
 
     <string name="smartcard_general_error_dialog_title">Réessayez ultérieurement</string>
     <string name="smartcard_general_error_dialog_message">Une erreur inattendue s’est produite. Réessayez plus tard.</string>
+
+    <string name="user_choice_dialog_title">Comment voulez-vous vous connecter ?</string>
+    <string name="user_choice_dialog_on_device_name">Certificat sur votre appareil</string>
+    <string name="user_choice_dialog_smartcard_name">Carte à puce physique</string>
+    <string name="user_choice_dialog_positive_button">Continuer</string>
+    <string name="user_choice_dialog_negative_button">Annuler</string>
+
+    <string name="smartcard_prompt_dialog_title">Préparez votre carte à puce</string>
+    <string name="smartcard_prompt_dialog_message">Branchez ou maintenez une carte à puce au dos de votre téléphone.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Annuler</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Lecture de votre carte à puce</string>
+    <string name="smartcard_nfc_loading_dialog_message">Gardez votre carte à puce en place.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Préparez votre carte à puce</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Maintenez une carte à puce au dos de votre téléphone.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Annuler</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Activer NFC dans les paramètres de l’appareil</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Pour vous connecter avec NFC, activez NFC dans les paramètres de votre appareil. Puis reconnectez-vous.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-gl/strings.xml
+++ b/common/src/main/res/values-gl/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Cancelar</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Escolla un certificado de cartón intelixente para iniciar sesión</string>
+    <string name="smartcard_cert_dialog_title">Seleccionar un certificado para iniciar sesión</string>
     <string name="smartcard_cert_dialog_positive_button">Continuar</string>
     <string name="smartcard_cert_dialog_negative_button">Cancelar</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Demasiados intentos erróneos. Ténteo de novo máis tarde.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Tentar de novo</string>
-    <string name="smartcard_early_unplug_dialog_message">Eliminouse o dispositivo de cartón intelixente. Volva inserir o dispositivo antes de intentar rexistrarse de novo.</string>
+    <string name="smartcard_early_unplug_dialog_message">Eliminouse o dispositivo de cartón intelixente. Volva inserir o dispositivo antes de tentar iniciar sesión de novo.</string>
 
     <string name="smartcard_no_cert_dialog_title">Non se atoparon certificados aplicables.</string>
-    <string name="smartcard_no_cert_dialog_message">Confirme que o certificado se proporcionase correctamente no dispositivo de cartón intelixente.</string>
+    <string name="smartcard_no_cert_dialog_message">Confirme que o certificado se forneceu correctamente no dispositivo de cartón intelixente.</string>
 
     <string name="smartcard_general_error_dialog_title">Tentar de novo máis tarde</string>
     <string name="smartcard_general_error_dialog_message">Ocorreu un erro inesperado. Ténteo novamente máis tarde.</string>
+
+    <string name="user_choice_dialog_title">Como quere iniciar sesión?</string>
+    <string name="user_choice_dialog_on_device_name">Certificado no dispositivo</string>
+    <string name="user_choice_dialog_smartcard_name">Cartón intelixente físico</string>
+    <string name="user_choice_dialog_positive_button">Continuar</string>
+    <string name="user_choice_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_prompt_dialog_title">Preparar o cartón intelixente</string>
+    <string name="smartcard_prompt_dialog_message">Conecte ou achegue un cartón intelixente á parte posterior do teléfono.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Lendo o cartón intelixente</string>
+    <string name="smartcard_nfc_loading_dialog_message">Manteña o cartón intelixente no sitio.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Preparar o cartón intelixente</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Achegue un cartón intelixente á parte posterior do teléfono.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Activar a NFC na configuración do dispositivo</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Para iniciar sesión con NFC, active a NFC na configuración do dispositivo. Logo inicie sesión de novo.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Entendido</string>
 </resources>

--- a/common/src/main/res/values-he/strings.xml
+++ b/common/src/main/res/values-he/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">ביטול</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">בחר אישור כרטיס חכם כדי להיכנס</string>
+    <string name="smartcard_cert_dialog_title">בחר אישור כדי להיכנס</string>
     <string name="smartcard_cert_dialog_positive_button">המשך</string>
     <string name="smartcard_cert_dialog_negative_button">ביטול</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">ניסיונות כושלים רבים מדי. נסה שוב מאוחר יותר.</string>
 
     <string name="smartcard_early_unplug_dialog_title">נסה שוב</string>
-    <string name="smartcard_early_unplug_dialog_message">התקן כרטיס חכם הוסר. הכנס מחדש את המכשיר לפני שתנסה להיכנס שוב.</string>
+    <string name="smartcard_early_unplug_dialog_message">התקן כרטיס חכם הוסר. הכנס מחדש את ההתקן לפני שתנסה להיכנס שוב.</string>
 
     <string name="smartcard_no_cert_dialog_title">לא נמצאו אישורים ישימים.</string>
     <string name="smartcard_no_cert_dialog_message">ודא שהאישור שלך הוקצה כראוי להתקן הכרטיס החכם שלך.</string>
 
     <string name="smartcard_general_error_dialog_title">נסה שוב מאוחר יותר</string>
     <string name="smartcard_general_error_dialog_message">‏‏אירעה שגיאה בלתי צפויה. נסה שוב מאוחר יותר.</string>
+
+    <string name="user_choice_dialog_title">כיצד ברצונך להיכנס?</string>
+    <string name="user_choice_dialog_on_device_name">אישור בהתקן שלך</string>
+    <string name="user_choice_dialog_smartcard_name">כרטיס חכם פיזי</string>
+    <string name="user_choice_dialog_positive_button">המשך</string>
+    <string name="user_choice_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_prompt_dialog_title">הכן את הכרטיס החכם שלך</string>
+    <string name="smartcard_prompt_dialog_message">חבר או הצמד כרטיס חכם בגב הטלפון.</string>
+    <string name="smartcard_prompt_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">קורא את הכרטיס החכם שלך</string>
+    <string name="smartcard_nfc_loading_dialog_message">השאר את הכרטיס החכם שלך במקומו.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">הכן את הכרטיס החכם שלך</string>
+    <string name="smartcard_nfc_prompt_dialog_message">הצמד כרטיס חכם לגב הטלפון.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">הפעל את NFC בהגדרות ההתקן</string>
+    <string name="smartcard_nfc_reminder_dialog_message">כדי להיכנס באמצעות NFC, הפעל את NFC בהגדרות המכשיר שלך. לאחר מכן היכנס שוב.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">הבנתי</string>
 </resources>

--- a/common/src/main/res/values-hi/strings.xml
+++ b/common/src/main/res/values-hi/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">रद्द करें</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">साइन इन करने के लिए कोई स्मार्टकार्ड प्रमाणपत्र चुनें</string>
+    <string name="smartcard_cert_dialog_title">साइन इन करने के लिए किसी प्रमाणपत्र का चयन करें</string>
     <string name="smartcard_cert_dialog_positive_button">जारी रखें</string>
     <string name="smartcard_cert_dialog_negative_button">रद्द करें</string>
 
-    <string name="smartcard_pin_dialog_title">स्मार्टकार्ड अनलॉक करें</string>
-    <string name="smartcard_pin_dialog_message">प्रमाणपत्र पर पहुँच प्राप्त करने और साइन इन करने के लिए स्मार्टकार्ड पिन दर्ज करें</string>
+    <string name="smartcard_pin_dialog_title">स्मार्ट कार्ड का लॉक खोलें</string>
+    <string name="smartcard_pin_dialog_message">प्रमाणपत्र पर पहुँच प्राप्त करने और साइन इन करने के लिए स्मार्ट कार्ड पिन दर्ज करें</string>
     <string name="smartcard_pin_dialog_positive_button">अनलॉक करें</string>
     <string name="smartcard_pin_dialog_negative_button">रद्द करें</string>
     <string name="smartcard_pin_dialog_error_message">आपके द्वारा दर्ज किया गया PIN गलत था.</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">बहुत अधिक विफल प्रयास, बाद में फिर से कोशिश करें.</string>
 
     <string name="smartcard_early_unplug_dialog_title">फिर से कोशिश करें</string>
-    <string name="smartcard_early_unplug_dialog_message">स्मार्टकार्ड डिवाइस निकाल दिया गया था. कृपया फिर से लॉग इन करने की कोशिश करने से पहले डिवाइस को फिर से लगाएँ.</string>
+    <string name="smartcard_early_unplug_dialog_message">स्मार् टकार्ड डिवाइस निकाल दिया गया था. कृपया फिर से लॉग इन करने की कोशिश करने से पहले डिवाइस को फिर से लगाएँ.</string>
 
     <string name="smartcard_no_cert_dialog_title">कोई लागू होने लायक प्रमाण पत्र नहीं मिले.</string>
-    <string name="smartcard_no_cert_dialog_message">कृपया पुष्टि करें कि आपके प्रमाणपत्र का आपके स्मार्टकार्ड डिवाइस पर सही तरीके से प्रावधान किया गया है.</string>
+    <string name="smartcard_no_cert_dialog_message">पुष्टि करें कि आपके प्रमाणपत्र का आपके स्मार्टकार्ड डिवाइस पर सही तरीके से प्रावधान किया गया है.</string>
 
     <string name="smartcard_general_error_dialog_title">बाद में फिर से कोशिश करें</string>
     <string name="smartcard_general_error_dialog_message">एक अनपेक्षित त्रुटि हुई है. कृपया बाद में पुनः प्रयास करें.</string>
+
+    <string name="user_choice_dialog_title">आप कैसे साइन इन करना चाहेंगे?</string>
+    <string name="user_choice_dialog_on_device_name">आपके डिवाइस पर प्रमाणपत्र</string>
+    <string name="user_choice_dialog_smartcard_name">फ़िज़िकल स्मार्ट कार्ड</string>
+    <string name="user_choice_dialog_positive_button">जारी रखें</string>
+    <string name="user_choice_dialog_negative_button">कैंसिल करें</string>
+
+    <string name="smartcard_prompt_dialog_title">अपना स्मार्ट कार्ड तैयार करें</string>
+    <string name="smartcard_prompt_dialog_message">अपने फ़ोन के पीछे किसी स्मार्ट कार्ड को प्लग इन या होल्ड करें.</string>
+    <string name="smartcard_prompt_dialog_negative_button">कैंसिल करें</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">आपका स्मार्ट कार्ड पढ़ा जा रहा है</string>
+    <string name="smartcard_nfc_loading_dialog_message">अपने स्मार्ट कार्ड को अपने स्थान पर रखें.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">अपना स्मार्ट कार्ड तैयार करें</string>
+    <string name="smartcard_nfc_prompt_dialog_message">स्मार्ट कार्ड को अपने फ़ोन के पीछे होल्ड करें.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">कैंसिल करें</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">डिवाइस सेटिंग्स में NFC चालू करें</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC के साथ साइन इन करने के लिए, अपनी डिवाइस सेटिंग्स में NFC चालू करें. फिर से साइन इन करें.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">समझ गया</string>
 </resources>

--- a/common/src/main/res/values-hr/strings.xml
+++ b/common/src/main/res/values-hr/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Odustani</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Odaberite certifikat pametne kartice za prijavu</string>
+    <string name="smartcard_cert_dialog_title">Odaberite certifikat za prijavu</string>
     <string name="smartcard_cert_dialog_positive_button">Nastavi</string>
     <string name="smartcard_cert_dialog_negative_button">Otkaži</string>
 
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Uređaj pametne kartice je uklonjen. Ponovno umetnite uređaj prije ponovnog pokušaja prijave.</string>
 
     <string name="smartcard_no_cert_dialog_title">Nisu pronađeni primjenjivi certifikati.</string>
-    <string name="smartcard_no_cert_dialog_message">Provjerite jesu li certifikati pravilno dodijeljeni na vaš uređaj pametne kartice.</string>
+    <string name="smartcard_no_cert_dialog_message">Potvrdite da je certifikat pravilno dodijeljen na vaš uređaj pametne kartice.</string>
 
     <string name="smartcard_general_error_dialog_title">Pokušajte ponovno poslije</string>
     <string name="smartcard_general_error_dialog_message">Došlo je do neočekivane pogreške. Pokušajte ponovno kasnije.</string>
+
+    <string name="user_choice_dialog_title">Kako se želite prijaviti?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikat na vašem uređaju</string>
+    <string name="user_choice_dialog_smartcard_name">Fizička pametna kartica</string>
+    <string name="user_choice_dialog_positive_button">Nastavi</string>
+    <string name="user_choice_dialog_negative_button">Odustani</string>
+
+    <string name="smartcard_prompt_dialog_title">Pripremite pametnu karticu</string>
+    <string name="smartcard_prompt_dialog_message">Priključite ili držite pametnu karticu na stražnjem dijelu telefona.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Odustani</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Čitanje pametne kartice</string>
+    <string name="smartcard_nfc_loading_dialog_message">Držite pametnu karticu na mjestu.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Pripremite pametnu karticu</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Držite pametnu karticu na stražnjem dijelu telefona.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Odustani</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Uključite NFC u postavkama uređaja</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Da biste se prijavili putem NFC-a, uključite NFC u postavkama uređaja. Zatim se ponovno prijavite.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Shvaćam</string>
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Mégse</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Válasszon ki egy intelligenskártya-tanúsítványt a bejelentkezéshez</string>
+    <string name="smartcard_cert_dialog_title">Jelölje ki a bejelentkezéshez használt tanúsítványt</string>
     <string name="smartcard_cert_dialog_positive_button">Tovább</string>
     <string name="smartcard_cert_dialog_negative_button">Mégse</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Próbálkozzon újra később</string>
     <string name="smartcard_general_error_dialog_message">Váratlan hiba történt. Később próbálja meg újból.</string>
+
+    <string name="user_choice_dialog_title">Hogyan szeretne bejelentkezni?</string>
+    <string name="user_choice_dialog_on_device_name">Tanúsítvány az eszközön</string>
+    <string name="user_choice_dialog_smartcard_name">Fizikai intelligens kártya</string>
+    <string name="user_choice_dialog_positive_button">Folytatás</string>
+    <string name="user_choice_dialog_negative_button">Mégse</string>
+
+    <string name="smartcard_prompt_dialog_title">Intelligens kártya előkészítése</string>
+    <string name="smartcard_prompt_dialog_message">Helyezzen be egy intelligens kártyát, vagy tartsa a telefon hátlapjához.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Mégse</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Intelligens kártya olvasása folyamatban</string>
+    <string name="smartcard_nfc_loading_dialog_message">Tartsa tovább az intelligens kártyát a telefonhoz.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Intelligens kártya előkészítése</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Tartson egy intelligens kártyát a telefon hátlapjához.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Mégse</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">NFC bekapcsolása az eszközbeállításokban</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Ha NFC-vel szeretne bejelentkezni, kapcsolja be az NFC-t az eszköz beállításai között. Ezután jelentkezzen be újra.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Értem</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Batal</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Pilih sertifikat kartu pintar untuk masuk</string>
+    <string name="smartcard_cert_dialog_title">Pilih sertifikat untuk masuk</string>
     <string name="smartcard_cert_dialog_positive_button">Lanjutkan</string>
     <string name="smartcard_cert_dialog_negative_button">Batal</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Coba lagi nanti</string>
     <string name="smartcard_general_error_dialog_message">Terjadi kesalahan yang tidak terduga. Coba lagi nanti.</string>
+
+    <string name="user_choice_dialog_title">Bagaimana Anda ingin masuk?</string>
+    <string name="user_choice_dialog_on_device_name">Sertifikat di perangkat Anda</string>
+    <string name="user_choice_dialog_smartcard_name">Kartu pintar fisik</string>
+    <string name="user_choice_dialog_positive_button">Lanjutkan</string>
+    <string name="user_choice_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_prompt_dialog_title">Siapkan kartu pintar Anda</string>
+    <string name="smartcard_prompt_dialog_message">Masukkan atau pegang kartu pintar ke bagian belakang ponsel Anda.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Membaca kartu pintar Anda</string>
+    <string name="smartcard_nfc_loading_dialog_message">Pertahankan kartu pintar Anda di tempat.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Siapkan kartu pintar Anda</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Tahan kartu pintar di bagian belakang telepon Anda.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Aktifkan NFC di pengaturan perangkat</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Untuk masuk dengan NFC, aktifkan NFC di pengaturan perangkat Anda. Kemudian, masuk lagi.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Mengerti</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Annulla</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Scegli un certificato smart card per accedere</string>
+    <string name="smartcard_cert_dialog_title">Selezionare un certificato per l\'accesso</string>
     <string name="smartcard_cert_dialog_positive_button">Continua</string>
     <string name="smartcard_cert_dialog_negative_button">Annulla</string>
 
     <string name="smartcard_pin_dialog_title">Sblocca smart card</string>
-    <string name="smartcard_pin_dialog_message">Immetti il PIN della smart card per accedere al certificato e accedere</string>
+    <string name="smartcard_pin_dialog_message">Immetti il PIN della smart card per accedere al certificato ed eseguire l\'accesso</string>
     <string name="smartcard_pin_dialog_positive_button">Sblocca</string>
     <string name="smartcard_pin_dialog_negative_button">Annulla</string>
     <string name="smartcard_pin_dialog_error_message">Il PIN immesso non è corretto.</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Troppi tentativi non riusciti. Riprova più tardi.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Riprova</string>
-    <string name="smartcard_early_unplug_dialog_message">Il dispositivo smart card è stato rimosso. Reinserisci il dispositivo prima di tentare di nuovo l\'accesso.</string>
+    <string name="smartcard_early_unplug_dialog_message">Il dispositivo smart card è stato rimosso. Reinserire il dispositivo prima di tentare di nuovo l\'accesso.</string>
 
     <string name="smartcard_no_cert_dialog_title">Non sono stati trovati certificati applicabili.</string>
-    <string name="smartcard_no_cert_dialog_message">Verifica che il provisioning del certificato sia stato eseguito correttamente nel dispositivo smart card.</string>
+    <string name="smartcard_no_cert_dialog_message">Verificare che il provisioning del certificato sia stato eseguito correttamente nel dispositivo smart card.</string>
 
     <string name="smartcard_general_error_dialog_title">Riprova più tardi</string>
     <string name="smartcard_general_error_dialog_message">Si è verificato un errore imprevisto. Riprova più tardi.</string>
+
+    <string name="user_choice_dialog_title">Come si vuole accedere?</string>
+    <string name="user_choice_dialog_on_device_name">Certificato nel dispositivo</string>
+    <string name="user_choice_dialog_smartcard_name">Smart card fisica</string>
+    <string name="user_choice_dialog_positive_button">Continua</string>
+    <string name="user_choice_dialog_negative_button">Annulla</string>
+
+    <string name="smartcard_prompt_dialog_title">Preparare la smart card</string>
+    <string name="smartcard_prompt_dialog_message">Collegare o tenere una smart card sul retro del telefono.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Annulla</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Lettura del smart card</string>
+    <string name="smartcard_nfc_loading_dialog_message">Mantenere la smart card al suo posto.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Preparare la smart card</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Tenere una smart card sul retro del telefono.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Annulla</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Attivare NFC nelle impostazioni del dispositivo</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Per accedere con NFC, attivarlo nelle impostazioni del dispositivo. Quindi accedi di nuovo.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Chiudi</string>
 </resources>

--- a/common/src/main/res/values-iw/strings.xml
+++ b/common/src/main/res/values-iw/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">ביטול</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">בחר אישור כרטיס חכם כדי להיכנס</string>
+    <string name="smartcard_cert_dialog_title">בחר אישור כדי להיכנס</string>
     <string name="smartcard_cert_dialog_positive_button">המשך</string>
     <string name="smartcard_cert_dialog_negative_button">ביטול</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">ניסיונות כושלים רבים מדי. נסה שוב מאוחר יותר.</string>
 
     <string name="smartcard_early_unplug_dialog_title">נסה שוב</string>
-    <string name="smartcard_early_unplug_dialog_message">התקן כרטיס חכם הוסר. הכנס מחדש את המכשיר לפני שתנסה להיכנס שוב.</string>
+    <string name="smartcard_early_unplug_dialog_message">התקן כרטיס חכם הוסר. הכנס מחדש את ההתקן לפני שתנסה להיכנס שוב.</string>
 
     <string name="smartcard_no_cert_dialog_title">לא נמצאו אישורים ישימים.</string>
     <string name="smartcard_no_cert_dialog_message">ודא שהאישור שלך הוקצה כראוי להתקן הכרטיס החכם שלך.</string>
 
     <string name="smartcard_general_error_dialog_title">נסה שוב מאוחר יותר</string>
     <string name="smartcard_general_error_dialog_message">‏‏אירעה שגיאה בלתי צפויה. נסה שוב מאוחר יותר.</string>
+
+    <string name="user_choice_dialog_title">כיצד ברצונך להיכנס?</string>
+    <string name="user_choice_dialog_on_device_name">אישור בהתקן שלך</string>
+    <string name="user_choice_dialog_smartcard_name">כרטיס חכם פיזי</string>
+    <string name="user_choice_dialog_positive_button">המשך</string>
+    <string name="user_choice_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_prompt_dialog_title">הכן את הכרטיס החכם שלך</string>
+    <string name="smartcard_prompt_dialog_message">חבר או הצמד כרטיס חכם בגב הטלפון.</string>
+    <string name="smartcard_prompt_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">קורא את הכרטיס החכם שלך</string>
+    <string name="smartcard_nfc_loading_dialog_message">השאר את הכרטיס החכם שלך במקומו.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">הכן את הכרטיס החכם שלך</string>
+    <string name="smartcard_nfc_prompt_dialog_message">הצמד כרטיס חכם לגב הטלפון.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">ביטול</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">הפעל את NFC בהגדרות ההתקן</string>
+    <string name="smartcard_nfc_reminder_dialog_message">כדי להיכנס באמצעות NFC, הפעל את NFC בהגדרות המכשיר שלך. לאחר מכן היכנס שוב.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">הבנתי</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">キャンセル</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">サインインするスマートカード証明書の選択</string>
+    <string name="smartcard_cert_dialog_title">サインインするには証明書を選択してください</string>
     <string name="smartcard_cert_dialog_positive_button">続行</string>
     <string name="smartcard_cert_dialog_negative_button">キャンセル</string>
 
-    <string name="smartcard_pin_dialog_title">スマートカードのロック解除</string>
-    <string name="smartcard_pin_dialog_message">スマートカードの PIN を入力して証明書にアクセスし、サインインしてください</string>
+    <string name="smartcard_pin_dialog_title">スマート カードのロック解除</string>
+    <string name="smartcard_pin_dialog_message">スマート カードの PIN を入力して証明書にアクセスし、サインインしてください</string>
     <string name="smartcard_pin_dialog_positive_button">ロック解除</string>
     <string name="smartcard_pin_dialog_negative_button">キャンセル</string>
     <string name="smartcard_pin_dialog_error_message">入力された PIN が正しくありません</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">失敗した試行回数が多すぎます。後でもう一度お試しください。</string>
 
     <string name="smartcard_early_unplug_dialog_title">もう一度お試しください</string>
-    <string name="smartcard_early_unplug_dialog_message">スマートカード デバイスが削除されました。もう一度ログインする前に、デバイスを再挿入してください。</string>
+    <string name="smartcard_early_unplug_dialog_message">スマート カード デバイスが削除されました。もう一度ログインする前に、デバイスをもう一度挿入してください。</string>
 
     <string name="smartcard_no_cert_dialog_title">該当する証明書が見つかりません。</string>
-    <string name="smartcard_no_cert_dialog_message">証明書がスマートカード デバイスに正しくプロビジョニングされていることを確認してください。</string>
+    <string name="smartcard_no_cert_dialog_message">証明書がスマート カード デバイスに正しくプロビジョニングされていることを確認してください。</string>
 
     <string name="smartcard_general_error_dialog_title">後でもう一度お試しください</string>
     <string name="smartcard_general_error_dialog_message">予期しないエラーが発生しました。後でもう一度お試しください。</string>
+
+    <string name="user_choice_dialog_title">サインインする方法を指定してください。</string>
+    <string name="user_choice_dialog_on_device_name">デバイス上の証明書</string>
+    <string name="user_choice_dialog_smartcard_name">物理スマート カード</string>
+    <string name="user_choice_dialog_positive_button">続行</string>
+    <string name="user_choice_dialog_negative_button">キャンセル</string>
+
+    <string name="smartcard_prompt_dialog_title">スマート カードの準備</string>
+    <string name="smartcard_prompt_dialog_message">スマート カードを差し込むか、スマートフォンの背面にかざしてください。</string>
+    <string name="smartcard_prompt_dialog_negative_button">キャンセル</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">スマート カードの読み取り</string>
+    <string name="smartcard_nfc_loading_dialog_message">スマート カードを所定の位置で保持します。</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">スマート カードの準備</string>
+    <string name="smartcard_nfc_prompt_dialog_message">スマート カードをスマートフォンの背面にかざしたままにします。</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">キャンセル</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">デバイス設定で NFC を有効にする</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC でサインインするには、デバイスの設定で NFC を有効にします。その後、もう一度サインインしてください。</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">了解</string>
 </resources>

--- a/common/src/main/res/values-kk/strings.xml
+++ b/common/src/main/res/values-kk/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Бас тарту</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Кіру үшін смарт-карта сертификатын таңдаңыз</string>
+    <string name="smartcard_cert_dialog_title">Кіру үшін сертификатты таңдаңыз</string>
     <string name="smartcard_cert_dialog_positive_button">Жалғастыру</string>
     <string name="smartcard_cert_dialog_negative_button">Бас тарту</string>
 
-    <string name="smartcard_pin_dialog_title">Смарт-картаның құлпын ашу</string>
-    <string name="smartcard_pin_dialog_message">Сертификатқа қол жеткізу және жүйеге кіру үшін смарт-карта PIN кодын енгізіңіз</string>
+    <string name="smartcard_pin_dialog_title">Смарт картаның құлпын ашу</string>
+    <string name="smartcard_pin_dialog_message">Сертификатқа қол жеткізу және жүйеге кіру үшін смарт карта PIN кодын енгізіңіз</string>
     <string name="smartcard_pin_dialog_positive_button">Құлыпты ашу</string>
     <string name="smartcard_pin_dialog_negative_button">Бас тарту</string>
     <string name="smartcard_pin_dialog_error_message">Сіз енгізген PIN код дұрыс емес</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Сәтсіз әрекеттер тым көп. Кейінірек қайталап көріңіз.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Әрекетті қайталау</string>
-    <string name="smartcard_early_unplug_dialog_message">Смарт-карта құрылғысы жойылды. Қайта кіруге әрекет жасамас бұрын құрылғыны қайта кірістіріңіз.</string>
+    <string name="smartcard_early_unplug_dialog_message">Смарт карта құрылғысы жойылды. Қайта кіруге әрекет жасамас бұрын құрылғыны қайта кірістіріңіз.</string>
 
     <string name="smartcard_no_cert_dialog_title">Жарамды сертификаттар табылмады.</string>
-    <string name="smartcard_no_cert_dialog_message">Сертификат смарт-карта құрылғысында дұрыс дайындалғанын тексеріңіз.</string>
+    <string name="smartcard_no_cert_dialog_message">Сертификат смарт карта құрылғысында дұрыс дайындалғанын тексеріңіз.</string>
 
     <string name="smartcard_general_error_dialog_title">Әрекетті кейінірек қайталаңыз</string>
     <string name="smartcard_general_error_dialog_message">Күтпеген қате пайда болды. Кейінірек қайталап көріңіз.</string>
+
+    <string name="user_choice_dialog_title">Қалау кіргіңіз келеді?</string>
+    <string name="user_choice_dialog_on_device_name">Құрылғыңыздағы сертификат</string>
+    <string name="user_choice_dialog_smartcard_name">Физикалық смарт карта</string>
+    <string name="user_choice_dialog_positive_button">Жалғастыру</string>
+    <string name="user_choice_dialog_negative_button">Бас тарту</string>
+
+    <string name="smartcard_prompt_dialog_title">Смарт картаны дайындау</string>
+    <string name="smartcard_prompt_dialog_message">Смарт картаны қосыңыз немесе оны телефоныңыздың артқы жағына жалғаңыз немесе ұстап тұрыңыз.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Бас тарту</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Смарт карта оқылуда</string>
+    <string name="smartcard_nfc_loading_dialog_message">Смарт картаны пайдалануға дайындаңыз.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Смарт картаны дайындау</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Смарт картаны қосыңыз немесе оны телефоныңыздың артқы жағына тіркеп ұстап тұрыңыз.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Бас тарту</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Құрылғы параметрлерінде NFC функциясын қосу</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC көмегімен кіру үшін, құрылғы параметрлерінде NFC функциясын қосыңыз. Содан кейін қайта кіріңіз.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Түсінікті</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">취소</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">로그인할 스마트 카드 인증서 선택</string>
+    <string name="smartcard_cert_dialog_title">로그인할 인증서 선택</string>
     <string name="smartcard_cert_dialog_positive_button">계속</string>
     <string name="smartcard_cert_dialog_negative_button">취소</string>
 
     <string name="smartcard_pin_dialog_title">스마트 카드 잠금 해제</string>
-    <string name="smartcard_pin_dialog_message">인증서에 액세스하고 로그인하려면 스마트 카드 PIN을 입력하세요.</string>
+    <string name="smartcard_pin_dialog_message">인증서에 액세스하여 로그인하려면 스마트 카드 PIN을 입력하세요.</string>
     <string name="smartcard_pin_dialog_positive_button">잠금 해제</string>
     <string name="smartcard_pin_dialog_negative_button">취소</string>
     <string name="smartcard_pin_dialog_error_message">입력한 PIN이 잘못되었습니다.</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">실패한 시도가 너무 많습니다. 나중에 다시 시도하세요.</string>
 
     <string name="smartcard_early_unplug_dialog_title">다시 시도하세요</string>
-    <string name="smartcard_early_unplug_dialog_message">스마트 카드 장치가 제거되었습니다. 다시 로그인을 시도하기 전에 장치를 다시 삽입하세요.</string>
+    <string name="smartcard_early_unplug_dialog_message">스마트 카드 장치를 제거했습니다. 다시 로그인을 시도하기 전에 장치를 다시 삽입하세요.</string>
 
     <string name="smartcard_no_cert_dialog_title">해당 인증서를 찾을 수 없습니다.</string>
     <string name="smartcard_no_cert_dialog_message">인증서가 스마트 카드 장치에 올바르게 프로비전되었는지 확인하세요.</string>
 
     <string name="smartcard_general_error_dialog_title">나중에 다시 시도</string>
     <string name="smartcard_general_error_dialog_message">예기치 않은 오류가 발생했습니다. 나중에 다시 시도하세요.</string>
+
+    <string name="user_choice_dialog_title">어떻게 로그인하길 원하시나요?</string>
+    <string name="user_choice_dialog_on_device_name">장치의 인증서</string>
+    <string name="user_choice_dialog_smartcard_name">실물 스마트 카드</string>
+    <string name="user_choice_dialog_positive_button">계속</string>
+    <string name="user_choice_dialog_negative_button">취소</string>
+
+    <string name="smartcard_prompt_dialog_title">스마트 카드를 준비하세요.</string>
+    <string name="smartcard_prompt_dialog_message">스마트 카드를 연결하거나 휴대폰 뒷면에 가져다 대세요.</string>
+    <string name="smartcard_prompt_dialog_negative_button">취소</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">스마트 카드를 읽는 중</string>
+    <string name="smartcard_nfc_loading_dialog_message">스마트 카드를 그대로 들고 있으세요.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">스마트 카드를 준비하세요.</string>
+    <string name="smartcard_nfc_prompt_dialog_message">스마트 카드를 휴대폰 뒷면에 가져다 대세요.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">취소</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">장치 설정에서 NFC를 활성화하세요.</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC로 로그인하려면 장치 설정에서 NFC를 활성화하세요. 그런 다음 다시 로그인하세요.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">확인</string>
 </resources>

--- a/common/src/main/res/values-lt/strings.xml
+++ b/common/src/main/res/values-lt/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Atšaukti</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Pasirinkite išmaniosios kortelės sertifikatą, kad prisijungtumėte</string>
+    <string name="smartcard_cert_dialog_title">Pasirinkite sertifikatą, kad galėtumėte prisijungti.</string>
     <string name="smartcard_cert_dialog_positive_button">Tęsti</string>
     <string name="smartcard_cert_dialog_negative_button">Atšaukti</string>
 
-    <string name="smartcard_pin_dialog_title">Atrakinti išmaniąją kortelę</string>
-    <string name="smartcard_pin_dialog_message">Įveskite išmaniosios kortelės PIN kodą, kad gautumėte prieigą prie sertifikato ir prisijungtumėte</string>
+    <string name="smartcard_pin_dialog_title">Atrakinti intelektualiąją kortelę</string>
+    <string name="smartcard_pin_dialog_message">Įveskite intelektualiosios kortelės PIN kodą, kad pasiektumėte sertifikatą ir prisijungtumėte</string>
     <string name="smartcard_pin_dialog_positive_button">Atrakinti</string>
     <string name="smartcard_pin_dialog_negative_button">Atšaukti</string>
     <string name="smartcard_pin_dialog_error_message">Įvestas PIN kodas yra neteisingas.</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Per daug nesėkmingų bandymų, bandykite dar kartą vėliau.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Bandykite dar kartą</string>
-    <string name="smartcard_early_unplug_dialog_message">Išmaniosios kortelės įrenginys pašalintas. Prieš bandydami prisijungti dar kartą, iš naujo įdėkite įrenginį.</string>
+    <string name="smartcard_early_unplug_dialog_message">Intelektualiosios kortelės įrenginys buvo pašalintas. Prieš bandydami prisijungti dar kartą, iš naujo įdėkite įrenginį.</string>
 
     <string name="smartcard_no_cert_dialog_title">Tinkamų sertifikatų nerasta.</string>
-    <string name="smartcard_no_cert_dialog_message">Patikrinkite, ar jūsų sertifikatas teisingai įdiegtas į jūsų išmaniosios kortelės įrenginį.</string>
+    <string name="smartcard_no_cert_dialog_message">Patvirtinkite, kad jūsų sertifikatas tinkamai parengtas intelektualiosios kortelės įrenginyje.</string>
 
     <string name="smartcard_general_error_dialog_title">Bandykite dar kartą vėliau</string>
     <string name="smartcard_general_error_dialog_message">Įvyko nenumatyta klaida. Bandykite dar kartą vėliau.</string>
+
+    <string name="user_choice_dialog_title">Kaip norėtumėte prisijungti?</string>
+    <string name="user_choice_dialog_on_device_name">Sertifikatas jūsų įrenginyje</string>
+    <string name="user_choice_dialog_smartcard_name">Fizinė intelektualioji kortelė</string>
+    <string name="user_choice_dialog_positive_button">Tęsti</string>
+    <string name="user_choice_dialog_negative_button">Atšaukti</string>
+
+    <string name="smartcard_prompt_dialog_title">Paruoškite savo intelektualiąją kortelę</string>
+    <string name="smartcard_prompt_dialog_message">Prijunkite arba laikykite intelektualiąją kortelę prie telefono galinės dalies.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Atšaukti</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Skaitoma jūsų intelektualioji kortelė</string>
+    <string name="smartcard_nfc_loading_dialog_message">Laikykite intelektualiąją kortelę vietoje.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Paruoškite savo intelektualiąją kortelę</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Laikykite intelektualiąją kortelę prie telefono galinės dalies.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Atšaukti</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Įjungti NFC įrenginio parametruose</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Norėdami prisijungti naudodami NFC, įrenginio parametruose įjunkite NFC. Tada prisijunkite dar kartą.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Supratau</string>
 </resources>

--- a/common/src/main/res/values-lv/strings.xml
+++ b/common/src/main/res/values-lv/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Atcelt</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Izvēlieties viedkartes sertifikātu, lai pierakstītos</string>
+    <string name="smartcard_cert_dialog_title">Atlasiet sertifikātu, lai pierakstītos</string>
     <string name="smartcard_cert_dialog_positive_button">Turpināt</string>
     <string name="smartcard_cert_dialog_negative_button">Atcelt</string>
 
-    <string name="smartcard_pin_dialog_title">Viedkartes atbloķēšana</string>
+    <string name="smartcard_pin_dialog_title">Atbloķēt viedkarti</string>
     <string name="smartcard_pin_dialog_message">Ievadiet viedkartes PIN kodu, lai piekļūtu sertifikātam un pierakstītos</string>
     <string name="smartcard_pin_dialog_positive_button">Atbloķēt</string>
     <string name="smartcard_pin_dialog_negative_button">Atcelt</string>
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Viedkartes ierīce tika noņemta. Lūdzu, atkārtoti ievietojiet ierīci, pirms vēlreiz mēģināt pieteikties.</string>
 
     <string name="smartcard_no_cert_dialog_title">Nav atrasts neviens lietojams sertifikāts.</string>
-    <string name="smartcard_no_cert_dialog_message">Lūdzu, pārliecinieties, vai jūsu sertifikāts ir pareizi nodrošināts viedkartes ierīcē.</string>
+    <string name="smartcard_no_cert_dialog_message">Pārliecinieties, vai jūsu sertifikāts ir pareizi nodrošināts viedkartes ierīcē.</string>
 
     <string name="smartcard_general_error_dialog_title">Vēlāk mēģiniet vēlreiz</string>
     <string name="smartcard_general_error_dialog_message">Radās neparedzēta kļūda. Vēlāk mēģiniet vēlreiz.</string>
+
+    <string name="user_choice_dialog_title">Kā vēlaties pierakstīties?</string>
+    <string name="user_choice_dialog_on_device_name">Sertifikāts jūsu ierīcē</string>
+    <string name="user_choice_dialog_smartcard_name">Fiziska viedkarte</string>
+    <string name="user_choice_dialog_positive_button">Turpināt</string>
+    <string name="user_choice_dialog_negative_button">Atcelt</string>
+
+    <string name="smartcard_prompt_dialog_title">Viedkartes sagatavošana</string>
+    <string name="smartcard_prompt_dialog_message">Pievienojiet viedkarti tālruņa aizmugurē vai turiet to.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Atcelt</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Viedkartes lasīšana</string>
+    <string name="smartcard_nfc_loading_dialog_message">Glabājiet viedkarti vietā.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Viedkartes sagatavošana</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Turiet viedkarti tālruņa aizmugurē.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Atcelt</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Ieslēdziet NFC ierīces iestatījumos</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Lai pierakstītos, izmantojot NFC, ieslēdziet NFC ierīces iestatījumos. Pēc tam pierakstieties vēlreiz.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Sapratu</string>
 </resources>

--- a/common/src/main/res/values-ms/strings.xml
+++ b/common/src/main/res/values-ms/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Batal</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Pilih sijil kad pintar untuk mendaftar masuk</string>
+    <string name="smartcard_cert_dialog_title">Pilih sijil untuk mendaftar masuk</string>
     <string name="smartcard_cert_dialog_positive_button">Teruskan</string>
     <string name="smartcard_cert_dialog_negative_button">Batalkan</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Cuba lagi kemudian</string>
     <string name="smartcard_general_error_dialog_message">Ralat tidak dijangka telah berlaku. Sila cuba semula sebentar lagi.</string>
+
+    <string name="user_choice_dialog_title">Bagaimanakah cara anda ingin mendaftar masuk?</string>
+    <string name="user_choice_dialog_on_device_name">Sijil pada peranti anda</string>
+    <string name="user_choice_dialog_smartcard_name">Kad pintar fizikal</string>
+    <string name="user_choice_dialog_positive_button">Teruskan</string>
+    <string name="user_choice_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_prompt_dialog_title">Sediakan kad pintar anda</string>
+    <string name="smartcard_prompt_dialog_message">Pasang masuk atau tahan kad pintar ke belakang telefon anda.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Membaca kad pintar anda</string>
+    <string name="smartcard_nfc_loading_dialog_message">Kekalkan kad pintar anda pada tempatnya.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Sediakan kad pintar anda</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Tahan kad pintar ke belakang telefon anda.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Batal</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Hidupkan NFC dalam seting peranti</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Untuk mendaftar masuk dengan NFC, hidupkan NFC dalam seting peranti anda. Kemudian daftar masuk sekali lagi.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Faham</string>
 </resources>

--- a/common/src/main/res/values-nb/strings.xml
+++ b/common/src/main/res/values-nb/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Avbryt</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Velg et smartkortsertifikat for å logge på</string>
+    <string name="smartcard_cert_dialog_title">Velg et sertifikat for å logge på</string>
     <string name="smartcard_cert_dialog_positive_button">Fortsett</string>
     <string name="smartcard_cert_dialog_negative_button">Avbryt</string>
 
     <string name="smartcard_pin_dialog_title">Lås opp smartkort</string>
-    <string name="smartcard_pin_dialog_message">Skriv inn PIN-koden for smartkortet for å få tilgang til sertifikatet, og logg på</string>
+    <string name="smartcard_pin_dialog_message">Angi PIN-koden for smartkortet for å få tilgang til sertifikatet, og logg på</string>
     <string name="smartcard_pin_dialog_positive_button">Lås opp</string>
     <string name="smartcard_pin_dialog_negative_button">Avbryt</string>
     <string name="smartcard_pin_dialog_error_message">PIN-koden du skrev inn er feil.</string>
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Prøv på nytt senere</string>
     <string name="smartcard_general_error_dialog_message">Det har oppstått en uventet feil. Prøv på nytt senere.</string>
+
+    <string name="user_choice_dialog_title">Hvordan vil du logge på?</string>
+    <string name="user_choice_dialog_on_device_name">Sertifikat på enheten</string>
+    <string name="user_choice_dialog_smartcard_name">Fysisk smartkort</string>
+    <string name="user_choice_dialog_positive_button">Fortsett</string>
+    <string name="user_choice_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_prompt_dialog_title">Klargjør smartkortet</string>
+    <string name="smartcard_prompt_dialog_message">Koble til eller hold et smartkort mot baksiden av telefonen.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Leser smartkortet</string>
+    <string name="smartcard_nfc_loading_dialog_message">Hold smartkortet på plass.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Klargjør smartkortet</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Hold et smartkort mot baksiden av telefonen.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Aktiver NFC i enhetsinnstillinger</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Hvis du vil logge på med NFC, må du aktivere NFC i enhetsinnstillingene. Logg deretter på igjen.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Jeg forstår</string>
 </resources>

--- a/common/src/main/res/values-nl/strings.xml
+++ b/common/src/main/res/values-nl/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Annuleren</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Kies een smartcard-certificaat om u aan te melden</string>
+    <string name="smartcard_cert_dialog_title">Selecteer een certificaat om u aan te melden</string>
     <string name="smartcard_cert_dialog_positive_button">Doorgaan</string>
     <string name="smartcard_cert_dialog_negative_button">Annuleren</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Te veel mislukte pogingen. Probeer het later opnieuw.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Opnieuw proberen</string>
-    <string name="smartcard_early_unplug_dialog_message">Smartcard-apparaat is verwijderd. Plaats het apparaat opnieuw voordat u zich opnieuw probeert aan te melden.</string>
+    <string name="smartcard_early_unplug_dialog_message">Smartcardapparaat is verwijderd. Plaats het apparaat opnieuw voordat u zich opnieuw probeert aan te melden.</string>
 
     <string name="smartcard_no_cert_dialog_title">Er zijn geen toepasselijke certificaten gevonden.</string>
-    <string name="smartcard_no_cert_dialog_message">Controleer of uw certificaat correct is ingericht op uw smartcard-apparaat.</string>
+    <string name="smartcard_no_cert_dialog_message">Controleer of uw certificaat correct is ingericht op uw smartcardapparaat.</string>
 
     <string name="smartcard_general_error_dialog_title">Probeer het later opnieuw</string>
     <string name="smartcard_general_error_dialog_message">Er is een onverwachte fout opgetreden. Probeer het later opnieuw.</string>
+
+    <string name="user_choice_dialog_title">Hoe wilt u zich aanmelden?</string>
+    <string name="user_choice_dialog_on_device_name">Certificaat op uw apparaat</string>
+    <string name="user_choice_dialog_smartcard_name">Fysieke smartcard</string>
+    <string name="user_choice_dialog_positive_button">Doorgaan</string>
+    <string name="user_choice_dialog_negative_button">Annuleren</string>
+
+    <string name="smartcard_prompt_dialog_title">Uw smartcard voorbereiden</string>
+    <string name="smartcard_prompt_dialog_message">Sluit een smartcard aan op de achterkant van uw telefoon of houd deze vast.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Annuleren</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Uw smartcard lezen</string>
+    <string name="smartcard_nfc_loading_dialog_message">Houd uw smartcard op zijn plaats.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Uw smartcard voorbereiden</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Houd een smartcard vast aan de achterkant van uw telefoon.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Annuleren</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">NFC inschakelen in apparaatinstellingen</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Als u zich wilt aanmelden met NFC, schakelt u NFC in de apparaatinstellingen in. Meld u vervolgens opnieuw aan.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Anuluj</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Wybierz certyfikat karty inteligentnej, aby się zalogować</string>
+    <string name="smartcard_cert_dialog_title">Wybierz certyfikat dla logowania</string>
     <string name="smartcard_cert_dialog_positive_button">Kontynuuj</string>
     <string name="smartcard_cert_dialog_negative_button">Anuluj</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Spróbuj ponownie później</string>
     <string name="smartcard_general_error_dialog_message">Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.</string>
+
+    <string name="user_choice_dialog_title">Jak chcesz się zalogować?</string>
+    <string name="user_choice_dialog_on_device_name">Certyfikat na urządzeniu</string>
+    <string name="user_choice_dialog_smartcard_name">Fizyczna karta inteligentna</string>
+    <string name="user_choice_dialog_positive_button">Kontynuuj</string>
+    <string name="user_choice_dialog_negative_button">Anuluj</string>
+
+    <string name="smartcard_prompt_dialog_title">Przygotuj kartę inteligentną</string>
+    <string name="smartcard_prompt_dialog_message">Podłącz lub przytrzymaj kartę inteligentną z tyłu telefonu.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Anuluj</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Odczytywanie karty inteligentnej</string>
+    <string name="smartcard_nfc_loading_dialog_message">Utrzymuj kartę inteligentną na miejscu.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Przygotuj kartę inteligentną</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Przytrzymaj kartę inteligentną z tyłu telefonu.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Anuluj</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Włącz komunikację NFC w ustawieniach urządzenia</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Aby zalogować się za pomocą komunikacji NFC, włącz ją w ustawieniach urządzenia. Następnie zaloguj się ponownie.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumiem</string>
 </resources>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Cancelar</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Escolher um certificado de cartão inteligente para entrar</string>
+    <string name="smartcard_cert_dialog_title">Selecione um certificado com o qual assinar</string>
     <string name="smartcard_cert_dialog_positive_button">Continuar</string>
     <string name="smartcard_cert_dialog_negative_button">Cancelar</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Tentar novamente mais tarde</string>
     <string name="smartcard_general_error_dialog_message">Erro. Tente mais tarde.</string>
+
+    <string name="user_choice_dialog_title">Como você deseja começar?</string>
+    <string name="user_choice_dialog_on_device_name">Certificado em seu dispositivo</string>
+    <string name="user_choice_dialog_smartcard_name">Cartão inteligente físico</string>
+    <string name="user_choice_dialog_positive_button">Continuar</string>
+    <string name="user_choice_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_prompt_dialog_title">Preparar seu cartão inteligente</string>
+    <string name="smartcard_prompt_dialog_message">Conecte ou segure um cartão inteligente na parte traseira do telefone.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Lendo seu cartão inteligente</string>
+    <string name="smartcard_nfc_loading_dialog_message">Mantenha seu cartão inteligente em vigor.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Preparar seu cartão inteligente</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Mantenha um cartão inteligente na parte traseira do telefone.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Ativar o NFC nas configurações do dispositivo</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Para entrar com NFC, ative o NFC nas configurações do dispositivo. Em seguida, entre novamente.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Entendi</string>
 </resources>

--- a/common/src/main/res/values-pt-rPT/strings.xml
+++ b/common/src/main/res/values-pt-rPT/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Cancelar</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Escolher um certificado de smartcard para entrar</string>
+    <string name="smartcard_cert_dialog_title">Selecionar um certificado para iniciar sessão</string>
     <string name="smartcard_cert_dialog_positive_button">Continuar</string>
     <string name="smartcard_cert_dialog_negative_button">Cancelar</string>
 
-    <string name="smartcard_pin_dialog_title">Desbloquear smartcard</string>
-    <string name="smartcard_pin_dialog_message">Insira o PIN do smartcard para aceder ao certificado e entrar</string>
+    <string name="smartcard_pin_dialog_title">Desbloquear smart card</string>
+    <string name="smartcard_pin_dialog_message">Introduza o PIN do smart card para aceder ao certificado e iniciar sessão</string>
     <string name="smartcard_pin_dialog_positive_button">Desbloquear</string>
     <string name="smartcard_pin_dialog_negative_button">Cancelar</string>
     <string name="smartcard_pin_dialog_error_message">O PIN que inseriu estava incorreto</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Muitas tentativas falhadas. Tente novamente mais tarde.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Volte a tentar</string>
-    <string name="smartcard_early_unplug_dialog_message">O dispositivo smartcard foi removido. Volte a inserir o dispositivo antes de tentar voltar a tentar entrar.</string>
+    <string name="smartcard_early_unplug_dialog_message">O dispositivo smart card foi removido. Volte a inserir o dispositivo antes de tentar iniciar sessão novamente.</string>
 
     <string name="smartcard_no_cert_dialog_title">Não foram encontrados certificados aplicáveis.</string>
-    <string name="smartcard_no_cert_dialog_message">Confirme que o certificado foi corretamente a provisionado no seu dispositivo smartcard.</string>
+    <string name="smartcard_no_cert_dialog_message">Confirme que o certificado foi corretamente aprovisionado no seu dispositivo smart card.</string>
 
     <string name="smartcard_general_error_dialog_title">Tente novamente mais tarde</string>
     <string name="smartcard_general_error_dialog_message">Ocorreu um erro inesperado. Tente novamente mais tarde.</string>
+
+    <string name="user_choice_dialog_title">Como gostaria de iniciar sessão?</string>
+    <string name="user_choice_dialog_on_device_name">Certificado no seu dispositivo</string>
+    <string name="user_choice_dialog_smartcard_name">Smart card físico</string>
+    <string name="user_choice_dialog_positive_button">Continuar</string>
+    <string name="user_choice_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_prompt_dialog_title">Preparar o seu smart card</string>
+    <string name="smartcard_prompt_dialog_message">Ligue ou segure um smart card na parte de trás do seu telemóvel.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">A ler o seu smart card</string>
+    <string name="smartcard_nfc_loading_dialog_message">Mantenha o seu smart card no lugar.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Preparar o seu smart card</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Segure um smart card na parte de trás do seu telemóvel.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Cancelar</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Ligue o NFC nas definições do dispositivo</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Para iniciar sessão com NFC, ligue o NFC nas definições do seu dispositivo. Em seguida, volte a iniciar sessão.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-ro/strings.xml
+++ b/common/src/main/res/values-ro/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Anulare</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Alegeți un certificat de smart card pentru a vă conecta</string>
+    <string name="smartcard_cert_dialog_title">Selectați un certificat pentru a vă conecta</string>
     <string name="smartcard_cert_dialog_positive_button">Continuați</string>
     <string name="smartcard_cert_dialog_negative_button">Anulați</string>
 
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">Dispozitivul smart card a fost eliminat. Reintroduceți dispozitivul înainte de a încerca să vă conectați din nou.</string>
 
     <string name="smartcard_no_cert_dialog_title">Nu s-au găsit certificate aplicabile.</string>
-    <string name="smartcard_no_cert_dialog_message">Confirmați că s-a asigurat corect accesul certificatului pe dispozitivul smart cardului.</string>
+    <string name="smartcard_no_cert_dialog_message">Confirmați că s-a asigurat corect accesul certificatului pe dispozitivul smart card.</string>
 
     <string name="smartcard_general_error_dialog_title">Încercați din nou mai târziu</string>
     <string name="smartcard_general_error_dialog_message">A apărut o eroare neașteptată. Încercați din nou mai târziu.</string>
+
+    <string name="user_choice_dialog_title">Cum doriți să vă conectați?</string>
+    <string name="user_choice_dialog_on_device_name">Certificat pe dispozitivul dvs.</string>
+    <string name="user_choice_dialog_smartcard_name">Smart card fizic</string>
+    <string name="user_choice_dialog_positive_button">Continuați</string>
+    <string name="user_choice_dialog_negative_button">Anulați</string>
+
+    <string name="smartcard_prompt_dialog_title">Pregătiți-vă smart cardul</string>
+    <string name="smartcard_prompt_dialog_message">Inserați un smart card sau apropiați-l de spatele telefonului.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Anulați</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Se citește smart cardul</string>
+    <string name="smartcard_nfc_loading_dialog_message">Țineți-vă smart cardul nemișcat.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Pregătiți-vă smart cardul</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Apropiați un smart card de spatele telefonului.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Anulați</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Activați NFC în setările dispozitivului</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Pentru a vă conecta cu NFC, activați NFC în setările dispozitivului. Apoi conectați-vă din nou.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Am înțeles</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Отмена</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Выберите сертификат смарт-карты для входа</string>
+    <string name="smartcard_cert_dialog_title">Выбор сертификата входа</string>
     <string name="smartcard_cert_dialog_positive_button">Продолжить</string>
     <string name="smartcard_cert_dialog_negative_button">Отмена</string>
 
-    <string name="smartcard_pin_dialog_title">Разблокировать смарт-карту</string>
+    <string name="smartcard_pin_dialog_title">Разблокировка смарт-карты</string>
     <string name="smartcard_pin_dialog_message">Введите ПИН-код смарт-карты для доступа к сертификату и входа</string>
     <string name="smartcard_pin_dialog_positive_button">Разблокировать</string>
     <string name="smartcard_pin_dialog_negative_button">Отмена</string>
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Повторите попытку позже</string>
     <string name="smartcard_general_error_dialog_message">Произошла непредвиденная ошибка. Повторите попытку позже.</string>
+
+    <string name="user_choice_dialog_title">Выбор способа входа.</string>
+    <string name="user_choice_dialog_on_device_name">Сертификат на устройстве</string>
+    <string name="user_choice_dialog_smartcard_name">Физическая смарт-карта</string>
+    <string name="user_choice_dialog_positive_button">Продолжить</string>
+    <string name="user_choice_dialog_negative_button">Отмена</string>
+
+    <string name="smartcard_prompt_dialog_title">Подготовка смарт-карты</string>
+    <string name="smartcard_prompt_dialog_message">Подключите смарт-карту или приложите ее к задней части телефона.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Отмена</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Чтение смарт-карты</string>
+    <string name="smartcard_nfc_loading_dialog_message">Приготовьте смарт-карту к использованию.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Подготовка смарт-карты</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Приложите смарт-карту к задней части телефона.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Отмена</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Включение NFC в параметрах устройства</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Чтобы войти с помощью NFC, включите NFC в параметрах устройства. Затем войдите еще раз.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Понятно</string>
 </resources>

--- a/common/src/main/res/values-sk/strings.xml
+++ b/common/src/main/res/values-sk/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">Zrušiť</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Vyberte certifikát čipovej karty na prihlásenie</string>
+    <string name="smartcard_cert_dialog_title">Vyberte certifikát na prihlásenie</string>
     <string name="smartcard_cert_dialog_positive_button">Pokračovať</string>
     <string name="smartcard_cert_dialog_negative_button">Zrušiť</string>
 
-    <string name="smartcard_pin_dialog_title">Odomknúť čipovú kartu</string>
-    <string name="smartcard_pin_dialog_message">Zadajte PIN kód čipovej karty na prístup k certifikátu a prihláste sa</string>
+    <string name="smartcard_pin_dialog_title">Odomknúť inteligentnú kartu</string>
+    <string name="smartcard_pin_dialog_message">Zadajte PIN kód inteligentnej karty na prístup k certifikátu a prihláste sa</string>
     <string name="smartcard_pin_dialog_positive_button">Odomknúť</string>
     <string name="smartcard_pin_dialog_negative_button">Zrušiť</string>
     <string name="smartcard_pin_dialog_error_message">PIN kód, ktorý ste zadali, bol nesprávny</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Príliš veľa neúspešných pokusov, skúste to znova neskôr.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Skúsiť znova</string>
-    <string name="smartcard_early_unplug_dialog_message">Zariadenie s čipovou kartou bolo odobraté. Pred opätovným pokusom o prihlásenie znova vložte zariadenie.</string>
+    <string name="smartcard_early_unplug_dialog_message">Zariadenie s inteligentnou kartou bolo odobraté. Pred opätovným pokusom o prihlásenie znova vložte zariadenie.</string>
 
     <string name="smartcard_no_cert_dialog_title">Nenašli sa žiadne použiteľné certifikáty.</string>
-    <string name="smartcard_no_cert_dialog_message">Potvrďte, že certifikát bol správne poskytnutý v zariadení s čipovou kartou.</string>
+    <string name="smartcard_no_cert_dialog_message">Potvrďte, že certifikát bol správne poskytnutý v zariadení s inteligentnou kartou.</string>
 
     <string name="smartcard_general_error_dialog_title">Skúste to znova neskôr</string>
     <string name="smartcard_general_error_dialog_message">Vyskytla sa neočakávaná chyba. Skúste to znova neskôr.</string>
+
+    <string name="user_choice_dialog_title">Ako sa chcete prihlásiť?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikát vo vašom zariadení</string>
+    <string name="user_choice_dialog_smartcard_name">Fyzická inteligentná karta</string>
+    <string name="user_choice_dialog_positive_button">Pokračovať</string>
+    <string name="user_choice_dialog_negative_button">Zrušiť</string>
+
+    <string name="smartcard_prompt_dialog_title">Príprava inteligentnej karty</string>
+    <string name="smartcard_prompt_dialog_message">Pripojte alebo podržte inteligentnú kartu na zadnej strane telefónu.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Zrušiť</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Čítanie inteligentnej karty</string>
+    <string name="smartcard_nfc_loading_dialog_message">Udržujte inteligentnú kartu na mieste.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Príprava inteligentnej karty</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Podržte inteligentnú kartu na zadnej strane telefónu.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Zrušiť</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Zapnúť technológiu NFC v nastaveniach zariadenia</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Ak sa chcete prihlásiť pomocou technológie NFC, zapnite technológiu NFC v nastaveniach zariadenia. Potom sa znova prihláste.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumiem</string>
 </resources>

--- a/common/src/main/res/values-sl/strings.xml
+++ b/common/src/main/res/values-sl/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Prekliči</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Izberite potrdilo pametne kartice za vpis</string>
+    <string name="smartcard_cert_dialog_title">Izberite potrdilo za vpis</string>
     <string name="smartcard_cert_dialog_positive_button">Nadaljuj</string>
     <string name="smartcard_cert_dialog_negative_button">Prekliči</string>
 
-    <string name="smartcard_pin_dialog_title">Odkleni pametno kartico</string>
+    <string name="smartcard_pin_dialog_title">Odklenite pametno kartico</string>
     <string name="smartcard_pin_dialog_message">Če želite dostopati do potrdila in se vpisati, vnesite kodo PIN pametne kartice</string>
     <string name="smartcard_pin_dialog_positive_button">Odkleni</string>
     <string name="smartcard_pin_dialog_negative_button">Prekliči</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Preveč neuspelih poskusov. Poskusite znova pozneje.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Poskusi znova</string>
-    <string name="smartcard_early_unplug_dialog_message">Naprava s pametno kartico je bila odstranjena. Znova vstavite napravo, preden se poskusite znova prijaviti.</string>
+    <string name="smartcard_early_unplug_dialog_message">Naprava s pametno kartico je bila odstranjena. Preden se poskusite znova prijaviti, znova vstavite napravo.</string>
 
     <string name="smartcard_no_cert_dialog_title">Ustreznih potrdil ni bilo mogoče najti.</string>
     <string name="smartcard_no_cert_dialog_message">Preverite, ali je bilo potrdilo pravilno nastavljeno in omogočeno v napravi s pametno kartico.</string>
 
     <string name="smartcard_general_error_dialog_title">Poskusite znova pozneje</string>
     <string name="smartcard_general_error_dialog_message">Prišlo je do nepričakovane napake. Poskusite znova pozneje.</string>
+
+    <string name="user_choice_dialog_title">Kako se želite vpisati?</string>
+    <string name="user_choice_dialog_on_device_name">Potrdilo v vaši napravi</string>
+    <string name="user_choice_dialog_smartcard_name">Fizična pametna kartica</string>
+    <string name="user_choice_dialog_positive_button">Nadaljuj</string>
+    <string name="user_choice_dialog_negative_button">Prekliči</string>
+
+    <string name="smartcard_prompt_dialog_title">Pripravite pametno kartico</string>
+    <string name="smartcard_prompt_dialog_message">Vstavite ali pridržite pametno kartico na zadnji strani telefona.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Prekliči</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Branje pametne kartice</string>
+    <string name="smartcard_nfc_loading_dialog_message">Pridržite pametno kartico na mestu.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Pripravite pametno kartico</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Pridržite pametno kartico na zadnji strani telefona.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Prekliči</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Vklopite NFC v nastavitvah naprave</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Če se želite vpisati s tehnologijo NFC, v nastavitvah naprave vklopite NFC. Nato se znova vpišite.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Razumem</string>
 </resources>

--- a/common/src/main/res/values-sr/strings.xml
+++ b/common/src/main/res/values-sr/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Откажи</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Одаберите цертификат паметне картице за пријављивање</string>
+    <string name="smartcard_cert_dialog_title">Изаберите цертификат за пријављивање</string>
     <string name="smartcard_cert_dialog_positive_button">Настави</string>
     <string name="smartcard_cert_dialog_negative_button">Откажи</string>
 
-    <string name="smartcard_pin_dialog_title">Откључавање паметне картице</string>
+    <string name="smartcard_pin_dialog_title">Откључајте паметну картицу</string>
     <string name="smartcard_pin_dialog_message">Унесите PIN кôд паметне картице да бисте приступили цертификату и пријавили се</string>
     <string name="smartcard_pin_dialog_positive_button">Откључај</string>
     <string name="smartcard_pin_dialog_negative_button">Откажи</string>
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Покушајте поново касније</string>
     <string name="smartcard_general_error_dialog_message">Дошло је до неочекиване грешке. Покушајте поново касније.</string>
+
+    <string name="user_choice_dialog_title">Како желите да се пријавите?</string>
+    <string name="user_choice_dialog_on_device_name">Цертификат на уређају</string>
+    <string name="user_choice_dialog_smartcard_name">Физичка паметна картица</string>
+    <string name="user_choice_dialog_positive_button">Настави</string>
+    <string name="user_choice_dialog_negative_button">Откажи</string>
+
+    <string name="smartcard_prompt_dialog_title">Припремите паметну картицу</string>
+    <string name="smartcard_prompt_dialog_message">Прикључите или држите паметну картицу на задњој страни телефона.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Откажи</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Читање паметне картице</string>
+    <string name="smartcard_nfc_loading_dialog_message">Држите паметну картицу на месту.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Припремите паметну картицу</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Држите паметну картицу на задњој страни телефона.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Откажи</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Укључите NFC у поставкама уређаја</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Да бисте се пријавили помоћу NFC-а, укључите NFC у поставкама уређаја. Затим се поново пријавите.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Разумем</string>
 </resources>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Avbryt</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Välj ett smartkortscertifikat för att logga in</string>
+    <string name="smartcard_cert_dialog_title">Välj ett certifikat att logga in</string>
     <string name="smartcard_cert_dialog_positive_button">Fortsätt</string>
     <string name="smartcard_cert_dialog_negative_button">Avbryt</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">Försök igen senare</string>
     <string name="smartcard_general_error_dialog_message">Ett oväntat fel uppstod. Försök igen senare.</string>
+
+    <string name="user_choice_dialog_title">Hur vill du logga in?</string>
+    <string name="user_choice_dialog_on_device_name">Certifikat på din enhet</string>
+    <string name="user_choice_dialog_smartcard_name">Fysiskt smartkort</string>
+    <string name="user_choice_dialog_positive_button">Fortsätt</string>
+    <string name="user_choice_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_prompt_dialog_title">Förbered smartkortet</string>
+    <string name="smartcard_prompt_dialog_message">Anslut eller håll ett smartkort mot telefonens baksida.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Läser ditt smartkort</string>
+    <string name="smartcard_nfc_loading_dialog_message">Håll smartkortet på plats.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Förbered smartkortet</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Håll ett smartkort mot telefonens baksida.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Avbryt</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Aktivera NFC i enhetsinställningarna</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Aktivera NFC i enhetsinställningarna om du vill logga in med NFC. Logga sedan in igen.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Jag förstår</string>
 </resources>

--- a/common/src/main/res/values-th/strings.xml
+++ b/common/src/main/res/values-th/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">ยกเลิก</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">เลือกใบรับรองสมาร์ทการ์ดเพื่อลงชื่อเข้าใช้</string>
+    <string name="smartcard_cert_dialog_title">เลือกใบรับรองเพื่อลงชื่อเข้าใช้</string>
     <string name="smartcard_cert_dialog_positive_button">ดำเนินการต่อ</string>
     <string name="smartcard_cert_dialog_negative_button">ยกเลิก</string>
 
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">นำอุปกรณ์สมาร์ทการ์ดออกแล้ว โปรดใส่อุปกรณ์ใหม่ก่อนที่จะพยายามเข้าสู่ระบบอีกครั้ง</string>
 
     <string name="smartcard_no_cert_dialog_title">ไม่พบใบรับรองที่เกี่ยวข้อง</string>
-    <string name="smartcard_no_cert_dialog_message">โปรดยืนยันว่าใบรับรองของคุณได้รับการเตรียมใช้งานอย่างถูกต้องบนอุปกรณ์สมาร์ทการ์ดของคุณ</string>
+    <string name="smartcard_no_cert_dialog_message">ยืนยันว่าใบรับรองของคุณได้รับการเตรียมใช้งานอย่างถูกต้องบนอุปกรณ์สมาร์ทการ์ดของคุณ</string>
 
     <string name="smartcard_general_error_dialog_title">ลองอีกครั้งในภายหลัง</string>
     <string name="smartcard_general_error_dialog_message">เกิดข้อผิดพลาดที่ไม่คาดคิด โปรดลองอีกครั้งภายหลัง</string>
+
+    <string name="user_choice_dialog_title">คุณต้องการลงชื่อเข้าใช้อย่างไร</string>
+    <string name="user_choice_dialog_on_device_name">ใบรับรองบนอุปกรณ์ของคุณ</string>
+    <string name="user_choice_dialog_smartcard_name">สมาร์ทการ์ดจริง</string>
+    <string name="user_choice_dialog_positive_button">ดำเนินการต่อ</string>
+    <string name="user_choice_dialog_negative_button">ยกเลิก</string>
+
+    <string name="smartcard_prompt_dialog_title">เตรียมสมาร์ทการ์ดของคุณ</string>
+    <string name="smartcard_prompt_dialog_message">เสียบปลั๊กหรือถือสมาร์ทการ์ดไว้ที่ด้านหลังของโทรศัพท์ของคุณ</string>
+    <string name="smartcard_prompt_dialog_negative_button">ยกเลิก</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">การอ่านสมาร์ทการ์ดของคุณ</string>
+    <string name="smartcard_nfc_loading_dialog_message">เก็บสมาร์ทการ์ดของคุณให้เข้าที่</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">เตรียมสมาร์ทการ์ดของคุณ</string>
+    <string name="smartcard_nfc_prompt_dialog_message">ถือสมาร์ทการ์ดไว้ที่ด้านหลังของโทรศัพท์ของคุณ</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">ยกเลิก</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">เปิดใช้งาน NFC ในการตั้งค่าอุปกรณ์</string>
+    <string name="smartcard_nfc_reminder_dialog_message">เมื่อต้องการลงชื่อเข้าใช้ด้วย NFC ให้เปิดใช้งาน NFC ในการตั้งค่าอุปกรณ์ของคุณ จากนั้นลงชื่อเข้าใช้อีกครั้ง</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">เข้าใจแล้ว</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -10,12 +10,12 @@
     <string name="http_auth_dialog_cancel">İptal</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Oturum açmak için bir akıllı kart sertifikası seçin</string>
+    <string name="smartcard_cert_dialog_title">Oturum açmak için bir sertifika seçin</string>
     <string name="smartcard_cert_dialog_positive_button">Devam</string>
     <string name="smartcard_cert_dialog_negative_button">İptal</string>
 
-    <string name="smartcard_pin_dialog_title">Akıllı kartın kilidini aç</string>
-    <string name="smartcard_pin_dialog_message">Sertifikaya erişmek ve oturum açmak için akıllı kart PIN\'ini girin</string>
+    <string name="smartcard_pin_dialog_title">Akıllı kartın kilidini açın</string>
+    <string name="smartcard_pin_dialog_message">Sertifikaya erişmek ve oturum açmak için akıllı kart PIN kodunu girin</string>
     <string name="smartcard_pin_dialog_positive_button">Kilidi aç</string>
     <string name="smartcard_pin_dialog_negative_button">İptal</string>
     <string name="smartcard_pin_dialog_error_message">Girdiğiniz PIN yanlıştı</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Çok fazla başarısız girişimde bulunuldu, daha sonra yeniden deneyin.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Yeniden deneyin</string>
-    <string name="smartcard_early_unplug_dialog_message">Akıllı kart cihazı kaldırıldı. Yeniden oturum açmaya çalışmadan önce lütfen cihazı yeniden ekleyin.</string>
+    <string name="smartcard_early_unplug_dialog_message">Akıllı kart cihazı kaldırıldı. Yeniden oturum açmaya çalışmadan önce lütfen cihazı yeniden takın.</string>
 
     <string name="smartcard_no_cert_dialog_title">Uygulanabilir sertifika bulunamadı.</string>
-    <string name="smartcard_no_cert_dialog_message">Lütfen sertifikanızın akıllı kart cihazınıza doğru şekilde sağlanmış olduğunu onaylayın.</string>
+    <string name="smartcard_no_cert_dialog_message">Sertifikanızın akıllı kart cihazınıza doğru şekilde sağlandığını onaylayın.</string>
 
     <string name="smartcard_general_error_dialog_title">Daha sonra tekrar deneyin</string>
     <string name="smartcard_general_error_dialog_message">Beklenmeyen bir hata oluştu. Lütfen daha sonra yeniden deneyin.</string>
+
+    <string name="user_choice_dialog_title">Nasıl oturum açmak istersiniz?</string>
+    <string name="user_choice_dialog_on_device_name">Cihazınızdaki sertifika</string>
+    <string name="user_choice_dialog_smartcard_name">Fiziksel akıllı kart</string>
+    <string name="user_choice_dialog_positive_button">Devam</string>
+    <string name="user_choice_dialog_negative_button">İptal</string>
+
+    <string name="smartcard_prompt_dialog_title">Akıllı kartınızı hazırlayın</string>
+    <string name="smartcard_prompt_dialog_message">Telefonunuzun arkasına bir akıllı kart takın veya akıllı kartı telefonunuza yakın tutun.</string>
+    <string name="smartcard_prompt_dialog_negative_button">İptal</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Akıllı kartınız okunuyor</string>
+    <string name="smartcard_nfc_loading_dialog_message">Akıllı kartınızı yerine yerleştirin.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Akıllı kartınızı hazırlayın</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Bir akıllı kartı telefonunuzun arkasına yakın tutun.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">İptal</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Cihaz ayarlarında NFC’yi etkinleştirin</string>
+    <string name="smartcard_nfc_reminder_dialog_message">NFC ile oturum açmak için cihaz ayarlarınızda NFC’yi etkinleştirin. Ardından yeniden oturum açın.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Anladım</string>
 </resources>

--- a/common/src/main/res/values-uk/strings.xml
+++ b/common/src/main/res/values-uk/strings.xml
@@ -10,11 +10,11 @@
     <string name="http_auth_dialog_cancel">Скасувати</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Виберіть сертифікат смарт-картки для входу</string>
+    <string name="smartcard_cert_dialog_title">Виберіть сертифікат, щоб увійти</string>
     <string name="smartcard_cert_dialog_positive_button">Продовжити</string>
     <string name="smartcard_cert_dialog_negative_button">Скасувати</string>
 
-    <string name="smartcard_pin_dialog_title">Розблокувати смарт-картку</string>
+    <string name="smartcard_pin_dialog_title">Розблокування смарт-картки</string>
     <string name="smartcard_pin_dialog_message">Введіть PIN-код смарт-картки, щоб отримати доступ до сертифіката, і ввійдіть</string>
     <string name="smartcard_pin_dialog_positive_button">Розблокувати</string>
     <string name="smartcard_pin_dialog_negative_button">Скасувати</string>
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Забагато невдалих спроб. Спробуйте ще раз пізніше.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Повторити спробу</string>
-    <string name="smartcard_early_unplug_dialog_message">Пристрій смарт-картки видалено. Вставте пристрій ще раз, перш ніж знову спробувати ввійти.</string>
+    <string name="smartcard_early_unplug_dialog_message">Пристрій читання смарт-карток вилучено. Вставте пристрій ще раз, перш ніж спробувати ввійти знову.</string>
 
     <string name="smartcard_no_cert_dialog_title">Застосовні сертифікати не знайдено.</string>
-    <string name="smartcard_no_cert_dialog_message">Переконайтеся, що сертифікат належним чином підготовлено на пристрої смарт-картки.</string>
+    <string name="smartcard_no_cert_dialog_message">Переконайтеся, що сертифікат належним чином підготовлено на пристрої читання смарт-карток.</string>
 
     <string name="smartcard_general_error_dialog_title">Спробуйте знову пізніше</string>
     <string name="smartcard_general_error_dialog_message">Сталася неочікувана помилка. Спробуйте ще раз пізніше.</string>
+
+    <string name="user_choice_dialog_title">Як потрібно ввійти?</string>
+    <string name="user_choice_dialog_on_device_name">Сертифікат на вашому пристрої</string>
+    <string name="user_choice_dialog_smartcard_name">Фізична смарт-картка</string>
+    <string name="user_choice_dialog_positive_button">Продовжити</string>
+    <string name="user_choice_dialog_negative_button">Скасувати</string>
+
+    <string name="smartcard_prompt_dialog_title">Підготовка смарт-картки</string>
+    <string name="smartcard_prompt_dialog_message">Вставте смарт-картку або прикладіть її до задньої панелі телефона.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Скасувати</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Читання смарт-картки</string>
+    <string name="smartcard_nfc_loading_dialog_message">Тримайте смарт-картку на місці.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Підготовка смарт-картки</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Прикладіть смарт-картку до задньої панелі телефона.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Скасувати</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Увімкнення NFC в параметрах пристрою</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Щоб увійти за допомогою NFC, увімкніть NFC в параметрах пристрою. Потім увійдіть ще раз.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Зрозуміло</string>
 </resources>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">Hủy</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">Chọn chứng chỉ thẻ thông minh để đăng nhập</string>
+    <string name="smartcard_cert_dialog_title">Chọn chứng chỉ để đăng nhập</string>
     <string name="smartcard_cert_dialog_positive_button">Tiếp tục</string>
     <string name="smartcard_cert_dialog_negative_button">Hủy</string>
 
@@ -27,11 +27,32 @@
     <string name="smartcard_max_attempt_dialog_message">Quá nhiều lần thử không thành công, hãy thử lại sau.</string>
 
     <string name="smartcard_early_unplug_dialog_title">Thử lại</string>
-    <string name="smartcard_early_unplug_dialog_message">Thiết bị thẻ thông minh đã bị loại bỏ. Vui lòng chèn lại thiết bị trước khi tìm cách đăng nhập lại.</string>
+    <string name="smartcard_early_unplug_dialog_message">Thiết bị thẻ thông minh đã bị gỡ. Vui lòng lắp lại thiết bị trước khi tìm cách đăng nhập lại.</string>
 
     <string name="smartcard_no_cert_dialog_title">Không tìm thấy chứng chỉ có thể áp dụng.</string>
-    <string name="smartcard_no_cert_dialog_message">Vui lòng xác nhận rằng chứng chỉ của bạn đã được cung cấp chính xác trên thiết bị thẻ thông minh của bạn.</string>
+    <string name="smartcard_no_cert_dialog_message">Xác nhận rằng chứng chỉ của bạn đã được cung cấp chính xác trên thiết bị thẻ thông minh.</string>
 
     <string name="smartcard_general_error_dialog_title">Thử lại sau</string>
     <string name="smartcard_general_error_dialog_message">Đã xảy ra lỗi bất ngờ. Xin thử lại sau.</string>
+
+    <string name="user_choice_dialog_title">Bạn muốn đăng nhập như thế nào?</string>
+    <string name="user_choice_dialog_on_device_name">Chứng chỉ trên thiết bị của bạn</string>
+    <string name="user_choice_dialog_smartcard_name">Thẻ thông minh vật lý</string>
+    <string name="user_choice_dialog_positive_button">Tiếp tục</string>
+    <string name="user_choice_dialog_negative_button">Hủy</string>
+
+    <string name="smartcard_prompt_dialog_title">Chuẩn bị thẻ thông minh của bạn</string>
+    <string name="smartcard_prompt_dialog_message">Cắm hoặc giữ thẻ thông minh ở mặt sau điện thoại của bạn.</string>
+    <string name="smartcard_prompt_dialog_negative_button">Hủy</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">Đọc thẻ thông minh của bạn</string>
+    <string name="smartcard_nfc_loading_dialog_message">Giữ thẻ thông minh của bạn ở đúng chỗ.</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">Chuẩn bị thẻ thông minh của bạn</string>
+    <string name="smartcard_nfc_prompt_dialog_message">Giữ thẻ thông minh ở mặt sau điện thoại của bạn.</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">Hủy</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">Bật NFC trong cài đặt thiết bị</string>
+    <string name="smartcard_nfc_reminder_dialog_message">Để đăng nhập bằng NFC, hãy bật NFC trong cài đặt thiết bị của bạn. Sau đó đăng nhập lại.</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">Đã hiểu</string>
 </resources>

--- a/common/src/main/res/values-zh-rCN/strings.xml
+++ b/common/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">取消</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">选择要登录的智能卡证书</string>
+    <string name="smartcard_cert_dialog_title">选择要登录的证书</string>
     <string name="smartcard_cert_dialog_positive_button">继续</string>
     <string name="smartcard_cert_dialog_negative_button">取消</string>
 
@@ -34,4 +34,25 @@
 
     <string name="smartcard_general_error_dialog_title">请稍后重试</string>
     <string name="smartcard_general_error_dialog_message">发生意外错误。请稍后再试。</string>
+
+    <string name="user_choice_dialog_title">你希望如何登录?</string>
+    <string name="user_choice_dialog_on_device_name">设备上的证书</string>
+    <string name="user_choice_dialog_smartcard_name">物理智能卡</string>
+    <string name="user_choice_dialog_positive_button">继续</string>
+    <string name="user_choice_dialog_negative_button">取消</string>
+
+    <string name="smartcard_prompt_dialog_title">准备智能卡</string>
+    <string name="smartcard_prompt_dialog_message">插入或将智能卡放在手机背面。</string>
+    <string name="smartcard_prompt_dialog_negative_button">取消</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">正在读取智能卡</string>
+    <string name="smartcard_nfc_loading_dialog_message">将智能卡放在适当的位置。</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">准备智能卡</string>
+    <string name="smartcard_nfc_prompt_dialog_message">将智能卡放在手机背面。</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">取消</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">在设备设置中打开 NFC</string>
+    <string name="smartcard_nfc_reminder_dialog_message">若要使用 NFC 登录，请在设备设置中启用 NFC。然后再次登录。</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">知道了</string>
 </resources>

--- a/common/src/main/res/values-zh-rTW/strings.xml
+++ b/common/src/main/res/values-zh-rTW/strings.xml
@@ -10,7 +10,7 @@
     <string name="http_auth_dialog_cancel">取消</string>
 
     <!-- strings for CBA dialogs and layouts -->
-    <string name="smartcard_cert_dialog_title">選擇要登入的智慧卡憑證</string>
+    <string name="smartcard_cert_dialog_title">選取憑證以登入</string>
     <string name="smartcard_cert_dialog_positive_button">繼續</string>
     <string name="smartcard_cert_dialog_negative_button">取消</string>
 
@@ -30,8 +30,29 @@
     <string name="smartcard_early_unplug_dialog_message">智慧卡裝置已移除。嘗試重新登入之前，請先重新插入裝置。</string>
 
     <string name="smartcard_no_cert_dialog_title">找不到適用的憑證。</string>
-    <string name="smartcard_no_cert_dialog_message">請確認您的憑證已正確佈建至您的智慧卡裝置。</string>
+    <string name="smartcard_no_cert_dialog_message">確認您的憑證已正確佈建至您的智慧卡裝置。</string>
 
     <string name="smartcard_general_error_dialog_title">請稍後再試</string>
     <string name="smartcard_general_error_dialog_message">發生意外錯誤。請稍後再試一次。</string>
+
+    <string name="user_choice_dialog_title">您想要如何登入?</string>
+    <string name="user_choice_dialog_on_device_name">您裝置上的憑證</string>
+    <string name="user_choice_dialog_smartcard_name">實體智慧卡</string>
+    <string name="user_choice_dialog_positive_button">繼續</string>
+    <string name="user_choice_dialog_negative_button">取消</string>
+
+    <string name="smartcard_prompt_dialog_title">準備您的智慧卡</string>
+    <string name="smartcard_prompt_dialog_message">插入或將智慧卡放在手機背面。</string>
+    <string name="smartcard_prompt_dialog_negative_button">取消</string>
+
+    <string name="smartcard_nfc_loading_dialog_title">讀取您的智慧卡</string>
+    <string name="smartcard_nfc_loading_dialog_message">將智慧卡放在適當位置。</string>
+
+    <string name="smartcard_nfc_prompt_dialog_title">準備您的智慧卡</string>
+    <string name="smartcard_nfc_prompt_dialog_message">將智慧卡放在手機背面。</string>
+    <string name="smartcard_nfc_prompt_dialog_negative_button">取消</string>
+
+    <string name="smartcard_nfc_reminder_dialog_title">在裝置設定中開啟 NFC</string>
+    <string name="smartcard_nfc_reminder_dialog_message">若要使用 NFC 來登入，請在裝置設定中開啟 NFC。然後重新登入。</string>
+    <string name="smartcard_nfc_reminder_dialog_positive_button">了解</string>
 </resources>


### PR DESCRIPTION
## Summary 
The addition of NFC compatibility to CBA brings new dialogs with strings that needed to be localized. Some existing strings also needed to be updated.
I got the new strings localized with the help of Authenticator, and I then copied the updated strings manually to each localized strings.xml file. 

## Testing
I set my testing phone's language to Spanish and went through multiple paths of CBA within msalTestApp, making sure to view the new dialogs in particular. I repeated the process with Hebrew. 

## Related PR
- [Adding Localization to Common](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1807)