### PR TITLE
ICancelCbaCallback

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Minor fixes to stop NFC discovery upon cancellation of some dialogs (#1972)
 - [MINOR] Add flighting capability for common (#1961)
 - [MINOR] Add preferred browser support (#1957)
 - [PATCH] Use android.net.NetworkCapabilities to check internet connectivity (#1887)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -112,7 +112,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
                 mDialogHolder.showCertPickerDialog(
                         certList,
                         getSmartcardCertPickerDialogPositiveButtonListener(request),
-                        new SmartcardCertPickerDialog.CancelCbaCallback() {
+                        new ICancelCbaCallback() {
                             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
                             @Override
                             public void onCancel() {
@@ -181,7 +181,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
                 //Need to prompt user for pin and verify pin. The positive button listener will handle the rest of the CBA flow.
                 mDialogHolder.showPinDialog(
                         getSmartcardPinDialogPositiveButtonListener(certDetails, request),
-                        new SmartcardPinDialog.CancelCbaCallback() {
+                        new ICancelCbaCallback() {
                             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
                             @Override
                             public void onCancel() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -107,20 +107,13 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
                     onPausedSmartcardDiscovery();
                     return;
                 }
-
+                final ICancelCbaCallback cancelCallback = getGeneralCancelCbaCallback(request);
                 //Build and show Smartcard cert picker, which also handles the rest of the smartcard CBA flow.
                 mDialogHolder.showCertPickerDialog(
                         certList,
                         getSmartcardCertPickerDialogPositiveButtonListener(request),
-                        new ICancelCbaCallback() {
-                            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-                            @Override
-                            public void onCancel() {
-                                mDialogHolder.dismissDialog();
-                                mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
-                                request.cancel();
-                            }
-                        });
+                        cancelCallback
+                );
 
                 onPausedSmartcardDiscovery();
             }
@@ -141,6 +134,24 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
     protected abstract void onPausedSmartcardDiscovery();
 
     /**
+     * Returns a callback that dismisses the current dialog, sends telemetry, and cancels the ClientCertRequest.
+     * @param request {@link ClientCertRequest}
+     * @return {@link ICancelCbaCallback}
+     */
+    @NonNull
+    protected ICancelCbaCallback getGeneralCancelCbaCallback(@NonNull final ClientCertRequest request) {
+        return new ICancelCbaCallback() {
+            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+            @Override
+            public void onCancel() {
+                mDialogHolder.dismissDialog();
+                mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
+                request.cancel();
+            }
+        };
+    }
+
+    /**
      * Helper method to log and show an error dialog with messages indicating that
      *  too many failed login attempts have occurred.
      * @param methodTag tag from calling method.
@@ -159,7 +170,8 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
      * @param methodTag tag from calling method.
      * @param e Exception thrown.
      */
-    protected void indicateGeneralException(@NonNull final String methodTag, @NonNull final Exception e) {
+    protected void indicateGeneralException(@NonNull final String methodTag,
+                                            @NonNull final Exception e) {
         Logger.error(methodTag, e.getMessage(), e);
         mTelemetryHelper.setResultFailure(e);
         //Show general error dialog.
@@ -179,17 +191,11 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
             @Override
             public void onClick(@NonNull final ICertDetails certDetails) {
                 //Need to prompt user for pin and verify pin. The positive button listener will handle the rest of the CBA flow.
+                final ICancelCbaCallback cancelCallback = getGeneralCancelCbaCallback(request);
                 mDialogHolder.showPinDialog(
                         getSmartcardPinDialogPositiveButtonListener(certDetails, request),
-                        new ICancelCbaCallback() {
-                            @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-                            @Override
-                            public void onCancel() {
-                                mDialogHolder.dismissDialog();
-                                mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
-                                request.cancel();
-                            }
-                        });
+                        cancelCallback
+                );
             }
         };
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -118,7 +118,7 @@ public class CertBasedAuthFactory {
                 telemetryHelper.setUserChoice(CertBasedAuthChoice.SMARTCARD_CHOICE);
                 setUpForSmartcardCertBasedAuth(callback, telemetryHelper);
             }
-        }, new UserChoiceDialog.CancelCbaCallback() {
+        }, new ICancelCbaCallback() {
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
             @Override
             public void onCancel() {
@@ -190,7 +190,7 @@ public class CertBasedAuthFactory {
      */
     private void showSmartcardPromptDialogAndSetConnectionCallback(@NonNull final CertBasedAuthChallengeHandlerCallback challengeHandlerCallback,
                                                                    @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
-        mDialogHolder.showSmartcardPromptDialog(new SmartcardPromptDialog.CancelCbaCallback() {
+        mDialogHolder.showSmartcardPromptDialog(new ICancelCbaCallback() {
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
             @Override
             public void onCancel() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -194,6 +194,9 @@ public class CertBasedAuthFactory {
             @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
             @Override
             public void onCancel() {
+                if (mNfcSmartcardCertBasedAuthManager != null) {
+                    mNfcSmartcardCertBasedAuthManager.stopDiscovery(mActivity);
+                }
                 onCancelHelper(challengeHandlerCallback, telemetryHelper);
             }
         });

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -60,7 +60,7 @@ public class DialogHolder implements IDialogHolder {
      */
     public synchronized void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
                                                   @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
-                                                  @NonNull final SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
+                                                  @NonNull final ICancelCbaCallback cancelCbaCallback) {
         final SmartcardCertPickerDialog certPickerDialog = new SmartcardCertPickerDialog(
                 certList,
                 positiveButtonListener,
@@ -75,7 +75,7 @@ public class DialogHolder implements IDialogHolder {
      * @param cancelCbaCallback      A Callback that holds code to be run when CBA is being cancelled.
      */
     public synchronized void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
-                                           @NonNull final SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
+                                           @NonNull final ICancelCbaCallback cancelCbaCallback) {
         final SmartcardPinDialog pinDialog = new SmartcardPinDialog(
                 positiveButtonListener,
                 cancelCbaCallback,
@@ -111,7 +111,7 @@ public class DialogHolder implements IDialogHolder {
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
     public synchronized void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
-                                                  @NonNull final UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
+                                                  @NonNull final ICancelCbaCallback cancelCbaCallback) {
         showDialog(new UserChoiceDialog(
                 positiveButtonListener,
                  cancelCbaCallback,
@@ -124,7 +124,7 @@ public class DialogHolder implements IDialogHolder {
      * either by plugging in (USB) or holding to back of phone (NFC).
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
-    public synchronized void showSmartcardPromptDialog(@NonNull final SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public synchronized void showSmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         showDialog(new SmartcardPromptDialog(
                 cancelCbaCallback,
                 mActivity
@@ -142,7 +142,7 @@ public class DialogHolder implements IDialogHolder {
      * Builds and shows a SmartcardDialog that prompts the user to connect their smartcard by holding it to the back of their phone.
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
-    public synchronized void showSmartcardNfcPromptDialog(@NonNull final SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public synchronized void showSmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         showDialog(new SmartcardNfcPromptDialog(
                 cancelCbaCallback,
                 mActivity));

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ICancelCbaCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ICancelCbaCallback.java
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+/**
+ * Callback interface for when CBA is being cancelled.
+ */
+public interface ICancelCbaCallback {
+    /**
+     * Method to be invoked upon a user cancelling out of CBA.
+     */
+    void onCancel();
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
@@ -40,7 +40,7 @@ public interface IDialogHolder {
      */
     void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
                               @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
-                              @NonNull final SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback);
+                              @NonNull final ICancelCbaCallback cancelCbaCallback);
 
     /**
      * Build and show PIN dialog that prompts user to type in their PIN for their YubiKey.
@@ -48,7 +48,7 @@ public interface IDialogHolder {
      * @param cancelCbaCallback      A Callback that holds code to be run when CBA is being cancelled.
      */
     void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
-                       @NonNull final SmartcardPinDialog.CancelCbaCallback cancelCbaCallback);
+                       @NonNull final ICancelCbaCallback cancelCbaCallback);
 
     /**
      * Builds and shows dialog informing the user of an expected or unexpected error.
@@ -65,14 +65,14 @@ public interface IDialogHolder {
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
     void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
-                              @NonNull final UserChoiceDialog.CancelCbaCallback cancelCbaCallback);
+                              @NonNull final ICancelCbaCallback cancelCbaCallback);
 
     /**
      * Builds and shows a SmartcardDialog that prompts the user to connect their smartcard,
      * either by plugging in (USB) or holding to back of phone (NFC).
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
-    void showSmartcardPromptDialog(@NonNull final SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback);
+    void showSmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback);
 
     /**
      * Builds and shows a SmartcardDialog that reminds the user to remain holding their smartcard device to their phone.
@@ -83,7 +83,7 @@ public interface IDialogHolder {
      * Builds and shows a SmartcardDialog that prompts the user to connect their smartcard by holding it to the back of their phone.
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
-    void showSmartcardNfcPromptDialog(@NonNull final SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback);
+    void showSmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback);
 
     /**
      * Builds and shows a SmartcardDialog that notifies user that NFC is not on for their device.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
@@ -80,9 +80,8 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
                 mDialogHolder.showSmartcardNfcPromptDialog(new ICancelCbaCallback() {
                     @Override
                     public void onCancel() {
-                        mDialogHolder.dismissDialog();
-                        mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
-                        request.cancel();
+                        getGeneralCancelCbaCallback(request).onCancel();
+                        mCbaManager.stopDiscovery(mActivity);
                     }
                 });
                 mCbaManager.setConnectionCallback(new IConnectionCallback() {
@@ -131,15 +130,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
                                                    @NonNull ClientCertRequest request) {
         mDialogHolder.showPinDialog(
                 getSmartcardPinDialogPositiveButtonListener(certDetails, request),
-                new ICancelCbaCallback() {
-                    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-                    @Override
-                    public void onCancel() {
-                        mDialogHolder.dismissDialog();
-                        mTelemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
-                        request.cancel();
-                    }
-                });
+                getGeneralCancelCbaCallback(request));
         //Update Dialog to indicate that an incorrect attempt was made.
         mDialogHolder.setPinDialogErrorMode();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandler.java
@@ -77,7 +77,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
             @Override
             public void onClick(@NonNull final char[] pin) {
                 //For NFC, we need another dialog prompting the user to hold the smartcard to the phone again.
-                mDialogHolder.showSmartcardNfcPromptDialog(new SmartcardNfcPromptDialog.CancelCbaCallback() {
+                mDialogHolder.showSmartcardNfcPromptDialog(new ICancelCbaCallback() {
                     @Override
                     public void onCancel() {
                         mDialogHolder.dismissDialog();
@@ -131,7 +131,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandler extends AbstractSmartcard
                                                    @NonNull ClientCertRequest request) {
         mDialogHolder.showPinDialog(
                 getSmartcardPinDialogPositiveButtonListener(certDetails, request),
-                new SmartcardPinDialog.CancelCbaCallback() {
+                new ICancelCbaCallback() {
                     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
                     @Override
                     public void onCancel() {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardCertPickerDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardCertPickerDialog.java
@@ -52,7 +52,7 @@ public class SmartcardCertPickerDialog extends SmartcardDialog {
     private static final String TAG = SmartcardCertPickerDialog.class.getSimpleName();
     private final List<ICertDetails> mCertList;
     private final PositiveButtonListener mPositiveButtonListener;
-    private final CancelCbaCallback mCancelCbaCallback;
+    private final ICancelCbaCallback mCancelCbaCallback;
 
     /**
      * Creates new instance of SmartcardCertPickerDialog.
@@ -63,7 +63,7 @@ public class SmartcardCertPickerDialog extends SmartcardDialog {
      */
     public SmartcardCertPickerDialog(@NonNull final List<ICertDetails> certList,
                                      @NonNull final PositiveButtonListener positiveButtonListener,
-                                     @NonNull final CancelCbaCallback cancelCbaCallback,
+                                     @NonNull final ICancelCbaCallback cancelCbaCallback,
                                      @NonNull final Activity activity) {
         super(activity);
         mCertList = certList;
@@ -157,13 +157,6 @@ public class SmartcardCertPickerDialog extends SmartcardDialog {
      */
     public interface PositiveButtonListener {
         void onClick(@NonNull final ICertDetails certDetails);
-    }
-
-    /**
-     * Callback interface for when CBA is being cancelled.
-     */
-    public interface CancelCbaCallback {
-        void onCancel();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcPromptDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcPromptDialog.java
@@ -36,8 +36,8 @@ import lombok.NonNull;
  */
 public class SmartcardNfcPromptDialog extends SmartcardDialog {
 
-    private final CancelCbaCallback mCancelCbaCallback;
-    public SmartcardNfcPromptDialog(@NonNull final CancelCbaCallback cancelCbaCallback,
+    private final ICancelCbaCallback mCancelCbaCallback;
+    public SmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback,
                                     @NonNull final Activity activity) {
         super(activity);
         mCancelCbaCallback = cancelCbaCallback;
@@ -77,12 +77,5 @@ public class SmartcardNfcPromptDialog extends SmartcardDialog {
     @Override
     void onCancelCba() {
 
-    }
-
-    /**
-     * Callback interface for when CBA is being cancelled.
-     */
-    public interface CancelCbaCallback {
-        void onCancel();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardPinDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardPinDialog.java
@@ -48,7 +48,7 @@ public class SmartcardPinDialog extends SmartcardDialog {
     private static final String TAG = SmartcardPinDialog.class.getSimpleName();
     private View mPinLayout;
     private final PositiveButtonListener mPositiveButtonListener;
-    private final CancelCbaCallback mCancelCbaCallback;
+    private final ICancelCbaCallback mCancelCbaCallback;
 
     /**
      * Creates new instance of SmartcardPinDialog.
@@ -57,7 +57,7 @@ public class SmartcardPinDialog extends SmartcardDialog {
      * @param activity Host activity.
      */
     public SmartcardPinDialog(@NonNull final PositiveButtonListener positiveButtonListener,
-                              @NonNull final CancelCbaCallback cancelCbaCallback,
+                              @NonNull final ICancelCbaCallback cancelCbaCallback,
                               @NonNull final Activity activity) {
         super(activity);
         mPositiveButtonListener = positiveButtonListener;
@@ -213,12 +213,4 @@ public class SmartcardPinDialog extends SmartcardDialog {
     public interface PositiveButtonListener {
         void onClick(@NonNull final char[] pin);
     }
-
-    /**
-     * Callback interface for when CBA is being cancelled.
-     */
-    public interface CancelCbaCallback {
-        void onCancel();
-    }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardPromptDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardPromptDialog.java
@@ -36,14 +36,14 @@ import lombok.NonNull;
  */
 public class SmartcardPromptDialog extends SmartcardDialog {
 
-    private final CancelCbaCallback mCancelCbaCallback;
+    private final ICancelCbaCallback mCancelCbaCallback;
 
     /**
      * Creates new instance of SmartcardPromptDialog.
      *
      * @param activity Host activity.
      */
-    public SmartcardPromptDialog(@NonNull final CancelCbaCallback cancelCbaCallback,
+    public SmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback,
                                  @NonNull final Activity activity) {
         super(activity);
         mCancelCbaCallback = cancelCbaCallback;
@@ -91,12 +91,5 @@ public class SmartcardPromptDialog extends SmartcardDialog {
     @Override
     void onCancelCba() {
         mCancelCbaCallback.onCancel();
-    }
-
-    /**
-     * Callback interface for when CBA is being cancelled.
-     */
-    public interface CancelCbaCallback {
-        void onCancel();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UserChoiceDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/UserChoiceDialog.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 public class UserChoiceDialog extends SmartcardDialog {
 
     private final PositiveButtonListener mPositiveButtonListener;
-    private final CancelCbaCallback mCancelCbaCallback;
+    private final ICancelCbaCallback mCancelCbaCallback;
 
     /**
      * Creates new instance of SmartcardDialog.
@@ -44,7 +44,7 @@ public class UserChoiceDialog extends SmartcardDialog {
      * @param activity Host activity.
      */
     public UserChoiceDialog(@NonNull final PositiveButtonListener positiveButtonListener,
-                            @NonNull final CancelCbaCallback cancelCbaCallback,
+                            @NonNull final ICancelCbaCallback cancelCbaCallback,
                             @NonNull final Activity activity) {
         super(activity);
         mPositiveButtonListener = positiveButtonListener;
@@ -107,12 +107,5 @@ public class UserChoiceDialog extends SmartcardDialog {
      */
     public interface PositiveButtonListener {
         void onClick(final int checkedPosition);
-    }
-
-    /**
-     * Callback interface for when CBA is being cancelled.
-     */
-    public interface CancelCbaCallback {
-        void onCancel();
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     public void testCancelAtPickerDialog() {
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
-        final SmartcardCertPickerDialog.CancelCbaCallback callback =  mDialogHolder.getCertPickerCancelCbaCallback();
+        final ICancelCbaCallback callback =  mDialogHolder.getCertPickerCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -76,7 +76,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final SmartcardPinDialog.CancelCbaCallback callback = mDialogHolder.getPinCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getPinCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -70,7 +70,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testCancelAtUserChoiceDialog() {
         challengeHandlerHelper(ExpectedChallengeHandler.NULL);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final UserChoiceDialog.CancelCbaCallback callback = mDialogHolder.getUserChoiceCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getUserChoiceCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -94,7 +94,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
         assertNotNull(listener);
         listener.onClick(1);
         checkIfCorrectDialogIsShowing(TestDialog.prompt);
-        final SmartcardPromptDialog.CancelCbaCallback callback = mDialogHolder.getPromptCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getPromptCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -50,7 +50,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         final char[] pin = {'1', '2', '3'};
         pinListener.onClick(pin);
         checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
-        final SmartcardNfcPromptDialog.CancelCbaCallback nfcCancelCallback = mDialogHolder.getNfcPromptCancelCbaCallback();
+        final ICancelCbaCallback nfcCancelCallback = mDialogHolder.getNfcPromptCancelCbaCallback();
         assertNotNull(nfcCancelCallback);
         nfcCancelCallback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -35,20 +35,20 @@ class TestDialogHolder implements IDialogHolder {
 
     private TestDialog mCurrentDialog;
     private SmartcardCertPickerDialog.PositiveButtonListener mCertPickerPositiveButtonListener;
-    private SmartcardCertPickerDialog.CancelCbaCallback mCertPickerCancelCbaCallback;
+    private ICancelCbaCallback mCertPickerCancelCbaCallback;
     private SmartcardPinDialog.PositiveButtonListener mPinPositiveButtonListener;
-    private SmartcardPinDialog.CancelCbaCallback mPinCancelCbaCallback;
+    private ICancelCbaCallback mPinCancelCbaCallback;
     private UserChoiceDialog.PositiveButtonListener mUserChoicePositiveButtonListener;
-    private UserChoiceDialog.CancelCbaCallback mUserChoiceCancelCbaCallback;
-    private SmartcardPromptDialog.CancelCbaCallback mPromptCancelCbaCallback;
-    private SmartcardNfcPromptDialog.CancelCbaCallback mNfcPromptCancelCbaCallback;
+    private ICancelCbaCallback mUserChoiceCancelCbaCallback;
+    private ICancelCbaCallback mPromptCancelCbaCallback;
+    private ICancelCbaCallback mNfcPromptCancelCbaCallback;
     private SmartcardNfcReminderDialog.DismissCallback mNfcReminderDismissCallback;
     private List<ICertDetails> mCertList;
 
     @Override
     public void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
                                      @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
-                                     @NonNull final SmartcardCertPickerDialog.CancelCbaCallback cancelCbaCallback) {
+                                     @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.cert_picker;
         mCertPickerPositiveButtonListener = positiveButtonListener;
         mCertPickerCancelCbaCallback = cancelCbaCallback;
@@ -57,7 +57,7 @@ class TestDialogHolder implements IDialogHolder {
 
     @Override
     public void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
-                              @NonNull final SmartcardPinDialog.CancelCbaCallback cancelCbaCallback) {
+                              @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.pin;
         mPinPositiveButtonListener = positiveButtonListener;
         mPinCancelCbaCallback = cancelCbaCallback;
@@ -71,14 +71,14 @@ class TestDialogHolder implements IDialogHolder {
 
     @Override
     public void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
-                                     @NonNull final UserChoiceDialog.CancelCbaCallback cancelCbaCallback) {
+                                     @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.user_choice;
         mUserChoicePositiveButtonListener = positiveButtonListener;
         mUserChoiceCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
-    public void showSmartcardPromptDialog(@NonNull final SmartcardPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showSmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.prompt;
         mPromptCancelCbaCallback = cancelCbaCallback;
     }
@@ -89,7 +89,7 @@ class TestDialogHolder implements IDialogHolder {
     }
 
     @Override
-    public void showSmartcardNfcPromptDialog(@NonNull final SmartcardNfcPromptDialog.CancelCbaCallback cancelCbaCallback) {
+    public void showSmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.nfc_prompt;
         mNfcPromptCancelCbaCallback = cancelCbaCallback;
     }


### PR DESCRIPTION
## Summary
The main purpose of this PR is to consolidate the local `cancelCallback` interfaces attached to each dialog into a universal `ICancelCbaCallback`. Most of the changes here pertain to parameter types of methods that are within `SmartcardDialog` classes or create `SmartcardDialog`s. 
A method `getGeneralCancelCbaCallback` was created within the abstract smartcard challenge handler to return a callback that will dismiss the current dialog, finish the current telemetry span, and cancel the request. 
No new features were added to this PR, but some small fixes regarding stopping discovery after a user cancels out are added, hence the changelog.
Note that this PR overlaps with [the current CBA feature work PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1966). I created this PR to help reduce the size of the feature work PR.

## Related PRs
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1971
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1966