### PR TITLE
Create a custom safe Global Open Telemetry that doesn't crash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ vNext
 - [MINOR] Wrap Runnable with Current Telemetry Context (#1956)
 - [MINOR] Update JweResponse APIs and added Additional Authenticated Data (AAD) (#1958)
 - [MINOR] Move JWT classes to common (#1968)
+- [PATCH] Create a custom safe Global Open Telemetry that doesn't crash (#1977)
 
 V.10.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -45,7 +45,7 @@ public class OTelUtility {
      **/
     @NonNull
     public static Span createSpan(@NonNull final String name) {
-        final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
+        final Tracer tracer = OpenTelemetryHolder.getOpenTelemetry().getTracer(TAG);
         return tracer.spanBuilder(name).startSpan();
     }
 
@@ -67,7 +67,7 @@ public class OTelUtility {
             return createSpan(name);
         }
 
-        final Tracer tracer = GlobalOpenTelemetry.getTracer(TAG);
+        final Tracer tracer = OpenTelemetryHolder.getOpenTelemetry().getTracer(TAG);
 
         return tracer.spanBuilder(name)
                 .setParent(Context.current().with(Span.wrap(parentSpanContext)))
@@ -79,7 +79,7 @@ public class OTelUtility {
      **/
     @NonNull
     public static LongCounter createLongCounter(@NonNull final String name, @NonNull final String description) {
-        final Meter meter = GlobalOpenTelemetry.getMeter(TAG);
+        final Meter meter = OpenTelemetryHolder.getOpenTelemetry().getMeter(TAG);
 
         return meter
                 .counterBuilder(name)

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.java
@@ -22,13 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.opentelemetry;
 
-import static com.microsoft.identity.common.java.opentelemetry.AttributeName.parent_span_name;
-
 import com.microsoft.identity.common.java.logging.Logger;
 
 import javax.annotation.Nullable;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
@@ -45,7 +42,7 @@ public class OTelUtility {
      **/
     @NonNull
     public static Span createSpan(@NonNull final String name) {
-        final Tracer tracer = OpenTelemetryHolder.getOpenTelemetry().getTracer(TAG);
+        final Tracer tracer = OpenTelemetryHolder.getTracer(TAG);
         return tracer.spanBuilder(name).startSpan();
     }
 
@@ -67,7 +64,7 @@ public class OTelUtility {
             return createSpan(name);
         }
 
-        final Tracer tracer = OpenTelemetryHolder.getOpenTelemetry().getTracer(TAG);
+        final Tracer tracer = OpenTelemetryHolder.getTracer(TAG);
 
         return tracer.spanBuilder(name)
                 .setParent(Context.current().with(Span.wrap(parentSpanContext)))
@@ -79,7 +76,7 @@ public class OTelUtility {
      **/
     @NonNull
     public static LongCounter createLongCounter(@NonNull final String name, @NonNull final String description) {
-        final Meter meter = OpenTelemetryHolder.getOpenTelemetry().getMeter(TAG);
+        final Meter meter = OpenTelemetryHolder.getMeter(TAG);
 
         return meter
                 .counterBuilder(name)

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.java.opentelemetry;
 
 import io.opentelemetry.api.NoopOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Tracer;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -56,5 +58,19 @@ public class OpenTelemetryHolder {
     @Getter
     @NonNull
     private static OpenTelemetry sOpenTelemetry = NOOP;
+
+    /**
+     * See {@link io.opentelemetry.api.GlobalOpenTelemetry#getTracer(String)}.
+     */
+    public static Tracer getTracer(final String instrumentationScopeName) {
+        return sOpenTelemetry.getTracerProvider().get(instrumentationScopeName);
+    }
+
+    /**
+     * See {@link io.opentelemetry.api.GlobalOpenTelemetry#getMeter(String)}.
+     */
+    public static Meter getMeter(String instrumentationScopeName) {
+        return sOpenTelemetry.getMeterProvider().get(instrumentationScopeName);
+    }
 
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.java.opentelemetry;
 import io.opentelemetry.api.NoopOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.NoopMeterProvider;
 import io.opentelemetry.api.trace.Tracer;
 import lombok.Getter;
 import lombok.NonNull;
@@ -59,6 +61,8 @@ public class OpenTelemetryHolder {
     @NonNull
     private static OpenTelemetry sOpenTelemetry = NOOP;
 
+    private static final MeterProvider NOOP_METER_PROVIDER = NoopMeterProvider.getInstance();
+
     /**
      * See {@link io.opentelemetry.api.GlobalOpenTelemetry#getTracer(String)}.
      */
@@ -70,7 +74,11 @@ public class OpenTelemetryHolder {
      * See {@link io.opentelemetry.api.GlobalOpenTelemetry#getMeter(String)}.
      */
     public static Meter getMeter(String instrumentationScopeName) {
-        return sOpenTelemetry.getMeterProvider().get(instrumentationScopeName);
+        try {
+            return sOpenTelemetry.getMeterProvider().get(instrumentationScopeName);
+        } catch (final AbstractMethodError error) {
+            return NOOP_METER_PROVIDER.get(instrumentationScopeName);
+        }
     }
 
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.opentelemetry;
 
+import io.opentelemetry.api.NoopOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import lombok.Getter;
 import lombok.NonNull;
@@ -48,10 +49,12 @@ import lombok.experimental.Accessors;
  */
 public class OpenTelemetryHolder {
 
+    private static final OpenTelemetry NOOP = new NoopOpenTelemetry();
+
     @Accessors(prefix = "s")
     @Setter
     @Getter
     @NonNull
-    private static OpenTelemetry sOpenTelemetry = OpenTelemetry.noop();
+    private static OpenTelemetry sOpenTelemetry = NOOP;
 
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OpenTelemetryHolder.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * A custom safe Open Telemetry Instance holder that doesn't crash on the call to "get" Open
+ * Telemetry. The motivation behind this is that all the Broker code has state that is per-process,
+ * whereas other libraries such as Open Telemetry can carry state across processes. The default
+ * Global Open Telemetry only allows initializing Open Telemetry once and subsequent calls to
+ * initialize it will throw an error. This is problematic for code such as ours that runs in
+ * multiple processes because we end up initializing OTel twice (once in app process and once in
+ * auth process).
+ * <p>
+ * Open Telemetry itself recommends not using {@link io.opentelemetry.api.GlobalOpenTelemetry} and
+ * with this change we are now moving away from that model.
+ * TODO: We should make this even better by putting an instance of {@link OpenTelemetry} on the
+ * {@link com.microsoft.identity.common.java.interfaces.IPlatformComponents} and completely move
+ * away from static state, however, that requires us to then pass around either the components or
+ * the Open Telemetry instances in all places where we want to create Spans and that change is
+ * trivial in some areas of the code but more complex in other areas where we don't currently
+ * pass platform components and therefore this will be handled in a separate PR.
+ */
+public class OpenTelemetryHolder {
+
+    @Accessors(prefix = "s")
+    @Setter
+    @Getter
+    @NonNull
+    private static OpenTelemetry sOpenTelemetry = OpenTelemetry.noop();
+
+}

--- a/common4j/src/main/io/opentelemetry/api/NoopOpenTelemetry.java
+++ b/common4j/src/main/io/opentelemetry/api/NoopOpenTelemetry.java
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package io.opentelemetry.api;
+
+import io.opentelemetry.api.trace.NoopTracerProvider;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.NoopContextPropagators;
+
+/**
+ * A custom noop implementation of {@link OpenTelemetry} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopOpenTelemetry implements OpenTelemetry {
+    @Override
+    public TracerProvider getTracerProvider() {
+        return NoopTracerProvider.getInstance();
+    }
+
+    @Override
+    public ContextPropagators getPropagators() {
+        return NoopContextPropagators.getInstance();
+    }
+}

--- a/common4j/src/main/io/opentelemetry/api/metrics/NoopMeterProvider.java
+++ b/common4j/src/main/io/opentelemetry/api/metrics/NoopMeterProvider.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package io.opentelemetry.api.metrics;
+
+/**
+ * A custom noop implementation of {@link MeterProvider} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopMeterProvider {
+
+    public static MeterProvider getInstance() {
+        return DefaultMeterProvider.getInstance();
+    }
+}

--- a/common4j/src/main/io/opentelemetry/api/trace/NoopTracerProvider.java
+++ b/common4j/src/main/io/opentelemetry/api/trace/NoopTracerProvider.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package io.opentelemetry.api.trace;
+
+/**
+ * A custom noop implementation of {@link TracerProvider} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopTracerProvider {
+
+    public static TracerProvider getInstance() {
+        return DefaultTracerProvider.getInstance();
+    }
+
+}

--- a/common4j/src/main/io/opentelemetry/context/propagation/NoopContextPropagators.java
+++ b/common4j/src/main/io/opentelemetry/context/propagation/NoopContextPropagators.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION
+package io.opentelemetry.context.propagation;
+
+/**
+ * A custom noop implementation of {@link ContextPropagators} to be used in MSAL for scenarios where
+ * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * implementation uses "static interface methods" and these get left out of the APK for applications
+ * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * honored when minification is disabled and R8 applies some default proguard rules that leaves
+ * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
+ * invoked.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
+ * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
+ * own Noop implementations, however, here we are just providing our own that DON'T use static
+ * interface methods.
+ */
+public class NoopContextPropagators {
+
+    public static ContextPropagators getInstance() {
+        return DefaultContextPropagators.noop();
+    }
+
+}


### PR DESCRIPTION
A custom safe Open Telemetry Instance holder that doesn't crash on the call to "get" Open Telemetry. The motivation behind this is that all the Broker code has state that is per-process, whereas other libraries such as Open Telemetry can carry state across processes. The default Global Open Telemetry only allows initializing Open Telemetry once and subsequent calls to initialize it will throw an error. This is problematic for code such as ours that runs in multiple processes because we end up initializing OTel twice (once in app process and once in auth process).

For more details, see Javadoc