### PR TITLE
Moving a util method to common

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/authorities/AzureActiveDirectoryAuthorityTests.java
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.authorities;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import com.microsoft.identity.common.java.authorities.AllAccounts;
 import com.microsoft.identity.common.java.authorities.AnyOrganizationalAccount;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority;
+import com.microsoft.identity.common.java.exception.ClientException;
 
 @RunWith(RobolectricTestRunner.class)
 public class AzureActiveDirectoryAuthorityTests {
@@ -71,5 +73,22 @@ public class AzureActiveDirectoryAuthorityTests {
         assertFalse(authorityWW.isSameCloudAsAuthority(authorityCN));
         assertFalse(authorityCN.isSameCloudAsAuthority(authorityUSGov));
         assertFalse(authorityUSGov.isSameCloudAsAuthority(authorityWW));
+    }
+
+    @Test
+    public void testConvertToDefaultAuthority() throws ClientException {
+        final String authority = "https://login.microsoftonline.com/tenant-id";
+        String defaultAuthority = AzureActiveDirectoryAuthority.convertToDefaultAuthority(authority);
+        Assert.assertEquals("https://login.microsoftonline.com/common", defaultAuthority);
+    }
+
+    @Test
+    public void testConvertToDefaultAuthorityMalformedUrl() {
+        final String authority = "malformed_url";
+        try {
+            String defaultAuthority = AzureActiveDirectoryAuthority.convertToDefaultAuthority(authority);
+        } catch (final ClientException e) {
+            Assert.assertEquals(ClientException.MALFORMED_URL, e.getErrorCode());
+        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -22,25 +22,19 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.authorities;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.java.WarningType;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
+import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
-import com.microsoft.identity.common.java.WarningType;
-import com.microsoft.identity.common.java.exception.ClientException;
-import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
-import com.microsoft.identity.common.java.logging.Logger;
-import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.CommonURIBuilder;
+import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -51,6 +45,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Accessors(prefix = "m")
 public class AzureActiveDirectoryAuthority extends Authority {
@@ -190,5 +190,25 @@ public class AzureActiveDirectoryAuthority extends Authority {
         }
 
         return Objects.equals(cloudOfThisAuthority, cloudOfAuthorityToCheck);
+    }
+
+    /**
+     * Convert the given authority URL to a default authority (common).
+     *
+     * @param authorityUrl authority url
+     * @return a common authority.
+     */
+    @NonNull
+    public static String convertToDefaultAuthority(@NonNull final String authorityUrl)
+            throws ClientException {
+
+        try {
+            final CommonURIBuilder builder = new CommonURIBuilder(authorityUrl);
+            builder.setPath(AzureActiveDirectoryAudience.ALL);
+            return builder.toString();
+        } catch (final URISyntaxException e) {
+            throw new ClientException(ClientException.MALFORMED_URL,
+                    "Cannot construct common authority URL", e);
+        }
     }
 }


### PR DESCRIPTION
Moving default authority util method to common as a result of refactor and comment on this PR https://github.com/AzureAD/ad-accounts-for-android/pull/2133