### PR TITLE
Capture span status and error codes in missing scenarios

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V.Next
 - [MINOR] Write back read successes to cache and stop extra lookups in getAll (#1927)
 - [MINOR] Add method to platform util to get package name from uid (#1932)
 - [MINOR] Move instrumentation of Token Requests from controllers to commands (#1939)
+- [MINOR] Capture span status and error codes in missing scenarios (#1940)
 
 V.9.1.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -26,6 +26,8 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommandParameters;
 import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
@@ -100,6 +102,7 @@ public class SilentTokenCommand extends TokenCommand {
                                         + ": Succeeded"
                         );
 
+                        span.setStatus(StatusCode.OK);
                         return result;
                     }
                 } catch (UiRequiredException | ClientException e) {
@@ -114,6 +117,20 @@ public class SilentTokenCommand extends TokenCommand {
                     } else {
                         throw e;
                     }
+                }
+            }
+
+            if (result == null) {
+                span.setStatus(StatusCode.ERROR, "empty result");
+            } else if (result.getSucceeded()) {
+                span.setStatus(StatusCode.OK);
+            } else {
+                final BaseException exception = ExceptionAdapter.exceptionFromAcquireTokenResult(result, getParameters());
+                if (exception != null) {
+                    span.recordException(exception);
+                    span.setStatus(StatusCode.ERROR);
+                } else {
+                    span.setStatus(StatusCode.ERROR, "empty exception");
                 }
             }
 


### PR DESCRIPTION
Span Status and error codes were not being captured in some scenarios to addressed that. 

An exception is not always thrown during an error and sometimes the error is just present on the Acquire Token Result. So we will read it from there to set it on the span.