### PR TITLE
Keep in-memory cache of all credentials and accountrecords

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.Next
 - [MINOR] Added application identifier to cache (physical identifier).  Prevents multiple apps using the same logical identifier from sharing tokens. (#1660)
 - [MINOR] Capture whether token is returned from cache during silent token requests (#1941)
 - [MINOR] Capture span status and error codes in missing scenarios (#1940)
+- [MINOR] Keep in-memory cache of all credentials and accountrecords (#1929)
 
 V.9.1.0
 ----------

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -57,7 +57,9 @@ import java.util.Map;
 
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -1838,6 +1840,10 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final String cacheKey = mDelegate.generateCacheKey(account);
 
         mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an account\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
 
         final AccountRecord malformedAccount = mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
         assertNull(malformedAccount);
@@ -1874,6 +1880,10 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final String cacheKey = mDelegate.generateCacheKey(accessToken);
 
         mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an accessToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
 
         final AccessTokenRecord malformedAccessToken = (AccessTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
         assertNull(malformedAccessToken);
@@ -1910,6 +1920,10 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final String cacheKey = mDelegate.generateCacheKey(refreshToken);
 
         mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not a refreshToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
 
         final RefreshTokenRecord malformedRefreshToken = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
         assertNull(malformedRefreshToken);
@@ -1946,6 +1960,10 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final String cacheKey = mDelegate.generateCacheKey(idToken);
 
         mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an idToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
 
         final IdTokenRecord restoredIdToken = (IdTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
         assertNull(restoredIdToken);
@@ -2373,5 +2391,127 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
         assertTrue(refreshTokenFirst.equals(restoredIdToken));
         assertEquals(additionalValue2, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
+    }
+
+    AccountRecord buildDefaultAccountRecord() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setMiddleName(MIDDLE_NAME);
+        account.setName(NAME);
+        return account;
+    }
+
+    RefreshTokenRecord buildDefaultRefreshToken() {
+        final RefreshTokenRecord rt = new RefreshTokenRecord();
+        rt.setCredentialType(CredentialType.RefreshToken.name());
+        rt.setHomeAccountId(HOME_ACCOUNT_ID);
+        rt.setEnvironment(ENVIRONMENT);
+        rt.setClientId(CLIENT_ID);
+        rt.setCachedAt(CACHED_AT);
+        rt.setSecret(SECRET);
+        return rt;
+    }
+
+    @Test
+    public void testSavedAccountIsCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        final String cacheKey = mDelegate.generateCacheKey(account);
+        AccountRecord retrieved = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(account, retrieved);
+        assertEquals(account, retrieved);
+
+        account.setLocalAccountId("banana");
+        retrieved = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(account, retrieved);
+        assertNotEquals(account, retrieved);
+    }
+
+    @Test
+    public void testSavedCredentialIsCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        final String cacheKey = mDelegate.generateCacheKey(rt);
+        RefreshTokenRecord retrieved = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(rt, retrieved);
+        assertEquals(rt, retrieved);
+
+        rt.setCachedAt("banana");
+        retrieved = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(rt, retrieved);
+        assertNotEquals(rt, retrieved);
+    }
+
+    @Test
+    public void testReturnedAccountIsCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        final String cacheKey = mDelegate.generateCacheKey(account);
+        AccountRecord retrieved1 = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        retrieved1.setLocalAccountId("banana");
+
+        AccountRecord retrieved2 = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(retrieved1, retrieved2);
+        assertNotEquals(retrieved1, retrieved2);
+    }
+
+    @Test
+    public void testReturnedCredentialIsCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        final String cacheKey = mDelegate.generateCacheKey(rt);
+        RefreshTokenRecord retrieved1 = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        retrieved1.setCachedAt("banana");
+
+        RefreshTokenRecord retrieved2 = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(retrieved1, retrieved2);
+        assertNotEquals(retrieved1, retrieved2);
+    }
+
+    @Test
+    public void testReturnedAllAccountsAreCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        List<AccountRecord> accounts1 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts1.size());
+
+        List<AccountRecord> accounts2 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts2.size());
+
+        assertNotSame(accounts1, accounts2);
+        assertNotSame(accounts1.get(0), accounts2.get(0));
+        assertEquals(accounts1.get(0), accounts2.get(0));
+
+        accounts1.get(0).setLocalAccountId("banana");
+        assertNotEquals(accounts1.get(0), accounts2.get(0));
+    }
+
+    @Test
+    public void testReturnedAllCredentialsAreCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        List<Credential> creds1 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds1.size());
+
+        List<Credential> creds2 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds2.size());
+
+        assertNotSame(creds1, creds2);
+        assertNotSame(creds1.get(0), creds2.get(0));
+        assertEquals(creds1.get(0), creds2.get(0));
+
+        creds1.get(0).setCachedAt("banana");
+        assertNotEquals(creds1.get(0), creds2.get(0));
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.java.cache;
 
 import com.microsoft.identity.common.java.dto.AccessTokenRecord;
+import com.microsoft.identity.common.java.dto.AccountCredentialBase;
 import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.dto.Credential;
 import com.microsoft.identity.common.java.dto.CredentialType;
@@ -88,6 +89,12 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
     private final ICacheKeyValueDelegate mCacheValueDelegate;
 
+    private final Object mCacheLock = new Object();
+    private boolean mLoaded = false;
+
+    private Map<String, AccountRecord> mCachedAccountRecordsWithKeys = new HashMap<>();
+    private Map<String, Credential> mCachedCredentialsWithKeys = new HashMap<>();
+
     /**
      * Constructor of SharedPreferencesAccountCredentialCache.
      *
@@ -100,113 +107,153 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Init: " + TAG);
         mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
+        new Thread(() -> load()).start();
+    }
+
+    private void load() {
+        final String methodTag = TAG + ":load";
+
+        synchronized (mCacheLock) {
+            try {
+                mCachedAccountRecordsWithKeys = loadAccountsWithKeys();
+                Logger.info(methodTag, "Loaded " + mCachedAccountRecordsWithKeys.size() + " AccountRecords");
+                mCachedCredentialsWithKeys = loadCredentialsWithKeys();
+                Logger.info(methodTag, "Loaded " + mCachedCredentialsWithKeys.size() + " Credentials");
+            } catch (final Throwable t) {
+                Logger.error(methodTag, "Failed to load initial accounts or credentials from SharedPreferences", t);
+            } finally {
+                mLoaded = true;
+                mCacheLock.notifyAll();
+            }
+        }
+    }
+
+    private void waitForInitialLoad() {
+        final String methodTag = TAG + ":waitForInitialLoad";
+
+        while (!mLoaded) {
+            try {
+                mCacheLock.wait();
+            } catch (final InterruptedException e) {
+                Logger.error(methodTag, "Caught InterruptedException while waiting", e);
+            }
+        }
     }
 
     @Override
-    public synchronized void saveAccount(@NonNull final AccountRecord accountToSave) {
-        Logger.verbose(TAG, "Saving Account...");
-        Logger.verbose(TAG, "Account type: [" + accountToSave.getClass().getSimpleName() + "]");
+    public void saveAccount(@NonNull final AccountRecord accountInput) {
+        final String methodTag = TAG + ":saveAccount";
+
+        AccountRecord accountToSave = null;
+        try {
+            accountToSave = (AccountRecord) accountInput.clone();
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone AccountRecord", e);
+            return;
+        }
+
+        Logger.verbose(methodTag, "Saving Account...");
+        Logger.verbose(methodTag, "Account type: [" + accountToSave.getClass().getSimpleName() + "]");
         final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToSave);
-        Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
+        Logger.verbosePII(methodTag, "Generated cache key: [" + cacheKey + "]");
 
-        // Perform any necessary field merging on the Account to save...
-        final AccountRecord existingAccount = getAccount(cacheKey);
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
 
-        if (null != existingAccount) {
-            accountToSave.mergeAdditionalFields(existingAccount);
+            // Perform any necessary field merging on the Account to save...
+            final AccountRecord existingAccount = getAccount(cacheKey);
+
+            if (null != existingAccount) {
+                accountToSave.mergeAdditionalFields(existingAccount);
+            }
+
+            final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+            mCachedAccountRecordsWithKeys.put(cacheKey, accountToSave);
         }
-
-        final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
-        mSharedPreferencesFileManager.put(cacheKey, cacheValue);
     }
 
     @Override
-    public synchronized void saveCredential(@NonNull Credential credentialToSave) {
-        Logger.verbose(TAG, "Saving credential...");
-        final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToSave);
-        Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
+    public void saveCredential(@NonNull Credential credentialInput) {
+        final String methodTag = TAG + ":saveCredential";
 
-        // Perform any necessary field merging on the Credential to save...
-        final Credential existingCredential = getCredential(cacheKey);
-
-        if (null != existingCredential) {
-            credentialToSave.mergeAdditionalFields(existingCredential);
+        Credential credentialToSave = null;
+        try {
+            credentialToSave = (Credential) credentialInput.clone();
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone Credential", e);
+            return;
         }
 
-        final String cacheValue = mCacheValueDelegate.generateCacheValue(credentialToSave);
-        mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+        Logger.verbose(methodTag, "Saving credential...");
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToSave);
+        Logger.verbosePII(methodTag, "Generated cache key: [" + cacheKey + "]");
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+
+            // Perform any necessary field merging on the Credential to save...
+            final Credential existingCredential = getCredential(cacheKey);
+
+            if (null != existingCredential) {
+                credentialToSave.mergeAdditionalFields(existingCredential);
+            }
+
+            final String cacheValue = mCacheValueDelegate.generateCacheValue(credentialToSave);
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+            mCachedCredentialsWithKeys.put(cacheKey, credentialToSave);
+        }
     }
 
     @Override
     public AccountRecord getAccount(@NonNull final String cacheKey) {
-        Logger.verbose(TAG, "Loading Account by key...");
-        AccountRecord account = mCacheValueDelegate.fromCacheValue(
-                mSharedPreferencesFileManager.get(cacheKey),
-                AccountRecord.class
-        );
+        final String methodTag = TAG + ":getAccount";
 
-        if (null == account) {
-            // We could not deserialize the target AccountRecord...
-            // Maybe it was encrypted for another application?
-            Logger.warn(
-                    TAG,
-                    ACCOUNT_RECORD_DESERIALIZATION_FAILED
-            );
-        } else if (EMPTY_ACCOUNT.equals(account)) {
-            Logger.warn(TAG, "The returned Account was uninitialized. Removing...");
-            mSharedPreferencesFileManager.remove(cacheKey);
-            account = null;
+        AccountRecord foundValue;
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            foundValue = mCachedAccountRecordsWithKeys.get(cacheKey);
         }
 
-        return account;
+        try {
+            if (foundValue != null) {
+                foundValue = (AccountRecord) foundValue.clone();
+            }
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone AccountRecord", e);
+        }
+        return foundValue;
     }
 
     @Override
     @Nullable
     public Credential getCredential(@NonNull final String cacheKey) {
-        // TODO add support for more Credential types...
-        Logger.verbose(TAG, "getCredential()");
-        Logger.verbosePII(TAG, "Using cache key: [" + cacheKey + "]");
+        final String methodTag = TAG + ":getCredential";
 
-        final CredentialType type = getCredentialTypeForCredentialCacheKey(cacheKey);
-        Class<? extends Credential> clazz = null;
+        Credential foundValue;
 
-        if (null != type) {
-            clazz = getTargetClassForCredentialType(cacheKey, type);
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            foundValue = mCachedCredentialsWithKeys.get(cacheKey);
         }
 
-        Credential credential = null;
-
-        if (null != clazz) {
-            credential = mCacheValueDelegate.fromCacheValue(
-                    mSharedPreferencesFileManager.get(cacheKey),
-                    clazz
-            );
+        try {
+            if (foundValue != null) {
+                foundValue = (Credential) foundValue.clone();
+            }
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone Credential", e);
         }
 
-        if (null == credential) {
-            // We could not deserialize the target Credential...
-            // Maybe it was encrypted for another application?
-            Logger.warn(
-                    TAG,
-                    CREDENTIAL_DESERIALIZATION_FAILED
-            );
-        } else if ((AccessTokenRecord.class == clazz && EMPTY_AT.equals(credential))
-                || (RefreshTokenRecord.class == clazz && EMPTY_RT.equals(credential))
-                || (IdTokenRecord.class == clazz) && EMPTY_ID.equals(credential)) {
-            // The returned credential came back uninitialized...
-            // Remove the entry and return null...
-            Logger.warn(TAG, "The returned Credential was uninitialized. Removing...");
-            mSharedPreferencesFileManager.remove(cacheKey);
-            credential = null;
-        }
-
-        return credential;
+        return foundValue;
     }
 
     @NonNull
-    private Map<String, AccountRecord> getAccountsWithKeys() {
-        Logger.verbose(TAG, "Loading Accounts + keys...");
+    private Map<String, AccountRecord> loadAccountsWithKeys() {
+        final String methodTag = TAG + ":loadAccountsWithKeys";
+
+        Logger.verbose(methodTag, "Loading Accounts + keys...");
         final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
             @Override
             public boolean test(String value) {
@@ -224,14 +271,17 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                 );
 
                 if (null == account) {
-                    Logger.warn(TAG, ACCOUNT_RECORD_DESERIALIZATION_FAILED);
+                    Logger.warn(methodTag, ACCOUNT_RECORD_DESERIALIZATION_FAILED);
+                } else if (EMPTY_ACCOUNT.equals(account)) {
+                    Logger.warn(methodTag, "The returned Account was uninitialized. Removing...");
+                    mSharedPreferencesFileManager.remove(cacheKey);
                 } else {
                     accounts.put(cacheKey, account);
                 }
             }
         }
 
-        Logger.verbose(TAG, "Returning [" + accounts.size() + "] Accounts w/ keys...");
+        Logger.verbose(methodTag, "Returning [" + accounts.size() + "] Accounts w/ keys...");
 
         return accounts;
     }
@@ -241,10 +291,20 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public List<AccountRecord> getAccounts() {
         final String methodTag = TAG + ":getAccounts";
         Logger.verbose(methodTag, "Loading Accounts...(no arg)");
-        final Map<String, AccountRecord> allAccounts = getAccountsWithKeys();
-        final List<AccountRecord> accounts = new ArrayList<>(allAccounts.values());
-        Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
-        return accounts;
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            final List<AccountRecord> accounts = new ArrayList<>();
+            for (AccountRecord record : mCachedAccountRecordsWithKeys.values()) {
+                try {
+                    accounts.add((AccountRecord) record.clone());
+                } catch (final CloneNotSupportedException e) {
+                    Logger.error(methodTag, "Failed to clone AccountRecord", e);
+                }
+            }
+            Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
+            return accounts;
+        }
     }
 
     @Override
@@ -271,9 +331,10 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     }
 
     @NonNull
-    private Map<String, Credential> getCredentialsWithKeys() {
+    private Map<String, Credential> loadCredentialsWithKeys() {
         final String methodTag = TAG + ":getCredentialsWithKeys";
         Logger.verbose(methodTag, "Loading Credentials with keys...");
+
         final Map<String, Credential> credentials = new HashMap<>();
         final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
             @Override
@@ -285,14 +346,23 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         while (cacheValues.hasNext()) {
             Map.Entry<String, ?> cacheValue = cacheValues.next();
             final String cacheKey = cacheValue.getKey();
+            final Class<? extends AccountCredentialBase> clazz = credentialClassForType(cacheKey);
             final Credential credential = mCacheValueDelegate.fromCacheValue(
                     cacheValue.getValue().toString(),
-                    credentialClassForType(cacheKey)
+                    clazz
             );
 
             if (null == credential) {
                 Logger.warn(methodTag, CREDENTIAL_DESERIALIZATION_FAILED);
-            } else {
+            } else if ((AccessTokenRecord.class == clazz && EMPTY_AT.equals(credential))
+                || (RefreshTokenRecord.class == clazz && EMPTY_RT.equals(credential))
+                || (IdTokenRecord.class == clazz) && EMPTY_ID.equals(credential)) {
+                // The returned credential came back uninitialized...
+                // Remove the entry and return null...
+                Logger.warn(methodTag, "The returned Credential was uninitialized. Removing...");
+                mSharedPreferencesFileManager.remove(cacheKey);
+            }
+            else {
                 credentials.put(cacheKey, credential);
             }
         }
@@ -307,9 +377,19 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public List<Credential> getCredentials() {
         final String methodTag = TAG + ":getCredentials";
         Logger.verbose(methodTag, "Loading Credentials...");
-        final Map<String, Credential> allCredentials = getCredentialsWithKeys();
-        final List<Credential> creds = new ArrayList<>(allCredentials.values());
-        return creds;
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            ArrayList<Credential> credentials = new ArrayList<>();
+            for (Credential credential : mCachedCredentialsWithKeys.values()) {
+                try {
+                    credentials.add((Credential)credential.clone());
+                } catch (final CloneNotSupportedException e) {
+                    Logger.error(methodTag, "Failed to clone Credential", e);
+                }
+            }
+            return credentials;
+        }
     }
 
     @Override
@@ -539,16 +619,20 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
         final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToRemove);
 
-        boolean accountRemoved = false;
-        if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
-        {
-            mSharedPreferencesFileManager.remove(cacheKey);
-            accountRemoved = true;
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            boolean accountRemoved = false;
+            if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
+            {
+                mSharedPreferencesFileManager.remove(cacheKey);
+                accountRemoved = true;
+            }
+            Logger.info(methodTag, "Account was removed? [" + accountRemoved + "]");
+
+            mCachedAccountRecordsWithKeys.remove(cacheKey);
+
+            return accountRemoved;
         }
-
-        Logger.info(methodTag, "Account was removed? [" + accountRemoved + "]");
-
-        return accountRemoved;
     }
 
     @Override
@@ -562,23 +646,33 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
         final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToRemove);
 
-        boolean credentialRemoved = false;
-        if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
-        {
-            mSharedPreferencesFileManager.remove(cacheKey);
-            credentialRemoved = true;
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            boolean credentialRemoved = false;
+            if (mSharedPreferencesFileManager.keySet().contains(cacheKey)) {
+                mSharedPreferencesFileManager.remove(cacheKey);
+                credentialRemoved = true;
+            }
+
+            Logger.info(methodTag, "Credential was removed? [" + credentialRemoved + "]");
+
+            mCachedCredentialsWithKeys.remove(cacheKey);
+
+            return credentialRemoved;
         }
 
-        Logger.info(methodTag, "Credential was removed? [" + credentialRemoved + "]");
-
-        return credentialRemoved;
     }
 
     @Override
     public void clearAll() {
         final String methodTag = TAG + ":clearAll";
         Logger.info(methodTag, "Clearing all SharedPreferences entries...");
-        mSharedPreferencesFileManager.clear();
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            mSharedPreferencesFileManager.clear();
+            mCachedCredentialsWithKeys.clear();
+            mCachedAccountRecordsWithKeys.clear();
+        }
         Logger.info(methodTag, "SharedPreferences cleared.");
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
@@ -33,7 +33,7 @@ import lombok.NonNull;
 /**
  * Base class for Objects to support the [de]/serialization of extra fields.
  */
-public abstract class AccountCredentialBase {
+public abstract class AccountCredentialBase implements Cloneable {
 
     private transient Map<String, JsonElement> mAdditionalFields = Collections.synchronizedMap(new HashMap<String, JsonElement>());
 
@@ -76,6 +76,13 @@ public abstract class AccountCredentialBase {
                 mAdditionalFields.put(entry.getKey(), entry.getValue());
             }
         }
+    }
+
+    @Override
+    public AccountCredentialBase clone() throws CloneNotSupportedException {
+        AccountCredentialBase other = (AccountCredentialBase) super.clone();
+        other.setAdditionalFields(new HashMap<>(mAdditionalFields));
+        return other;
     }
 
     //CHECKSTYLE:OFF


### PR DESCRIPTION
High level token operations start with SharedPreferencesFileManager.getCredentails()/getAccountRecords().  Right now, this requires hitting the SharedPreferencesFileManager and at the very least deserializing all credential/account types every time.

This change maintains a layer of caching at the List<AccountRecord> and List<Credential> level. that will prevent any decryption/deserialization from taking place in the 'get' path.