### PR TITLE
Unit Tests for Smartcard CBA

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -31,7 +31,7 @@ import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.R;
 import com.microsoft.identity.common.java.exception.BaseException;
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.logging.Logger;
 
@@ -51,8 +51,8 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
     protected final String TAG;
     protected final Activity mActivity;
     protected final T mCbaManager;
-    protected final DialogHolder mDialogHolder;
-    protected final CertBasedAuthTelemetryHelper mTelemetryHelper;
+    protected final IDialogHolder mDialogHolder;
+    protected final ICertBasedAuthTelemetryHelper mTelemetryHelper;
     protected boolean mIsSmartcardCertBasedAuthProceeding;
 
     /**
@@ -65,8 +65,8 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
      */
     public AbstractSmartcardCertBasedAuthChallengeHandler(@NonNull final Activity activity,
                                                           @NonNull final T smartcardCertBasedAuthManager,
-                                                          @NonNull final DialogHolder dialogHolder,
-                                                          @NonNull final CertBasedAuthTelemetryHelper telemetryHelper,
+                                                          @NonNull final IDialogHolder dialogHolder,
+                                                          @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper,
                                                           @NonNull final String tag) {
         TAG = tag;
         mActivity = activity;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthManager.java
@@ -27,7 +27,7 @@ import android.app.Activity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -68,7 +68,7 @@ public abstract class AbstractSmartcardCertBasedAuthManager<T extends IConnectio
      * Runs implementation specific processes that may need to occur just before calling {@link android.webkit.ClientCertRequest#proceed(PrivateKey, X509Certificate[])}.
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
-    abstract void initBeforeProceedingWithRequest(@NonNull final CertBasedAuthTelemetryHelper telemetryHelper);
+    abstract void initBeforeProceedingWithRequest(@NonNull final ICertBasedAuthTelemetryHelper telemetryHelper);
 
     /**
      * Cleanup to be done upon host activity being destroyed.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -28,6 +28,7 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
@@ -59,6 +60,24 @@ public class CertBasedAuthFactory {
             //Connection and disconnection callbacks for discovery are set in the SmartcardCertBasedAuthChallengeHandlers.
             mUsbSmartcardCertBasedAuthManager.startDiscovery(activity);
         }
+    }
+
+    /**
+     * Creates an instance of CertBasedAuthFactory for testing purposes.
+     * @param activity host activity.
+     * @param usbManager manager for usb connections.
+     * @param nfcManager manager for nfc connections.
+     * @param dialogHolder IDialogHolder instance.
+     */
+    @VisibleForTesting
+    protected CertBasedAuthFactory(@NonNull final Activity activity,
+                                   @NonNull final AbstractUsbSmartcardCertBasedAuthManager usbManager,
+                                   @NonNull final AbstractNfcSmartcardCertBasedAuthManager nfcManager,
+                                   @NonNull final IDialogHolder dialogHolder) {
+        mActivity = activity;
+        mUsbSmartcardCertBasedAuthManager = usbManager;
+        mNfcSmartcardCertBasedAuthManager = nfcManager;
+        mDialogHolder = dialogHolder;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -31,6 +31,7 @@ import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 
 /**
  * Instantiates handlers for certificate based authentication.
@@ -42,7 +43,7 @@ public class CertBasedAuthFactory {
     private final Activity mActivity;
     private final AbstractUsbSmartcardCertBasedAuthManager mUsbSmartcardCertBasedAuthManager;
     private final AbstractNfcSmartcardCertBasedAuthManager mNfcSmartcardCertBasedAuthManager;
-    private final DialogHolder mDialogHolder;
+    private final IDialogHolder mDialogHolder;
 
     /**
      * Creates an instance of CertBasedAuthFactory.
@@ -65,7 +66,7 @@ public class CertBasedAuthFactory {
      * @param callback logic to run after a ICertBasedAuthChallengeHandler is chosen.
      */
     public void createCertBasedAuthChallengeHandler(@NonNull final CertBasedAuthChallengeHandlerCallback callback) {
-        final CertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
+        final ICertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
         telemetryHelper.setUserChoice(CertBasedAuthChoice.NON_APPLICABLE);
         telemetryHelper.setCertBasedAuthChallengeHandler(NON_APPLICABLE);
 
@@ -113,7 +114,7 @@ public class CertBasedAuthFactory {
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     private void onCancelHelper(@NonNull final CertBasedAuthChallengeHandlerCallback callback,
-                                @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         mDialogHolder.dismissDialog();
         telemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
         callback.onReceived(null);
@@ -127,7 +128,7 @@ public class CertBasedAuthFactory {
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     private void setUpForSmartcardCertBasedAuth(@NonNull final CertBasedAuthChallengeHandlerCallback callback,
-                                                @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                                @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         //If smartcard is already plugged in, go straight to cert picker.
         if (mUsbSmartcardCertBasedAuthManager != null
                 && mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {
@@ -146,7 +147,8 @@ public class CertBasedAuthFactory {
                 @Override
                 public void onClick() {
                     //If smartcard is already plugged in, go straight to cert picker.
-                    if (mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {
+                    if (mUsbSmartcardCertBasedAuthManager != null
+                    && mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {
                         callback.onReceived(new UsbSmartcardCertBasedAuthChallengeHandler(
                                 mActivity,
                                 mUsbSmartcardCertBasedAuthManager,
@@ -168,7 +170,7 @@ public class CertBasedAuthFactory {
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     private void showSmartcardPromptDialogAndSetConnectionCallback(@NonNull final CertBasedAuthChallengeHandlerCallback challengeHandlerCallback,
-                                                                   @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                                                   @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         mDialogHolder.showSmartcardPromptDialog(new SmartcardPromptDialog.CancelCbaCallback() {
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
             @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -37,7 +37,7 @@ import java.util.List;
  * Builds and shows SmartcardDialog instances while keeping track of the current dialog being shown to the user.
  */
 @ThreadSafe
-public class DialogHolder {
+public class DialogHolder implements IDialogHolder {
     //Current host activity.
     private final Activity mActivity;
     //The current dialog that is showing, if any.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Builds and shows dialog instances while keeping track of the current dialog being shown to the user.
+ */
+public interface IDialogHolder {
+
+    /**
+     * Build and show picker that prompts user to select a certificate for authentication.
+     * @param certList List of ICertDetails that contains cert details only pertinent to the cert picker.
+     * @param positiveButtonListener A PositiveButtonListener to be set for a SmartcardCertPickerDialog.
+     * @param cancelCbaCallback      A Callback that holds code to be run when CBA is being cancelled.
+     */
+    void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
+                              @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
+                              @NonNull final SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback);
+
+    /**
+     * Build and show PIN dialog that prompts user to type in their PIN for their YubiKey.
+     * @param positiveButtonListener A PositiveButtonListener to be set for a SmartcardPinDialog.
+     * @param cancelCbaCallback      A Callback that holds code to be run when CBA is being cancelled.
+     */
+    void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
+                       @NonNull final SmartcardPinDialog.CancelCbaCallback cancelCbaCallback);
+
+    /**
+     * Builds and shows dialog informing the user of an expected or unexpected error.
+     * @param titleStringResourceId String resource id of the title text.
+     * @param messageStringResourceId String resource id of the message text.
+     */
+    void showErrorDialog(final int titleStringResourceId,
+                         final int messageStringResourceId);
+
+    /**
+     * Builds and shows dialog that prompts user to choose if they would like to proceed with on-device
+     * or smartcard certificate based authentication.
+     * @param positiveButtonListener A Listener containing code to be run upon a positive button click.
+     * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
+     */
+    void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
+                              @NonNull final UserChoiceDialog.CancelCbaCallback cancelCbaCallback);
+
+    /**
+     * Builds and shows a SmartcardDialog that prompts the user to connect their smartcard,
+     * either by plugging in (USB) or holding to back of phone (NFC).
+     * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
+     */
+    void showSmartcardPromptDialog(@NonNull final SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback);
+
+    /**
+     * Builds and shows a SmartcardDialog that reminds the user to remain holding their smartcard device to their phone.
+     */
+    void showSmartcardNfcLoadingDialog();
+
+    /**
+     * Builds and shows a SmartcardDialog that prompts the user to connect their smartcard by holding it to the back of their phone.
+     * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
+     */
+    void showSmartcardNfcPromptDialog(@NonNull final SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback);
+
+    /**
+     * Builds and shows a SmartcardDialog that notifies user that NFC is not on for their device.
+     * @param dismissCallback a callback that holds logic to be run upon dismissal of the dialog.
+     */
+    void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback);
+
+    /**
+     * Dismisses current dialog, if one is showing.
+     */
+    void dismissDialog();
+
+    /**
+     * Shows provided SmartcardDialog if not null.
+     * Automatically dismisses existing dialog (if showing).
+     * @param dialog SmartcardDialog object to be shown.
+     */
+    void showDialog(@Nullable final SmartcardDialog dialog);
+
+    /**
+     * Informs if an existing dialog is currently showing.
+     * @return True if a SmartcardDialog is currently showing. False otherwise.
+     */
+    boolean isDialogShowing();
+
+    /**
+     * Runs the onCancelCbaCallback code for the current dialog.
+     * Used when YubiKey is unexpectedly disconnected from device.
+     */
+    void onCancelCba();
+
+    /**
+     * Sets error mode for an existing SmartcardPinDialog.
+     */
+    void setPinDialogErrorMode();
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
@@ -29,7 +29,7 @@ import android.webkit.ClientCertRequest;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 
 /**
  * Handles a received ClientCertRequest by prompting the user to choose from certificates
@@ -45,8 +45,8 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
      */
     public NfcSmartcardCertBasedAuthChallengeHandler(@NonNull final Activity activity,
                                                      @NonNull final AbstractNfcSmartcardCertBasedAuthManager nfcSmartcardCertBasedAuthManager,
-                                                     @NonNull final DialogHolder dialogHolder,
-                                                     @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                                     @NonNull final IDialogHolder dialogHolder,
+                                                     @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         super(activity, nfcSmartcardCertBasedAuthManager, dialogHolder, telemetryHelper, NfcSmartcardCertBasedAuthChallengeHandler.class.getSimpleName());
     }
 
@@ -88,7 +88,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
                 mCbaManager.setConnectionCallback(new IConnectionCallback() {
                     @Override
                     public void onCreateConnection() {
-                        mDialogHolder.showDialog(new SmartcardNfcLoadingDialog(mActivity));
+                        mDialogHolder.showSmartcardNfcLoadingDialog();
                         if (mCbaManager.isDeviceChanged()) {
                             //In a future version, an error dialog with a custom message could be shown here instead of a general error.
                             indicateGeneralException(methodTag, new Exception("Device connected via NFC is different from initially connected device."));

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -33,7 +33,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.java.exception.BaseException;
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.logging.Logger;
 
@@ -49,7 +49,7 @@ public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChal
     private static final String TAG = OnDeviceCertBasedAuthChallengeHandler.class.getSimpleName();
     private static final String ACCEPTABLE_ISSUER = "CN=MS-Organization-Access";
     private final Activity mActivity;
-    private final CertBasedAuthTelemetryHelper mTelemetryHelper;
+    private final ICertBasedAuthTelemetryHelper mTelemetryHelper;
     private boolean mIsOnDeviceCertBasedAuthProceeding;
 
     /**
@@ -58,7 +58,7 @@ public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChal
      * @param telemetryHelper CertBasedAuthTelemetryHelder instance.
      */
     public OnDeviceCertBasedAuthChallengeHandler(@NonNull final Activity activity,
-                                                 @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                                 @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         mActivity = activity;
         mTelemetryHelper = telemetryHelper;
         mTelemetryHelper.setCertBasedAuthChallengeHandler(TAG);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandler.java
@@ -30,7 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 
 /**
@@ -49,8 +49,8 @@ public class UsbSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
      */
     public UsbSmartcardCertBasedAuthChallengeHandler(@NonNull final Activity activity,
                                                      @NonNull final AbstractUsbSmartcardCertBasedAuthManager usbSmartcardCertBasedAuthManager,
-                                                     @NonNull final DialogHolder dialogHolder,
-                                                     @NonNull final CertBasedAuthTelemetryHelper telemetryHelper) {
+                                                     @NonNull final IDialogHolder dialogHolder,
+                                                     @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         super(activity, usbSmartcardCertBasedAuthManager, dialogHolder, telemetryHelper, UsbSmartcardCertBasedAuthChallengeHandler.class.getSimpleName());
         final String methodTag = TAG + ":UsbSmartcardCertBasedAuthChallengeHandler";
         mCbaManager.setConnectionCallback(new IUsbConnectionCallback() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKeyPivProviderManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKeyPivProviderManager.java
@@ -24,7 +24,7 @@ package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
@@ -46,7 +46,7 @@ public class YubiKeyPivProviderManager {
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      * @param pivProviderCallback A Callback which returns a Callback that will return a new PivSession instance.
      */
-    public static void addPivProvider(@NonNull final CertBasedAuthTelemetryHelper telemetryHelper,
+    public static void addPivProvider(@NonNull final ICertBasedAuthTelemetryHelper telemetryHelper,
                                       @NonNull final Callback<Callback<Result<PivSession, Exception>>> pivProviderCallback) {
         final String methodTag = TAG + ":addPivProvider";
         if (Security.getProvider(YUBIKEY_PROVIDER) != null) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
@@ -30,7 +30,7 @@ import android.webkit.ClientCertRequest;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 import com.yubico.yubikit.android.transport.nfc.NfcConfiguration;
 import com.yubico.yubikit.android.transport.nfc.NfcNotAvailable;
@@ -164,7 +164,7 @@ public class YubiKitNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcar
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     @Override
-    void initBeforeProceedingWithRequest(@NonNull CertBasedAuthTelemetryHelper telemetryHelper) {
+    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
         //Need to add a PivProvider instance to the beginning of the array of Security providers in order for signature logic to occur.
         //Note that this provider is removed when the UsbYubiKeyDevice connection is closed.
         YubiKeyPivProviderManager.addPivProvider(telemetryHelper, getPivProviderCallback());

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitUsbSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitUsbSmartcardCertBasedAuthManager.java
@@ -30,7 +30,7 @@ import android.webkit.ClientCertRequest;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
-import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 import com.yubico.yubikit.android.transport.usb.UsbConfiguration;
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice;
@@ -160,7 +160,7 @@ public class YubiKitUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcar
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     @Override
-    void initBeforeProceedingWithRequest(@NonNull CertBasedAuthTelemetryHelper telemetryHelper) {
+    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
         YubiKeyPivProviderManager.addPivProvider(telemetryHelper, getPivProviderCallback());
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
@@ -49,8 +49,8 @@ public class AbstractCertBasedAuthTest {
             assertFalse(mDialogHolder.isDialogShowing());
             return;
         }
-        assertNotNull(mDialogHolder.getMCurrentDialog());
+        assertNotNull(mDialogHolder.getCurrentDialog());
         assertTrue(mDialogHolder.isDialogShowing());
-        assertEquals(expectedDialog, mDialogHolder.getMCurrentDialog());
+        assertEquals(expectedDialog, mDialogHolder.getCurrentDialog());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
@@ -1,0 +1,36 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+
+import androidx.annotation.Nullable;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+public class AbstractCertBasedAuthTest {
+    protected Activity mActivity;
+    protected TestDialogHolder mDialogHolder;
+
+    @Before
+    public void setUp() {
+        mActivity = Robolectric.buildActivity(Activity.class).get();
+        mDialogHolder = new TestDialogHolder();
+    }
+
+    protected void checkIfCorrectDialogIsShowing(@Nullable final TestDialog expectedDialog) {
+        if (expectedDialog == null) {
+            assertFalse(mDialogHolder.isDialogShowing());
+            return;
+        }
+        assertNotNull(mDialogHolder.getMCurrentDialog());
+        assertTrue(mDialogHolder.isDialogShowing());
+        assertEquals(expectedDialog, mDialogHolder.getMCurrentDialog());
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractCertBasedAuthTest.java
@@ -32,9 +32,7 @@ import android.app.Activity;
 import androidx.annotation.Nullable;
 
 import org.junit.Before;
-import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 
 public class AbstractCertBasedAuthTest {
     protected Activity mActivity;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -22,20 +22,20 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-
-import android.webkit.ClientCertRequest;
+import static org.junit.Assert.assertTrue;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.math.BigInteger;
 import java.security.Principal;
-import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -46,10 +46,18 @@ import java.util.Set;
 @RunWith(RobolectricTestRunner.class)
 public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends AbstractCertBasedAuthTest {
 
+    protected TestClientCertRequest mRequest;
+
+    @Before
+    public void handlerSetUp() {
+        mRequest = new TestClientCertRequest();
+    }
+
     @Test
     public void testNoCertsOnSmartcard() {
         setAndProcessChallengeHandler(new ArrayList<>());
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Test
@@ -60,6 +68,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
+        checkIfProceeded(false);
     }
 
     @Test
@@ -71,6 +80,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
+        checkIfProceeded(false);
     }
 
     @Test
@@ -79,6 +89,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         certList.add(getMockCertificate("Exception", "Exception"));
         setAndProcessChallengeHandler(certList);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Test
@@ -90,6 +101,9 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     @Test
     public abstract void testExceptionThrownWhenGettingKey();
 
+    @Test
+    public abstract void testProceed();
+
     protected abstract void setAndProcessChallengeHandler(@NonNull final List<X509Certificate> certList);
 
     protected void goToPinDialog() {
@@ -97,6 +111,16 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         assertNotNull(listener);
         listener.onClick(mDialogHolder.getCertList().get(0));
         checkIfCorrectDialogIsShowing(TestDialog.pin);
+    }
+
+    protected void checkIfProceeded(final boolean isExpected) {
+        if (isExpected) {
+            assertTrue(mRequest.isProceeded());
+            assertFalse(mRequest.isCancelled());
+        } else {
+            assertFalse(mRequest.isProceeded());
+            assertTrue(mRequest.isCancelled());
+        }
     }
 
     @NonNull
@@ -251,46 +275,6 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
             @Override
             public byte[] getExtensionValue(String s) {
                 return new byte[0];
-            }
-        };
-    }
-
-    @NonNull
-    protected ClientCertRequest getMockClientCertRequest() {
-        return new ClientCertRequest() {
-            @Override
-            public String[] getKeyTypes() {
-                return new String[0];
-            }
-
-            @Override
-            public Principal[] getPrincipals() {
-                return new Principal[0];
-            }
-
-            @Override
-            public String getHost() {
-                return null;
-            }
-
-            @Override
-            public int getPort() {
-                return 0;
-            }
-
-            @Override
-            public void proceed(PrivateKey privateKey, X509Certificate[] x509Certificates) {
-
-            }
-
-            @Override
-            public void ignore() {
-
-            }
-
-            @Override
-            public void cancel() {
-
             }
         };
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     public void testCancelAtPickerDialog() {
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
-        final SmartcardCertPickerDialog.CancelCbaCallback callback =  mDialogHolder.getMCertPickerCancelCbaCallback();
+        final SmartcardCertPickerDialog.CancelCbaCallback callback =  mDialogHolder.getCertPickerCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -67,7 +67,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.CancelCbaCallback callback = mDialogHolder.getMPinCancelCbaCallback();
+        final SmartcardPinDialog.CancelCbaCallback callback = mDialogHolder.getPinCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -93,9 +93,9 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     protected abstract void setAndProcessChallengeHandler(@NonNull final List<X509Certificate> certList);
 
     protected void goToPinDialog() {
-        final SmartcardCertPickerDialog.PositiveButtonListener listener = mDialogHolder.getMCertPickerPositiveButtonListener();
+        final SmartcardCertPickerDialog.PositiveButtonListener listener = mDialogHolder.getCertPickerPositiveButtonListener();
         assertNotNull(listener);
-        listener.onClick(mDialogHolder.getMCertList().get(0));
+        listener.onClick(mDialogHolder.getCertList().get(0));
         checkIfCorrectDialogIsShowing(TestDialog.pin);
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -1,0 +1,550 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.webkit.ClientCertRequest;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.math.BigInteger;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import lombok.Getter;
+
+@RunWith(RobolectricTestRunner.class)
+public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest {
+    protected Activity mActivity;
+    protected TestDialogHolder mDialogHolder;
+
+    @Before
+    public void setUp() {
+        mActivity = Robolectric.buildActivity(Activity.class).get();
+        mDialogHolder = new TestDialogHolder();
+    }
+
+    @Test
+    public void testNoCertsOnSmartcard() {
+        setAndProcessChallengeHandler(new ArrayList<>());
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Test
+    public void testCancelAtPickerDialog() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        final SmartcardCertPickerDialog.CancelCbaCallback callback =  mDialogHolder.getMCertPickerCancelCbaCallback();
+        assertNotNull(callback);
+        callback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
+    }
+
+    @Test
+    public void testCancelAtPinDialog() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.CancelCbaCallback callback = mDialogHolder.getMPinCancelCbaCallback();
+        assertNotNull(callback);
+        callback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
+    }
+
+    @Test
+    public abstract void testLockedOut();
+
+    @Test
+    public void testExceptionThrownWhenGettingCertDetailsList() {
+        final List<X509Certificate> certList = new ArrayList<>();
+        certList.add(getMockCertificate("Exception", "Exception"));
+        setAndProcessChallengeHandler(certList);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Test
+    public abstract void testExceptionThrownWhenVerifyingPin();
+
+    @Test
+    public abstract void testExceptionThrownWhenGettingKey();
+
+    protected abstract void setAndProcessChallengeHandler(@NonNull final List<X509Certificate> certList);
+
+    protected void checkIfCorrectDialogIsShowing(@Nullable final TestDialog expectedDialog) {
+        if (expectedDialog == null) {
+            assertFalse(mDialogHolder.isDialogShowing());
+            return;
+        }
+        assertNotNull(mDialogHolder.getMCurrentDialog());
+        assertTrue(mDialogHolder.isDialogShowing());
+        assertEquals(expectedDialog, mDialogHolder.getMCurrentDialog());
+    }
+
+    protected void goToPinDialog() {
+        final SmartcardCertPickerDialog.PositiveButtonListener listener = mDialogHolder.getMCertPickerPositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(mDialogHolder.getMCertList().get(0));
+        checkIfCorrectDialogIsShowing(TestDialog.pin);
+    }
+
+    //Return a list containing two mock certificates.
+    @NonNull
+    protected List<X509Certificate> getMockCertList() {
+        final X509Certificate cert1 = getMockCertificate("SomeIssuer1", "SomeSubject1");
+        final X509Certificate cert2 = getMockCertificate("SomeIssuer2", "SomeSubject2");
+        final List<X509Certificate> certList = new ArrayList<>();
+        certList.add(cert1);
+        certList.add(cert2);
+        return certList;
+    }
+
+    //Return an empty ClientCertRequest only to be used for testing.
+    @NonNull
+    protected ClientCertRequest getMockClientCertRequest() {
+        return new ClientCertRequest() {
+            @Override
+            public String[] getKeyTypes() {
+                return new String[0];
+            }
+
+            @Override
+            public Principal[] getPrincipals() {
+                return new Principal[0];
+            }
+
+            @Override
+            public String getHost() {
+                return null;
+            }
+
+            @Override
+            public int getPort() {
+                return 0;
+            }
+
+            @Override
+            public void proceed(PrivateKey privateKey, X509Certificate[] x509Certificates) {
+
+            }
+
+            @Override
+            public void ignore() {
+
+            }
+
+            @Override
+            public void cancel() {
+
+            }
+        };
+    }
+
+    //Return a mock certificate only to be used for testing.
+    @NonNull
+    protected X509Certificate getMockCertificate(@Nullable final String issuerDNName, @Nullable final String subjectDNName) {
+        return new X509Certificate() {
+            @Override
+            public void checkValidity() {
+
+            }
+
+            @Override
+            public void checkValidity(Date date) {
+
+            }
+
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public BigInteger getSerialNumber() {
+                return null;
+            }
+
+            @Override
+            public Principal getIssuerDN() {
+                return new Principal() {
+                    @Override
+                    public String getName() {
+                        return issuerDNName;
+                    }
+                };
+            }
+
+            @Override
+            public Principal getSubjectDN() {
+                return new Principal() {
+                    @Override
+                    public String getName() {
+                        return subjectDNName;
+                    }
+                };
+            }
+
+            @Override
+            public Date getNotBefore() {
+                return null;
+            }
+
+            @Override
+            public Date getNotAfter() {
+                return null;
+            }
+
+            @Override
+            public byte[] getTBSCertificate() {
+                return new byte[0];
+            }
+
+            @Override
+            public byte[] getSignature() {
+                return new byte[0];
+            }
+
+            @Override
+            public String getSigAlgName() {
+                return null;
+            }
+
+            @Override
+            public String getSigAlgOID() {
+                return null;
+            }
+
+            @Override
+            public byte[] getSigAlgParams() {
+                return new byte[0];
+            }
+
+            @Override
+            public boolean[] getIssuerUniqueID() {
+                return new boolean[0];
+            }
+
+            @Override
+            public boolean[] getSubjectUniqueID() {
+                return new boolean[0];
+            }
+
+            @Override
+            public boolean[] getKeyUsage() {
+                return new boolean[0];
+            }
+
+            @Override
+            public int getBasicConstraints() {
+                return 0;
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return new byte[0];
+            }
+
+            @Override
+            public void verify(PublicKey publicKey) {
+
+            }
+
+            @Override
+            public void verify(PublicKey publicKey, String s) {
+
+            }
+
+            @NonNull
+            @Override
+            public String toString() {
+                return issuerDNName + " " + subjectDNName;
+            }
+
+            @Override
+            public PublicKey getPublicKey() {
+                return null;
+            }
+
+            @Override
+            public boolean hasUnsupportedCriticalExtension() {
+                return false;
+            }
+
+            @Override
+            public Set<String> getCriticalExtensionOIDs() {
+                return null;
+            }
+
+            @Override
+            public Set<String> getNonCriticalExtensionOIDs() {
+                return null;
+            }
+
+            @Override
+            public byte[] getExtensionValue(String s) {
+                return new byte[0];
+            }
+        };
+    }
+
+    //Implements ISmartcardSession in order to carry out testing of dialogs.
+    //Only meant to be used for testing purposes.
+    protected static class TestSmartcardSession implements ISmartcardSession {
+
+        private final List<ICertDetails> mCertDetailsList;
+        private final char[] mPin;
+        private int mPinAttemptsRemaining;
+
+        private final TestSmartcardSession.ITestSessionCallback mCallback;
+
+        //Used to keep the pinAttemptsRemaining variable consistent between the manager and session.
+        interface ITestSessionCallback {
+            void onIncorrectAttempt();
+        }
+
+        public TestSmartcardSession(@NonNull final List<ICertDetails> certDetailsList,
+                                    final int pinAttemptsRemaining,
+                                    @NonNull final TestSmartcardSession.ITestSessionCallback callback) {
+            mCertDetailsList = certDetailsList;
+            mPin = new char[]{'1', '2', '3', '4', '5', '6'};
+            mPinAttemptsRemaining = pinAttemptsRemaining;
+            mCallback = callback;
+        }
+
+        @NonNull
+        @Override
+        public List<ICertDetails> getCertDetailsList() throws Exception {
+            //Check for a specific testing case where if there's only one cert
+            // and it has a subject value of "Exception", throw an Exception.
+            if (mCertDetailsList.size() == 1 &&
+                    mCertDetailsList.get(0).getCertificate().getIssuerDN().getName().equals("Exception")) {
+                throw new Exception();
+            }
+            return mCertDetailsList;
+        }
+
+        @Override
+        public boolean verifyPin(@NonNull final char[] pin) throws Exception {
+            if (Arrays.equals(mPin, pin)) {
+                return true;
+            }
+            else if (Arrays.equals(new char[]{'e', 'x', 'c'}, pin)) {
+                //This is a special case where we want to test handling an exception.
+                throw new Exception();
+            }
+            else {
+                mPinAttemptsRemaining = mPinAttemptsRemaining > 0 ? mPinAttemptsRemaining - 1 : 0;
+                mCallback.onIncorrectAttempt();
+                return false;
+            }
+        }
+
+        @Override
+        public int getPinAttemptsRemaining() {
+            return mPinAttemptsRemaining;
+        }
+
+        //This method is going to be used to test handling a thrown exception,
+        // so we should never get to the return statement.
+        @NonNull
+        @Override
+        public PrivateKey getKeyForAuth(@NonNull final ICertDetails certDetails, @NonNull final char[] pin) throws Exception {
+            if (Arrays.equals(mPin, pin)) {
+                throw new Exception("Testing, 1,2,3");
+            }
+            return new PrivateKey() {
+                @Override
+                public String getAlgorithm() {
+                    return null;
+                }
+
+                @Override
+                public String getFormat() {
+                    return null;
+                }
+
+                @Override
+                public byte[] getEncoded() {
+                    return new byte[0];
+                }
+            };
+        }
+    }
+
+    enum TestDialog {
+        cert_picker,
+        pin,
+        error,
+        user_choice,
+        prompt,
+        nfc_loading,
+        nfc_prompt,
+        nfc_reminder
+    }
+
+    @Getter
+    protected static class TestDialogHolder implements IDialogHolder {
+
+        private TestDialog mCurrentDialog;
+        private SmartcardCertPickerDialog.PositiveButtonListener mCertPickerPositiveButtonListener;
+        private SmartcardCertPickerDialog.CancelCbaCallback mCertPickerCancelCbaCallback;
+        private SmartcardPinDialog.PositiveButtonListener mPinPositiveButtonListener;
+        private SmartcardPinDialog.CancelCbaCallback mPinCancelCbaCallback;
+        private SmartcardNfcPromptDialog.CancelCbaCallback mNfcPromptCancelCbaCallback;
+        private List<ICertDetails> mCertList;
+
+
+        TestDialogHolder() {
+            mCurrentDialog = null;
+            mCertPickerPositiveButtonListener = null;
+            mCertPickerCancelCbaCallback = null;
+            mPinPositiveButtonListener = null;
+            mPinCancelCbaCallback = null;
+        }
+
+        @Override
+        public void showCertPickerDialog(@NonNull List<ICertDetails> certList, @NonNull SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
+            mCurrentDialog = TestDialog.cert_picker;
+            mCertPickerPositiveButtonListener = positiveButtonListener;
+            mCertPickerCancelCbaCallback = cancelCbaCallback;
+            mCertList = certList;
+        }
+
+        @Override
+        public void showPinDialog(@NonNull SmartcardPinDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
+            mCurrentDialog = TestDialog.pin;
+            mPinPositiveButtonListener = positiveButtonListener;
+            mPinCancelCbaCallback = cancelCbaCallback;
+        }
+
+        @Override
+        public void showErrorDialog(int titleStringResourceId, int messageStringResourceId) {
+            mCurrentDialog = TestDialog.error;
+        }
+
+        @Override
+        public void showUserChoiceDialog(@NonNull UserChoiceDialog.PositiveButtonListener positiveButtonListener, @NonNull UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
+            mCurrentDialog = TestDialog.user_choice;
+        }
+
+        @Override
+        public void showSmartcardPromptDialog(@NonNull SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
+            mCurrentDialog = TestDialog.prompt;
+        }
+
+        @Override
+        public void showSmartcardNfcLoadingDialog() {
+            mCurrentDialog = TestDialog.nfc_loading;
+        }
+
+        @Override
+        public void showSmartcardNfcPromptDialog(@NonNull SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
+            mCurrentDialog = TestDialog.nfc_prompt;
+            mNfcPromptCancelCbaCallback = cancelCbaCallback;
+        }
+
+        @Override
+        public void showSmartcardNfcReminderDialog(@NonNull SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+            mCurrentDialog = TestDialog.nfc_reminder;
+        }
+
+        @Override
+        public void dismissDialog() {
+            mCurrentDialog = null;
+        }
+
+        @Override
+        public void showDialog(@Nullable SmartcardDialog dialog) {
+
+        }
+
+        @Override
+        public boolean isDialogShowing() {
+            return mCurrentDialog != null;
+        }
+
+        @Override
+        public void onCancelCba() {
+
+        }
+
+        @Override
+        public void setPinDialogErrorMode() {
+
+        }
+    }
+
+    protected static class TestCertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelper {
+
+        @Override
+        public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {
+
+        }
+
+        @Override
+        public void setExistingPivProviderPresent(boolean present) {
+
+        }
+
+        @Override
+        public void setResultSuccess() {
+
+        }
+
+        @Override
+        public void setResultFailure(String message) {
+
+        }
+
+        @Override
+        public void setResultFailure(Exception exception) {
+
+        }
+
+        @Override
+        public void setUserChoice(CertBasedAuthChoice choice) {
+
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -22,12 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import android.app.Activity;
 import android.webkit.ClientCertRequest;
 
 import androidx.annotation.NonNull;
@@ -78,15 +74,15 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     }
 
     @Test
-    public abstract void testLockedOut();
-
-    @Test
     public void testExceptionThrownWhenGettingCertDetailsList() {
         final List<X509Certificate> certList = new ArrayList<>();
         certList.add(getMockCertificate("Exception", "Exception"));
         setAndProcessChallengeHandler(certList);
         checkIfCorrectDialogIsShowing(TestDialog.error);
     }
+
+    @Test
+    public abstract void testLockedOut();
 
     @Test
     public abstract void testExceptionThrownWhenVerifyingPin();
@@ -103,7 +99,6 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         checkIfCorrectDialogIsShowing(TestDialog.pin);
     }
 
-    //Return a list containing two mock certificates.
     @NonNull
     protected List<X509Certificate> getMockCertList() {
         final X509Certificate cert1 = getMockCertificate("SomeIssuer1", "SomeSubject1");
@@ -114,48 +109,6 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         return certList;
     }
 
-    //Return an empty ClientCertRequest only to be used for testing.
-    @NonNull
-    protected ClientCertRequest getMockClientCertRequest() {
-        return new ClientCertRequest() {
-            @Override
-            public String[] getKeyTypes() {
-                return new String[0];
-            }
-
-            @Override
-            public Principal[] getPrincipals() {
-                return new Principal[0];
-            }
-
-            @Override
-            public String getHost() {
-                return null;
-            }
-
-            @Override
-            public int getPort() {
-                return 0;
-            }
-
-            @Override
-            public void proceed(PrivateKey privateKey, X509Certificate[] x509Certificates) {
-
-            }
-
-            @Override
-            public void ignore() {
-
-            }
-
-            @Override
-            public void cancel() {
-
-            }
-        };
-    }
-
-    //Return a mock certificate only to be used for testing.
     @NonNull
     protected X509Certificate getMockCertificate(@Nullable final String issuerDNName, @Nullable final String subjectDNName) {
         return new X509Certificate() {
@@ -298,6 +251,46 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
             @Override
             public byte[] getExtensionValue(String s) {
                 return new byte[0];
+            }
+        };
+    }
+
+    @NonNull
+    protected ClientCertRequest getMockClientCertRequest() {
+        return new ClientCertRequest() {
+            @Override
+            public String[] getKeyTypes() {
+                return new String[0];
+            }
+
+            @Override
+            public Principal[] getPrincipals() {
+                return new Principal[0];
+            }
+
+            @Override
+            public String getHost() {
+                return null;
+            }
+
+            @Override
+            public int getPort() {
+                return 0;
+            }
+
+            @Override
+            public void proceed(PrivateKey privateKey, X509Certificate[] x509Certificates) {
+
+            }
+
+            @Override
+            public void ignore() {
+
+            }
+
+            @Override
+            public void cancel() {
+
             }
         };
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -70,7 +70,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testCancelAtUserChoiceDialog() {
         challengeHandlerHelper(ExpectedChallengeHandler.NULL);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final UserChoiceDialog.CancelCbaCallback callback = mDialogHolder.getMUserChoiceCancelCbaCallback();
+        final UserChoiceDialog.CancelCbaCallback callback = mDialogHolder.getUserChoiceCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -81,7 +81,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
         challengeHandlerHelper(ExpectedChallengeHandler.USB);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
         mUsbManager.mockConnect();
-        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getUserChoicePositiveButtonListener();
         assertNotNull(listener);
         listener.onClick(1);
     }
@@ -90,11 +90,11 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testCancelAtPromptDialog() {
         challengeHandlerHelper(ExpectedChallengeHandler.NULL);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getUserChoicePositiveButtonListener();
         assertNotNull(listener);
         listener.onClick(1);
         checkIfCorrectDialogIsShowing(TestDialog.prompt);
-        final SmartcardPromptDialog.CancelCbaCallback callback = mDialogHolder.getMPromptCancelCbaCallback();
+        final SmartcardPromptDialog.CancelCbaCallback callback = mDialogHolder.getPromptCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -104,7 +104,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testChooseSmartcardAndProceedWithUsb() {
         challengeHandlerHelper(ExpectedChallengeHandler.USB);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getUserChoicePositiveButtonListener();
         assertNotNull(listener);
         listener.onClick(1);
         checkIfCorrectDialogIsShowing(TestDialog.prompt);
@@ -115,7 +115,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testChooseSmartcardAndProceedWithNfc() {
         challengeHandlerHelper(ExpectedChallengeHandler.NFC);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getUserChoicePositiveButtonListener();
         assertNotNull(listener);
         listener.onClick(1);
         checkIfCorrectDialogIsShowing(TestDialog.prompt);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import static org.junit.Assert.assertNotNull;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -43,8 +43,6 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     private CertBasedAuthFactory mFactory;
     protected TestUsbSmartcardCertBasedAuthManager mUsbManager;
     protected TestNfcSmartcardCertBasedAuthManager mNfcManager;
-    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
-
 
     @Before
     public void factorySetUp() {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -23,8 +23,10 @@
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.shadows.ShadowCertBasedAuthTelemetryHelper;
@@ -40,9 +42,16 @@ import java.util.ArrayList;
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows={ShadowCertBasedAuthTelemetryHelper.class})
 public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
+
     private CertBasedAuthFactory mFactory;
     protected TestUsbSmartcardCertBasedAuthManager mUsbManager;
     protected TestNfcSmartcardCertBasedAuthManager mNfcManager;
+
+    private enum ExpectedChallengeHandler {
+        USB,
+        NFC,
+        NULL
+    }
 
     @Before
     public void factorySetUp() {
@@ -54,22 +63,13 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     @Test
     public void testInitiallyUsbConnected() {
         mUsbManager.mockConnect();
-        mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
-            @Override
-            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
-                assertTrue(challengeHandler instanceof UsbSmartcardCertBasedAuthChallengeHandler);
-            }
-        });
+        challengeHandlerHelper(ExpectedChallengeHandler.USB);
     }
 
     @Test
     public void testCancelAtUserChoiceDialog() {
-        mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
-            @Override
-            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
-                //nothing needed
-            }
-        });
+        challengeHandlerHelper(ExpectedChallengeHandler.NULL);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
         final UserChoiceDialog.CancelCbaCallback callback = mDialogHolder.getMUserChoiceCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
@@ -77,17 +77,68 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     }
 
     @Test
-    public void testCancelAtPromptDialog() {
+    public void testPlugInAtUserChoiceDialog() {
+        challengeHandlerHelper(ExpectedChallengeHandler.USB);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
+        mUsbManager.mockConnect();
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(1);
+    }
 
+    @Test
+    public void testCancelAtPromptDialog() {
+        challengeHandlerHelper(ExpectedChallengeHandler.NULL);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(1);
+        checkIfCorrectDialogIsShowing(TestDialog.prompt);
+        final SmartcardPromptDialog.CancelCbaCallback callback = mDialogHolder.getMPromptCancelCbaCallback();
+        assertNotNull(callback);
+        callback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
     }
 
     @Test
     public void testChooseSmartcardAndProceedWithUsb() {
-
+        challengeHandlerHelper(ExpectedChallengeHandler.USB);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(1);
+        checkIfCorrectDialogIsShowing(TestDialog.prompt);
+        mUsbManager.mockConnect();
     }
 
     @Test
     public void testChooseSmartcardAndProceedWithNfc() {
+        challengeHandlerHelper(ExpectedChallengeHandler.NFC);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getMUserChoicePositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(1);
+        checkIfCorrectDialogIsShowing(TestDialog.prompt);
+        mNfcManager.mockConnect(false);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_loading);
+    }
 
+    private void challengeHandlerHelper(@NonNull final ExpectedChallengeHandler expectedChallengeHandler) {
+        mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
+            @Override
+            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
+                switch (expectedChallengeHandler) {
+                    case USB:
+                        assertTrue(challengeHandler instanceof UsbSmartcardCertBasedAuthChallengeHandler);
+                        break;
+                    case NFC:
+                        assertTrue(challengeHandler instanceof NfcSmartcardCertBasedAuthChallengeHandler);
+                        break;
+                    default:
+                        assertNull(challengeHandler);
+                        break;
+                }
+            }
+        });
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -1,0 +1,73 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.shadows.ShadowCertBasedAuthTelemetryHelper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows={ShadowCertBasedAuthTelemetryHelper.class})
+public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
+    private CertBasedAuthFactory mFactory;
+    protected TestUsbSmartcardCertBasedAuthManager mUsbManager;
+    protected TestNfcSmartcardCertBasedAuthManager mNfcManager;
+    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
+
+
+    @Before
+    public void factorySetUp() {
+        mUsbManager = new TestUsbSmartcardCertBasedAuthManager(new ArrayList<>());
+        mNfcManager = new TestNfcSmartcardCertBasedAuthManager(new ArrayList<>());
+        mFactory = new CertBasedAuthFactory(mActivity, mUsbManager, mNfcManager, mDialogHolder);
+    }
+
+    @Test
+    public void testInitiallyUsbConnected() {
+        mUsbManager.mockConnect();
+        mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
+            @Override
+            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
+                assertTrue(challengeHandler instanceof UsbSmartcardCertBasedAuthChallengeHandler);
+            }
+        });
+    }
+
+    @Test
+    public void testCancelAtUserChoiceDialog() {
+        mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
+            @Override
+            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
+                //nothing needed
+            }
+        });
+        final UserChoiceDialog.CancelCbaCallback callback = mDialogHolder.getMUserChoiceCancelCbaCallback();
+        assertNotNull(callback);
+        callback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
+    }
+
+    @Test
+    public void testCancelAtPromptDialog() {
+
+    }
+
+    @Test
+    public void testChooseSmartcardAndProceedWithUsb() {
+
+    }
+
+    @Test
+    public void testChooseSmartcardAndProceedWithNfc() {
+
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -24,18 +24,16 @@ package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import static org.junit.Assert.assertNotNull;
 
-import android.app.Activity;
-
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
-
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
 
+@RunWith(RobolectricTestRunner.class)
 public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmartcardCertBasedAuthChallengeHandlerTest {
     private NfcSmartcardCertBasedAuthChallengeHandler mChallengeHandler;
     final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
@@ -145,80 +143,5 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
                 mTestCertBasedAuthTelemetryHelper
         );
         mChallengeHandler.processChallenge(getMockClientCertRequest());
-    }
-
-    protected class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
-
-        private boolean mIsConnected;
-        private final List<ICertDetails> mCertDetailsList;
-        private int mPinAttemptsRemaining;
-
-        public TestNfcSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
-            mIsConnected = false;
-            //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
-            mPinAttemptsRemaining = 2;
-            //Convert cert list into certDetails list.
-            mCertDetailsList = new ArrayList<>();
-            for (X509Certificate cert : certList) {
-                mCertDetailsList.add(new ICertDetails() {
-                    @NonNull
-                    @Override
-                    public X509Certificate getCertificate() {
-                        return cert;
-                    }
-                });
-            }
-        }
-
-        @Override
-        boolean startDiscovery(@NonNull Activity activity) {
-            return false;
-        }
-
-        @Override
-        void stopDiscovery(@NonNull Activity activity) {
-            mockDisconnect();
-        }
-
-        @Override
-        void requestDeviceSession(@NonNull ISessionCallback callback) {
-            try {
-                callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
-                    @Override
-                    public void onIncorrectAttempt() {
-                        mPinAttemptsRemaining--;
-                    }
-                }));
-            } catch (@NonNull final Exception e) {
-                callback.onException(e);
-            }
-        }
-
-        @Override
-        boolean isDeviceConnected() {
-            return mIsConnected;
-        }
-
-        @Override
-        void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
-
-        }
-
-        @Override
-        void onDestroy(@NonNull Activity activity) {
-            stopDiscovery(mActivity);
-        }
-
-        public void mockConnect(final boolean isChanged) {
-            mIsConnected = true;
-            isDeviceChanged = isChanged;
-            if (mConnectionCallback != null) {
-                mConnectionCallback.onCreateConnection();
-            }
-        }
-
-        public void mockDisconnect() {
-            mIsConnected = false;
-        }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -44,12 +44,12 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] pin = {'1', '2', '3'};
         pinListener.onClick(pin);
         checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
-        final SmartcardNfcPromptDialog.CancelCbaCallback nfcCancelCallback = mDialogHolder.getMNfcPromptCancelCbaCallback();
+        final SmartcardNfcPromptDialog.CancelCbaCallback nfcCancelCallback = mDialogHolder.getNfcPromptCancelCbaCallback();
         assertNotNull(nfcCancelCallback);
         nfcCancelCallback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -62,7 +62,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(manager);
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] wrongPin = {'1', '2', '3'};
         pinListener.onClick(wrongPin);
@@ -84,7 +84,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(manager);
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] exceptionPin = {'e', 'x', 'c'};
         pinListener.onClick(exceptionPin);
@@ -100,7 +100,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(manager);
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] pin = {'1', '2', '3', '4', '5', '6'};
         pinListener.onClick(pin);
@@ -116,7 +116,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(manager);
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] pin = {'1', '2', '3', '4', '5', '6'};
         pinListener.onClick(pin);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import static org.junit.Assert.assertNotNull;
+
+import android.app.Activity;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+import org.junit.Test;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmartcardCertBasedAuthChallengeHandlerTest {
+    private NfcSmartcardCertBasedAuthChallengeHandler mChallengeHandler;
+    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
+
+    @Test
+    public void testCancelAtNfcPromptDialog() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] pin = {'1', '2', '3'};
+        pinListener.onClick(pin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        final SmartcardNfcPromptDialog.CancelCbaCallback nfcCancelCallback = mDialogHolder.getMNfcPromptCancelCbaCallback();
+        assertNotNull(nfcCancelCallback);
+        nfcCancelCallback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
+    }
+
+    @Override
+    @Test
+    public void testLockedOut() {
+        final TestNfcSmartcardCertBasedAuthManager manager = new TestNfcSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] wrongPin = {'1', '2', '3'};
+        pinListener.onClick(wrongPin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        manager.mockConnect(false);
+        checkIfCorrectDialogIsShowing(TestDialog.pin);
+        manager.mockDisconnect();
+
+        pinListener.onClick(wrongPin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        manager.mockConnect(false);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    @Test
+    public void testExceptionThrownWhenVerifyingPin() {
+        final TestNfcSmartcardCertBasedAuthManager manager = new TestNfcSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] exceptionPin = {'e', 'x', 'c'};
+        pinListener.onClick(exceptionPin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        manager.mockConnect(false);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    @Test
+    public void testExceptionThrownWhenGettingKey() {
+        final TestNfcSmartcardCertBasedAuthManager manager = new TestNfcSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] pin = {'1', '2', '3', '4', '5', '6'};
+        pinListener.onClick(pin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        manager.mockConnect(false);
+        //In between, loading dialog will show.
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Test
+    public void testDeviceChanged() {
+        final TestNfcSmartcardCertBasedAuthManager manager = new TestNfcSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] pin = {'1', '2', '3', '4', '5', '6'};
+        pinListener.onClick(pin);
+        checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
+        manager.mockConnect(true);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    protected void setAndProcessChallengeHandler(@NonNull List<X509Certificate> certList) {
+        mChallengeHandler = new NfcSmartcardCertBasedAuthChallengeHandler(
+                mActivity,
+                new TestNfcSmartcardCertBasedAuthManager(certList),
+                mDialogHolder,
+                mTestCertBasedAuthTelemetryHelper
+        );
+        mChallengeHandler.processChallenge(getMockClientCertRequest());
+    }
+
+    private void setAndProcessChallengeHandler(@NonNull final TestNfcSmartcardCertBasedAuthManager manager) {
+        mChallengeHandler = new NfcSmartcardCertBasedAuthChallengeHandler(
+                mActivity,
+                manager,
+                mDialogHolder,
+                mTestCertBasedAuthTelemetryHelper
+        );
+        mChallengeHandler.processChallenge(getMockClientCertRequest());
+    }
+
+    protected class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
+
+        private boolean mIsConnected;
+        private final List<ICertDetails> mCertDetailsList;
+        private int mPinAttemptsRemaining;
+
+        public TestNfcSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
+            mIsConnected = false;
+            //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
+            mPinAttemptsRemaining = 2;
+            //Convert cert list into certDetails list.
+            mCertDetailsList = new ArrayList<>();
+            for (X509Certificate cert : certList) {
+                mCertDetailsList.add(new ICertDetails() {
+                    @NonNull
+                    @Override
+                    public X509Certificate getCertificate() {
+                        return cert;
+                    }
+                });
+            }
+        }
+
+        @Override
+        boolean startDiscovery(@NonNull Activity activity) {
+            return false;
+        }
+
+        @Override
+        void stopDiscovery(@NonNull Activity activity) {
+            mockDisconnect();
+        }
+
+        @Override
+        void requestDeviceSession(@NonNull ISessionCallback callback) {
+            try {
+                callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
+                    @Override
+                    public void onIncorrectAttempt() {
+                        mPinAttemptsRemaining--;
+                    }
+                }));
+            } catch (@NonNull final Exception e) {
+                callback.onException(e);
+            }
+        }
+
+        @Override
+        boolean isDeviceConnected() {
+            return mIsConnected;
+        }
+
+        @Override
+        void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
+
+        }
+
+        @Override
+        void onDestroy(@NonNull Activity activity) {
+            stopDiscovery(mActivity);
+        }
+
+        public void mockConnect(final boolean isChanged) {
+            mIsConnected = true;
+            isDeviceChanged = isChanged;
+            if (mConnectionCallback != null) {
+                mConnectionCallback.onCreateConnection();
+            }
+        }
+
+        public void mockDisconnect() {
+            mIsConnected = false;
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -35,8 +35,9 @@ import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmartcardCertBasedAuthChallengeHandlerTest {
+
     private NfcSmartcardCertBasedAuthChallengeHandler mChallengeHandler;
-    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
+    private final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
 
     @Test
     public void testCancelAtNfcPromptDialog() {
@@ -125,7 +126,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
     }
 
     @Override
-    protected void setAndProcessChallengeHandler(@NonNull List<X509Certificate> certList) {
+    protected void setAndProcessChallengeHandler(@NonNull final List<X509Certificate> certList) {
         mChallengeHandler = new NfcSmartcardCertBasedAuthChallengeHandler(
                 mActivity,
                 new TestNfcSmartcardCertBasedAuthManager(certList),

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
@@ -28,32 +28,20 @@ import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryH
 class TestCertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelper {
 
     @Override
-    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {
-
-    }
+    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {}
 
     @Override
-    public void setExistingPivProviderPresent(boolean present) {
-
-    }
+    public void setExistingPivProviderPresent(boolean present) {}
 
     @Override
-    public void setResultSuccess() {
-
-    }
+    public void setResultSuccess() {}
 
     @Override
-    public void setResultFailure(String message) {
-
-    }
+    public void setResultFailure(String message) {}
 
     @Override
-    public void setResultFailure(Exception exception) {
-
-    }
+    public void setResultFailure(Exception exception) {}
 
     @Override
-    public void setUserChoice(CertBasedAuthChoice choice) {
-
-    }
+    public void setUserChoice(CertBasedAuthChoice choice) {}
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
@@ -1,0 +1,37 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+class TestCertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelper {
+
+    @Override
+    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {
+
+    }
+
+    @Override
+    public void setExistingPivProviderPresent(boolean present) {
+
+    }
+
+    @Override
+    public void setResultSuccess() {
+
+    }
+
+    @Override
+    public void setResultFailure(String message) {
+
+    }
+
+    @Override
+    public void setResultFailure(Exception exception) {
+
+    }
+
+    @Override
+    public void setUserChoice(CertBasedAuthChoice choice) {
+
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestClientCertRequest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestClientCertRequest.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.webkit.ClientCertRequest;
+
+import androidx.annotation.Nullable;
+
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter @Accessors(prefix = "m")
+public class TestClientCertRequest extends ClientCertRequest {
+
+    private boolean mProceeded;
+    private boolean mCancelled;
+
+    @Nullable
+    @Override
+    public String[] getKeyTypes() {
+        return new String[0];
+    }
+
+    @Nullable
+    @Override
+    public Principal[] getPrincipals() {
+        return new Principal[0];
+    }
+
+    @Override
+    public String getHost() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return 0;
+    }
+
+    @Override
+    public void proceed(PrivateKey privateKey, X509Certificate[] chain) {
+        mProceeded = true;
+    }
+
+    @Override
+    public void ignore() {
+
+    }
+
+    @Override
+    public void cancel() {
+        mCancelled = true;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialog.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 enum TestDialog {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialog.java
@@ -1,0 +1,12 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+enum TestDialog {
+    cert_picker,
+    pin,
+    error,
+    user_choice,
+    prompt,
+    nfc_loading,
+    nfc_prompt,
+    nfc_reminder
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -114,7 +114,25 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void onCancelCba() {}
+    public void onCancelCba() {
+        switch (mCurrentDialog) {
+            case cert_picker:
+                mCertPickerCancelCbaCallback.onCancel();
+                break;
+            case pin:
+                mPinCancelCbaCallback.onCancel();
+                break;
+            case user_choice:
+                mUserChoiceCancelCbaCallback.onCancel();
+                break;
+            case prompt:
+                mPromptCancelCbaCallback.onCancel();
+                break;
+            case nfc_prompt:
+                mNfcPromptCancelCbaCallback.onCancel();
+                break;
+        }
+    }
 
     @Override
     public void setPinDialogErrorMode() {}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -28,8 +28,9 @@ import androidx.annotation.Nullable;
 import java.util.List;
 
 import lombok.Getter;
+import lombok.experimental.Accessors;
 
-@Getter
+@Getter @Accessors(prefix = "m")
 class TestDialogHolder implements IDialogHolder {
 
     private TestDialog mCurrentDialog;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -1,0 +1,108 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+class TestDialogHolder implements IDialogHolder {
+
+    private TestDialog mCurrentDialog;
+    private SmartcardCertPickerDialog.PositiveButtonListener mCertPickerPositiveButtonListener;
+    private SmartcardCertPickerDialog.CancelCbaCallback mCertPickerCancelCbaCallback;
+    private SmartcardPinDialog.PositiveButtonListener mPinPositiveButtonListener;
+    private SmartcardPinDialog.CancelCbaCallback mPinCancelCbaCallback;
+    private UserChoiceDialog.PositiveButtonListener mUserChoicePositiveButtonListener;
+    private UserChoiceDialog.CancelCbaCallback mUserChoiceCancelCbaCallback;
+    private SmartcardPromptDialog.CancelCbaCallback mPromptCancelCbaCallback;
+    private SmartcardNfcPromptDialog.CancelCbaCallback mNfcPromptCancelCbaCallback;
+    private SmartcardNfcReminderDialog.DismissCallback mNfcReminderDismissCallback;
+    private List<ICertDetails> mCertList;
+
+
+    public TestDialogHolder() {
+        mCurrentDialog = null;
+        mCertPickerPositiveButtonListener = null;
+        mCertPickerCancelCbaCallback = null;
+        mPinPositiveButtonListener = null;
+        mPinCancelCbaCallback = null;
+    }
+
+    @Override
+    public void showCertPickerDialog(@NonNull List<ICertDetails> certList, @NonNull SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
+        mCurrentDialog = TestDialog.cert_picker;
+        mCertPickerPositiveButtonListener = positiveButtonListener;
+        mCertPickerCancelCbaCallback = cancelCbaCallback;
+        mCertList = certList;
+    }
+
+    @Override
+    public void showPinDialog(@NonNull SmartcardPinDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
+        mCurrentDialog = TestDialog.pin;
+        mPinPositiveButtonListener = positiveButtonListener;
+        mPinCancelCbaCallback = cancelCbaCallback;
+    }
+
+    @Override
+    public void showErrorDialog(int titleStringResourceId, int messageStringResourceId) {
+        mCurrentDialog = TestDialog.error;
+    }
+
+    @Override
+    public void showUserChoiceDialog(@NonNull UserChoiceDialog.PositiveButtonListener positiveButtonListener, @NonNull UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
+        mCurrentDialog = TestDialog.user_choice;
+        mUserChoicePositiveButtonListener = positiveButtonListener;
+        mUserChoiceCancelCbaCallback = cancelCbaCallback;
+    }
+
+    @Override
+    public void showSmartcardPromptDialog(@NonNull SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
+        mCurrentDialog = TestDialog.prompt;
+        mPromptCancelCbaCallback = cancelCbaCallback;
+    }
+
+    @Override
+    public void showSmartcardNfcLoadingDialog() {
+        mCurrentDialog = TestDialog.nfc_loading;
+    }
+
+    @Override
+    public void showSmartcardNfcPromptDialog(@NonNull SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
+        mCurrentDialog = TestDialog.nfc_prompt;
+        mNfcPromptCancelCbaCallback = cancelCbaCallback;
+    }
+
+    @Override
+    public void showSmartcardNfcReminderDialog(@NonNull SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+        mCurrentDialog = TestDialog.nfc_reminder;
+        mNfcReminderDismissCallback = dismissCallback;
+    }
+
+    @Override
+    public void dismissDialog() {
+        mCurrentDialog = null;
+    }
+
+    @Override
+    public void showDialog(@Nullable SmartcardDialog dialog) {
+
+    }
+
+    @Override
+    public boolean isDialogShowing() {
+        return mCurrentDialog != null;
+    }
+
+    @Override
+    public void onCancelCba() {
+
+    }
+
+    @Override
+    public void setPinDialogErrorMode() {
+
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import androidx.annotation.NonNull;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -44,17 +44,10 @@ class TestDialogHolder implements IDialogHolder {
     private SmartcardNfcReminderDialog.DismissCallback mNfcReminderDismissCallback;
     private List<ICertDetails> mCertList;
 
-
-    public TestDialogHolder() {
-        mCurrentDialog = null;
-        mCertPickerPositiveButtonListener = null;
-        mCertPickerCancelCbaCallback = null;
-        mPinPositiveButtonListener = null;
-        mPinCancelCbaCallback = null;
-    }
-
     @Override
-    public void showCertPickerDialog(@NonNull List<ICertDetails> certList, @NonNull SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
+                                     @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
+                                     @NonNull final SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.cert_picker;
         mCertPickerPositiveButtonListener = positiveButtonListener;
         mCertPickerCancelCbaCallback = cancelCbaCallback;
@@ -62,26 +55,29 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void showPinDialog(@NonNull SmartcardPinDialog.PositiveButtonListener positiveButtonListener, @NonNull SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
+                              @NonNull final SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.pin;
         mPinPositiveButtonListener = positiveButtonListener;
         mPinCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
-    public void showErrorDialog(int titleStringResourceId, int messageStringResourceId) {
+    public void showErrorDialog(final int titleStringResourceId,
+                                final int messageStringResourceId) {
         mCurrentDialog = TestDialog.error;
     }
 
     @Override
-    public void showUserChoiceDialog(@NonNull UserChoiceDialog.PositiveButtonListener positiveButtonListener, @NonNull UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
+                                     @NonNull final UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.user_choice;
         mUserChoicePositiveButtonListener = positiveButtonListener;
         mUserChoiceCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
-    public void showSmartcardPromptDialog(@NonNull SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showSmartcardPromptDialog(@NonNull final SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.prompt;
         mPromptCancelCbaCallback = cancelCbaCallback;
     }
@@ -92,13 +88,13 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void showSmartcardNfcPromptDialog(@NonNull SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showSmartcardNfcPromptDialog(@NonNull final SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.nfc_prompt;
         mNfcPromptCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
-    public void showSmartcardNfcReminderDialog(@NonNull SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+    public void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
         mCurrentDialog = TestDialog.nfc_reminder;
         mNfcReminderDismissCallback = dismissCallback;
     }
@@ -109,9 +105,7 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void showDialog(@Nullable SmartcardDialog dialog) {
-
-    }
+    public void showDialog(@Nullable SmartcardDialog dialog) {}
 
     @Override
     public boolean isDialogShowing() {
@@ -119,12 +113,8 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void onCancelCba() {
-
-    }
+    public void onCancelCba() {}
 
     @Override
-    public void setPinDialogErrorMode() {
-
-    }
+    public void setPinDialogErrorMode() {}
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
@@ -34,15 +34,14 @@ import java.util.List;
 
 class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
 
-    private boolean mIsConnected;
     private final List<ICertDetails> mCertDetailsList;
+    private boolean mIsConnected;
     private int mPinAttemptsRemaining;
 
     public TestNfcSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
         mIsConnected = false;
         //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
         mPinAttemptsRemaining = 2;
-        //Convert cert list into certDetails list.
         mCertDetailsList = new ArrayList<>();
         for (X509Certificate cert : certList) {
             mCertDetailsList.add(new ICertDetails() {
@@ -56,17 +55,17 @@ class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBased
     }
 
     @Override
-    boolean startDiscovery(@NonNull Activity activity) {
+    boolean startDiscovery(@NonNull final Activity activity) {
         return false;
     }
 
     @Override
-    void stopDiscovery(@NonNull Activity activity) {
+    void stopDiscovery(@NonNull final Activity activity) {
         mockDisconnect();
     }
 
     @Override
-    void requestDeviceSession(@NonNull ISessionCallback callback) {
+    void requestDeviceSession(@NonNull final ISessionCallback callback) {
         try {
             callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
                 @Override
@@ -85,12 +84,10 @@ class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBased
     }
 
     @Override
-    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
-
-    }
+    void initBeforeProceedingWithRequest(@NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {}
 
     @Override
-    void onDestroy(@NonNull Activity activity) {
+    void onDestroy(@NonNull final Activity activity) {
         stopDiscovery(activity);
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
@@ -1,0 +1,86 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.app.Activity;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+class TestNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
+
+    private boolean mIsConnected;
+    private final List<ICertDetails> mCertDetailsList;
+    private int mPinAttemptsRemaining;
+
+    public TestNfcSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
+        mIsConnected = false;
+        //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
+        mPinAttemptsRemaining = 2;
+        //Convert cert list into certDetails list.
+        mCertDetailsList = new ArrayList<>();
+        for (X509Certificate cert : certList) {
+            mCertDetailsList.add(new ICertDetails() {
+                @NonNull
+                @Override
+                public X509Certificate getCertificate() {
+                    return cert;
+                }
+            });
+        }
+    }
+
+    @Override
+    boolean startDiscovery(@NonNull Activity activity) {
+        return false;
+    }
+
+    @Override
+    void stopDiscovery(@NonNull Activity activity) {
+        mockDisconnect();
+    }
+
+    @Override
+    void requestDeviceSession(@NonNull ISessionCallback callback) {
+        try {
+            callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
+                @Override
+                public void onIncorrectAttempt() {
+                    mPinAttemptsRemaining--;
+                }
+            }));
+        } catch (@NonNull final Exception e) {
+            callback.onException(e);
+        }
+    }
+
+    @Override
+    boolean isDeviceConnected() {
+        return mIsConnected;
+    }
+
+    @Override
+    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
+
+    }
+
+    @Override
+    void onDestroy(@NonNull Activity activity) {
+        stopDiscovery(activity);
+    }
+
+    public void mockConnect(final boolean isChanged) {
+        mIsConnected = true;
+        isDeviceChanged = isChanged;
+        if (mConnectionCallback != null) {
+            mConnectionCallback.onCreateConnection();
+        }
+    }
+
+    public void mockDisconnect() {
+        mIsConnected = false;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestNfcSmartcardCertBasedAuthManager.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import android.app.Activity;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
@@ -87,7 +87,8 @@ class TestSmartcardSession implements ISmartcardSession {
     @NonNull
     @Override
     public PrivateKey getKeyForAuth(@NonNull final ICertDetails certDetails, @NonNull final char[] pin) throws Exception {
-        if (Arrays.equals(mPin, pin)) {
+        if (certDetails.getCertificate().getIssuerDN().getName().equals("ExceptionKey")
+            && Arrays.equals(mPin, pin)) {
             throw new Exception("Testing, 1,2,3");
         }
         return new PrivateKey() {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
@@ -28,15 +28,12 @@ import java.security.PrivateKey;
 import java.util.Arrays;
 import java.util.List;
 
-//Implements ISmartcardSession in order to carry out testing of dialogs.
-//Only meant to be used for testing purposes.
 class TestSmartcardSession implements ISmartcardSession {
 
     private final List<ICertDetails> mCertDetailsList;
     private final char[] mPin;
-    private int mPinAttemptsRemaining;
-
     private final TestSmartcardSession.ITestSessionCallback mCallback;
+    private int mPinAttemptsRemaining;
 
     //Used to keep the pinAttemptsRemaining variable consistent between the manager and session.
     interface ITestSessionCallback {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import androidx.annotation.NonNull;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestSmartcardSession.java
@@ -1,0 +1,91 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import androidx.annotation.NonNull;
+
+import java.security.PrivateKey;
+import java.util.Arrays;
+import java.util.List;
+
+//Implements ISmartcardSession in order to carry out testing of dialogs.
+//Only meant to be used for testing purposes.
+class TestSmartcardSession implements ISmartcardSession {
+
+    private final List<ICertDetails> mCertDetailsList;
+    private final char[] mPin;
+    private int mPinAttemptsRemaining;
+
+    private final TestSmartcardSession.ITestSessionCallback mCallback;
+
+    //Used to keep the pinAttemptsRemaining variable consistent between the manager and session.
+    interface ITestSessionCallback {
+        void onIncorrectAttempt();
+    }
+
+    public TestSmartcardSession(@NonNull final List<ICertDetails> certDetailsList,
+                                final int pinAttemptsRemaining,
+                                @NonNull final TestSmartcardSession.ITestSessionCallback callback) {
+        mCertDetailsList = certDetailsList;
+        mPin = new char[]{'1', '2', '3', '4', '5', '6'};
+        mPinAttemptsRemaining = pinAttemptsRemaining;
+        mCallback = callback;
+    }
+
+    @NonNull
+    @Override
+    public List<ICertDetails> getCertDetailsList() throws Exception {
+        //Check for a specific testing case where if there's only one cert
+        // and it has a subject value of "Exception", throw an Exception.
+        if (mCertDetailsList.size() == 1 &&
+                mCertDetailsList.get(0).getCertificate().getIssuerDN().getName().equals("Exception")) {
+            throw new Exception();
+        }
+        return mCertDetailsList;
+    }
+
+    @Override
+    public boolean verifyPin(@NonNull final char[] pin) throws Exception {
+        if (Arrays.equals(mPin, pin)) {
+            return true;
+        }
+        else if (Arrays.equals(new char[]{'e', 'x', 'c'}, pin)) {
+            //This is a special case where we want to test handling an exception.
+            throw new Exception();
+        }
+        else {
+            mPinAttemptsRemaining = mPinAttemptsRemaining > 0 ? mPinAttemptsRemaining - 1 : 0;
+            mCallback.onIncorrectAttempt();
+            return false;
+        }
+    }
+
+    @Override
+    public int getPinAttemptsRemaining() {
+        return mPinAttemptsRemaining;
+    }
+
+    //This method is going to be used to test handling a thrown exception,
+    // so we should never get to the return statement.
+    @NonNull
+    @Override
+    public PrivateKey getKeyForAuth(@NonNull final ICertDetails certDetails, @NonNull final char[] pin) throws Exception {
+        if (Arrays.equals(mPin, pin)) {
+            throw new Exception("Testing, 1,2,3");
+        }
+        return new PrivateKey() {
+            @Override
+            public String getAlgorithm() {
+                return null;
+            }
+
+            @Override
+            public String getFormat() {
+                return null;
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return new byte[0];
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
@@ -1,0 +1,89 @@
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.app.Activity;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBasedAuthManager {
+
+    private boolean mIsConnected;
+    private final List<ICertDetails> mCertDetailsList;
+    private int mPinAttemptsRemaining;
+
+    public TestUsbSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
+        mIsConnected = false;
+        //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
+        mPinAttemptsRemaining = 2;
+        //Convert cert list into certDetails list.
+        mCertDetailsList = new ArrayList<>();
+        for (X509Certificate cert : certList) {
+            mCertDetailsList.add(new ICertDetails() {
+                @NonNull
+                @Override
+                public X509Certificate getCertificate() {
+                    return cert;
+                }
+            });
+        }
+    }
+
+    @Override
+    boolean startDiscovery(@NonNull Activity activity) {
+        mockConnect();
+        return false;
+    }
+
+    @Override
+    void stopDiscovery(@NonNull Activity activity) {
+        mockDisconnect();
+    }
+
+    @Override
+    void requestDeviceSession(@NonNull ISessionCallback callback) {
+        try {
+            callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
+                @Override
+                public void onIncorrectAttempt() {
+                    mPinAttemptsRemaining--;
+                }
+            }));
+        } catch (@NonNull final Exception e) {
+            callback.onException(e);
+        }
+    }
+
+    @Override
+    boolean isDeviceConnected() {
+        return mIsConnected;
+    }
+
+    @Override
+    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
+
+    }
+
+    @Override
+    void onDestroy(@NonNull Activity activity) {
+        stopDiscovery(activity);
+    }
+
+    public void mockConnect() {
+        mIsConnected = true;
+        if (mConnectionCallback != null) {
+            mConnectionCallback.onCreateConnection();
+        }
+    }
+
+    public void mockDisconnect() {
+        mIsConnected = false;
+        if (mConnectionCallback != null) {
+            mConnectionCallback.onClosedConnection();
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import android.app.Activity;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestUsbSmartcardCertBasedAuthManager.java
@@ -34,15 +34,14 @@ import java.util.List;
 
 class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBasedAuthManager {
 
-    private boolean mIsConnected;
     private final List<ICertDetails> mCertDetailsList;
+    private boolean mIsConnected;
     private int mPinAttemptsRemaining;
 
     public TestUsbSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
         mIsConnected = false;
         //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
         mPinAttemptsRemaining = 2;
-        //Convert cert list into certDetails list.
         mCertDetailsList = new ArrayList<>();
         for (X509Certificate cert : certList) {
             mCertDetailsList.add(new ICertDetails() {
@@ -56,18 +55,18 @@ class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBased
     }
 
     @Override
-    boolean startDiscovery(@NonNull Activity activity) {
+    boolean startDiscovery(@NonNull final Activity activity) {
         mockConnect();
         return false;
     }
 
     @Override
-    void stopDiscovery(@NonNull Activity activity) {
+    void stopDiscovery(@NonNull final Activity activity) {
         mockDisconnect();
     }
 
     @Override
-    void requestDeviceSession(@NonNull ISessionCallback callback) {
+    void requestDeviceSession(@NonNull final ISessionCallback callback) {
         try {
             callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
                 @Override
@@ -86,12 +85,10 @@ class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBased
     }
 
     @Override
-    void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
-
-    }
+    void initBeforeProceedingWithRequest(@NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {}
 
     @Override
-    void onDestroy(@NonNull Activity activity) {
+    void onDestroy(@NonNull final Activity activity) {
         stopDiscovery(activity);
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -64,7 +64,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] wrongPin = {'1', '2', '3'};
         pinListener.onClick(wrongPin);
@@ -79,7 +79,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] exceptionPin = {'e', 'x', 'c'};
         pinListener.onClick(exceptionPin);
@@ -92,7 +92,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
         assertNotNull(pinListener);
         final char[] pin = {'1', '2', '3', '4', '5', '6'};
         pinListener.onClick(pin);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -35,8 +35,9 @@ import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmartcardCertBasedAuthChallengeHandlerTest {
+
     private UsbSmartcardCertBasedAuthChallengeHandler mChallengeHandler;
-    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
+    private final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
 
     @Test
     public void testUnplugAtPickerDialog() {
@@ -57,9 +58,6 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         checkIfCorrectDialogIsShowing(TestDialog.error);
     }
 
-    //Incorrect PIN attempts before reaching limit should remain on same dialog with error message.
-    //Upon no PIN attempts remaining, an error dialog should show instead.
-    //Note: pin attempts remaining is initially set to 2.
     @Override
     @Test
     public void testLockedOut() {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
@@ -46,6 +47,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         manager.stopDiscovery(mActivity);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Test
@@ -56,6 +58,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         goToPinDialog();
         manager.stopDiscovery(mActivity);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Override
@@ -71,6 +74,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         checkIfCorrectDialogIsShowing(TestDialog.pin);
         pinListener.onClick(wrongPin);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Override
@@ -84,12 +88,15 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         final char[] exceptionPin = {'e', 'x', 'c'};
         pinListener.onClick(exceptionPin);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
     }
 
     @Override
     @Test
     public void testExceptionThrownWhenGettingKey() {
-        setAndProcessChallengeHandler(getMockCertList());
+        final List<X509Certificate> certList = new ArrayList<>();
+        certList.add(getMockCertificate("ExceptionKey", "ExceptionKey"));
+        setAndProcessChallengeHandler(certList);
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
         final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
@@ -97,6 +104,21 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         final char[] pin = {'1', '2', '3', '4', '5', '6'};
         pinListener.onClick(pin);
         checkIfCorrectDialogIsShowing(TestDialog.error);
+        checkIfProceeded(false);
+    }
+
+    @Override
+    @Test
+    public void testProceed() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] pin = {'1', '2', '3', '4', '5', '6'};
+        pinListener.onClick(pin);
+        checkIfCorrectDialogIsShowing(null);
+        checkIfProceeded(true);
     }
 
     @Override
@@ -107,7 +129,7 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
                 mDialogHolder,
                 mTestCertBasedAuthTelemetryHelper
         );
-        mChallengeHandler.processChallenge(getMockClientCertRequest());
+        mChallengeHandler.processChallenge(mRequest);
     }
 
     private void setAndProcessChallengeHandler(@NonNull final TestUsbSmartcardCertBasedAuthManager manager) {
@@ -117,6 +139,6 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
                 mDialogHolder,
                 mTestCertBasedAuthTelemetryHelper
         );
-        mChallengeHandler.processChallenge(getMockClientCertRequest());
+        mChallengeHandler.processChallenge(mRequest);
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import static org.junit.Assert.assertNotNull;
+
+import android.app.Activity;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmartcardCertBasedAuthChallengeHandlerTest {
+    private UsbSmartcardCertBasedAuthChallengeHandler mChallengeHandler;
+    final TestCertBasedAuthTelemetryHelper mTestCertBasedAuthTelemetryHelper = new TestCertBasedAuthTelemetryHelper();
+
+    @Test
+    public void testUnplugAtPickerDialog() {
+        final TestUsbSmartcardCertBasedAuthManager manager = new TestUsbSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        manager.stopDiscovery(mActivity);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Test
+    public void testUnplugAtPinDialog() {
+        final TestUsbSmartcardCertBasedAuthManager manager = new TestUsbSmartcardCertBasedAuthManager(getMockCertList());
+        setAndProcessChallengeHandler(manager);
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        manager.stopDiscovery(mActivity);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    //Incorrect PIN attempts before reaching limit should remain on same dialog with error message.
+    //Upon no PIN attempts remaining, an error dialog should show instead.
+    //Note: pin attempts remaining is initially set to 2.
+    @Override
+    @Test
+    public void testLockedOut() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] wrongPin = {'1', '2', '3'};
+        pinListener.onClick(wrongPin);
+        checkIfCorrectDialogIsShowing(TestDialog.pin);
+        pinListener.onClick(wrongPin);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    @Test
+    public void testExceptionThrownWhenVerifyingPin() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] exceptionPin = {'e', 'x', 'c'};
+        pinListener.onClick(exceptionPin);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    @Test
+    public void testExceptionThrownWhenGettingKey() {
+        setAndProcessChallengeHandler(getMockCertList());
+        checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
+        goToPinDialog();
+        final SmartcardPinDialog.PositiveButtonListener pinListener = mDialogHolder.getMPinPositiveButtonListener();
+        assertNotNull(pinListener);
+        final char[] pin = {'1', '2', '3', '4', '5', '6'};
+        pinListener.onClick(pin);
+        checkIfCorrectDialogIsShowing(TestDialog.error);
+    }
+
+    @Override
+    protected void setAndProcessChallengeHandler(@NonNull final List<X509Certificate> certList) {
+        mChallengeHandler = new UsbSmartcardCertBasedAuthChallengeHandler(
+                mActivity,
+                new TestUsbSmartcardCertBasedAuthManager(certList),
+                mDialogHolder,
+                mTestCertBasedAuthTelemetryHelper
+        );
+        mChallengeHandler.processChallenge(getMockClientCertRequest());
+    }
+
+    private void setAndProcessChallengeHandler(@NonNull final TestUsbSmartcardCertBasedAuthManager manager) {
+        mChallengeHandler = new UsbSmartcardCertBasedAuthChallengeHandler(
+                mActivity,
+                manager,
+                mDialogHolder,
+                mTestCertBasedAuthTelemetryHelper
+        );
+        mChallengeHandler.processChallenge(getMockClientCertRequest());
+    }
+
+    protected class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBasedAuthManager {
+
+        private boolean mIsConnected;
+        private final List<ICertDetails> mCertDetailsList;
+        private int mPinAttemptsRemaining;
+
+        public TestUsbSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
+            mIsConnected = false;
+            //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
+            mPinAttemptsRemaining = 2;
+            //Convert cert list into certDetails list.
+            mCertDetailsList = new ArrayList<>();
+            for (X509Certificate cert : certList) {
+                mCertDetailsList.add(new ICertDetails() {
+                    @NonNull
+                    @Override
+                    public X509Certificate getCertificate() {
+                        return cert;
+                    }
+                });
+            }
+        }
+
+        @Override
+        boolean startDiscovery(@NonNull Activity activity) {
+            mockConnect();
+            return false;
+        }
+
+        @Override
+        void stopDiscovery(@NonNull Activity activity) {
+            mockDisconnect();
+        }
+
+        @Override
+        void requestDeviceSession(@NonNull ISessionCallback callback) {
+            try {
+                callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
+                    @Override
+                    public void onIncorrectAttempt() {
+                        mPinAttemptsRemaining--;
+                    }
+                }));
+            } catch (@NonNull final Exception e) {
+                callback.onException(e);
+            }
+        }
+
+        @Override
+        boolean isDeviceConnected() {
+            return mIsConnected;
+        }
+
+        @Override
+        void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
+
+        }
+
+        @Override
+        void onDestroy(@NonNull Activity activity) {
+            stopDiscovery(mActivity);
+        }
+
+        public void mockConnect() {
+            mIsConnected = true;
+            if (mConnectionCallback != null) {
+                mConnectionCallback.onCreateConnection();
+            }
+        }
+
+        public void mockDisconnect() {
+            mIsConnected = false;
+            if (mConnectionCallback != null) {
+                mConnectionCallback.onClosedConnection();
+            }
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UsbSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -24,18 +24,13 @@ package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import static org.junit.Assert.assertNotNull;
 
-import android.app.Activity;
-
 import androidx.annotation.NonNull;
-
-import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
@@ -125,83 +120,5 @@ public class UsbSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
                 mTestCertBasedAuthTelemetryHelper
         );
         mChallengeHandler.processChallenge(getMockClientCertRequest());
-    }
-
-    protected class TestUsbSmartcardCertBasedAuthManager extends AbstractUsbSmartcardCertBasedAuthManager {
-
-        private boolean mIsConnected;
-        private final List<ICertDetails> mCertDetailsList;
-        private int mPinAttemptsRemaining;
-
-        public TestUsbSmartcardCertBasedAuthManager(@NonNull final List<X509Certificate> certList) {
-            mIsConnected = false;
-            //Attempts remaining is usually 3, but 2 attempts is all that's necessary for testing.
-            mPinAttemptsRemaining = 2;
-            //Convert cert list into certDetails list.
-            mCertDetailsList = new ArrayList<>();
-            for (X509Certificate cert : certList) {
-                mCertDetailsList.add(new ICertDetails() {
-                    @NonNull
-                    @Override
-                    public X509Certificate getCertificate() {
-                        return cert;
-                    }
-                });
-            }
-        }
-
-        @Override
-        boolean startDiscovery(@NonNull Activity activity) {
-            mockConnect();
-            return false;
-        }
-
-        @Override
-        void stopDiscovery(@NonNull Activity activity) {
-            mockDisconnect();
-        }
-
-        @Override
-        void requestDeviceSession(@NonNull ISessionCallback callback) {
-            try {
-                callback.onGetSession(new TestSmartcardSession(mCertDetailsList, mPinAttemptsRemaining, new TestSmartcardSession.ITestSessionCallback() {
-                    @Override
-                    public void onIncorrectAttempt() {
-                        mPinAttemptsRemaining--;
-                    }
-                }));
-            } catch (@NonNull final Exception e) {
-                callback.onException(e);
-            }
-        }
-
-        @Override
-        boolean isDeviceConnected() {
-            return mIsConnected;
-        }
-
-        @Override
-        void initBeforeProceedingWithRequest(@NonNull ICertBasedAuthTelemetryHelper telemetryHelper) {
-
-        }
-
-        @Override
-        void onDestroy(@NonNull Activity activity) {
-            stopDiscovery(mActivity);
-        }
-
-        public void mockConnect() {
-            mIsConnected = true;
-            if (mConnectionCallback != null) {
-                mConnectionCallback.onCreateConnection();
-            }
-        }
-
-        public void mockDisconnect() {
-            mIsConnected = false;
-            if (mConnectionCallback != null) {
-                mConnectionCallback.onClosedConnection();
-            }
-        }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
@@ -1,0 +1,25 @@
+package com.microsoft.identity.common.shadows;
+
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
+import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthTelemetryHelper;
+import com.microsoft.identity.common.logging.Logger;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(CertBasedAuthTelemetryHelper.class)
+public class ShadowCertBasedAuthTelemetryHelper {
+
+    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {
+        Logger.info("hello", "testing");
+    }
+
+    public void setExistingPivProviderPresent(boolean present) {}
+
+    public void setResultSuccess() {}
+
+    public void setResultFailure(String message) {}
+
+    public void setResultFailure(Exception exception) {}
+
+    public void setUserChoice(CertBasedAuthChoice choice) {}
+}

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
@@ -31,9 +31,9 @@ import org.robolectric.annotation.Implements;
 @Implements(CertBasedAuthTelemetryHelper.class)
 public class ShadowCertBasedAuthTelemetryHelper {
 
-    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {}
+    public void setCertBasedAuthChallengeHandler(final String challengeHandlerName) {}
 
-    public void setExistingPivProviderPresent(boolean present) {}
+    public void setExistingPivProviderPresent(final boolean present) {}
 
     public void setResultSuccess() {}
 

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowCertBasedAuthTelemetryHelper.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.shadows;
 
 import com.microsoft.identity.common.java.opentelemetry.CertBasedAuthChoice;
@@ -9,9 +31,7 @@ import org.robolectric.annotation.Implements;
 @Implements(CertBasedAuthTelemetryHelper.class)
 public class ShadowCertBasedAuthTelemetryHelper {
 
-    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {
-        Logger.info("hello", "testing");
-    }
+    public void setCertBasedAuthChallengeHandler(String challengeHandlerName) {}
 
     public void setExistingPivProviderPresent(boolean present) {}
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/ICertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/ICertBasedAuthTelemetryHelper.java
@@ -23,52 +23,33 @@
 package com.microsoft.identity.common.java.opentelemetry;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
 import lombok.NonNull;
 
 /**
  * Assists classes associated with Certificate Based Authentication (CBA) with
  *  telemetry-related tasks.
  */
-public class CertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelper{
-
-    private final Span mSpan;
-
-    public CertBasedAuthTelemetryHelper() {
-        mSpan = OTelUtility.createSpan(SpanName.CertBasedAuth.name());
-    }
+public interface ICertBasedAuthTelemetryHelper {
 
     /**
      * Sets attribute that indicates the ICertBasedAuthChallengeHandler handling the current CBA flow.
      * @param challengeHandlerName name of the ICertBasedAuthChallengeHandler class.
      */
-    public void setCertBasedAuthChallengeHandler(@NonNull final String challengeHandlerName) {
-        mSpan.setAttribute(
-                AttributeName.cert_based_auth_challenge_handler.name(),
-                challengeHandlerName);
-    }
+    void setCertBasedAuthChallengeHandler(@NonNull final String challengeHandlerName);
 
     /**
      * Sets attribute that indicates if a PivProvider instance is already present in the
      *  Java Security static list upon adding a new instance.
      * @param present true if PivProvider instance present; false otherwise.
      */
-    public void setExistingPivProviderPresent(final boolean present) {
-        mSpan.setAttribute(
-                AttributeName.cert_based_auth_existing_piv_provider_present.name(),
-                present);
-    }
+    void setExistingPivProviderPresent(final boolean present);
 
     /**
      * Indicates on the Span that CBA was successful and then ends current Span.
      */
     //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
     @SuppressFBWarnings
-    public void setResultSuccess() {
-        mSpan.setStatus(StatusCode.OK);
-        mSpan.end();
-    }
+    void setResultSuccess();
 
     /**
      * Indicates on the Span that CBA failed and then ends current Span.
@@ -78,10 +59,7 @@ public class CertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelp
      */
     //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
     @SuppressFBWarnings
-    public void setResultFailure(@NonNull final String message) {
-        mSpan.setStatus(StatusCode.ERROR, message);
-        mSpan.end();
-    }
+    void setResultFailure(@NonNull final String message);
 
     /**
      * Indicates on the Span that CBA failed and then ends current Span.
@@ -89,32 +67,11 @@ public class CertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelp
      */
     //Suppressing warnings for RETURN_VALUE_IGNORED_NO_SIDE_EFFECT
     @SuppressFBWarnings
-    public void setResultFailure(@NonNull final Exception exception) {
-        mSpan.recordException(exception);
-        mSpan.setStatus(StatusCode.ERROR);
-        mSpan.end();
-    }
+    void setResultFailure(@NonNull final Exception exception);
 
     /**
      * Sets attribute that indicates the user's intended choice for CBA (smartcard or on-device).
      * @param choice enum indicating user's intended choice for CBA.
      */
-    public void setUserChoice(@NonNull final CertBasedAuthChoice choice) {
-        switch(choice) {
-            case ON_DEVICE_CHOICE:
-                mSpan.setAttribute(
-                        AttributeName.cert_based_auth_user_choice.name(),
-                        "on-device");
-                break;
-            case SMARTCARD_CHOICE:
-                mSpan.setAttribute(
-                        AttributeName.cert_based_auth_user_choice.name(),
-                        "smartcard");
-                break;
-            default:
-                mSpan.setAttribute(
-                        AttributeName.cert_based_auth_user_choice.name(),
-                        "N/A");
-        }
-    }
+    void setUserChoice(@NonNull final CertBasedAuthChoice choice);
 }


### PR DESCRIPTION
## Summary
This PR adds unit tests for CBA that cover challenge handlers `NfcSmartcardCertBasedAuthChallengeHandler` and `UsbSmartcardCertBasedAuthChallengeHandler`) and `CertBasedAuthFactory`. The tests mostly focus on error and cancel scenarios (such as exceptions, key getting unplugged early, etc), but also ensure that the user can get to the dialog right before actual auth occurs, or that the factory is returning the correct challenge handler.

These tests rely on test implementations of the `DialogHolder`, managers, telemetry helpers, and sessions, while the factory tests also make use of a shadowed telemetry helper (that does nothing, so no telemetry is being recorded or sent).
Inheritance was used when possible, since there is a lot of repeated code and variables among the test classes. This is also why I decided to create separate classes for the test implementations ( `TestDialogHolder` and `TestUsbSmartcardCertBasedAuthManager`, for example). The unit tests and test implementations were put in their own package (certbasedauth).

I've learned from my last attempt at making these tests and stayed away from interacting with real Dialogs or shadowing YubiKit code. The manual tests cover these two aspects. 