### PR TITLE
Add flighting capability for common.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add flighting capability for common (#1961)
 - [MINOR] Add preferred browser support (#1957)
 - [PATCH] Use android.net.NetworkCapabilities to check internet connectivity (#1887)
 - [MINOR] Adding new methods in IAccountCredentialAdapter (#1954)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -31,6 +31,8 @@ import android.os.Build;
 
 import com.microsoft.identity.common.adal.internal.PowerManagerWrapper;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightManager;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.java.telemetry.events.BaseEvent;
 
@@ -64,8 +66,9 @@ public class DefaultConnectionService implements IConnectionService {
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 
         final boolean isConnectionAvailable;
-
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+        final boolean useNetworkCapabilityForNetworkCheck
+                = CommonFlightManager.isFlightEnabled(CommonFlight.USE_NETWORK_CAPABILITY_FOR_NETWORK_CHECK);
+        if (useNetworkCapabilityForNetworkCheck && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             final NetworkCapabilities networkCapabilities =
                     connectivityManager.getNetworkCapabilities(connectivityManager.getActiveNetwork());
             isConnectionAvailable =

--- a/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionServiceTest.java
@@ -51,7 +51,7 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {
         PowerManagerWrapperShadow.class
-})
+}, sdk = 28)
 public class DefaultConnectionServiceTest {
 
     protected Context mContext;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.java.flighting;
+
+import lombok.NonNull;
+
+/**
+ * List of Active Common flights.
+ */
+public enum CommonFlight implements IFlightConfig {
+    /**
+     * Flight to control whether or not to use Network capability for performing network check.
+     */
+    USE_NETWORK_CAPABILITY_FOR_NETWORK_CHECK("UseNetworkCapabilityForNetworkCheck", false);
+
+    private String key;
+    private Object defaultValue;
+    CommonFlight(@NonNull String key, @NonNull Object defaultValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+
+    @Override
+    public Object getDefaultValue() {
+        return this.defaultValue;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlightManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlightManager.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+import lombok.NonNull;
+
+/**
+ * Class to set Flight Provider for Common Flights
+ * Consumer of commons needs to implement {@link IFlightsProvider} interface
+ * and set it using CommonFlightManager.setFlightProvider(@NonNull IFlightsProvider flightProvider)
+ * to provide Flight Values for CommonFlights
+ * If no Flight Provider is set, default value of the flight will be used
+ */
+public class CommonFlightManager {
+    private static IFlightsProvider mFlightProvider;
+
+    public static void setFlightProvider(@NonNull IFlightsProvider flightProvider) {
+        mFlightProvider = flightProvider;
+    }
+
+    /**
+     * Checks if a flight is enabled
+     * @param flightConfig flight to check
+     * @return true if the flight is enabled otherwise returns the defaultValue
+     */
+    public static boolean isFlightEnabled(@NonNull IFlightConfig flightConfig) {
+        if (mFlightProvider == null) {
+            return (Boolean) flightConfig.getDefaultValue();
+        }
+
+        return mFlightProvider.isFlightEnabled(flightConfig);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/IFlightConfig.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/IFlightConfig.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+/**
+ * Interface for defining a Flight
+ */
+public interface IFlightConfig {
+    String getKey();
+    Object getDefaultValue();
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/IFlightsProvider.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/IFlightsProvider.java
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+import lombok.NonNull;
+
+/**
+ * Interface for flights provider to read flights values.
+ */
+public interface IFlightsProvider {
+    /**
+     * Checks if a flight is enabled
+     * @param flightConfig flight to check
+     * @return true if the flight is enabled otherwise returns the defaultValue
+     */
+    boolean isFlightEnabled(@NonNull IFlightConfig flightConfig);
+
+    /**
+     * Gets the value of a boolean flight
+     * @param flightConfig {@link IFlightConfig} to check
+     * @return the flight value if set otherwise returns the defaultValue
+     */
+    boolean getBooleanValue(@NonNull IFlightConfig flightConfig);
+
+    /**
+     * Gets the value of a integer flight
+     * @param flightConfig {@link IFlightConfig} to check
+     * @return the flight value if set otherwise returns the defaultValue
+     */
+    int getIntValue(@NonNull IFlightConfig flightConfig);
+
+    /**
+     * Gets the value of a double flight.
+     * @param flightConfig {@link IFlightConfig} to check
+     * @return the flight value if set otherwise returns the defaultValue
+     */
+    double getDoubleValue(@NonNull IFlightConfig flightConfig);
+
+    /**
+     * Gets the value of a flight
+     * @param flightConfig {@link IFlightConfig} flight to check
+     * @return
+     */
+    String getStringValue(@NonNull IFlightConfig flightConfig);
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/flighting/CommonFlightManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/flighting/CommonFlightManagerTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CommonFlightManagerTest {
+    private IFlightsProvider flightsProvider = new MockFlightsProvider();
+
+    @Test
+    public void testIsFlightEnabled() {
+        ((MockFlightsProvider)flightsProvider).addFlight(MockFlights.ENABLED_FLIGHT.getKey(), "true");
+        ((MockFlightsProvider)flightsProvider).addFlight(MockFlights.DISABLED_FLIGHT.getKey(), "false");
+        CommonFlightManager.setFlightProvider(flightsProvider);
+
+        Assert.assertTrue(CommonFlightManager.isFlightEnabled(MockFlights.ENABLED_FLIGHT));
+        Assert.assertFalse(CommonFlightManager.isFlightEnabled(MockFlights.DISABLED_FLIGHT));
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/flighting/MockFlights.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/flighting/MockFlights.java
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+import lombok.NonNull;
+
+public enum MockFlights implements IFlightConfig{
+    ENABLED_FLIGHT("enabledFlight", false),
+    DISABLED_FLIGHT("disabledFlight", false);
+
+    private String key;
+    private Object defaultValue;
+    MockFlights(@NonNull String key, @NonNull Object defaultValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+
+    @Override
+    public Object getDefaultValue() {
+        return this.defaultValue;
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/flighting/MockFlightsProvider.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/flighting/MockFlightsProvider.java
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.flighting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockFlightsProvider implements IFlightsProvider {
+    private final Map<String, String> mFlights;
+    public MockFlightsProvider() {
+        mFlights = new HashMap<>();
+    }
+
+    public void addFlight(String key, String value) {
+        mFlights.put(key, value);
+    }
+
+    public void removeFlight(String key) {
+        mFlights.remove(key);
+    }
+    @Override
+    public boolean isFlightEnabled(IFlightConfig flightConfig) {
+        return Boolean.parseBoolean(
+                mFlights.getOrDefault(
+                        flightConfig.getKey(), flightConfig.getDefaultValue().toString()));
+    }
+
+    @Override
+    public boolean getBooleanValue(IFlightConfig flightConfig) {
+        return false;
+    }
+
+    @Override
+    public int getIntValue(IFlightConfig flightConfig) {
+        return 0;
+    }
+
+    @Override
+    public double getDoubleValue(IFlightConfig flightConfig) {
+        return 0;
+    }
+
+    @Override
+    public String getStringValue(IFlightConfig flightConfig) {
+        return null;
+    }
+}


### PR DESCRIPTION
### What
Adding flighting capability to common

### Why
To dynamically change the behavior of common code based on the flight value, which can be provided without code deployment

### How
Adding class CommonFlightManager which is used to set the FlightsProvider for CommonFlights.
This FlightsProvider is used to read the value of the flights. If no flightsProvider is set default Values will be used.

### Testing
Using the flighting capability to control whether or not to use NetworkCapability for checking network connectivity.

Corresponding Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2158