### PR TITLE
Add application identifier during authorization request initialization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Add application identifier during authorization request initialization (#1942)
 - [MINOR] Add NFC compatibility and telemetry to CBA (#1896)
 - [MINOR] Format thread+correlationId metadata only once logging is clearly opted-in (#1917)
 - [MINOR] Remove unnecessary synchronization when storage access is already guarded (#1928)

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.java.cache;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.DEFAULT_SCOPES;
 
+import com.microsoft.identity.common.java.authscheme.PopAuthenticationSchemeInternal;
+import com.microsoft.identity.common.java.authscheme.PopAuthenticationSchemeWithClientKeyInternal;
 import com.microsoft.identity.common.java.dto.AccessTokenRecord;
 import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.dto.Credential;
@@ -32,6 +34,7 @@ import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.PrimaryRefreshTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.util.ArrayList;
@@ -241,7 +244,14 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
                     atType = atType.trim();
                 }
 
-                matches = matches && authScheme.equalsIgnoreCase(atType);
+                if (atType.equalsIgnoreCase(TokenRequest.TokenType.POP)) {
+                    matches = matches && (
+                            authScheme.equalsIgnoreCase(PopAuthenticationSchemeWithClientKeyInternal.SCHEME_POP_WITH_CLIENT_KEY)
+                            || authScheme.equalsIgnoreCase(PopAuthenticationSchemeInternal.SCHEME_POP)
+                    );
+                } else {
+                    matches = matches && authScheme.equalsIgnoreCase(atType);
+                }
             }
 
             if(mustMatchOnKid && credential instanceof AccessTokenRecord) {

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -244,7 +244,7 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
                     atType = atType.trim();
                 }
 
-                if (atType.equalsIgnoreCase(TokenRequest.TokenType.POP)) {
+                if (TokenRequest.TokenType.POP.equalsIgnoreCase(atType)) {
                     matches = matches && (
                             authScheme.equalsIgnoreCase(PopAuthenticationSchemeWithClientKeyInternal.SCHEME_POP_WITH_CLIENT_KEY)
                             || authScheme.equalsIgnoreCase(PopAuthenticationSchemeInternal.SCHEME_POP)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -269,6 +269,10 @@ public abstract class BaseController {
             ((MicrosoftAuthorizationRequest.Builder) builder).setCorrelationId(correlationId);
         }
 
+        if (builder instanceof MicrosoftStsAuthorizationRequest.Builder) {
+            ((MicrosoftStsAuthorizationRequest.Builder) builder).setApplicationIdentifier(parameters.getApplicationIdentifier());
+        }
+
         final Set<String> scopes = parameters.getScopes();
 
         if (parameters instanceof InteractiveTokenCommandParameters) {


### PR DESCRIPTION
### What
Add application identifier during authorization request initialization

### Why
This is later used to filter the credentials from the cache, if this is not set it results in cache miss, and silent requests might not be served from cache.

### How
Setting the application identifier in authorization request based on the application identifier passed in token parameters.

### Testing
Tested locally with unitTest in broker testATSWithPopAuthenticationSchemeWithClientKey, which was failing before this change. it passes after the change.
Also added change to compare authscheme to SCHEME_POP_WITH_CLIENT_KEY and SCHEME_POP in case access token type is "pop", as both of these scheme set the token type as "pop" in cache.