### PR TITLE
Teams add another account

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/TeamsApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/TeamsApp.java
@@ -106,12 +106,8 @@ public class TeamsApp extends App implements IFirstPartyApp {
     public void addAnotherAccount(@NonNull final String username,
                                   @NonNull final String password,
                                   @NonNull final FirstPartyAppPromptHandlerParameters promptHandlerParameters) {
-
-        //Allow nearby devices access - screen appears; click cancel
-        UiAutomatorUtils.handleButtonClick("android:id/button2");
-
-        try {
-            //click user icon
+       try {
+            //click account drawer icon
             final UiObject userIcon = UiAutomatorUtils.obtainUiObjectWithUiSelector(new UiSelector().className("android.widget.ImageView"), CommonUtils.FIND_UI_ELEMENT_TIMEOUT);
             userIcon.click();
 


### PR DESCRIPTION
Removing cancel step of "Allow nearby devices access" screen which is no longer showing after signing into teams app. This is a corresponding change to PR - https://github.com/AzureAD/ad-accounts-for-android/pull/2089 and it must be merged before 2089.