### PR TITLE
Add preferred browser support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [MINOR] Adding new methods in IAccountCredentialAdapter (#1954)
+- [MINOR] Add preferred browser support (#1957)
 
 V.10.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationSchem
 import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext;
 import com.microsoft.identity.common.java.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.java.request.SdkType;
+import com.microsoft.identity.common.java.ui.BrowserDescriptor;
 
 import java.io.Serializable;
 
@@ -71,6 +72,7 @@ public class BrokerRequest implements Serializable {
         final static String AUTHENTICATION_SCHEME = "authentication_scheme";
         final static String POWER_OPT_CHECK_ENABLED = "power_opt_check_enabled";
         final static String SPAN_CONTEXT = "span_context";
+        final static String PREFERRED_BROWSER = "preferred_browser";
     }
 
     /**
@@ -224,5 +226,9 @@ public class BrokerRequest implements Serializable {
     @Nullable
     @SerializedName(SerializedNames.SPAN_CONTEXT)
     private SerializableSpanContext mSpanContext;
+
+    @Nullable
+    @SerializedName(SerializedNames.PREFERRED_BROWSER)
+    private BrowserDescriptor mPreferredBrowser;
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -124,6 +124,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                         .traceFlags(SpanExtension.current().getSpanContext().getTraceFlags().asByte())
                         .build()
                 )
+                .preferredBrowser(parameters.getPreferredBrowser())
                 .build();
 
         return brokerRequest;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -61,7 +61,7 @@ public abstract class BrowserAuthorizationStrategy<
 
     private CustomTabsManager mCustomTabManager;
     private ResultFuture<AuthorizationResult> mAuthorizationResultFuture;
-    private List<BrowserDescriptor> mBrowserSafeList;
+    private Browser mBrowser;
     private boolean mDisposed;
     private GenericOAuth2Strategy mOAuth2Strategy; //NOPMD
     private GenericAuthorizationRequest mAuthorizationRequest; //NOPMD
@@ -72,8 +72,8 @@ public abstract class BrowserAuthorizationStrategy<
         super(applicationContext, activity, fragment);
     }
 
-    public void setBrowserSafeList(final List<BrowserDescriptor> browserSafeList) {
-        mBrowserSafeList = browserSafeList;
+    public void setBrowser(final Browser browser) {
+        mBrowser = browser;
     }
 
     @Override
@@ -87,18 +87,17 @@ public abstract class BrowserAuthorizationStrategy<
         mOAuth2Strategy = oAuth2Strategy;
         mAuthorizationRequest = authorizationRequest;
         mAuthorizationResultFuture = new ResultFuture<>();
-        final Browser browser = BrowserSelector.select(context, mBrowserSafeList);
 
         //ClientException will be thrown if no browser found.
         Intent authIntent;
-        if (browser.isCustomTabsServiceSupported()) {
+        if (mBrowser.isCustomTabsServiceSupported()) {
             Logger.info(
                     methodTag,
                     "CustomTabsService is supported."
             );
             //create customTabsIntent
             mCustomTabManager = new CustomTabsManager(context);
-            if (!mCustomTabManager.bind(context, browser.getPackageName())) {
+            if (!mCustomTabManager.bind(context, mBrowser.getPackageName())) {
                 //create browser auth intent
                 authIntent = new Intent(Intent.ACTION_VIEW);
             } else {
@@ -113,7 +112,7 @@ public abstract class BrowserAuthorizationStrategy<
             authIntent = new Intent(Intent.ACTION_VIEW);
         }
 
-        authIntent.setPackage(browser.getPackageName());
+        authIntent.setPackage(mBrowser.getPackageName());
         final URI requestUrl = authorizationRequest.getAuthorizationRequestAsHttpRequest();
 
         authIntent.setData(Uri.parse(requestUrl.toString()));

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -82,17 +82,9 @@ public class BrowserSelector {
         throw new ClientException(ErrorStrings.NO_AVAILABLE_BROWSER_FOUND, "No available browser installed on the device.");
     }
 
-    private static boolean matches(@NonNull final BrowserDescriptor browserDescriptor,
+    private static boolean matches(@NonNull final BrowserDescriptor descriptor,
                                    @NonNull Browser browser) {
         final String methodTag = TAG + ":matches";
-
-        final BrowserDescriptor descriptor;
-        try {
-            descriptor = (BrowserDescriptor) browserDescriptor;
-        } catch (final ClassCastException e) {
-            Logger.error(methodTag, "Cannot cast IBrowserDescriptor to BrowserDescriptor", e);
-            return false;
-        }
 
         if (!StringUtil.equalsIgnoreCase(descriptor.getPackageName(), browser.getPackageName())) {
             return false;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -51,6 +51,9 @@ public class BrowserSelector {
     private static final String SCHEME_HTTP = "http";
     private static final String SCHEME_HTTPS = "https";
 
+    // Added to avoid "avoidduplicateliterals" issues in pmd.
+    private static final String LOGGING_MSG_BROWSER = "Browser: ";
+
     /**
      * Searches through all browsers for the best match.
      * Browsers are evaluated in the order returned by the package manager,
@@ -91,13 +94,13 @@ public class BrowserSelector {
         }
 
         if (!descriptor.getSignatureHashes().equals(browser.getSignatureHashes())) {
-            Logger.warn(methodTag, "Browser" + browser.getPackageName() + " signature hash not match");
+            Logger.warn(methodTag,LOGGING_MSG_BROWSER + browser.getPackageName() + " signature hash not match");
             return false;
         }
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionLowerBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionLowerBound()) == -1) {
-            Logger.warn(methodTag,  "Browser" + browser.getPackageName() +
+            Logger.warn(methodTag,LOGGING_MSG_BROWSER + browser.getPackageName() +
                     " version too low (Expected: " + descriptor.getVersionLowerBound() +
                     " Get: " + browser.getVersion() + ")");
             return false;
@@ -105,7 +108,7 @@ public class BrowserSelector {
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionUpperBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionUpperBound()) == 1) {
-            Logger.warn(methodTag, "Browser" + browser.getPackageName() +
+            Logger.warn(methodTag,LOGGING_MSG_BROWSER + browser.getPackageName() +
                     " version too high (Expected: " + descriptor.getVersionUpperBound() +
                     " Get: " + browser.getVersion() + ")");
             return false;
@@ -194,7 +197,7 @@ public class BrowserSelector {
         for (ResolveInfo info : resolvedActivityList) {
             // ignore handlers which are not browsers
             if (!isFullBrowser(info)) {
-                Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " is not a full browser app.");
+                Logger.verbose(methodTag,LOGGING_MSG_BROWSER + info.activityInfo.packageName + " is not a full browser app.");
                 continue;
             }
 
@@ -203,15 +206,15 @@ public class BrowserSelector {
                 //TODO if the browser is in the block list, do not add it into the return browserList.
                 if (isCustomTabsServiceSupported(context, packageInfo)) {
                     //if the browser has custom tab enabled, set the custom tab support as true.
-                    Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " supports custom tab.");
+                    Logger.verbose(methodTag,LOGGING_MSG_BROWSER + info.activityInfo.packageName + " supports custom tab.");
                     browserList.add(new Browser(packageInfo, true));
                 } else {
-                    Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " does NOT support custom tab.");
+                    Logger.verbose(methodTag,LOGGING_MSG_BROWSER + info.activityInfo.packageName + " does NOT support custom tab.");
                     browserList.add(new Browser(packageInfo, false));
                 }
             } catch (PackageManager.NameNotFoundException e) {
                 // a browser cannot be generated without the package info
-                Logger.warn(methodTag, "Browser " + info.activityInfo.packageName + " cannot be generated without the package info.");
+                Logger.warn(methodTag,LOGGING_MSG_BROWSER + info.activityInfo.packageName + " cannot be generated without the package info.");
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -188,10 +188,13 @@ public class BrowserSelector {
         final List<ResolveInfo> resolvedActivityList =
                 pm.queryIntentActivities(BROWSER_INTENT, queryFlag);
 
+        Logger.verbose(methodTag, "Querying browsers. Got back " + resolvedActivityList.size() + " browsers.");
+
         final List<Browser> browserList = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             // ignore handlers which are not browsers
             if (!isFullBrowser(info)) {
+                Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " is not a full browser app.");
                 continue;
             }
 
@@ -200,12 +203,15 @@ public class BrowserSelector {
                 //TODO if the browser is in the block list, do not add it into the return browserList.
                 if (isCustomTabsServiceSupported(context, packageInfo)) {
                     //if the browser has custom tab enabled, set the custom tab support as true.
+                    Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " supports custom tab.");
                     browserList.add(new Browser(packageInfo, true));
                 } else {
+                    Logger.verbose(methodTag, "Browser " + info.activityInfo.packageName + " does NOT support custom tab.");
                     browserList.add(new Browser(packageInfo, false));
                 }
             } catch (PackageManager.NameNotFoundException e) {
                 // a browser cannot be generated without the package info
+                Logger.warn(methodTag, "Browser " + info.activityInfo.packageName + " cannot be generated without the package info.");
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -33,6 +33,7 @@ import android.net.Uri;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
@@ -59,23 +60,22 @@ public class BrowserSelector {
      * @param context {@link Context} to use for accessing {@link PackageManager}.
      * @return Browser selected to use.
      */
-    public static Browser select(final Context context, final List<BrowserDescriptor> browserSafeList) throws ClientException {
+    public static Browser select(@NonNull final Context context,
+                                 @NonNull final List<BrowserDescriptor> browserSafeList,
+                                 @Nullable final BrowserDescriptor preferredBrowserDescriptor) throws ClientException {
         final String methodTag = TAG + ":select";
-        final List<Browser> allBrowsers = getAllBrowsers(context);
         Logger.verbose(methodTag, "Select the browser to launch.");
 
-        for (final Browser browser : allBrowsers) {
-            for (final BrowserDescriptor browserDescriptor : browserSafeList) {
-                if (matches(browserDescriptor, browser)) {
-                    Logger.info(
-                            methodTag,
-                            "Browser's package name: "
-                                    + browser.getPackageName()
-                                    + " version: "
-                                    + browser.getVersion());
-                    return browser;
-                }
+        if (preferredBrowserDescriptor != null){
+            final Browser preferredBrowser = getPreferredBrowser(context, preferredBrowserDescriptor);
+            if (preferredBrowser != null) {
+                return preferredBrowser;
             }
+        }
+
+        final Browser defaultBrowser = getDefaultBrowser(context, browserSafeList);
+        if (defaultBrowser != null) {
+            return defaultBrowser;
         }
 
         Logger.error(methodTag, "No available browser installed on the device.", null);
@@ -97,21 +97,71 @@ public class BrowserSelector {
         }
 
         if (!descriptor.getSignatureHashes().equals(browser.getSignatureHashes())) {
+            Logger.warn(TAG + ":matches", "Browser" + browser.getPackageName() + " signature hash not match");
             return false;
         }
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionLowerBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionLowerBound()) == -1) {
+            Logger.warn(TAG + ":matches",  "Browser" + browser.getPackageName() +
+                    " version too low (Expected: " + descriptor.getVersionLowerBound() +
+                    " Get: " + browser.getVersion() + ")");
             return false;
         }
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionUpperBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionUpperBound()) == 1) {
+            Logger.warn(TAG + ":matches", "Browser" + browser.getPackageName() +
+                    " version too high (Expected: " + descriptor.getVersionUpperBound() +
+                    " Get: " + browser.getVersion() + ")");
             return false;
         }
 
         return true;
     }
+
+    private static Browser getPreferredBrowser(@NonNull final Context context,
+                                              @NonNull final BrowserDescriptor preferredBrowserDescriptor){
+        final String methodTag = TAG + ":getPreferredBrowser";
+
+        final List<Browser> allBrowsers = getBrowsers(context, preferredBrowserDescriptor);
+        for (final Browser browser : allBrowsers) {
+            if (matches(preferredBrowserDescriptor, browser)) {
+                Logger.info(
+                        methodTag,
+                        "Preferred Browser's package name: "
+                                + browser.getPackageName()
+                                + " version: "
+                                + browser.getVersion());
+                return browser;
+            }
+        }
+
+        return null;
+    }
+
+    private static Browser getDefaultBrowser(@NonNull final Context context,
+                                             @NonNull final List<BrowserDescriptor> browserSafeList) {
+        final String methodTag = TAG + ":getDefaultBrowser";
+
+        final List<Browser> allBrowsers = getBrowsers(context, null);
+        for (final Browser browser : allBrowsers) {
+            for (final BrowserDescriptor browserDescriptor : browserSafeList) {
+                if (matches(browserDescriptor, browser)) {
+                    Logger.info(
+                            methodTag,
+                            "Browser's package name: "
+                                    + browser.getPackageName()
+                                    + " version: "
+                                    + browser.getVersion());
+                    return browser;
+                }
+            }
+        }
+
+        return null;
+    }
+
 
     /**
      * Retrieves the full list of browsers installed on the device.
@@ -120,24 +170,31 @@ public class BrowserSelector {
      * order returned by the package manager, so indirectly reflects the user's preferences
      * (i.e. their default browser, if set, should be the first entry in the list).
      */
-    public static List<Browser> getAllBrowsers(final Context context) {
-        final String methodTag = TAG + ":getAllBrowsers";
+    protected static List<Browser> getBrowsers(@NonNull final Context context,
+                                               @Nullable final BrowserDescriptor preferredBrowserDescriptor) {
+        final String methodTag = TAG + ":getBrowsers";
+
         //get the list of browsers
         final Intent BROWSER_INTENT = new Intent(
                 Intent.ACTION_VIEW,
                 Uri.parse("http://www.example.com"));
 
-        List<Browser> browserList = new ArrayList<>();
-        PackageManager pm = context.getPackageManager();
+        if (preferredBrowserDescriptor != null){
+            Logger.info(methodTag, "Querying preferred browser: " + preferredBrowserDescriptor.getPackageName());
+            BROWSER_INTENT.setPackage(preferredBrowserDescriptor.getPackageName());
+        }
+
+        final PackageManager pm = context.getPackageManager();
 
         int queryFlag = PackageManager.GET_RESOLVED_FILTER;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             queryFlag |= PackageManager.MATCH_DEFAULT_ONLY;
         }
 
-        List<ResolveInfo> resolvedActivityList =
+        final List<ResolveInfo> resolvedActivityList =
                 pm.queryIntentActivities(BROWSER_INTENT, queryFlag);
 
+        final List<Browser> browserList = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             // ignore handlers which are not browsers
             if (!isFullBrowser(info)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelector.java
@@ -84,11 +84,13 @@ public class BrowserSelector {
 
     private static boolean matches(@NonNull final BrowserDescriptor browserDescriptor,
                                    @NonNull Browser browser) {
+        final String methodTag = TAG + ":matches";
+
         final BrowserDescriptor descriptor;
         try {
             descriptor = (BrowserDescriptor) browserDescriptor;
         } catch (final ClassCastException e) {
-            Logger.error(TAG + ":matches", "Cannot cast IBrowserDescriptor to BrowserDescriptor", e);
+            Logger.error(methodTag, "Cannot cast IBrowserDescriptor to BrowserDescriptor", e);
             return false;
         }
 
@@ -97,13 +99,13 @@ public class BrowserSelector {
         }
 
         if (!descriptor.getSignatureHashes().equals(browser.getSignatureHashes())) {
-            Logger.warn(TAG + ":matches", "Browser" + browser.getPackageName() + " signature hash not match");
+            Logger.warn(methodTag, "Browser" + browser.getPackageName() + " signature hash not match");
             return false;
         }
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionLowerBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionLowerBound()) == -1) {
-            Logger.warn(TAG + ":matches",  "Browser" + browser.getPackageName() +
+            Logger.warn(methodTag,  "Browser" + browser.getPackageName() +
                     " version too low (Expected: " + descriptor.getVersionLowerBound() +
                     " Get: " + browser.getVersion() + ")");
             return false;
@@ -111,7 +113,7 @@ public class BrowserSelector {
 
         if (!StringUtil.isNullOrEmpty(descriptor.getVersionUpperBound())
                 && compareSemanticVersion(browser.getVersion(), descriptor.getVersionUpperBound()) == 1) {
-            Logger.warn(TAG + ":matches", "Browser" + browser.getPackageName() +
+            Logger.warn(methodTag, "Browser" + browser.getPackageName() +
                     " version too high (Expected: " + descriptor.getVersionUpperBound() +
                     " Get: " + browser.getVersion() + ")");
             return false;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelectorTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/browser/BrowserSelectorTest.java
@@ -153,16 +153,16 @@ public class BrowserSelectorTest {
         List<BrowserDescriptor> browserSafelist = new ArrayList<>();
         browserSafelist.add(
                 new BrowserDescriptor(
-                        "com.android.chrome",
-                        "ChromeSignature",
+                        CHROME.mPackageName,
+                        CHROME.mSignatureHashes,
                         "50",
                         null)
         );
         browserSafelist.add(preferredBrowser);
         browserSafelist.add(
                 new BrowserDescriptor(
-                        "org.mozilla.firefox",
-                        "FireFoxSignature",
+                        FIREFOX.mPackageName,
+                        FIREFOX.mSignatureHashes,
                         "10",
                         null)
         );

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
@@ -43,6 +43,8 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
 
     private final transient List<BrowserDescriptor> browserSafeList;
 
+    private final transient BrowserDescriptor preferredBrowser;
+
     private final transient HashMap<String, String> requestHeaders;
 
     private final boolean brokerBrowserSupportEnabled;


### PR DESCRIPTION
Workaround for https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2314902

If "preferred_browser" is set (in MSAL configuration), then MSAL and Broker (for Intune COBO/CloutExt only) will use that browser if it's installed and the package condition matches.

Otherwise, It will fall back to the existing behavior.

i.e. Opera will be used regardless of what default browser is if the following configuration is used
```
{
  "client_id" : "XXXXXXXX",
  "authorization_user_agent" : "BROWSER",
  "redirect_uri" : "msauth://XXXXXXXX/YYYYYYYYYYYYYYYYYY",
  "authorities" : [
    {
      "type": "AAD",
      "audience": {
        "type": "AzureADMultipleOrgs"
      }
    }
  ],
  "preferred_browser" : {
    "browser_package_name": "com.opera.browser",
    "browser_signature_hashes": [
      "FIJ3IIeqB7V0qHpRNEpYNkhEGA_eJaf7ntca-Oa_6Feev3UkgnpguTNV31JdAmpEFPGNPo0RHqdlU0k-3jWJWw=="
    ]
  }
}
```

Did manual test with MSAL + Broker. Added 2 unit tests. 
Will ask for explicit sign off from Intune before merging in.
