### PR TITLE
Add method to platform util to get package name from uid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V.Next
 - [MINOR] Format thread+correlationId metadata only once logging is clearly opted-in (#1917)
 - [MINOR] Remove unnecessary synchronization when storage access is already guarded (#1928)
 - [MINOR] Write back read successes to cache and stop extra lookups in getAll (#1927)
+- [MINOR] Add method to platform util to get package name from uid (#1932)
 
 V.9.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -38,9 +38,9 @@ import android.os.SystemClock;
 import com.microsoft.identity.common.adal.internal.net.DefaultConnectionService;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.broker.IntuneMAMEnrollmentIdGateway;
-import com.microsoft.identity.common.java.commands.InteractiveTokenCommand;
 import com.microsoft.identity.common.internal.ui.webview.WebViewUtil;
 import com.microsoft.identity.common.java.commands.ICommand;
+import com.microsoft.identity.common.java.commands.InteractiveTokenCommand;
 import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
@@ -170,6 +170,12 @@ public class AndroidPlatformUtil implements IPlatformUtil {
         return KeyManagerFactory.getInstance("X509");
     }
 
+    @Nullable
+    @Override
+    public String getPackageNameFromUid(int uid) {
+        return mContext.getPackageManager().getNameForUid(uid);
+    }
+
     /**
      * This method optionally re-orders tasks to bring the task that launched
      * the interactive activity to the foreground. This is useful when the activity provided
@@ -182,7 +188,7 @@ public class AndroidPlatformUtil implements IPlatformUtil {
     private void optionallyReorderTasks(@NonNull final ICommand<?> command) {
         final String methodTag = TAG + ":optionallyReorderTasks";
         if (command instanceof InteractiveTokenCommand) {
-            if (mActivity == null){
+            if (mActivity == null) {
                 throw new IllegalStateException("Activity cannot be null in an interactive session.");
             }
 

--- a/common4j/src/main/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
@@ -232,5 +232,11 @@ public class MockPlatformComponentsFactory {
         public KeyManagerFactory getSslContextKeyManagerFactory() {
             throw new UnsupportedOperationException();
         }
+
+        @Nullable
+        @Override
+        public String getPackageNameFromUid(int uid) {
+            return null;
+        }
     };
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -103,19 +103,28 @@ public interface IPlatformUtil {
     /**
      * BouncyCastle doesn't play well with Conscrypt (Android 11's default SSLSocket implementation)
      * https://developer.android.com/about/versions/11/behavior-changes-all#ssl-sockets-conscrypt
-     *
+     * <p>
      * This causes the DRS request TLS handshake to fail - 'key not found' - even if cert is provided.
-     *
+     * <p>
      * As a short-term work around, we're going to use the 'default' KeyManagerFactory in Android,
      * and keeps using BouncyCastle in Linux.
-     *
+     * <p>
      * Long term, we're going to move away from platform's default implementation
      * and use external libraries that are FIPS compliant.
-     *
+     * <p>
      * We use KeyManagerFactory to construct an {@link javax.net.ssl.SSLContext} object
      * with a WPJ certificate - to authenticate into DRS (via TLS challenge).
      *
      * @link https://developer.android.com/reference/javax/net/ssl/KeyManagerFactory
      **/
     KeyManagerFactory getSslContextKeyManagerFactory() throws NoSuchAlgorithmException;
+
+    /**
+     * Returns the package name of the app for which the uid is supplied.
+     *
+     * @param uid the uid of the app for which to return package name
+     * @return package name
+     */
+    @Nullable
+    String getPackageNameFromUid(final int uid);
 }


### PR DESCRIPTION
Added a method to platform util that when provided with uid will return the package name.

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2119