### PR TITLE
Expose Cached Credential Service request ID in tokenResponse

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Expose Cached Credential Service request ID in tokenResponse (#1991)
 - [PATCH] Make changes for jetpack datastore broker support (#1986)
 - [PATCH] Getting rid of account manager strategy in MSAL/OneAuth (#1988)
 - [MINOR] Add JWT Claims to MicrosoftStsTokenRequest to support PRT v3 (#1969)

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -32,7 +32,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to control whether or not to use Network capability for performing network check.
      */
-    USE_NETWORK_CAPABILITY_FOR_NETWORK_CHECK("UseNetworkCapabilityForNetworkCheck", false);
+    USE_NETWORK_CAPABILITY_FOR_NETWORK_CHECK("UseNetworkCapabilityForNetworkCheck", false),
+    /**
+     * Flight to control whether to expose the CCS (CachedCredService) request ID in TokenResponse.
+     * This flight is default-on 
+     */
+    EXPOSE_CCS_REQUEST_ID_IN_TOKENRESPONSE("ExposeCcsRequestIdInTokenResponse", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -82,6 +82,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -619,10 +620,26 @@ public class MicrosoftStsOAuth2Strategy
                     tokenResponse.setCliTelemSubErrorCode(cliTelemInfo.getServerSubErrorCode());
                 }
             }
+            final String ccsRequestId = response.getHeaderValue(XMS_CCS_REQUEST_ID, 0);
+            if(null != ccsRequestId)
+            {
+                if(null != tokenResponse)
+                {
+                    Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
+                    mapWithAdditionalEntry.put(XMS_CCS_REQUEST_ID, ccsRequestId);
+                    if(null != tokenResponse.getExtraParameters())
+                    {
+                        for(Map.Entry<String, String> entry : tokenResponse.getExtraParameters())
+                        {
+                            mapWithAdditionalEntry.put(entry.getKey(), entry.getValue());
+                        }
+                    }
+                    tokenResponse.setExtraParameters(mapWithAdditionalEntry.entrySet());
+                }
 
-            SpanExtension.current().setAttribute(
-                    AttributeName.ccs_request_id.name(),
-                    response.getHeaderValue(XMS_CCS_REQUEST_ID, 0));
+                SpanExtension.current().setAttribute(
+                        AttributeName.ccs_request_id.name(), ccsRequestId);
+            }
         }
 
         return result;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -623,13 +623,13 @@ public class MicrosoftStsOAuth2Strategy
                 }
             }
             final String ccsRequestId = response.getHeaderValue(XMS_CCS_REQUEST_ID, 0);
-            if(null != ccsRequestId){
-                if(CommonFlightManager.isFlightEnabled(CommonFlight.EXPOSE_CCS_REQUEST_ID_IN_TOKENRESPONSE)){
-                    if(null != tokenResponse){
+            if (null != ccsRequestId){
+                if (CommonFlightManager.isFlightEnabled(CommonFlight.EXPOSE_CCS_REQUEST_ID_IN_TOKENRESPONSE)){
+                    if (null != tokenResponse){
                         final Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
                         mapWithAdditionalEntry.put(XMS_CCS_REQUEST_ID, ccsRequestId);
-                        if(null != tokenResponse.getExtraParameters()){
-                            for(final Map.Entry<String, String> entry : tokenResponse.getExtraParameters()){
+                        if (null != tokenResponse.getExtraParameters()){
+                            for (final Map.Entry<String, String> entry : tokenResponse.getExtraParameters()){
                                 mapWithAdditionalEntry.put(entry.getKey(), entry.getValue());
                             }
                         }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -621,16 +621,12 @@ public class MicrosoftStsOAuth2Strategy
                 }
             }
             final String ccsRequestId = response.getHeaderValue(XMS_CCS_REQUEST_ID, 0);
-            if(null != ccsRequestId)
-            {
-                if(null != tokenResponse)
-                {
-                    Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
+            if(null != ccsRequestId){
+                if(null != tokenResponse){
+                    final Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
                     mapWithAdditionalEntry.put(XMS_CCS_REQUEST_ID, ccsRequestId);
-                    if(null != tokenResponse.getExtraParameters())
-                    {
-                        for(Map.Entry<String, String> entry : tokenResponse.getExtraParameters())
-                        {
+                    if(null != tokenResponse.getExtraParameters()){
+                        for(final Map.Entry<String, String> entry : tokenResponse.getExtraParameters()){
                             mapWithAdditionalEntry.put(entry.getKey(), entry.getValue());
                         }
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -46,6 +46,8 @@ import com.microsoft.identity.common.java.dto.IAccountRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightManager;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.net.HttpClient;
@@ -622,17 +624,18 @@ public class MicrosoftStsOAuth2Strategy
             }
             final String ccsRequestId = response.getHeaderValue(XMS_CCS_REQUEST_ID, 0);
             if(null != ccsRequestId){
-                if(null != tokenResponse){
-                    final Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
-                    mapWithAdditionalEntry.put(XMS_CCS_REQUEST_ID, ccsRequestId);
-                    if(null != tokenResponse.getExtraParameters()){
-                        for(final Map.Entry<String, String> entry : tokenResponse.getExtraParameters()){
-                            mapWithAdditionalEntry.put(entry.getKey(), entry.getValue());
+                if(CommonFlightManager.isFlightEnabled(CommonFlight.EXPOSE_CCS_REQUEST_ID_IN_TOKENRESPONSE)){
+                    if(null != tokenResponse){
+                        final Map<String, String> mapWithAdditionalEntry = new HashMap<String, String>();
+                        mapWithAdditionalEntry.put(XMS_CCS_REQUEST_ID, ccsRequestId);
+                        if(null != tokenResponse.getExtraParameters()){
+                            for(final Map.Entry<String, String> entry : tokenResponse.getExtraParameters()){
+                                mapWithAdditionalEntry.put(entry.getKey(), entry.getValue());
+                            }
                         }
+                        tokenResponse.setExtraParameters(mapWithAdditionalEntry.entrySet());
                     }
-                    tokenResponse.setExtraParameters(mapWithAdditionalEntry.entrySet());
                 }
-
                 SpanExtension.current().setAttribute(
                         AttributeName.ccs_request_id.name(), ccsRequestId);
             }


### PR DESCRIPTION
Following up on PR #1866 to expose this data in a way MSAL C++ can access and add to our telemetry.

ADO Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2391983