### PR TITLE
Remove OTel SDK from common and common4j

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V.Next
 - [MAJOR] Added application identifier to cache (physical identifier).  Prevents multiple apps using the same logical identifier from sharing tokens. (#1660)
 - [MINOR] Capture whether token is returned from cache during silent token requests (#1941)
 - [MINOR] Capture span status and error codes in missing scenarios (#1940)
+- [MINOR] Remove OTel SDK from common and common4j (#1948)
 
 V.9.1.0
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -30,7 +30,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 0.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "7.0.0-RC1"
+def common4jVersion = "7.0.0-RC2"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -179,7 +179,6 @@ dependencies {
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.18.0")
     implementation('io.opentelemetry:opentelemetry-api:1.18.0')
-    implementation('io.opentelemetry:opentelemetry-sdk-trace:1.18.0')
     implementation ('androidx.activity:activity:1.2.3')
 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -122,7 +122,6 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                         .traceId(SpanExtension.current().getSpanContext().getTraceId())
                         .spanId(SpanExtension.current().getSpanContext().getSpanId())
                         .traceFlags(SpanExtension.current().getSpanContext().getTraceFlags().asByte())
-                        .parentSpanName(OTelUtility.getCurrentSpanName())
                         .build()
                 )
                 .build();
@@ -162,7 +161,6 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                         .traceId(SpanExtension.current().getSpanContext().getTraceId())
                         .spanId(SpanExtension.current().getSpanContext().getSpanId())
                         .traceFlags(SpanExtension.current().getSpanContext().getTraceFlags().asByte())
-                        .parentSpanName(OTelUtility.getCurrentSpanName())
                         .build()
                 )
                 .build();

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -221,7 +221,6 @@ dependencies {
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.18.0")
     implementation('io.opentelemetry:opentelemetry-api:1.18.0')
-    implementation('io.opentelemetry:opentelemetry-sdk-trace:1.18.0')
 }
 
 sourceCompatibility = "1.8"

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CryptoFactoryTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CryptoFactoryTelemetryHelper.java
@@ -64,11 +64,9 @@ public class CryptoFactoryTelemetryHelper {
         try {
             return cryptoOperation.perform();
         } catch (final Exception e) {
-            final String parentSpanName = OTelUtility.getCurrentSpanName();
             final Attributes attributes = Attributes.of(
                     stringKey(crypto_controller.name()), cryptoFactory.getTelemetryClassName().name(),
                     stringKey(crypto_operation.name()), getCryptoOperationEventName(operationName, algorithmName),
-                    stringKey(parent_span_name.name()), parentSpanName == null ? "N/A" : parentSpanName,
                     stringKey(error_type.name()), e.getClass().getSimpleName(),
                     stringKey(error_code.name()), e instanceof IErrorInformation ? ((IErrorInformation) e).getErrorCode() : "N/A",
                     stringKey(crypto_exception_stack_trace.name()), ThrowableUtil.getStackTraceAsString(e)

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -29,14 +29,12 @@ import com.microsoft.identity.common.java.logging.Logger;
 import javax.annotation.Nullable;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.sdk.trace.ReadableSpan;
 import lombok.NonNull;
 
 public class OTelUtility {
@@ -48,11 +46,7 @@ public class OTelUtility {
     @NonNull
     public static Span createSpan(@NonNull final String name) {
         final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
-        final Span span = tracer.spanBuilder(name).startSpan();
-
-        // Current span is the parent of span just created.
-        span.setAttribute(parent_span_name.name(), getCurrentSpanName());
-        return span;
+        return tracer.spanBuilder(name).startSpan();
     }
 
     /**
@@ -104,29 +98,4 @@ public class OTelUtility {
                 .setUnit("count")
                 .build();
     }
-
-    /**
-     * Get name of the current span, if possible.
-     **/
-    @Nullable
-    public static Attributes getCurrentSpanAttributes() {
-        final Span span = SpanExtension.current();
-        if (span instanceof ReadableSpan) {
-            return ((ReadableSpan) span).toSpanData().getAttributes();
-        }
-        return null;
-    }
-
-    /**
-     * Get name of the current span, if possible.
-     **/
-    @NonNull
-    public static String getCurrentSpanName() {
-        final Span span = SpanExtension.current();
-        if (span instanceof ReadableSpan) {
-            return ((ReadableSpan) span).getName();
-        }
-        return "";
-    }
-
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -68,21 +68,10 @@ public class OTelUtility {
         }
 
         final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
-        final Span span = tracer.spanBuilder(name)
+
+        return tracer.spanBuilder(name)
                 .setParent(Context.current().with(Span.wrap(parentSpanContext)))
                 .startSpan();
-
-        if (parentSpanContext instanceof SerializableSpanContext) {
-            span.setAttribute(parent_span_name.name(), ((SerializableSpanContext) parentSpanContext).getParentSpanName());
-        } else {
-            Logger.warn(
-                    methodTag,
-                    "span context received is not of type SerializableSpanContext, " +
-                            "instead received: [" + parentSpanContext.getClass().getSimpleName() + "]"
-            );
-        }
-
-        return span;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SerializableSpanContext.java
@@ -59,11 +59,6 @@ public class SerializableSpanContext implements SpanContext, Serializable {
     @SerializedName(SerializedNames.TRACE_FLAGS)
     private final byte mTraceFlags;
 
-    @Getter
-    @SerializedName(SerializedNames.PARENT_SPAN_NAME)
-    @NonNull
-    private final String mParentSpanName;
-
     @Override
     public String getTraceId() {
         return mTraceId;

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=7.0.0-RC1
+versionName=7.0.0-RC2
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=10.0.0-RC1
+versionName=10.0.0-RC2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
The otel sdk package is causing size increase for common and common4j so removing it from these libs. This means we cannot capture `parent_span_name` on the spans, but that's fine as we would still have `parent_span_id` and can look it up that way.