### PR TITLE
Wrap Runnable with Current Telemetry Context

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.Next
+----------
+- [MINOR] Wrap Runnable with Current Telemetry Context (#1956)
+
 V.10.0.0
 ----------
 - [MINOR] Setting sub error codes to UiRequiredException for MsalUiRequiredException (#1944)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -54,6 +54,7 @@ import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.logging.RequestContext;
 import com.microsoft.identity.common.java.marker.CodeMarkerManager;
+import com.microsoft.identity.common.java.opentelemetry.OtelContextExtension;
 import com.microsoft.identity.common.java.request.SdkType;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.FinalizableResultFuture;
@@ -252,7 +253,7 @@ public class CommandDispatcher {
                 finalFuture.whenComplete(getCommandResultConsumer(command));
             }
 
-            sSilentExecutor.execute(Context.current().wrap(new Runnable() {
+            sSilentExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                 @Override
                 public void run() {
                     codeMarkerManager.markCode(ACQUIRE_TOKEN_SILENT_EXECUTOR_START);
@@ -339,7 +340,7 @@ public class CommandDispatcher {
         synchronized (mapAccessLock) {
             final FinalizableResultFuture<CommandResult> finalFuture = new FinalizableResultFuture<>();
             finalFuture.whenComplete(getCommandResultConsumer(command));
-            sSilentExecutor.execute(Context.current().wrap(new Runnable() {
+            sSilentExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                 @Override
                 public void run() {
 
@@ -646,7 +647,7 @@ public class CommandDispatcher {
                     }
                 }
 
-                sInteractiveExecutor.execute(Context.current().wrap(new Runnable() {
+                sInteractiveExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                     @Override
                     public void run() {
                         final CommandParameters commandParameters = command.getParameters();

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -88,8 +88,8 @@ public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
-    private static ExecutorService sInteractiveExecutor = Context.current().wrap(Executors.newSingleThreadExecutor());
-    private static final ExecutorService sSilentExecutor = Context.current().wrap(Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE));
+    private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
+    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();
@@ -252,7 +252,7 @@ public class CommandDispatcher {
                 finalFuture.whenComplete(getCommandResultConsumer(command));
             }
 
-            sSilentExecutor.execute(new Runnable() {
+            sSilentExecutor.execute(Context.current().wrap(new Runnable() {
                 @Override
                 public void run() {
                     codeMarkerManager.markCode(ACQUIRE_TOKEN_SILENT_EXECUTOR_START);
@@ -308,7 +308,7 @@ public class CommandDispatcher {
                     }
                     codeMarkerManager.markCode(ACQUIRE_TOKEN_SILENT_FUTURE_OBJECT_CREATION_END);
                 }
-            });
+            }));
             return finalFuture;
         }
     }
@@ -339,7 +339,7 @@ public class CommandDispatcher {
         synchronized (mapAccessLock) {
             final FinalizableResultFuture<CommandResult> finalFuture = new FinalizableResultFuture<>();
             finalFuture.whenComplete(getCommandResultConsumer(command));
-            sSilentExecutor.execute(new Runnable() {
+            sSilentExecutor.execute(Context.current().wrap(new Runnable() {
                 @Override
                 public void run() {
 
@@ -365,7 +365,7 @@ public class CommandDispatcher {
                     }
 
                 }
-            });
+            }));
             return finalFuture;
         }
     }
@@ -646,7 +646,7 @@ public class CommandDispatcher {
                     }
                 }
 
-                sInteractiveExecutor.execute(new Runnable() {
+                sInteractiveExecutor.execute(Context.current().wrap(new Runnable() {
                     @Override
                     public void run() {
                         final CommandParameters commandParameters = command.getParameters();
@@ -696,7 +696,7 @@ public class CommandDispatcher {
                             DiagnosticContext.INSTANCE.clear();
                         }
                     }
-                });
+                }));
             }
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -81,14 +81,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.opentelemetry.context.Context;
 import lombok.NonNull;
 
 public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
     private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
-    private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
-    private static final ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
+    private static ExecutorService sInteractiveExecutor = Context.current().wrap(Executors.newSingleThreadExecutor());
+    private static final ExecutorService sSilentExecutor = Context.current().wrap(Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE));
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
     private static final CommandResultCache sCommandResultCache = new CommandResultCache();

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
@@ -45,6 +45,13 @@ public class OtelContextExtension {
 
     private static final String TAG = OtelContextExtension.class.getSimpleName();
 
+    /**
+     * Returns a Runnable that makes this the current context and then invokes the input Runnable.
+     * See {@link Context#current()#wrap(Runnable)}
+     *
+     * @param runnable the runnable to wrap
+     * @return the wrapped runnable
+     */
     public static Runnable wrap(final Runnable runnable) {
         try {
             return Context.current().wrap(runnable);

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CO
+package com.microsoft.identity.common.java.opentelemetry;
+
+import com.microsoft.identity.common.java.logging.Logger;
+
+import io.opentelemetry.context.Context;
+
+/**
+ * Extension methods for {@link Context}.
+ * <p>
+ * This basically provides a custom, safe implementation of {@link Context#current()#wrap(Runnable)}
+ * to be used in MSAL for scenarios where minSdkVersion of calling application < 24. The reason for
+ * this is because the default implementation uses "static interface methods" and these get left out
+ * of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because
+ * the consumers-rules are NOT honored when minification is disabled and R8 applies some default
+ * proguard rules that leaves static interface methods out of the APK. This causes a
+ * "NoSuchMethodError" when such methods are invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class OtelContextExtension {
+
+    private static final String TAG = OtelContextExtension.class.getSimpleName();
+
+    public static Runnable wrap(final Runnable runnable) {
+        try {
+            return Context.current().wrap(runnable);
+        } catch (final NoSuchMethodError error) {
+            Logger.error(
+                    TAG + ":wrapRunnableWithCurrentTelemetryContext",
+                    error.getMessage(),
+                    error
+            );
+            return runnable;
+        }
+    }
+
+}


### PR DESCRIPTION
This ensure that if spans or traces are started outside of a runnable, then we can carry the same span or trace forward into the runnable. This is particularly required for our partners that have integrated with our broker open telemetry work and have also decided to create their own spans wrapping around MSAL usage. In this case, we must carry the trace information forward so we can create child spans with correct trace ids.

Prior Specs:

- https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview/pullrequest/6646?_a=files&path=/%5BAndroid%5D%20Telemetry/open_telemetry.md
- https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview/pullrequest/6841?_a=files&path=/%5BAndroid%5D%20Telemetry/span_context_propagation.md

Related: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1747