### PR TITLE
IDismissCallback Refactor

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -162,9 +162,9 @@ public class CertBasedAuthFactory {
         if (mNfcSmartcardCertBasedAuthManager != null
                 && mNfcSmartcardCertBasedAuthManager.startDiscovery(mActivity)) {
             //Inform user to turn on NFC if they want to use NFC.
-            mDialogHolder.showSmartcardNfcReminderDialog(new SmartcardNfcReminderDialog.DismissCallback() {
+            mDialogHolder.showSmartcardNfcReminderDialog(new IDismissCallback() {
                 @Override
-                public void onClick() {
+                public void onAction() {
                     //If smartcard is already plugged in, go straight to cert picker.
                     if (mUsbSmartcardCertBasedAuthManager != null
                     && mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -164,7 +164,7 @@ public class CertBasedAuthFactory {
             //Inform user to turn on NFC if they want to use NFC.
             mDialogHolder.showSmartcardNfcReminderDialog(new IDismissCallback() {
                 @Override
-                public void onAction() {
+                public void onDismiss() {
                     //If smartcard is already plugged in, go straight to cert picker.
                     if (mUsbSmartcardCertBasedAuthManager != null
                     && mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -94,9 +94,9 @@ public class DialogHolder implements IDialogHolder {
         showDialog(new SmartcardErrorDialog(
                 titleStringResourceId,
                 messageStringResourceId,
-                new SmartcardErrorDialog.DismissCallback() {
+                new IDismissCallback() {
                     @Override
-                    public void onClick() {
+                    public void onAction() {
                         //Call dismissDialog
                         dismissDialog();
                     }
@@ -152,7 +152,7 @@ public class DialogHolder implements IDialogHolder {
      * Builds and shows a SmartcardDialog that notifies user that NFC is not on for their device.
      * @param dismissCallback a callback that holds logic to be run upon dismissal of the dialog.
      */
-    public synchronized void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+    public synchronized void showSmartcardNfcReminderDialog(@NonNull final IDismissCallback dismissCallback) {
         showDialog(new SmartcardNfcReminderDialog(
                 dismissCallback,
                 mActivity

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -96,7 +96,7 @@ public class DialogHolder implements IDialogHolder {
                 messageStringResourceId,
                 new IDismissCallback() {
                     @Override
-                    public void onAction() {
+                    public void onDismiss() {
                         //Call dismissDialog
                         dismissDialog();
                     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDialogHolder.java
@@ -89,7 +89,7 @@ public interface IDialogHolder {
      * Builds and shows a SmartcardDialog that notifies user that NFC is not on for their device.
      * @param dismissCallback a callback that holds logic to be run upon dismissal of the dialog.
      */
-    void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback);
+    void showSmartcardNfcReminderDialog(@NonNull final IDismissCallback dismissCallback);
 
     /**
      * Dismisses current dialog, if one is showing.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDismissCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDismissCallback.java
@@ -30,5 +30,5 @@ public interface IDismissCallback {
     /**
      * Action that prompts dismissal.
      */
-    void onAction();
+    void onDismiss();
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDismissCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/IDismissCallback.java
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+/**
+ * Callback interface for when dialog is to be dismissed
+ * (usually by positive button click,back button, or by an expected user interaction).
+ */
+public interface IDismissCallback {
+    /**
+     * Action that prompts dismissal.
+     */
+    void onAction();
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardErrorDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardErrorDialog.java
@@ -37,7 +37,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
 
     private final int mTitleStringResourceId;
     private final int mMessageStringResourceId;
-    private final DismissCallback mDismissCallback;
+    private final IDismissCallback mDismissCallback;
 
     /**
      * Create new instance of SmartcardErrorDialog.
@@ -48,7 +48,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
      */
     public SmartcardErrorDialog(final int titleStringResourceId,
                                 final int messageStringResourceId,
-                                @NonNull final DismissCallback dismissCallback,
+                                @NonNull final IDismissCallback dismissCallback,
                                 @NonNull final Activity activity) {
         super(activity);
         mTitleStringResourceId = titleStringResourceId;
@@ -74,7 +74,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
                         .setPositiveButton(R.string.smartcard_error_dialog_positive_button, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                mDismissCallback.onClick();
+                                mDismissCallback.onAction();
                             }
                         });
                 final AlertDialog dialog = builder.create();
@@ -85,7 +85,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
                 dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        mDismissCallback.onClick();
+                        mDismissCallback.onAction();
                     }
                 });
                 mDialog = dialog;
@@ -99,13 +99,6 @@ public class SmartcardErrorDialog extends SmartcardDialog {
     @Override
     void onCancelCba() {
         //Handle cancelling the same as the positive button.
-        mDismissCallback.onClick();
-    }
-
-    /**
-     * Callback interface for when dialog is to be dismissed (usually by positive button click or back button).
-     */
-    public interface DismissCallback {
-        void onClick();
+        mDismissCallback.onAction();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardErrorDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardErrorDialog.java
@@ -74,7 +74,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
                         .setPositiveButton(R.string.smartcard_error_dialog_positive_button, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                mDismissCallback.onAction();
+                                mDismissCallback.onDismiss();
                             }
                         });
                 final AlertDialog dialog = builder.create();
@@ -85,7 +85,7 @@ public class SmartcardErrorDialog extends SmartcardDialog {
                 dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        mDismissCallback.onAction();
+                        mDismissCallback.onDismiss();
                     }
                 });
                 mDialog = dialog;
@@ -99,6 +99,6 @@ public class SmartcardErrorDialog extends SmartcardDialog {
     @Override
     void onCancelCba() {
         //Handle cancelling the same as the positive button.
-        mDismissCallback.onAction();
+        mDismissCallback.onDismiss();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcReminderDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcReminderDialog.java
@@ -66,7 +66,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                         .setPositiveButton(R.string.smartcard_nfc_reminder_dialog_positive_button, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                mDismissCallback.onAction();
+                                mDismissCallback.onDismiss();
                             }
                         });
                 final AlertDialog dialog = builder.create();
@@ -77,7 +77,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                 dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        mDismissCallback.onAction();
+                        mDismissCallback.onDismiss();
                     }
                 });
                 mDialog = dialog;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcReminderDialog.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/SmartcardNfcReminderDialog.java
@@ -35,14 +35,14 @@ import com.microsoft.identity.common.R;
  */
 public class SmartcardNfcReminderDialog extends SmartcardDialog {
 
-    private final DismissCallback mDismissCallback;
+    private final IDismissCallback mDismissCallback;
 
     /**
      * Creates new instance of SmartcardNfcReminderDialog.
      * @param dismissCallback callback containing logic to be run upon dialog dismissal.
      * @param activity current host activity.
      */
-    public SmartcardNfcReminderDialog(@NonNull final DismissCallback dismissCallback,
+    public SmartcardNfcReminderDialog(@NonNull final IDismissCallback dismissCallback,
                                       @NonNull final Activity activity) {
         super(activity);
         mDismissCallback = dismissCallback;
@@ -66,7 +66,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                         .setPositiveButton(R.string.smartcard_nfc_reminder_dialog_positive_button, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                mDismissCallback.onClick();
+                                mDismissCallback.onAction();
                             }
                         });
                 final AlertDialog dialog = builder.create();
@@ -77,7 +77,7 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
                 dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
                     @Override
                     public void onCancel(DialogInterface dialog) {
-                        mDismissCallback.onClick();
+                        mDismissCallback.onAction();
                     }
                 });
                 mDialog = dialog;
@@ -91,12 +91,5 @@ public class SmartcardNfcReminderDialog extends SmartcardDialog {
     @Override
     void onCancelCba() {
         //This method will never be called on this dialog, so no logic needed.
-    }
-
-    /**
-     * Callback interface for a dialog dismissal.
-     */
-    public interface DismissCallback {
-        void onClick();
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
     public void testCancelAtPickerDialog() {
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
-        final ICancelCbaCallback callback =  mDialogHolder.getCertPickerCancelCbaCallback();
+        final ICancelCbaCallback callback =  mDialogHolder.getCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -76,7 +76,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
         setAndProcessChallengeHandler(getMockCertList());
         checkIfCorrectDialogIsShowing(TestDialog.cert_picker);
         goToPinDialog();
-        final ICancelCbaCallback callback = mDialogHolder.getPinCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -70,7 +70,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     public void testCancelAtUserChoiceDialog() {
         challengeHandlerHelper(ExpectedChallengeHandler.NULL);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);
-        final ICancelCbaCallback callback = mDialogHolder.getUserChoiceCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);
@@ -94,7 +94,7 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
         assertNotNull(listener);
         listener.onClick(1);
         checkIfCorrectDialogIsShowing(TestDialog.prompt);
-        final ICancelCbaCallback callback = mDialogHolder.getPromptCancelCbaCallback();
+        final ICancelCbaCallback callback = mDialogHolder.getCancelCbaCallback();
         assertNotNull(callback);
         callback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/NfcSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -50,7 +50,7 @@ public class NfcSmartcardCertBasedAuthChallengeHandlerTest extends AbstractSmart
         final char[] pin = {'1', '2', '3'};
         pinListener.onClick(pin);
         checkIfCorrectDialogIsShowing(TestDialog.nfc_prompt);
-        final ICancelCbaCallback nfcCancelCallback = mDialogHolder.getNfcPromptCancelCbaCallback();
+        final ICancelCbaCallback nfcCancelCallback = mDialogHolder.getCancelCbaCallback();
         assertNotNull(nfcCancelCallback);
         nfcCancelCallback.onCancel();
         checkIfCorrectDialogIsShowing(null);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -35,14 +35,10 @@ class TestDialogHolder implements IDialogHolder {
 
     private TestDialog mCurrentDialog;
     private SmartcardCertPickerDialog.PositiveButtonListener mCertPickerPositiveButtonListener;
-    private ICancelCbaCallback mCertPickerCancelCbaCallback;
     private SmartcardPinDialog.PositiveButtonListener mPinPositiveButtonListener;
-    private ICancelCbaCallback mPinCancelCbaCallback;
     private UserChoiceDialog.PositiveButtonListener mUserChoicePositiveButtonListener;
-    private ICancelCbaCallback mUserChoiceCancelCbaCallback;
-    private ICancelCbaCallback mPromptCancelCbaCallback;
-    private ICancelCbaCallback mNfcPromptCancelCbaCallback;
-    private SmartcardNfcReminderDialog.DismissCallback mNfcReminderDismissCallback;
+    private IDismissCallback mDismissCallback;
+    private ICancelCbaCallback mCancelCbaCallback;
     private List<ICertDetails> mCertList;
 
     @Override
@@ -51,7 +47,7 @@ class TestDialogHolder implements IDialogHolder {
                                      @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.cert_picker;
         mCertPickerPositiveButtonListener = positiveButtonListener;
-        mCertPickerCancelCbaCallback = cancelCbaCallback;
+        mCancelCbaCallback = cancelCbaCallback;
         mCertList = certList;
     }
 
@@ -60,7 +56,7 @@ class TestDialogHolder implements IDialogHolder {
                               @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.pin;
         mPinPositiveButtonListener = positiveButtonListener;
-        mPinCancelCbaCallback = cancelCbaCallback;
+        mCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
@@ -74,13 +70,13 @@ class TestDialogHolder implements IDialogHolder {
                                      @NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.user_choice;
         mUserChoicePositiveButtonListener = positiveButtonListener;
-        mUserChoiceCancelCbaCallback = cancelCbaCallback;
+        mCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
     public void showSmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.prompt;
-        mPromptCancelCbaCallback = cancelCbaCallback;
+        mCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
@@ -91,13 +87,13 @@ class TestDialogHolder implements IDialogHolder {
     @Override
     public void showSmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
         mCurrentDialog = TestDialog.nfc_prompt;
-        mNfcPromptCancelCbaCallback = cancelCbaCallback;
+        mCancelCbaCallback = cancelCbaCallback;
     }
 
     @Override
-    public void showSmartcardNfcReminderDialog(@NonNull final SmartcardNfcReminderDialog.DismissCallback dismissCallback) {
+    public void showSmartcardNfcReminderDialog(@NonNull final IDismissCallback dismissCallback) {
         mCurrentDialog = TestDialog.nfc_reminder;
-        mNfcReminderDismissCallback = dismissCallback;
+        mDismissCallback = dismissCallback;
     }
 
     @Override
@@ -117,19 +113,13 @@ class TestDialogHolder implements IDialogHolder {
     public void onCancelCba() {
         switch (mCurrentDialog) {
             case cert_picker:
-                mCertPickerCancelCbaCallback.onCancel();
-                break;
             case pin:
-                mPinCancelCbaCallback.onCancel();
-                break;
             case user_choice:
-                mUserChoiceCancelCbaCallback.onCancel();
-                break;
             case prompt:
-                mPromptCancelCbaCallback.onCancel();
+                mCancelCbaCallback.onCancel();
                 break;
             case nfc_prompt:
-                mNfcPromptCancelCbaCallback.onCancel();
+                mDismissCallback.onAction();
                 break;
         }
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestDialogHolder.java
@@ -119,7 +119,7 @@ class TestDialogHolder implements IDialogHolder {
                 mCancelCbaCallback.onCancel();
                 break;
             case nfc_prompt:
-                mDismissCallback.onAction();
+                mDismissCallback.onDismiss();
                 break;
         }
     }


### PR DESCRIPTION
## Summary
Similar to https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1972#pullrequestreview-1316779182 , this PR consolidates the local `dismissCallback` interfaces attached to two types of `SmartcardDialog`s into `IDismissCallback` and updates the appropriate method parameters to use the new type.
This PR also cleans up some of the smartcard CBA test classes to use one instance of `IDismissCallback` and `ICancelCallback` (since no two dialogs will be shown at the same time).
All of the unit tests (order of operations untouched) passed, and I manually tested to confirm that the smartcard CBA flow still functioned, especially in the error case.

## Related PRs
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1972#pullrequestreview-1316779182
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1966