### PR TITLE
Add a Basic Encryptor Interface + Add support to Encrypt / Decrypt using AES GCM

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.Next
+------
+[MINOR] Add a Basic Encryptor Interface + Add support to Encrypt / Decrypt using AES GCM (#1953)
+
 V.10.0.0
 ----------
 - [MINOR] Setting sub error codes to UiRequiredException for MsalUiRequiredException (#1944)

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
@@ -125,7 +125,7 @@ public class BasicDecryptor implements IDecryptor {
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(decryptAlgorithm);
         try {
-            final GCMParameterSpec spec = new GCMParameterSpec(tagLength * 8, iv);
+            final GCMParameterSpec spec = new GCMParameterSpec(tagLength * Byte.SIZE, iv);
             cipher.init(Cipher.DECRYPT_MODE, key, spec);
 
             if (aad != null) {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
@@ -62,7 +62,7 @@ public class BasicDecryptor implements IDecryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return decryptWithCipher(key, decryptAlgorithm, iv, dataToBeDecrypted);
+                        return decryptWithIv(key, decryptAlgorithm, iv, dataToBeDecrypted);
                     }
                 }
         );
@@ -82,7 +82,7 @@ public class BasicDecryptor implements IDecryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return decryptWithCipher(
+                        return decryptWithGcm(
                                 key, decryptAlgorithm, iv, dataToBeDecrypted, tagLength, aad
                         );
                     }
@@ -90,10 +90,10 @@ public class BasicDecryptor implements IDecryptor {
         );
     }
 
-    private byte[] decryptWithCipher(@NonNull final Key key,
-                                     @NonNull final String decryptAlgorithm,
-                                     final byte[] iv,
-                                     byte[] dataToBeDecrypted)
+    private byte[] decryptWithIv(@NonNull final Key key,
+                                 @NonNull final String decryptAlgorithm,
+                                 final byte[] iv,
+                                 byte[] dataToBeDecrypted)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(decryptAlgorithm);
         try {
@@ -116,12 +116,12 @@ public class BasicDecryptor implements IDecryptor {
     }
 
     @SuppressWarnings("NewApi")
-    private byte[] decryptWithCipher(@NonNull final Key key,
-                                     @NonNull final String decryptAlgorithm,
-                                     final byte[] iv,
-                                     byte[] dataToBeDecrypted,
-                                     final int tagLength,
-                                     @Nullable final byte[] aad)
+    private byte[] decryptWithGcm(@NonNull final Key key,
+                                  @NonNull final String decryptAlgorithm,
+                                  final byte[] iv,
+                                  byte[] dataToBeDecrypted,
+                                  final int tagLength,
+                                  @Nullable final byte[] aad)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(decryptAlgorithm);
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
@@ -132,9 +132,7 @@ public class BasicDecryptor implements IDecryptor {
                 cipher.updateAAD(aad);
             }
 
-            return cipher.doFinal(
-                    dataToBeDecrypted, iv.length, dataToBeDecrypted.length - iv.length
-            );
+            return cipher.doFinal(dataToBeDecrypted);
         } catch (final BadPaddingException e) {
             throw new ClientException(ClientException.BAD_PADDING, e.getMessage(), e);
         } catch (final IllegalBlockSizeException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicDecryptor.java
@@ -51,10 +51,10 @@ public class BasicDecryptor implements IDecryptor {
     private final ICryptoFactory mCryptoFactory;
 
     @Override
-    public byte[] decrypt(@NonNull final Key key,
-                          @NonNull final String decryptAlgorithm,
-                          final byte[] iv,
-                          byte[] dataToBeDecrypted) throws ClientException {
+    public byte[] decryptWithIv(@NonNull final Key key,
+                                @NonNull final String decryptAlgorithm,
+                                final byte[] iv,
+                                byte[] dataToBeDecrypted) throws ClientException {
         return performCryptoOperationAndUploadTelemetry(
                 CryptoObjectName.Cipher,
                 decryptAlgorithm,
@@ -62,19 +62,19 @@ public class BasicDecryptor implements IDecryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return decryptWithIv(key, decryptAlgorithm, iv, dataToBeDecrypted);
+                        return decryptWithIvInternal(key, decryptAlgorithm, iv, dataToBeDecrypted);
                     }
                 }
         );
     }
 
     @Override
-    public byte[] decrypt(@NonNull final Key key,
-                          @NonNull final String decryptAlgorithm,
-                          final byte[] iv,
-                          final byte[] dataToBeDecrypted,
-                          final int tagLength,
-                          final byte[] aad) throws ClientException {
+    public byte[] decryptWithGcm(@NonNull final Key key,
+                                 @NonNull final String decryptAlgorithm,
+                                 final byte[] iv,
+                                 final byte[] dataToBeDecrypted,
+                                 final int tagLength,
+                                 final byte[] aad) throws ClientException {
         return performCryptoOperationAndUploadTelemetry(
                 CryptoObjectName.Cipher,
                 decryptAlgorithm,
@@ -82,7 +82,7 @@ public class BasicDecryptor implements IDecryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return decryptWithGcm(
+                        return decryptWithGcmInternal(
                                 key, decryptAlgorithm, iv, dataToBeDecrypted, tagLength, aad
                         );
                     }
@@ -90,10 +90,10 @@ public class BasicDecryptor implements IDecryptor {
         );
     }
 
-    private byte[] decryptWithIv(@NonNull final Key key,
-                                 @NonNull final String decryptAlgorithm,
-                                 final byte[] iv,
-                                 byte[] dataToBeDecrypted)
+    private byte[] decryptWithIvInternal(@NonNull final Key key,
+                                         @NonNull final String decryptAlgorithm,
+                                         final byte[] iv,
+                                         byte[] dataToBeDecrypted)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(decryptAlgorithm);
         try {
@@ -116,12 +116,12 @@ public class BasicDecryptor implements IDecryptor {
     }
 
     @SuppressWarnings("NewApi")
-    private byte[] decryptWithGcm(@NonNull final Key key,
-                                  @NonNull final String decryptAlgorithm,
-                                  final byte[] iv,
-                                  byte[] dataToBeDecrypted,
-                                  final int tagLength,
-                                  @Nullable final byte[] aad)
+    private byte[] decryptWithGcmInternal(@NonNull final Key key,
+                                          @NonNull final String decryptAlgorithm,
+                                          final byte[] iv,
+                                          byte[] dataToBeDecrypted,
+                                          final int tagLength,
+                                          @Nullable final byte[] aad)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(decryptAlgorithm);
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
@@ -59,7 +59,7 @@ public class BasicEncryptor implements IEncryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return encryptWithCipher(key, encryptAlgorithm, iv, dataToBeEncrypted);
+                        return encryptWithIv(key, encryptAlgorithm, iv, dataToBeEncrypted);
                     }
                 }
         );
@@ -79,7 +79,7 @@ public class BasicEncryptor implements IEncryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return encryptWithCipher(
+                        return encryptWithGcm(
                                 key, encryptAlgorithm, iv, dataToBeEncrypted, tagLength, aad
                         );
                     }
@@ -87,10 +87,10 @@ public class BasicEncryptor implements IEncryptor {
         );
     }
 
-    private byte[] encryptWithCipher(@NonNull final Key key,
-                                     @NonNull final String encryptAlgorithm,
-                                     final byte[] iv,
-                                     byte[] dataToBeEncrypted)
+    private byte[] encryptWithIv(@NonNull final Key key,
+                                 @NonNull final String encryptAlgorithm,
+                                 final byte[] iv,
+                                 byte[] dataToBeEncrypted)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(encryptAlgorithm);
         try {
@@ -113,12 +113,12 @@ public class BasicEncryptor implements IEncryptor {
     }
 
     @SuppressWarnings("NewApi")
-    private byte[] encryptWithCipher(@NonNull final Key key,
-                                     @NonNull final String encryptAlgorithm,
-                                     final byte[] iv,
-                                     byte[] dataToBeEncrypted,
-                                     final int tagLength,
-                                     final byte[] aad)
+    private byte[] encryptWithGcm(@NonNull final Key key,
+                                  @NonNull final String encryptAlgorithm,
+                                  final byte[] iv,
+                                  byte[] dataToBeEncrypted,
+                                  final int tagLength,
+                                  final byte[] aad)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(encryptAlgorithm);
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.crypto;
+
+import static com.microsoft.identity.common.java.opentelemetry.CryptoFactoryTelemetryHelper.performCryptoOperationAndUploadTelemetry;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.opentelemetry.CryptoObjectName;
+import com.microsoft.identity.common.java.opentelemetry.ICryptoOperation;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.IvParameterSpec;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+
+@AllArgsConstructor
+public class BasicEncryptor implements IEncryptor {
+
+    private final ICryptoFactory mCryptoFactory;
+
+    @Override
+    public byte[] encrypt(@NonNull final Key key,
+                          @NonNull final String encryptAlgorithm,
+                          final byte[] iv,
+                          byte[] dataToBeEncrypted) throws ClientException {
+        return performCryptoOperationAndUploadTelemetry(
+                CryptoObjectName.Cipher,
+                encryptAlgorithm,
+                mCryptoFactory,
+                new ICryptoOperation<byte[]>() {
+                    @Override
+                    public byte[] perform() throws ClientException {
+                        return encryptWithCipher(key, encryptAlgorithm, iv, dataToBeEncrypted);
+                    }
+                }
+        );
+    }
+
+    private byte[] encryptWithCipher(@NonNull final Key key,
+                                     @NonNull final String encryptAlgorithm,
+                                     final byte[] iv,
+                                     byte[] dataToBeEncrypted)
+            throws ClientException {
+        final Cipher cipher = mCryptoFactory.getCipher(encryptAlgorithm);
+        try {
+            if (iv != null && iv.length > 0) {
+                final IvParameterSpec ivSpec = new IvParameterSpec(iv);
+                cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+            } else {
+                cipher.init(Cipher.ENCRYPT_MODE, key);
+            }
+            return cipher.doFinal(dataToBeEncrypted);
+        } catch (final BadPaddingException e) {
+            throw new ClientException(ClientException.BAD_PADDING, e.getMessage(), e);
+        } catch (final IllegalBlockSizeException e) {
+            throw new ClientException(ClientException.INVALID_BLOCK_SIZE, e.getMessage(), e);
+        } catch (final InvalidKeyException e) {
+            throw new ClientException(ClientException.INVALID_KEY, e.getMessage(), e);
+        } catch (final InvalidAlgorithmParameterException e) {
+            throw new ClientException(ClientException.INVALID_ALG_PARAMETER, e.getMessage(), e);
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
@@ -28,7 +28,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.opentelemetry.CryptoObjectName;
 import com.microsoft.identity.common.java.opentelemetry.ICryptoOperation;
 
-import java.nio.ByteBuffer;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -129,12 +128,7 @@ public class BasicEncryptor implements IEncryptor {
                 cipher.updateAAD(aad);
             }
 
-            final byte[] cipherText = cipher.doFinal(dataToBeEncrypted);
-
-            final ByteBuffer encryptedText = ByteBuffer.allocate(iv.length + cipherText.length);
-            encryptedText.put(iv);
-            encryptedText.put(cipherText);
-            return encryptedText.array();
+            return cipher.doFinal(dataToBeEncrypted);
         } catch (final BadPaddingException e) {
             throw new ClientException(ClientException.BAD_PADDING, e.getMessage(), e);
         } catch (final IllegalBlockSizeException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/BasicEncryptor.java
@@ -47,10 +47,10 @@ public class BasicEncryptor implements IEncryptor {
     private final ICryptoFactory mCryptoFactory;
 
     @Override
-    public byte[] encrypt(@NonNull final Key key,
-                          @NonNull final String encryptAlgorithm,
-                          final byte[] iv,
-                          byte[] dataToBeEncrypted) throws ClientException {
+    public byte[] encryptWithIv(@NonNull final Key key,
+                                @NonNull final String encryptAlgorithm,
+                                final byte[] iv,
+                                byte[] dataToBeEncrypted) throws ClientException {
         return performCryptoOperationAndUploadTelemetry(
                 CryptoObjectName.Cipher,
                 encryptAlgorithm,
@@ -58,19 +58,19 @@ public class BasicEncryptor implements IEncryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return encryptWithIv(key, encryptAlgorithm, iv, dataToBeEncrypted);
+                        return encryptWithIvInternal(key, encryptAlgorithm, iv, dataToBeEncrypted);
                     }
                 }
         );
     }
 
     @Override
-    public byte[] encrypt(@NonNull final Key key,
-                          @NonNull final String encryptAlgorithm,
-                          final byte[] iv,
-                          final byte[] dataToBeEncrypted,
-                          final int tagLength,
-                          final byte[] aad) throws ClientException {
+    public byte[] encryptWithGcm(@NonNull final Key key,
+                                 @NonNull final String encryptAlgorithm,
+                                 final byte[] iv,
+                                 final byte[] dataToBeEncrypted,
+                                 final int tagLength,
+                                 final byte[] aad) throws ClientException {
         return performCryptoOperationAndUploadTelemetry(
                 CryptoObjectName.Cipher,
                 encryptAlgorithm,
@@ -78,7 +78,7 @@ public class BasicEncryptor implements IEncryptor {
                 new ICryptoOperation<byte[]>() {
                     @Override
                     public byte[] perform() throws ClientException {
-                        return encryptWithGcm(
+                        return encryptWithGcmInternal(
                                 key, encryptAlgorithm, iv, dataToBeEncrypted, tagLength, aad
                         );
                     }
@@ -86,10 +86,10 @@ public class BasicEncryptor implements IEncryptor {
         );
     }
 
-    private byte[] encryptWithIv(@NonNull final Key key,
-                                 @NonNull final String encryptAlgorithm,
-                                 final byte[] iv,
-                                 byte[] dataToBeEncrypted)
+    private byte[] encryptWithIvInternal(@NonNull final Key key,
+                                         @NonNull final String encryptAlgorithm,
+                                         final byte[] iv,
+                                         byte[] dataToBeEncrypted)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(encryptAlgorithm);
         try {
@@ -112,12 +112,12 @@ public class BasicEncryptor implements IEncryptor {
     }
 
     @SuppressWarnings("NewApi")
-    private byte[] encryptWithGcm(@NonNull final Key key,
-                                  @NonNull final String encryptAlgorithm,
-                                  final byte[] iv,
-                                  byte[] dataToBeEncrypted,
-                                  final int tagLength,
-                                  final byte[] aad)
+    private byte[] encryptWithGcmInternal(@NonNull final Key key,
+                                          @NonNull final String encryptAlgorithm,
+                                          final byte[] iv,
+                                          byte[] dataToBeEncrypted,
+                                          final int tagLength,
+                                          final byte[] aad)
             throws ClientException {
         final Cipher cipher = mCryptoFactory.getCipher(encryptAlgorithm);
         try {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
@@ -49,4 +49,20 @@ public interface IDecryptor {
                    @NonNull final String decryptAlgorithm,
                    final byte[] iv,
                    final byte[] dataToBeDecrypted) throws ClientException;
+
+    /**
+     * Decrypt the given byte array.
+     *
+     * @param key               the key to decrypt with.
+     * @param decryptAlgorithm  algorithm to decrypt with.
+     * @param iv                an initialization vector (IV).
+     * @param dataToBeDecrypted the data to be encrypted.
+     * @return a decrypted byte array.
+     */
+    byte[] decrypt(@NonNull final Key key,
+                   @NonNull final String decryptAlgorithm,
+                   final byte[] iv,
+                   final byte[] dataToBeDecrypted,
+                   final int tagLength,
+                   final byte[] aad) throws ClientException;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
@@ -25,9 +25,6 @@ package com.microsoft.identity.common.java.crypto;
 import com.microsoft.identity.common.java.exception.ClientException;
 
 import java.security.Key;
-import java.security.PrivateKey;
-
-import javax.crypto.SecretKey;
 
 import lombok.NonNull;
 
@@ -45,10 +42,10 @@ public interface IDecryptor {
      * @param dataToBeDecrypted the data to be encrypted.
      * @return a decrypted byte array.
      */
-    byte[] decrypt(@NonNull final Key key,
-                   @NonNull final String decryptAlgorithm,
-                   final byte[] iv,
-                   final byte[] dataToBeDecrypted) throws ClientException;
+    byte[] decryptWithIv(@NonNull final Key key,
+                         @NonNull final String decryptAlgorithm,
+                         final byte[] iv,
+                         final byte[] dataToBeDecrypted) throws ClientException;
 
     /**
      * Decrypt the given byte array.
@@ -57,14 +54,14 @@ public interface IDecryptor {
      * @param decryptAlgorithm  algorithm to decrypt with.
      * @param iv                an initialization vector (IV).
      * @param dataToBeDecrypted the data to be encrypted.
-     * @param tagLength the length of tag being used
-     * @param aad the additional authentication data
+     * @param tagLength         the length of tag being used
+     * @param aad               the additional authentication data
      * @return a decrypted byte array.
      */
-    byte[] decrypt(@NonNull final Key key,
-                   @NonNull final String decryptAlgorithm,
-                   final byte[] iv,
-                   final byte[] dataToBeDecrypted,
-                   final int tagLength,
-                   final byte[] aad) throws ClientException;
+    byte[] decryptWithGcm(@NonNull final Key key,
+                          @NonNull final String decryptAlgorithm,
+                          final byte[] iv,
+                          final byte[] dataToBeDecrypted,
+                          final int tagLength,
+                          final byte[] aad) throws ClientException;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDecryptor.java
@@ -57,6 +57,8 @@ public interface IDecryptor {
      * @param decryptAlgorithm  algorithm to decrypt with.
      * @param iv                an initialization vector (IV).
      * @param dataToBeDecrypted the data to be encrypted.
+     * @param tagLength the length of tag being used
+     * @param aad the additional authentication data
      * @return a decrypted byte array.
      */
     byte[] decrypt(@NonNull final Key key,

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.crypto;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import java.security.Key;
+
+import lombok.NonNull;
+
+/**
+ * Interface for an Encryptor.
+ */
+public interface IEncryptor {
+
+    /**
+     * Encrypt the given byte array.
+     *
+     * @param key               the key to encrypt with.
+     * @param encryptAlgorithm  algorithm to encrypt with.
+     * @param iv                an initialization vector (IV).
+     * @param dataToBeEncrypted the data to be encrypted.
+     * @return a decrypted byte array.
+     */
+    byte[] encrypt(@NonNull final Key key,
+                   @NonNull final String encryptAlgorithm,
+                   final byte[] iv,
+                   final byte[] dataToBeEncrypted) throws ClientException;
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
@@ -42,10 +42,10 @@ public interface IEncryptor {
      * @param dataToBeEncrypted the data to be encrypted.
      * @return a decrypted byte array.
      */
-    byte[] encrypt(@NonNull final Key key,
-                   @NonNull final String encryptAlgorithm,
-                   final byte[] iv,
-                   final byte[] dataToBeEncrypted) throws ClientException;
+    byte[] encryptWithIv(@NonNull final Key key,
+                         @NonNull final String encryptAlgorithm,
+                         final byte[] iv,
+                         final byte[] dataToBeEncrypted) throws ClientException;
 
     /**
      * Encrypt the given byte array.
@@ -54,14 +54,14 @@ public interface IEncryptor {
      * @param encryptAlgorithm  algorithm to encrypt with.
      * @param iv                an initialization vector (IV).
      * @param dataToBeEncrypted the data to be encrypted.
-     * @param tagLength the length of tag being used
-     * @param aad the additional authentication data
+     * @param tagLength         the length of tag being used
+     * @param aad               the additional authentication data
      * @return an encrypted byte array.
      */
-    byte[] encrypt(@NonNull final Key key,
-                   @NonNull final String encryptAlgorithm,
-                   final byte[] iv,
-                   final byte[] dataToBeEncrypted,
-                   final int tagLength,
-                   final byte[] aad) throws ClientException;
+    byte[] encryptWithGcm(@NonNull final Key key,
+                          @NonNull final String encryptAlgorithm,
+                          final byte[] iv,
+                          final byte[] dataToBeEncrypted,
+                          final int tagLength,
+                          final byte[] aad) throws ClientException;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
@@ -46,4 +46,20 @@ public interface IEncryptor {
                    @NonNull final String encryptAlgorithm,
                    final byte[] iv,
                    final byte[] dataToBeEncrypted) throws ClientException;
+
+    /**
+     * Encrypt the given byte array.
+     *
+     * @param key               the key to encrypt with.
+     * @param encryptAlgorithm  algorithm to encrypt with.
+     * @param iv                an initialization vector (IV).
+     * @param dataToBeEncrypted the data to be encrypted.
+     * @return a decrypted byte array.
+     */
+    byte[] encrypt(@NonNull final Key key,
+                   @NonNull final String encryptAlgorithm,
+                   final byte[] iv,
+                   final byte[] dataToBeEncrypted,
+                   final int tagLength,
+                   final byte[] aad) throws ClientException;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IEncryptor.java
@@ -54,7 +54,9 @@ public interface IEncryptor {
      * @param encryptAlgorithm  algorithm to encrypt with.
      * @param iv                an initialization vector (IV).
      * @param dataToBeEncrypted the data to be encrypted.
-     * @return a decrypted byte array.
+     * @param tagLength the length of tag being used
+     * @param aad the additional authentication data
+     * @return an encrypted byte array.
      */
     byte[] encrypt(@NonNull final Key key,
                    @NonNull final String encryptAlgorithm,


### PR DESCRIPTION
Related: https://github.com/AzureAD/ad-accounts-for-android/pull/2147

I was primarily interested adding support for decrypting with AES GCM and in writing tests for BasicDecryptor here: https://github.com/AzureAD/ad-accounts-for-android/pull/2147
https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/2194698

The BasicDecryptor is used in a number of places so it would be good to get some tests for it. While writing tests I noticed the need to encrypt prior to trying out decrypt and noticed there was no BasicEncryptor. That seemed strange so I've also added a basic encryptor here.

**Testing**: Tests are in the associated broker repo and utilizing Broker Crypto Factory: https://github.com/AzureAD/ad-accounts-for-android/pull/2147/files