### PR TITLE
Add DEVICE_TOKEN_EMPTY_OR_NULL  constant to ClientExceptions

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -139,6 +139,11 @@ public class ClientException extends BaseException {
     public static final String INVALID_JWT = "invalid_jwt";
 
     /**
+     * JWE returned by the server is not valid, empty or malformed.
+     */
+    public static final String INVALID_JWE = "invalid_jwe";
+
+    /**
      * State from authorization response did not match the state in the authorization request.
      * For authorization requests, the sdk will verify the state returned from redirect and the one sent in the request.
      */
@@ -148,6 +153,12 @@ public class ClientException extends BaseException {
      * Unsupported url, cannot perform adfs authority validation.
      */
     public static final String UNSUPPORTED_URL = "unsupported_url";
+
+    /**
+     * Unsupported android api version.
+     */
+    public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
+
 
     /**
      * The authority is not supported for authority validation. The sdk supports b2c authority, but we don't support b2c authority validation yet.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -83,7 +83,7 @@ public class ClientException extends BaseException {
     public static final String SCOPE_EMPTY_OR_NULL = "scope_empty_or_null";
 
     /**
-     * Emitted when the device Token is not present in successful response
+     * Emitted when the device Token is not present in successful response.
      */
     public static final String DEVICE_TOKEN_EMPTY_OR_NULL = "device_token_empty_or_null";
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -144,11 +144,6 @@ public class ClientException extends BaseException {
     public static final String INVALID_JWT = "invalid_jwt";
 
     /**
-     * JWE returned by the server is not valid, empty or malformed.
-     */
-    public static final String INVALID_JWE = "invalid_jwe";
-
-    /**
      * State from authorization response did not match the state in the authorization request.
      * For authorization requests, the sdk will verify the state returned from redirect and the one sent in the request.
      */
@@ -158,13 +153,7 @@ public class ClientException extends BaseException {
      * Unsupported url, cannot perform adfs authority validation.
      */
     public static final String UNSUPPORTED_URL = "unsupported_url";
-
-    /**
-     * Unsupported android api version.
-     */
-    public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
-
-
+    
     /**
      * The authority is not supported for authority validation. The sdk supports b2c authority, but we don't support b2c authority validation yet.
      * Only well-known host will be supported.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -153,7 +153,7 @@ public class ClientException extends BaseException {
      * Unsupported url, cannot perform adfs authority validation.
      */
     public static final String UNSUPPORTED_URL = "unsupported_url";
-    
+
     /**
      * The authority is not supported for authority validation. The sdk supports b2c authority, but we don't support b2c authority validation yet.
      * Only well-known host will be supported.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -83,6 +83,11 @@ public class ClientException extends BaseException {
     public static final String SCOPE_EMPTY_OR_NULL = "scope_empty_or_null";
 
     /**
+     * A scope is required when making a token request
+     */
+    public static final String DEVICE_TOKEN_EMPTY_OR_NULL = "device_token_empty_or_null";
+
+    /**
      * The sdk failed to parse the Json format.
      */
     public static final String JSON_PARSE_FAILURE = "json_parse_failure";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -83,7 +83,7 @@ public class ClientException extends BaseException {
     public static final String SCOPE_EMPTY_OR_NULL = "scope_empty_or_null";
 
     /**
-     * A scope is required when making a token request
+     * Emitted when the device Token is not present in successful response
      */
     public static final String DEVICE_TOKEN_EMPTY_OR_NULL = "device_token_empty_or_null";
 


### PR DESCRIPTION
Related PR https://github.com/AzureAD/ad-accounts-for-android/pull/2086