### PR TITLE
Revert "Write back read successes to cache and stop extra lookups in getAll (#1927)"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ vNext
 - [PATCH] Getting rid of account manager strategy in MSAL/OneAuth (#1988)
 - [MINOR] Add JWT Claims to MicrosoftStsTokenRequest to support PRT v3 (#1969)
 - [MAJOR] Some improvements to Open Id Provider Configuration Client (#1990)
+- [PATCH] Revert 'Write back read successes to cache and stop extra lookups in getAll (#1927)' (#1997)
 
 V.10.1.1
 ----------


### PR DESCRIPTION
Office detected a problem with requestedClaims using ADAL with this change. They couldn't repro the issue with OneAuth/MSAL, but reverting this for safety for the ADAL case. With the memory caching in place, this is less important from a performance perspective.