### PR TITLE
Move JWT classes from broker to common

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ vNext
 - [MINOR] Setting sub error codes to UiRequiredException for MsalUiRequiredException (#1944)
 - [MINOR] Wrap Runnable with Current Telemetry Context (#1956)
 - [MINOR] Update JweResponse APIs and added Additional Authenticated Data (AAD) (#1958)
+- [MINOR] Move JWT classes to common (#1968)
 
 V.10.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/AbstractJwtRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/AbstractJwtRequest.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.jwt;
+
+import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.java.util.StringUtil;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@SuppressFBWarnings({"URF_UNREAD_FIELD", "URF_UNREAD_FIELD"})
+public abstract class AbstractJwtRequest {
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("ctx")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "This is output through serialization")
+    private String mCtx;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("refresh_token")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "This is output through serialization")
+    private String mRefreshToken;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("x5c")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "This is output through serialization")
+    private String mCert;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("client_id")
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "This is output through serialization")
+    private String mClientId;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("use")
+    private String mUse;
+
+    @SerializedName("resource")
+    private String mResource;
+
+    // HACKHACK: once AAD fixes the bug where it cannot accept scopes unless there is a resource,
+    // remove this and fix all compiler errors and unused variable warnings
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "This may be required for some time")
+    public void setResource(final String resource) {
+        if (!StringUtil.isNullOrEmpty(resource)) {
+            mResource = resource;
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/IJweResponseDecryptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/IJweResponseDecryptor.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.jwt;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import lombok.NonNull;
+
+/**
+ * Facilitate decoding and decrypting JWE token response
+ * using session key per PRT protocol.
+ */
+public interface IJweResponseDecryptor {
+    /**
+     * Decrypt jwe token response using session key.
+     * @param jwe the JWE token response
+     * @return decrypted response
+     */
+    String decryptJwe(@NonNull String jwe) throws ClientException;
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/IJwtRequestSigner.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/IJwtRequestSigner.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.jwt;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import java.security.cert.CertificateEncodingException;
+
+import lombok.NonNull;
+
+/**
+ * Interface for signing JWT for broker token requests
+ * given JWT payload.
+ */
+public interface IJwtRequestSigner {
+    /**
+     * Generate signed JWT given payload.
+     * Payload is provided as {@link JwtRequestBody}
+     * @param jwtRequestBody JWT payload
+     * @return Return signed JWT string (encodedJwtHeader.encodedJwtBody.Signature(encodedJwtHeader, encodedJwtBody))
+     */
+    @NonNull String getSignedJwt(@NonNull final JwtRequestBody jwtRequestBody) throws ClientException, CertificateEncodingException;
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestBody.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestBody.java
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.jwt;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+public final class JwtRequestBody extends AbstractJwtRequest {
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("scope")
+    private String mJwtScope;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("aud")
+    private String mAudience;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("iss")
+    private String mIssuer;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("assertion")
+    private String mAssertion;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("grant_type")
+    private String mGrantType;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("request_nonce")
+    private String mNonce;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("redirect_uri")
+    private String mRedirectUri;
+
+    @SerializedName("iat")
+    private String mIat;
+
+    @SerializedName("nbf")
+    private String mNbf;
+
+    @SerializedName("exp")
+    private String mExp;
+
+    public void setIat(final long iat) {
+        mIat = String.valueOf(iat);
+    }
+
+    public void setNBF(final long nbf) {
+        mNbf = String.valueOf(nbf);
+    }
+
+    public void setExp(final long exp, final long buffer) {
+        mExp = String.valueOf(exp + buffer);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestBody.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestBody.java
@@ -27,6 +27,9 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+/**
+ * Represents body of JWT. These JWTs can be used in token requests.
+ */
 public final class JwtRequestBody extends AbstractJwtRequest {
 
     @Setter

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestHeader.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestHeader.java
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.jwt;
+
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+public final class JwtRequestHeader extends AbstractJwtRequest {
+
+    private static final String JWT_VALUE = "JWT";
+
+    public static final String ALG_VALUE_HS256 = "HS256";
+
+    public static final String ALG_VALUE_RS256 = "RS256";
+
+    @SerializedName("typ")
+    private String mType;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("alg")
+    private String mAlg;
+
+    @Setter
+    @Accessors(prefix = "m")
+    @SerializedName("kid")
+    private String mKId;
+
+    public void setType() {
+        mType = JWT_VALUE;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestHeader.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtRequestHeader.java
@@ -27,12 +27,17 @@ import com.google.gson.annotations.SerializedName;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+/**
+ * Represents header in a JWT. These JWTs can be used in token requests
+ */
 public final class JwtRequestHeader extends AbstractJwtRequest {
 
     private static final String JWT_VALUE = "JWT";
 
+    // HMAC using SHA256 - symmetric key signing algorithm
     public static final String ALG_VALUE_HS256 = "HS256";
 
+    // RSA using SHA256 - asymmetric key signing algorithm
     public static final String ALG_VALUE_RS256 = "RS256";
 
     @SerializedName("typ")

--- a/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtUtils.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/jwt/JwtUtils.java
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.java.jwt;
+
+import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
+
+import com.google.gson.Gson;
+import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.StringUtil;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utility class to hold methods related to JWT processing.
+ */
+@UtilityClass
+public final class JwtUtils {
+
+    private static final String TAG = JwtUtils.class.getSimpleName();
+
+    /**
+     * Helper method to generate generic String key/value pair JWT.
+     * This method combines the header and the body of the JWT and returns
+     * a combined string to the caller.
+     *
+     * @param header Jwt request header
+     * @param body Jwt request body
+     * @return String Base64URLSafe(mJweHeader)+Base64URLSafe(body)
+     */
+    public static String generateJWT(@NonNull final JwtRequestHeader header,
+                                     @NonNull final JwtRequestBody body) {
+        final String methodTag = TAG + ":generateJWT";
+        Logger.verbose(methodTag, "Generating JWT.");
+        final String headerJson = new Gson().toJson(header);
+        final String bodyJson = new Gson().toJson(body);
+        final String encodedJwt =
+                StringUtil.encodeUrlSafeString(headerJson.getBytes(ENCODING_UTF8)) + "." + StringUtil.encodeUrlSafeString(bodyJson.getBytes(ENCODING_UTF8));
+        return encodedJwt;
+    }
+}
+

--- a/common4j/src/test/com/microsoft/identity/common/java/jwt/JwtUtilsTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/jwt/JwtUtilsTest.java
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.microsoft.identity.common.java.jwt;
+
+import static com.microsoft.identity.common.java.AuthenticationConstants.ENCODING_UTF8;
+
+import com.google.gson.Gson;
+import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
+import com.microsoft.identity.common.java.util.StringUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class JwtUtilsTest {
+
+    @Test
+    public void testGenerateJWT() {
+        final JwtRequestHeader jwtRequestHeader = new JwtRequestHeader();
+        jwtRequestHeader.setType();
+        jwtRequestHeader.setAlg(JwtRequestHeader.ALG_VALUE_HS256);
+        jwtRequestHeader.setCtx("ctx");
+        final JwtRequestBody jwtRequestBody = new JwtRequestBody();
+        jwtRequestBody.setAudience("aud");
+        jwtRequestBody.setIssuer("issuer");
+        jwtRequestBody.setJwtScope("scopes");
+        jwtRequestBody.setRedirectUri("redirecturi");
+        jwtRequestBody.setNonce("nonce");
+        jwtRequestBody.setGrantType(TokenRequest.GrantTypes.REFRESH_TOKEN);
+        jwtRequestBody.setRefreshToken("refresh_token");
+        final String headerJson = new Gson().toJson(jwtRequestHeader);
+        final String bodyJson = new Gson().toJson(jwtRequestBody);
+        final String expectedJwt =
+                StringUtil.encodeUrlSafeString(headerJson.getBytes(ENCODING_UTF8)) + "." + StringUtil.encodeUrlSafeString(bodyJson.getBytes(ENCODING_UTF8));
+
+        final String encodedJwt = JwtUtils.generateJWT(jwtRequestHeader, jwtRequestBody);
+        Assert.assertEquals(expectedJwt, encodedJwt);;
+    }
+}


### PR DESCRIPTION
Move JWT classes from broker to common.
This is to help using these functionalities in common. 

I intend to use that in Prtv3 implementation to add new OAuth2Strategy

Related broker PR https://github.com/AzureAD/ad-accounts-for-android/pull/2166