### PR TITLE
Move instrumentation of Token Requests from controllers to commands

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V.Next
 - [MINOR] Remove unnecessary synchronization when storage access is already guarded (#1928)
 - [MINOR] Write back read successes to cache and stop extra lookups in getAll (#1927)
 - [MINOR] Add method to platform util to get package name from uid (#1932)
+- [MINOR] Move instrumentation of Token Requests from controllers to commands (#1939)
 
 V.9.1.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
@@ -26,11 +26,17 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 
 import java.util.List;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
@@ -55,18 +61,32 @@ public class InteractiveTokenCommand extends TokenCommand {
     @Override
     public AcquireTokenResult execute() throws Exception {
         final String methodName = ":execute";
-        if (getParameters() instanceof InteractiveTokenCommandParameters) {
-            Logger.info(
-                    TAG + methodName,
-                    "Executing interactive token command..."
-            );
 
-            return getDefaultController()
-                    .acquireToken(
-                            (InteractiveTokenCommandParameters) getParameters()
-                    );
-        } else {
-            throw new IllegalArgumentException("Invalid operation parameters");
+        final Span span = OTelUtility.createSpan(SpanName.AcquireTokenInteractive.name());
+        span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
+        span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
+
+        try (final Scope scope = span.makeCurrent()) {
+            if (getParameters() instanceof InteractiveTokenCommandParameters) {
+                Logger.info(
+                        TAG + methodName,
+                        "Executing interactive token command..."
+                );
+
+                final BaseController controller = getDefaultController();
+
+                span.setAttribute(AttributeName.controller_name.name(), controller.getClass().getSimpleName());
+
+                return controller.acquireToken((InteractiveTokenCommandParameters) getParameters());
+            } else {
+                throw new IllegalArgumentException("Invalid operation parameters");
+            }
+        } catch (final Throwable throwable) {
+            span.setStatus(StatusCode.ERROR);
+            span.recordException(throwable);
+            throw throwable;
+        } finally {
+            span.end();
         }
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
@@ -62,7 +62,9 @@ public class InteractiveTokenCommand extends TokenCommand {
     public AcquireTokenResult execute() throws Exception {
         final String methodName = ":execute";
 
-        final Span span = OTelUtility.createSpan(SpanName.AcquireTokenInteractive.name());
+        final Span span = OTelUtility.createSpanFromParent(
+                SpanName.AcquireTokenInteractive.name(), getParameters().getSpanContext()
+        );
         span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
         span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -69,7 +69,9 @@ public class SilentTokenCommand extends TokenCommand {
         AcquireTokenResult result = null;
         final String methodName = ":execute";
 
-        final Span span = OTelUtility.createSpan(SpanName.AcquireTokenSilent.name());
+        final Span span = OTelUtility.createSpanFromParent(
+                SpanName.AcquireTokenSilent.name(), getParameters().getSpanContext()
+        );
         span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
         span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -78,4 +78,19 @@ public enum AttributeName {
      * The IPC strategy being used.
      */
     ipc_strategy,
+
+    /**
+     * The API ID of an MSAL PCA method.
+     */
+    public_api_id,
+
+    /**
+     * The name of the controller being used to process the request.
+     */
+    controller_name,
+
+    /**
+     * The name of the application making the request.
+     */
+    application_name
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -38,5 +38,5 @@ public enum SpanName {
     DeviceState,
     UploadBrokerLogs,
     InitializePowerLift,
-    MSAL_PerformIpcStrategy
+    MSAL_PerformIpcStrategy,
 }

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -27,4 +27,9 @@
     <Class name="com.microsoft.identity.common.java.opentelemetry.CryptoFactoryTelemetryHelper" />
     <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
 </Match>
+<Match>
+    <!-- Return value of method without side effect is ignored. -->
+    <Package name="com.microsoft.identity.common.java.commands.*" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+</Match>
 </FindBugsFilter>


### PR DESCRIPTION
Moving the instrumentation of Token Requests from controllers to commands so that it can be leveraged in MSAL as well. We will also emit the name of controller being used.

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2129