### PR TITLE
Small Removal From On-Device CBA class

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -47,7 +47,6 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     private static final String TAG = OnDeviceCertBasedAuthChallengeHandler.class.getSimpleName();
     private static final String ACCEPTABLE_ISSUER = "CN=MS-Organization-Access";
     private final Activity mActivity;
-    private final ICertBasedAuthTelemetryHelper mTelemetryHelper;
 
     /**
      * Creates new instance of OnDeviceCertBasedAuthChallengeHandler.


### PR DESCRIPTION
## Summary
Related to this merged  PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1960
Needed to also remove the `mTelemetryHelper` variable from the on device challenge handler, as it's a duplicate of the one in the abstract challenge handler.
Tested by running through on-device CBA a few times. 