### PR TITLE
Pull up method to AbstractCertBasedAuthChallengeHandler

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -41,8 +41,8 @@ import androidx.annotation.RequiresApi;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.PackageHelper;
+import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.certbasedauth.ICertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
@@ -80,7 +80,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public static final String ERROR_DESCRIPTION = "error_description";
     private final String mRedirectUrl;
     private final CertBasedAuthFactory mCertBasedAuthFactory;
-    private ICertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
+    private AbstractCertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -464,7 +464,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
         mCertBasedAuthFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
             @Override
-            public void onReceived(@Nullable final ICertBasedAuthChallengeHandler challengeHandler) {
+            public void onReceived(@Nullable final AbstractCertBasedAuthChallengeHandler challengeHandler) {
                 mCertBasedAuthChallengeHandler = challengeHandler;
                 if (mCertBasedAuthChallengeHandler == null) {
                     //User cancelled out of CBA.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -275,7 +275,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
     }
 
     /**
-     * Clean up logic to run when AbstractCertBasedAuthChallengeHandler is no longer going to be used.
+     * Clean up logic to run when AbstractSmartcardCertBasedAuthChallengeHandler is no longer going to be used.
      */
     @Override
     public void cleanUp() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -30,9 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
-import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.security.PrivateKey;
@@ -44,7 +42,7 @@ import java.util.List;
  * Abstract class which handles a received ClientCertRequest by prompting the user to choose from certificates
  *  stored on a smartcard device.
  */
-public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends AbstractSmartcardCertBasedAuthManager<?>> implements ICertBasedAuthChallengeHandler {
+public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends AbstractSmartcardCertBasedAuthManager<?>> extends AbstractCertBasedAuthChallengeHandler {
     protected static final String MAX_ATTEMPTS_MESSAGE = "User has reached the maximum failed attempts allowed.";
     protected static final String NO_PIV_CERTS_FOUND_MESSAGE = "No PIV certificates found on smartcard device.";
     protected static final String USER_CANCEL_MESSAGE = "User canceled smartcard CBA flow.";
@@ -52,8 +50,6 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
     protected final Activity mActivity;
     protected final T mCbaManager;
     protected final IDialogHolder mDialogHolder;
-    protected final ICertBasedAuthTelemetryHelper mTelemetryHelper;
-    protected boolean mIsSmartcardCertBasedAuthProceeding;
 
     /**
      * Creates new instance of AbstractSmartcardCertBasedAuthChallengeHandler.
@@ -70,7 +66,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
                                                           @NonNull final String tag) {
         TAG = tag;
         mActivity = activity;
-        mIsSmartcardCertBasedAuthProceeding = false;
+        mIsCertBasedAuthProceeding = false;
         mCbaManager = smartcardCertBasedAuthManager;
         mDialogHolder = dialogHolder;
         mTelemetryHelper = telemetryHelper;
@@ -266,7 +262,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
         final X509Certificate[] chain = new X509Certificate[]{certDetails.getCertificate()};
         //Clear current dialog.
         mDialogHolder.dismissDialog();
-        mIsSmartcardCertBasedAuthProceeding = true;
+        mIsCertBasedAuthProceeding = true;
         request.proceed(privateKey, chain);
     }
 
@@ -279,32 +275,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
     }
 
     /**
-     * Emit telemetry for results from certificate based authentication (CBA) if CBA occurred.
-     * @param response a RawAuthorizationResult object received upon a challenge response received.
-     */
-    @Override
-    public void emitTelemetryForCertBasedAuthResults(@NonNull final RawAuthorizationResult response) {
-        if (!mIsSmartcardCertBasedAuthProceeding) {
-            return;
-        }
-        final RawAuthorizationResult.ResultCode resultCode = response.getResultCode();
-        if (resultCode == RawAuthorizationResult.ResultCode.NON_OAUTH_ERROR
-                || resultCode == RawAuthorizationResult.ResultCode.SDK_CANCELLED
-                || resultCode == RawAuthorizationResult.ResultCode.CANCELLED) {
-            final BaseException exception = response.getException();
-            if (exception != null) {
-                mTelemetryHelper.setResultFailure(exception);
-                return;
-            }
-            //Putting result code as message.
-            mTelemetryHelper.setResultFailure(resultCode.toString());
-            return;
-        }
-        mTelemetryHelper.setResultSuccess();
-    }
-
-    /**
-     * Clean up logic to run when ICertBasedAuthChallengeHandler is no longer going to be used.
+     * Clean up logic to run when AbstractCertBasedAuthChallengeHandler is no longer going to be used.
      */
     @Override
     public void cleanUp() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -81,8 +81,8 @@ public class CertBasedAuthFactory {
     }
 
     /**
-     * Asynchronously chooses and returns a ICertBasedAuthChallengeHandler.
-     * @param callback logic to run after a ICertBasedAuthChallengeHandler is chosen.
+     * Asynchronously chooses and returns a AbstractCertBasedAuthChallengeHandler.
+     * @param callback logic to run after a AbstractCertBasedAuthChallengeHandler is chosen.
      */
     public void createCertBasedAuthChallengeHandler(@NonNull final CertBasedAuthChallengeHandlerCallback callback) {
         final ICertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
@@ -129,7 +129,7 @@ public class CertBasedAuthFactory {
 
     /**
      * Helper method for logic to be run upon user cancelling out of CBA.
-     * @param callback logic to run after a ICertBasedAuthChallengeHandler is chosen.
+     * @param callback logic to run after a AbstractCertBasedAuthChallengeHandler is chosen.
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     private void onCancelHelper(@NonNull final CertBasedAuthChallengeHandlerCallback callback,
@@ -259,8 +259,8 @@ public class CertBasedAuthFactory {
     public interface CertBasedAuthChallengeHandlerCallback {
         /**
          * Callback object that should contain logic to run after a CertBasedAuthChallengeHandler is chosen by the factory.
-         * @param challengeHandler An ICertBasedAuthChallengeHandler implementation instance, or null if user cancels out of CBA.
+         * @param challengeHandler An AbstractCertBasedAuthChallengeHandler implementation instance, or null if user cancels out of CBA.
          */
-        void onReceived(@Nullable final ICertBasedAuthChallengeHandler challengeHandler);
+        void onReceived(@Nullable final AbstractCertBasedAuthChallengeHandler challengeHandler);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -81,8 +81,8 @@ public class CertBasedAuthFactory {
     }
 
     /**
-     * Asynchronously chooses and returns a AbstractCertBasedAuthChallengeHandler.
-     * @param callback logic to run after a AbstractCertBasedAuthChallengeHandler is chosen.
+     * Asynchronously chooses and returns an AbstractCertBasedAuthChallengeHandler.
+     * @param callback logic to run after an AbstractCertBasedAuthChallengeHandler is chosen.
      */
     public void createCertBasedAuthChallengeHandler(@NonNull final CertBasedAuthChallengeHandlerCallback callback) {
         final ICertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
@@ -129,7 +129,7 @@ public class CertBasedAuthFactory {
 
     /**
      * Helper method for logic to be run upon user cancelling out of CBA.
-     * @param callback logic to run after a AbstractCertBasedAuthChallengeHandler is chosen.
+     * @param callback logic to run after an AbstractCertBasedAuthChallengeHandler is chosen.
      * @param telemetryHelper CertBasedAuthTelemetryHelper instance.
      */
     private void onCancelHelper(@NonNull final CertBasedAuthChallengeHandlerCallback callback,

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -130,7 +130,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     }
 
     /**
-     * Clean up logic to run when AbstractCertBasedAuthChallengeHandler is no longer going to be used.
+     * Clean up logic to run when OnDeviceCertBasedAuthChallengeHandler is no longer going to be used.
      */
     @Override
     public void cleanUp() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -32,9 +32,7 @@ import android.webkit.ClientCertRequest;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
-import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
-import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.security.Principal;
@@ -45,12 +43,11 @@ import java.security.cert.X509Certificate;
  * Handles a received ClientCertRequest by prompting the user to choose from certificates
  *  stored on the Android device.
  */
-public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChallengeHandler {
+public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuthChallengeHandler {
     private static final String TAG = OnDeviceCertBasedAuthChallengeHandler.class.getSimpleName();
     private static final String ACCEPTABLE_ISSUER = "CN=MS-Organization-Access";
     private final Activity mActivity;
     private final ICertBasedAuthTelemetryHelper mTelemetryHelper;
-    private boolean mIsOnDeviceCertBasedAuthProceeding;
 
     /**
      * Creates new instance of OnDeviceCertBasedAuthChallengeHandler.
@@ -62,7 +59,7 @@ public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChal
         mActivity = activity;
         mTelemetryHelper = telemetryHelper;
         mTelemetryHelper.setCertBasedAuthChallengeHandler(TAG);
-        mIsOnDeviceCertBasedAuthProceeding = false;
+        mIsCertBasedAuthProceeding = false;
     }
 
     /**
@@ -110,7 +107,7 @@ public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChal
 
                             Logger.info(methodTag,"Certificate is chosen by user, proceed with TLS request.");
                             //Set mIsOnDeviceCertBasedAuthProceeding to true so telemetry is emitted for the result.
-                            mIsOnDeviceCertBasedAuthProceeding = true;
+                            mIsCertBasedAuthProceeding = true;
                             request.proceed(privateKey, certChain);
                             return;
                         } catch (final KeyChainException e) {
@@ -133,32 +130,7 @@ public class OnDeviceCertBasedAuthChallengeHandler implements ICertBasedAuthChal
     }
 
     /**
-     * Emit telemetry for results from certificate based authentication (CBA) if CBA occurred.
-     *
-     * @param response a RawAuthorizationResult object received upon a challenge response received.
-     */
-    @Override
-    public void emitTelemetryForCertBasedAuthResults(@NonNull final RawAuthorizationResult response) {
-        if (mIsOnDeviceCertBasedAuthProceeding) {
-            final RawAuthorizationResult.ResultCode resultCode = response.getResultCode();
-            if (resultCode == RawAuthorizationResult.ResultCode.NON_OAUTH_ERROR
-                    || resultCode == RawAuthorizationResult.ResultCode.SDK_CANCELLED
-                    || resultCode == RawAuthorizationResult.ResultCode.CANCELLED) {
-                final BaseException exception = response.getException();
-                if (exception != null) {
-                    mTelemetryHelper.setResultFailure(exception);
-                } else {
-                    //Putting result code as message.
-                    mTelemetryHelper.setResultFailure(resultCode.toString());
-                }
-            } else {
-                mTelemetryHelper.setResultSuccess();
-            }
-        }
-    }
-
-    /**
-     * Clean up logic to run when ICertBasedAuthChallengeHandler is no longer going to be used.
+     * Clean up logic to run when AbstractCertBasedAuthChallengeHandler is no longer going to be used.
      */
     @Override
     public void cleanUp() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
@@ -51,7 +51,7 @@ import java.util.concurrent.Callable;
 public class YubiKitNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
     private static final String TAG = YubiKitNfcSmartcardCertBasedAuthManager.class.getSimpleName();
     private static final String DEVICE_ERROR_MESSAGE = "No NFC device is currently connected.";
-    private static final int NFC_TIMEOUT = 5000;
+    private static final int NFC_TIMEOUT = 10000;
 
     private final NfcYubiKeyManager mNfcYubiKitManager;
     private NfcYubiKeyDevice mNfcDevice;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/YubiKitNfcSmartcardCertBasedAuthManager.java
@@ -51,7 +51,7 @@ import java.util.concurrent.Callable;
 public class YubiKitNfcSmartcardCertBasedAuthManager extends AbstractNfcSmartcardCertBasedAuthManager {
     private static final String TAG = YubiKitNfcSmartcardCertBasedAuthManager.class.getSimpleName();
     private static final String DEVICE_ERROR_MESSAGE = "No NFC device is currently connected.";
-    private static final int NFC_TIMEOUT = 10000;
+    private static final int NFC_TIMEOUT = 5000;
 
     private final NfcYubiKeyManager mNfcYubiKitManager;
     private NfcYubiKeyDevice mNfcDevice;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -126,7 +126,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     private void challengeHandlerHelper(@NonNull final ExpectedChallengeHandler expectedChallengeHandler) {
         mFactory.createCertBasedAuthChallengeHandler(new CertBasedAuthFactory.CertBasedAuthChallengeHandlerCallback() {
             @Override
-            public void onReceived(@Nullable ICertBasedAuthChallengeHandler challengeHandler) {
+            public void onReceived(@Nullable AbstractCertBasedAuthChallengeHandler challengeHandler) {
                 switch (expectedChallengeHandler) {
                     case USB:
                         assertTrue(challengeHandler instanceof UsbSmartcardCertBasedAuthChallengeHandler);


### PR DESCRIPTION
## Summary
Per feedback received in one of my last PRs, the `emitTelemetryForCertBasedAuthResults` method is being pulled up to `AbstractCertBasedAuthChallengeHandler` (Formerly `ICertBasedAuthChallengeHandler`) since the logic is shared between the challenge handlers for USB and NFC.

- `ICertBasedAuthChallengeHandler` becomes an abstract class named `AbstractCertBasedAuthChallengeHandler` that implements `emitTelemetryForCertBasedAuthResults` and has local variables `mIsCertBasedAuthProceeding` and `mTelemetryHelper`. 
- Duplicate method and variables removed from USB and NFC challenge handlers.

Tested manually by making sure I could still see CBA telemetry spans in kustos.