### PR TITLE
Propagate span context from MSAL to Broker

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ----------
 - [MINOR] Convert crypto operation spans into metrics (#1909)
 - [PATCH] Move clearClientCertPreferences to onCreateView only (#1915)
+- [MINOR] Propagate span context from MSAL to Broker (#1926)
 
 V.9.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext;
 import com.microsoft.identity.common.java.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.java.request.SdkType;
 
@@ -69,6 +70,7 @@ public class BrokerRequest implements Serializable {
         final static String AUTHORIZATION_AGENT = "authorization_agent";
         final static String AUTHENTICATION_SCHEME = "authentication_scheme";
         final static String POWER_OPT_CHECK_ENABLED = "power_opt_check_enabled";
+        final static String SPAN_CONTEXT = "span_context";
     }
 
     /**
@@ -218,5 +220,9 @@ public class BrokerRequest implements Serializable {
     @Nullable
     @SerializedName(SerializedNames.POWER_OPT_CHECK_ENABLED)
     private boolean mPowerOptCheckEnabled;
+
+    @Nullable
+    @SerializedName(SerializedNames.SPAN_CONTEXT)
+    private SerializableSpanContext mSpanContext;
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerOperationExecutor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerOperationExecutor.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.marker.CodeMarkerManager;
 import com.microsoft.identity.common.java.marker.PerfConstants;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.util.StringUtil;
@@ -222,7 +223,7 @@ public class BrokerOperationExecutor {
         final Span span = OTelUtility.createSpan(SpanName.MSAL_PerformIpcStrategy.name());
 
         try (final Scope scope = span.makeCurrent()) {
-            span.setAttribute("strategy", strategy.getType().name());
+            span.setAttribute(AttributeName.ipc_strategy.name(), strategy.getType().name());
             operation.performPrerequisites(strategy);
             final BrokerOperationBundle brokerOperationBundle = operation.getBundle();
             final Bundle resultBundle = strategy.communicateToBroker(brokerOperationBundle);

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -52,6 +52,9 @@ import com.microsoft.identity.common.internal.broker.BrokerRequest;
 import com.microsoft.identity.common.java.commands.parameters.AcquirePrtSsoTokenCommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.ui.BrowserDescriptor;
 import com.microsoft.identity.common.java.util.BrokerProtocolVersionUtil;
 import com.microsoft.identity.common.java.util.QueryParamsAdapter;
@@ -74,6 +77,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+
+import io.opentelemetry.api.trace.Span;
 
 public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
@@ -113,6 +118,13 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                                 AuthorizationAgent.WEBVIEW.name()
                 ).authenticationScheme(parameters.getAuthenticationScheme())
                 .powerOptCheckEnabled(parameters.isPowerOptCheckEnabled())
+                .spanContext(SerializableSpanContext.builder()
+                        .traceId(SpanExtension.current().getSpanContext().getTraceId())
+                        .spanId(SpanExtension.current().getSpanContext().getSpanId())
+                        .traceFlags(SpanExtension.current().getSpanContext().getTraceFlags().asByte())
+                        .parentSpanName(OTelUtility.getCurrentSpanName())
+                        .build()
+                )
                 .build();
 
         return brokerRequest;
@@ -146,6 +158,13 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .multipleCloudsSupported(getMultipleCloudsSupported(parameters))
                 .authenticationScheme(parameters.getAuthenticationScheme())
                 .powerOptCheckEnabled(parameters.isPowerOptCheckEnabled())
+                .spanContext(SerializableSpanContext.builder()
+                        .traceId(SpanExtension.current().getSpanContext().getTraceId())
+                        .spanId(SpanExtension.current().getSpanContext().getSpanId())
+                        .traceFlags(SpanExtension.current().getSpanContext().getTraceFlags().asByte())
+                        .parentSpanName(OTelUtility.getCurrentSpanName())
+                        .build()
+                )
                 .build();
 
         return brokerRequest;

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.java.commands.parameters;
 import com.google.gson.annotations.Expose;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.request.SdkType;
 
@@ -86,4 +87,7 @@ public class CommandParameters {
     @EqualsAndHashCode.Exclude
     @Expose()
     private String correlationId;
+
+    @Expose()
+    private SerializableSpanContext spanContext;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -72,5 +72,10 @@ public enum AttributeName {
     /**
      * An error code.
      */
-    error_code
+    error_code,
+
+    /**
+     * The IPC strategy being used.
+     */
+    ipc_strategy,
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -80,6 +80,12 @@ public class OTelUtility {
 
         if (parentSpanContext instanceof SerializableSpanContext) {
             span.setAttribute(parent_span_name.name(), ((SerializableSpanContext) parentSpanContext).getParentSpanName());
+        } else {
+            Logger.warn(
+                    methodTag,
+                    "span context received is not of type SerializableSpanContext, " +
+                            "instead received: [" + parentSpanContext.getClass().getSimpleName() + "]"
+            );
         }
 
         return span;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -126,7 +126,7 @@ public class OTelUtility {
         if (span instanceof ReadableSpan) {
             return ((ReadableSpan) span).getName();
         }
-        return "null";
+        return "";
     }
 
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.java.opentelemetry;
 
 import static com.microsoft.identity.common.java.opentelemetry.AttributeName.parent_span_name;
 
+import com.microsoft.identity.common.java.logging.Logger;
+
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -54,11 +56,23 @@ public class OTelUtility {
     }
 
     /**
-     * Creates a span (with shared basic attributes).
+     * Creates a span from a parent Span Context (with shared basic attributes).
      **/
     @NonNull
     public static Span createSpanFromParent(@NonNull final String name,
-                                            @NonNull final SpanContext parentSpanContext) {
+                                            @Nullable final SpanContext parentSpanContext) {
+        final String methodTag = TAG + ":createSpanFromParent";
+
+        if (parentSpanContext == null) {
+            Logger.verbose(methodTag, "parentSpanContext is NULL. Creating span without parent.");
+            return createSpan(name);
+        }
+
+        if (!parentSpanContext.isValid()) {
+            Logger.warn(methodTag, "parentSpanContext is INVALID. Creating span without parent.");
+            return createSpan(name);
+        }
+
         final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
         final Span span = tracer.spanBuilder(name)
                 .setParent(Context.current().with(Span.wrap(parentSpanContext)))

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import com.google.gson.annotations.SerializedName;
+
+import javax.annotation.Nullable;
+
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+@Builder
+@Accessors(prefix = "m")
+public class SerializableSpanContext implements SpanContext {
+
+    public static class SerializedNames {
+        public static final String TRACE_ID = "trace_id";
+        public static final String SPAN_ID = "span_id";
+        public static final String TRACE_FLAGS = "trace_flags";
+        public static final String PARENT_SPAN_NAME = "parent_span_name";
+    }
+
+    @SerializedName(SerializedNames.TRACE_ID)
+    @NonNull
+    private final String mTraceId;
+
+    @SerializedName(SerializedNames.SPAN_ID)
+    @NonNull
+    private final String mSpanId;
+
+    @SerializedName(SerializedNames.TRACE_FLAGS)
+    private final byte mTraceFlags;
+
+    @Getter
+    @SerializedName(SerializedNames.PARENT_SPAN_NAME)
+    @NonNull
+    private final String mParentSpanName;
+
+    @Override
+    public String getTraceId() {
+        return mTraceId;
+    }
+
+    @Override
+    public String getSpanId() {
+        return mSpanId;
+    }
+
+    @Override
+    public TraceFlags getTraceFlags() {
+        return TraceFlags.fromByte(mTraceFlags);
+    }
+
+    @Override
+    public TraceState getTraceState() {
+        return TraceState.getDefault();
+    }
+
+    @Override
+    public boolean isRemote() {
+        return false;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.java.opentelemetry;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.io.Serializable;
+
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -37,7 +39,7 @@ import lombok.experimental.Accessors;
  */
 @Builder
 @Accessors(prefix = "m")
-public class SerializableSpanContext implements SpanContext {
+public class SerializableSpanContext implements SpanContext, Serializable {
 
     public static class SerializedNames {
         public static final String TRACE_ID = "trace_id";

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
@@ -24,8 +24,6 @@ package com.microsoft.identity.common.java.opentelemetry;
 
 import com.google.gson.annotations.SerializedName;
 
-import javax.annotation.Nullable;
-
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -34,6 +32,9 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
+/**
+ * A JSON Serializable implementation of {@link SpanContext}.
+ */
 @Builder
 @Accessors(prefix = "m")
 public class SerializableSpanContext implements SpanContext {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -36,7 +36,5 @@ public enum SpanName {
     DoDiscovery,
     WorkplaceLeave,
     DeviceState,
-    MSAL_AcquireTokenInteractive,
-    MSAL_AcquireTokenSilent,
     MSAL_PerformIpcStrategy,
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -35,5 +35,8 @@ public enum SpanName {
     WorkplaceJoin,
     DoDiscovery,
     WorkplaceLeave,
-    DeviceState
+    DeviceState,
+    MSAL_AcquireTokenInteractive,
+    MSAL_AcquireTokenSilent,
+    MSAL_PerformIpcStrategy,
 }


### PR DESCRIPTION
This creates a Serializable variant of Span Context that is added to BrokerRequest.

This is done per the [spec for Span Context Propagation](https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?version=GBshahzaibj/context-propagation&path=/%5BAndroid%5D%20Telemetry/span_context_propagation.md&_a=preview) which is being done to allow our partners to onboard to Open Telemetry and allows us to start traces directly in client applications and allows broker to pick up that trace as part of the flow.

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2101