### PR TITLE
Update pipeline to not publish common and common4j

### DIFF
--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -19,29 +19,6 @@ variables:
 pool:
   name: Hosted Windows 2019 with VS2019
 jobs:
-# common4j
-- job: common4j_phase
-  displayName: 'common4j: Build, Test and Publish'
-  steps:
-  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
-    parameters:
-      project: common4j
-      buildArguments: '-PprojVersion=$(versionNumber)'
-      artifactFolder: 'common4j/build/outputs'
-# common
-- job: common_phase
-  displayName: 'common: Build, Test and Publish'
-  dependsOn:
-  - common4j_phase
-  steps:
-  - template: ../templates/steps/automation-cert.yml
-    parameters:
-      envVstsMvnAt: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
-  - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
-    parameters:
-      project: common
-      buildArguments: '-PprojVersion=$(versionNumber) -PdistCommon4jVersion=$(versionNumber)'
-      artifactFolder: 'common/build/outputs'
 # Key Vault
 - job: keyvault_phase
   displayName: 'Key Vault: Build, Test and Publish'

--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -66,7 +66,6 @@ jobs:
   dependsOn:
   - keyvault_phase
   - labapi_phase
-  - common_phase
   steps:
   - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:
@@ -78,7 +77,6 @@ jobs:
   displayName: 'UI Automation utilities: Build, Test and Publish'
   dependsOn:
   - testutils_phase
-  - common_phase
   steps:
   - template: ../templates/steps/continuous-delivery/assemble-publish-projversion.yml
     parameters:


### PR DESCRIPTION
Common and common4j packages are getting published daily from the [daily-release pipeline](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1515&_a=summary).
Removing these from this pipeline to avoid conflicts with packages published with daily-release piplne 

Test run with the changes
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1043679&view=results
