### PR TITLE
Fix for ADAL W/Broker Silent call 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Send AT on KEY_AUTHTOKEN for ADAL Acquire token silently with Broker (#1996)
 - [PATCH] Expose Cached Credential Service request ID in tokenResponse (#1991)
 - [MINOR] Adding YubiKit remove method back in; bumping YubiKit Versions (#1994)
 - [PATCH] Make changes for jetpack datastore broker support (#1986)

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.result;
 
+import static android.accounts.AccountManager.KEY_AUTHTOKEN;
+
 import android.accounts.AccountManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -121,6 +123,16 @@ public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
         resultBundle.putString(
                 RT_AGE,
                 authenticationResult.getRefreshTokenAge()
+        );
+
+        // ADAL Acquire token silently with Broker relies on this key (KEY_AUTHTOKEN) 
+        // to get the AT (see BrokerProxy.getResultFromBrokerResponse() L:548).
+        // Broker was using Authenticator.getAuthToken() to get the AT, and the KEY_AUTHTOKEN key to store it.
+        // After #2200 broker does not use Authenticator.getAuthToken() for ATS with broker,
+        // in order to be compatible with ADAL we need to keep sending the AT on KEY_AUTHTOKEN.
+        resultBundle.putString(
+                KEY_AUTHTOKEN,
+                authenticationResult.getAccessToken()
         );
 
         return resultBundle;


### PR DESCRIPTION

related to https://github.com/AzureAD/ad-accounts-for-android/pull/2200

Description on https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=2483343

## Tested 

Install BrokerHost 
Install Adal Test App
Call AcquireToken (this should pass)
Call AcquireTokenSilent(this should pass too)