### PR TITLE
Capture whether token is returned from cache during silent token requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ V.Next
 - [MINOR] Write back read successes to cache and stop extra lookups in getAll (#1927)
 - [MINOR] Add method to platform util to get package name from uid (#1932)
 - [MINOR] Move instrumentation of Token Requests from controllers to commands (#1939)
+- [MINOR] Capture whether token is returned from cache during silent token requests (#1941)
 
 V.9.1.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -100,6 +100,11 @@ public class SilentTokenCommand extends TokenCommand {
                                         + ": Succeeded"
                         );
 
+                        span.setAttribute(
+                                AttributeName.is_serviced_from_cache.name(),
+                                result.getLocalAuthenticationResult().isServicedFromCache()
+                        );
+
                         return result;
                     }
                 } catch (UiRequiredException | ClientException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -92,5 +92,10 @@ public enum AttributeName {
     /**
      * The name of the application making the request.
      */
-    application_name
+    application_name,
+
+    /**
+     * Indicates if token was return from token cache
+     */
+    is_serviced_from_cache;
 }


### PR DESCRIPTION
See title.

Related: https://github.com/AzureAD/ad-accounts-for-android/pull/2132