### PR TITLE
Adding in removal prompt dialog positive button string to string res files

### DIFF
--- a/common/src/main/res/values-ar/strings.xml
+++ b/common/src/main/res/values-ar/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">فهمت</string>
 
     <string name="smartcard_removal_prompt_dialog_title">يمكنك الآن إزالة بطاقتك الذكية</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">فهمت</string>
 </resources>

--- a/common/src/main/res/values-b+sr+Latn/strings.xml
+++ b/common/src/main/res/values-b+sr+Latn/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Razumem</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Sada možete ukloniti pametnu karticu</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Razumem</string>
 </resources>

--- a/common/src/main/res/values-bg/strings.xml
+++ b/common/src/main/res/values-bg/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Разбрах</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Сега можете да извадите вашата смарт карта</string>
+    \<string name="smartcard_removal_prompt_dialog_positive_button">Разбрах</string>
 </resources>

--- a/common/src/main/res/values-ca/strings.xml
+++ b/common/src/main/res/values-ca/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Entesos</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Ara ja podeu suprimir la targeta intel·ligent</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Entesos</string>
 </resources>

--- a/common/src/main/res/values-cs/strings.xml
+++ b/common/src/main/res/values-cs/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumím</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Teď můžete čipovou kartu odebrat.</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Rozumím</string>
 </resources>

--- a/common/src/main/res/values-da/strings.xml
+++ b/common/src/main/res/values-da/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Forstået</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Du kan nu fjerne dit chipkort</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Forstået</string>
 </resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Sie können jetzt Ihre Smartcard entfernen.</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-el/strings.xml
+++ b/common/src/main/res/values-el/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Το κατάλαβα</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Τώρα μπορείτε να καταργήσετε την έξυπνη κάρτα σας</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Το κατάλαβα</string>
 </resources>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Entendido</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Ahora es posible quitar la tarjeta inteligente</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Entendido</string>
 </resources>

--- a/common/src/main/res/values-et/strings.xml
+++ b/common/src/main/res/values-et/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Sain aru</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Võite nüüd kiipkaardi eemaldada</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Sain aru</string>
 </resources>

--- a/common/src/main/res/values-eu/strings.xml
+++ b/common/src/main/res/values-eu/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Ados</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Txartel adimenduna kendu dezakezu orain</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Ados</string>
 </resources>

--- a/common/src/main/res/values-fi/strings.xml
+++ b/common/src/main/res/values-fi/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Selvä juttu</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Voit nyt poistaa älykortin</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Selvä juttu</string>
 </resources>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Vous pouvez maintenant supprimer votre carte à puce</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-gl/strings.xml
+++ b/common/src/main/res/values-gl/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Entendido</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Agora podes eliminar o teu cartón intelixente</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Entendido</string>
 </resources>

--- a/common/src/main/res/values-he/strings.xml
+++ b/common/src/main/res/values-he/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">הבנתי</string>
 
     <string name="smartcard_removal_prompt_dialog_title">כעת באפשרותך להסיר את הכרטיס החכם שלך</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">הבנתי</string>
 </resources>

--- a/common/src/main/res/values-hi/strings.xml
+++ b/common/src/main/res/values-hi/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">समझ गया</string>
 
     <string name="smartcard_removal_prompt_dialog_title">अब आप अपना स्मार्ट कार्ड निकाल सकते हैं</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">समझ गया</string>
 </resources>

--- a/common/src/main/res/values-hr/strings.xml
+++ b/common/src/main/res/values-hr/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Shvaćam</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Sada možete ukloniti pametnu karticu</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Shvaćam</string>
 </resources>

--- a/common/src/main/res/values-hu/strings.xml
+++ b/common/src/main/res/values-hu/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Értem</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Most már eltávolíthatja az intelligens kártyát</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Értem</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Mengerti</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Kini Anda dapat menghapus kartu pintar</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Mengerti</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Chiudi</string>
 
     <string name="smartcard_removal_prompt_dialog_title">È ora possibile rimuovere la smart card</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Chiudi</string>
 </resources>

--- a/common/src/main/res/values-iw/strings.xml
+++ b/common/src/main/res/values-iw/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">הבנתי</string>
 
     <string name="smartcard_removal_prompt_dialog_title">כעת באפשרותך להסיר את הכרטיס החכם שלך</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">הבנתי</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">了解</string>
 
     <string name="smartcard_removal_prompt_dialog_title">スマート カードを削除できるようになりました</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">了解</string>
 </resources>

--- a/common/src/main/res/values-kk/strings.xml
+++ b/common/src/main/res/values-kk/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Түсінікті</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Енді смарт картаны шығаруға болады</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Түсінікті</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">확인</string>
 
     <string name="smartcard_removal_prompt_dialog_title">이제 스마트 카드를 제거할 수 있습니다.</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">확인</string>
 </resources>

--- a/common/src/main/res/values-lt/strings.xml
+++ b/common/src/main/res/values-lt/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Supratau</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Dabar galite pašalinti savo intelektualiąją kortelę</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Supratau</string>
 </resources>

--- a/common/src/main/res/values-lv/strings.xml
+++ b/common/src/main/res/values-lv/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Sapratu</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Tagad varat noņemt viedkarti</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Sapratu</string>
 </resources>

--- a/common/src/main/res/values-ms/strings.xml
+++ b/common/src/main/res/values-ms/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Faham</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Anda kini boleh mengalih keluar kad pintar anda</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Faham</string>
 </resources>

--- a/common/src/main/res/values-nb/strings.xml
+++ b/common/src/main/res/values-nb/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Jeg forstår</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Du kan nå fjerne smartkortet</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Jeg forstår</string>
 </resources>

--- a/common/src/main/res/values-nl/strings.xml
+++ b/common/src/main/res/values-nl/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 
     <string name="smartcard_removal_prompt_dialog_title">U kunt nu uw smartcard verwijderen</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumiem</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Teraz możesz usunąć kartę inteligentną</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Rozumiem</string>
 </resources>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Entendi</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Agora você pode remover seu cartão inteligente</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Entendi</string>
 </resources>

--- a/common/src/main/res/values-pt-rPT/strings.xml
+++ b/common/src/main/res/values-pt-rPT/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">OK</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Agora pode remover o seu smart card</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">OK</string>
 </resources>

--- a/common/src/main/res/values-ro/strings.xml
+++ b/common/src/main/res/values-ro/strings.xml
@@ -57,4 +57,6 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Am înțeles</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Acum vă puteți elimina smart card-ul</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Am înțeles</string>
+
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Понятно</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Теперь вы можете удалить смарт-карту</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Понятно</string>
 </resources>

--- a/common/src/main/res/values-sk/strings.xml
+++ b/common/src/main/res/values-sk/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Rozumiem</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Teraz môžete inteligentnú kartu odobrať</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Rozumiem</string>
 </resources>

--- a/common/src/main/res/values-sl/strings.xml
+++ b/common/src/main/res/values-sl/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Razumem</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Zdaj lahko odstranite pametno kartico</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Razumem</string>
 </resources>

--- a/common/src/main/res/values-sr/strings.xml
+++ b/common/src/main/res/values-sr/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Разумем</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Сада можете уклонити паметну картицу</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Разумем</string>
 </resources>

--- a/common/src/main/res/values-sv/strings.xml
+++ b/common/src/main/res/values-sv/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Jag förstår</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Nu kan du ta bort smartkortet</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Jag förstår</string>
 </resources>

--- a/common/src/main/res/values-th/strings.xml
+++ b/common/src/main/res/values-th/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">เข้าใจแล้ว</string>
 
     <string name="smartcard_removal_prompt_dialog_title">ขณะนี้คุณสามารถเอาสมาร์ทการ์ดของคุณออกได้แล้ว</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">เข้าใจแล้ว</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Anladım</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Şimdi akıllı kartınızı kaldırabilirsiniz</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Anladım</string>
 </resources>

--- a/common/src/main/res/values-uk/strings.xml
+++ b/common/src/main/res/values-uk/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Зрозуміло</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Тепер ви можете видалити смарт-картку</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Зрозуміло</string>
 </resources>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Đã hiểu</string>
 
     <string name="smartcard_removal_prompt_dialog_title">Giờ đây, bạn có thể loại bỏ thẻ thông minh của mình</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Đã hiểu</string>
 </resources>

--- a/common/src/main/res/values-zh-rCN/strings.xml
+++ b/common/src/main/res/values-zh-rCN/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">知道了</string>
 
     <string name="smartcard_removal_prompt_dialog_title">现在可以取下智能卡</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">知道了</string>
 </resources>

--- a/common/src/main/res/values-zh-rTW/strings.xml
+++ b/common/src/main/res/values-zh-rTW/strings.xml
@@ -57,4 +57,5 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">了解</string>
 
     <string name="smartcard_removal_prompt_dialog_title">您現在可以移除智慧卡</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">了解</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -57,5 +57,6 @@
     <string name="smartcard_nfc_reminder_dialog_positive_button">Got it</string>
 
     <string name="smartcard_removal_prompt_dialog_title">You can now remove your smart card</string>
+    <string name="smartcard_removal_prompt_dialog_positive_button">Got it</string>
 
 </resources>


### PR DESCRIPTION
## Summary
Title summarizes it... since the string being added is the same phrase as one added before ("Got it" in English), I C+P the strings from the "smartcard_nfc_reminder_dialog_positive_button" string resource. This string is used for the positive button in the smartcard removal prompt dialog.
I'll be adding this string into my next localization PR to AuthApp for consistency. 