### PR TITLE
Remove unnecessary synchronization when storage access is already guarded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Remove unnecessary synchronization when storage access is already guarded (#1928)
 
 V.9.1.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -146,7 +146,7 @@ public class MsalCppOAuth2TokenCache
      *
      * @param accountRecord : accountRecord to be saved.
      */
-    public synchronized void saveAccountRecord(@NonNull final AccountRecord accountRecord) {
+    public void saveAccountRecord(@NonNull final AccountRecord accountRecord) {
         getAccountCredentialCache().saveAccount(accountRecord);
     }
 
@@ -155,7 +155,7 @@ public class MsalCppOAuth2TokenCache
      * Note: This method is intended to be only used for testing purposes.
      */
     //@VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public synchronized void clearCache() {
+    public void clearCache() {
         getAccountCredentialCache().clearAll();
     }
 
@@ -166,7 +166,7 @@ public class MsalCppOAuth2TokenCache
      * @return A immutable List of Credentials contained in this cache.
      */
     //@VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public synchronized List<Credential> getCredentials() {
+    public List<Credential> getCredentials() {
         return Collections.unmodifiableList(
                 getAccountCredentialCache().getCredentials()
         );

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -138,7 +138,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     }
 
     @Override
-    public synchronized AccountRecord getAccount(@NonNull final String cacheKey) {
+    public AccountRecord getAccount(@NonNull final String cacheKey) {
         Logger.verbose(TAG, "Loading Account by key...");
         AccountRecord account = mCacheValueDelegate.fromCacheValue(
                 mSharedPreferencesFileManager.get(cacheKey),
@@ -163,7 +163,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
     @Override
     @Nullable
-    public synchronized Credential getCredential(@NonNull final String cacheKey) {
+    public Credential getCredential(@NonNull final String cacheKey) {
         // TODO add support for more Credential types...
         Logger.verbose(TAG, "getCredential()");
         Logger.verbosePII(TAG, "Using cache key: [" + cacheKey + "]");
@@ -238,7 +238,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
     @Override
     @NonNull
-    public synchronized List<AccountRecord> getAccounts() {
+    public List<AccountRecord> getAccounts() {
         final String methodTag = TAG + ":getAccounts";
         Logger.verbose(methodTag, "Loading Accounts...(no arg)");
         final Map<String, AccountRecord> allAccounts = getAccountsWithKeys();
@@ -304,7 +304,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
     @Override
     @NonNull
-    public synchronized List<Credential> getCredentials() {
+    public List<Credential> getCredentials() {
         final String methodTag = TAG + ":getCredentials";
         Logger.verbose(methodTag, "Loading Credentials...");
         final Map<String, Credential> allCredentials = getCredentialsWithKeys();


### PR DESCRIPTION
While this seems risky, this seems to be the #1 remaining cause of Office performance problems.  Multiple token requests issued simultaneously are queueing up and serializing on token cache access behind these high level `synchronized` calls.  While we've made all the performance improvements we can without changing the underlying data access patterns, reads still involve at least deserializing every credential to loop through and match Java object properties.  In the worst cases, those can take ~100ms of CPU time.  When multiple requests come in that all do wind up with cache hits, they take time stacking up behind each other.

None of these high level token cache read operations need to exclude others.  The underlying storage access `SharedPreferencesFileManager` is guarded correctly, and these extra layers on top are either strictly processing, or don't represent a series of operations that need to be atomic as viewed by other callers.  Most other platforms share storage among multiple processes, and they don't mutually exclude each other at a level more granular than subdivisions of storage.  (e.g. there is no way to lock the entirety of storage while one caller looks up some assets, mutates some, deletes others, and then writes it all back atomically).