### PR TITLE
Add method to clear receiver concurrentHashMap in LocalBroadcaster

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ vNext
 - [PATCH] Make changes for jetpack datastore broker support (#1986)
 - [PATCH] Getting rid of account manager strategy in MSAL/OneAuth (#1988)
 - [MINOR] Add JWT Claims to MicrosoftStsTokenRequest to support PRT v3 (#1969)
-- [MINOR] Clear receiver concurrentHashMap when resetting broadcast service (#1993)
+- [MINOR] Add method to clear receiver concurrentHashMap in LocalBroadcaster (#1993)
 
 V.10.1.1
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Make changes for jetpack datastore broker support (#1986)
 - [PATCH] Getting rid of account manager strategy in MSAL/OneAuth (#1988)
 - [MINOR] Add JWT Claims to MicrosoftStsTokenRequest to support PRT v3 (#1969)
+- [MINOR] Clear receiver concurrentHashMap when resetting broadcast service (#1993)
 
 V.10.1.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -68,18 +68,18 @@ public enum LocalBroadcaster {
 
     public void broadcast(@NonNull final String alias, @NonNull final PropertyBag propertyBag) {
         final String methodName = ":broadcast";
-//        sBroadcastExecutor.execute(new Runnable() {
-//            public void run() {
-        final IReceiverCallback receiver = mReceivers.get(alias);
-        if (receiver != null) {
-            Logger.info(TAG + methodName, "broadcasting to alias: " + alias);
-            receiver.onReceive(propertyBag);
-        } else {
-            Logger.info(TAG + methodName, "No callback is registered with alias: " + alias +
-                    ". Do nothing.");
-        }
-//            }
-        //});
+        sBroadcastExecutor.execute(new Runnable() {
+            public void run() {
+                final IReceiverCallback receiver = mReceivers.get(alias);
+                if (receiver != null) {
+                    Logger.info(TAG + methodName, "broadcasting to alias: " + alias);
+                    receiver.onReceive(propertyBag);
+                } else {
+                    Logger.info(TAG + methodName, "No callback is registered with alias: " + alias +
+                            ". Do nothing.");
+                }
+            }
+        });
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -83,10 +83,16 @@ public enum LocalBroadcaster {
     }
 
     /**
+     * Clears the receivers associated with this instance.
+     */
+    public void clearReceivers() {
+        mReceivers.clear();
+    }
+
+    /**
      * Resets the broadcast executor service.
      */
     public static void resetBroadcast() {
-        mReceivers.clear();
         shutdownAndAwaitTerminationForBroadcasterService();
         sBroadcastExecutor = Executors.newSingleThreadExecutor();
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -86,6 +86,7 @@ public enum LocalBroadcaster {
      * Resets the broadcast executor service.
      */
     public static void resetBroadcast() {
+        mReceivers.clear();
         shutdownAndAwaitTerminationForBroadcasterService();
         sBroadcastExecutor = Executors.newSingleThreadExecutor();
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -68,18 +68,18 @@ public enum LocalBroadcaster {
 
     public void broadcast(@NonNull final String alias, @NonNull final PropertyBag propertyBag) {
         final String methodName = ":broadcast";
-        sBroadcastExecutor.execute(new Runnable() {
-            public void run() {
-                final IReceiverCallback receiver = mReceivers.get(alias);
-                if (receiver != null) {
-                    Logger.info(TAG + methodName, "broadcasting to alias: " + alias);
-                    receiver.onReceive(propertyBag);
-                } else {
-                    Logger.info(TAG + methodName, "No callback is registered with alias: " + alias +
-                            ". Do nothing.");
-                }
-            }
-        });
+//        sBroadcastExecutor.execute(new Runnable() {
+//            public void run() {
+        final IReceiverCallback receiver = mReceivers.get(alias);
+        if (receiver != null) {
+            Logger.info(TAG + methodName, "broadcasting to alias: " + alias);
+            receiver.onReceive(propertyBag);
+        } else {
+            Logger.info(TAG + methodName, "No callback is registered with alias: " + alias +
+                    ". Do nothing.");
+        }
+//            }
+        //});
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -67,5 +67,10 @@ public class LocalBroadcasterTest {
         final PropertyBag propertyBag = new PropertyBag();
         propertyBag.put(RESULT_CODE, 1);
         LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
+
+        LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
+        propertyBag.put(RESULT_CODE, 2);
+        LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -32,7 +32,9 @@ public class LocalBroadcasterTest {
 
     @Test
     public void testClearReceivers() {
-        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag -> {
+            LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);
+        });
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
@@ -40,7 +42,9 @@ public class LocalBroadcasterTest {
 
     @Test
     public void testResetBroadcast() {
-        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag -> {
+            LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);
+        });
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
         LocalBroadcaster.resetBroadcast();

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -26,10 +26,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
-import com.microsoft.identity.common.java.util.ported.PropertyBag;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;;
 
 public class LocalBroadcasterTest {
 
@@ -54,23 +52,4 @@ public class LocalBroadcasterTest {
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
     }
 
-    @Test
-    public void testBroadcast() {
-        LocalBroadcaster.INSTANCE.registerCallback(
-                RETURN_AUTHORIZATION_REQUEST_RESULT, new LocalBroadcaster.IReceiverCallback() {
-                    @Override
-                    public void onReceive(PropertyBag propertyBag) {
-                        int resultCode = propertyBag.getOrDefault(RESULT_CODE, 0);
-                        Assert.assertEquals(resultCode, 1);
-                    }
-                });
-        final PropertyBag propertyBag = new PropertyBag();
-        propertyBag.put(RESULT_CODE, 1);
-        LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
-
-        LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);
-        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
-        propertyBag.put(RESULT_CODE, 2);
-        LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
-    }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -37,7 +37,7 @@ public class LocalBroadcasterTest {
         });
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
-        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
     }
 
     @Test
@@ -48,6 +48,6 @@ public class LocalBroadcasterTest {
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
         LocalBroadcaster.resetBroadcast();
-        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -37,7 +37,7 @@ public class LocalBroadcasterTest {
         LocalBroadcaster.INSTANCE.registerCallback(AuthenticationConstants.RETURN_AUTHORIZATION_REQUEST_RESULT, null);
         Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
         LocalBroadcaster.INSTANCE.clearReceivers();
-        LocalBroadcaster.resetBroadcast()
+        LocalBroadcaster.resetBroadcast();
         Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -65,7 +65,7 @@ public class LocalBroadcasterTest {
                     }
                 });
         final PropertyBag propertyBag = new PropertyBag();
-        propertyBag.put(RESULT_CODE, 2);
+        propertyBag.put(RESULT_CODE, 1);
         LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
 
         LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -26,13 +26,13 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
-import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
 
 public class LocalBroadcasterTest {
 
     @Test
     public void testClearReceivers() {
-        LocalBroadcaster.INSTANCE.registerCallback(AuthenticationConstants.RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
         Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
         LocalBroadcaster.INSTANCE.clearReceivers();
         Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
@@ -40,7 +40,7 @@ public class LocalBroadcasterTest {
 
     @Test
     public void testResetBroadcast() {
-        LocalBroadcaster.INSTANCE.registerCallback(AuthenticationConstants.RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
         Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
         LocalBroadcaster.INSTANCE.clearReceivers();
         LocalBroadcaster.resetBroadcast();

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -22,6 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.util;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 public class LocalBroadcasterTest {
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.util;
+
+public class LocalBroadcasterTest {
+
+    @Test
+    public void testClearReceivers() {
+        LocalBroadcaster.INSTANCE.registerCallback(AuthenticationConstants.RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
+        LocalBroadcaster.INSTANCE.clearReceivers();
+        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
+    }
+
+    @Test
+    public void testResetBroadcast() {
+        LocalBroadcaster.INSTANCE.registerCallback(AuthenticationConstants.RETURN_AUTHORIZATION_REQUEST_RESULT, null);
+        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
+        LocalBroadcaster.INSTANCE.clearReceivers();
+        LocalBroadcaster.resetBroadcast()
+        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -26,24 +26,24 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
-import com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
 
 public class LocalBroadcasterTest {
 
     @Test
     public void testClearReceivers() {
         LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
-        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
-        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
     }
 
     @Test
     public void testResetBroadcast() {
         LocalBroadcaster.INSTANCE.registerCallback(RETURN_AUTHORIZATION_REQUEST_RESULT, null);
-        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 1);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
         LocalBroadcaster.INSTANCE.clearReceivers();
         LocalBroadcaster.resetBroadcast();
-        Assert.assertEquals(LocalBroadcaster.mReceivers.size(), 0);
+        Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), true);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -25,6 +25,9 @@ package com.microsoft.identity.common.java.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
+import com.microsoft.identity.common.java.AuthenticationConstants;
+
 public class LocalBroadcasterTest {
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -26,7 +26,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
+import com.microsoft.identity.common.java.util.ported.PropertyBag;
+
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;;
 
 public class LocalBroadcasterTest {
 
@@ -49,5 +52,20 @@ public class LocalBroadcasterTest {
         LocalBroadcaster.INSTANCE.clearReceivers();
         LocalBroadcaster.resetBroadcast();
         Assert.assertEquals(LocalBroadcaster.INSTANCE.hasReceivers(RETURN_AUTHORIZATION_REQUEST_RESULT), false);
+    }
+
+    @Test
+    public void testBroadcast() {
+        LocalBroadcaster.INSTANCE.registerCallback(
+                RETURN_AUTHORIZATION_REQUEST_RESULT, new LocalBroadcaster.IReceiverCallback() {
+                    @Override
+                    public void onReceive(PropertyBag propertyBag) {
+                        int resultCode = propertyBag.getOrDefault(RESULT_CODE, 0);
+                        Assert.assertEquals(resultCode, 1);
+                    }
+                });
+        final PropertyBag propertyBag = new PropertyBag();
+        propertyBag.put(RESULT_CODE, 1);
+        LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/LocalBroadcasterTest.java
@@ -65,7 +65,7 @@ public class LocalBroadcasterTest {
                     }
                 });
         final PropertyBag propertyBag = new PropertyBag();
-        propertyBag.put(RESULT_CODE, 1);
+        propertyBag.put(RESULT_CODE, 2);
         LocalBroadcaster.INSTANCE.broadcast(RETURN_AUTHORIZATION_REQUEST_RESULT, propertyBag);
 
         LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);


### PR DESCRIPTION
This is continuation of changes done in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1895.
Even though we are now resetting the broadcast service between 2 tests, the cancel authorization request broadcast is triggered while the executor service is being reset causing a concurrent.RejectedExecutionException which kills the MSAL test app.
With current change a method to clear receiver concurrent hash map is introduced and this should be called just before calling resetBroadcast().
AB#2478513