### PR TITLE
Allow MsalCpp to specify an InMemoryCache implementation of SharedPreferencesAccountCredentialCache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ vNext
 - [PATCH] Getting rid of account manager strategy in MSAL/OneAuth (#1988)
 - [MINOR] Add JWT Claims to MicrosoftStsTokenRequest to support PRT v3 (#1969)
 - [MAJOR] Some improvements to Open Id Provider Configuration Client (#1990)
+- [MINOR] Optional support for in-memory cache of all credentials and accountrecords (#1929)
 
 V.10.1.1
 ----------

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -1,0 +1,2517 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
+import com.microsoft.identity.common.java.authscheme.BearerAuthenticationSchemeInternal;
+import com.microsoft.identity.common.java.cache.CacheKeyValueDelegate;
+import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCacheWithMemoryCache;
+import com.microsoft.identity.common.java.dto.AccessTokenRecord;
+import com.microsoft.identity.common.java.dto.AccountRecord;
+import com.microsoft.identity.common.java.dto.Credential;
+import com.microsoft.identity.common.java.dto.CredentialType;
+import com.microsoft.identity.common.java.dto.IdTokenRecord;
+import com.microsoft.identity.common.java.dto.PrimaryRefreshTokenRecord;
+import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
+import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
+import com.microsoft.identity.common.shadows.ShadowAndroidSdkStorageEncryptionManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {ShadowAndroidSdkStorageEncryptionManager.class})
+public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
+
+    static final BearerAuthenticationSchemeInternal BEARER_AUTHENTICATION_SCHEME = new BearerAuthenticationSchemeInternal();
+    static final String HOME_ACCOUNT_ID = "29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
+    static final String ENVIRONMENT = "login.microsoftonline.com";
+    static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
+    static final String APPLICATION_IDENTIFIER = "UNSET/UNSET";
+    static final String MAM_ENROLLMENT_IDENTIFIER = "UNSET";
+    static final String TARGET = "user.read user.write https://graph.windows.net";
+    // In the case of AAD, the realm is the tenantId
+    static final String REALM = "3c62ac97-29eb-4aed-a3c8-add0298508d";
+    static final String MIDDLE_NAME = "Q";
+    static final String NAME = "Jane Doe";
+    static final String LOCAL_ACCOUNT_ID = "00000000-0000-0000-088f-0e042cc22ac0";
+    static final String USERNAME = "user.foo@tenant.onmicrosoft.com";
+    static final String AUTHORITY_TYPE = "MSSTS";
+    static final String CACHED_AT = "0";
+    static final String EXPIRES_ON = "0";
+    static final String SECRET = "3642fe2f-2c46-4824-9f27-e44b0e3e1278";
+    static final String REALM2 = "20d3e9fa-982a-40bc-bea4-26bbe3fd332e";
+    static final String SESSION_KEY = "ZmVldnVvWDBvYmVldGg5aQo=";
+    public static final String ESCAPE_SEQ_CHARS = "\r\f\n\t";
+
+    private static final String ENVIRONMENT_LEGACY = "login.windows.net";
+    private static final String REALM3 = "fc5171ec-2889-4ba6-bd1f-216fe87a8613";
+
+    // The names of the SharedPreferences file on disk - must match SharedPreferencesAccountCredentialCache declaration to test impl
+    private static final String sAccountCredentialSharedPreferences =
+            "com.microsoft.identity.client.account_credential_cache";
+
+    private SharedPreferencesAccountCredentialCacheWithMemoryCache mSharedPreferencesAccountCredentialCache;
+    private CacheKeyValueDelegate mDelegate;
+    private INameValueStorage<String> mSharedPreferencesFileManager;
+
+    @Before
+    public void setUp() throws Exception {
+        final Context testContext = ApplicationProvider.getApplicationContext();
+        mDelegate = new CacheKeyValueDelegate();
+        mSharedPreferencesFileManager = AndroidPlatformComponentsFactory.createFromContext(testContext).getEncryptedNameValueStore(
+                sAccountCredentialSharedPreferences,
+                AndroidPlatformComponentsFactory.createFromContext(testContext).getStorageEncryptionManager(), // Use encrypted storage for tests...
+                String.class
+        );
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+    }
+
+    @After
+    public void tearDown() {
+        // Wipe the SharedPreferences between tests...
+        mSharedPreferencesAccountCredentialCache.clearAll();
+    }
+
+    private static String wrapInEscapeSequenceChars(final String inputString) {
+        return ESCAPE_SEQ_CHARS + inputString + ESCAPE_SEQ_CHARS;
+    }
+
+    @Test
+    public void saveAccount() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setMiddleName(MIDDLE_NAME);
+        account.setName(NAME);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Synthesize a cache key for it
+        final String accountCacheKey = mDelegate.generateCacheKey(account);
+
+        // Resurrect the Account
+        final AccountRecord restoredAccount = mSharedPreferencesAccountCredentialCache.getAccount(accountCacheKey);
+        assertTrue(account.equals(restoredAccount));
+    }
+
+    @Test
+    public void saveAccountNoRealm() {
+        final AccountRecord account = new AccountRecord();
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Synthesize a cache key for it
+        final String accountCacheKey = mDelegate.generateCacheKey(account);
+
+        // Resurrect the Account
+        final AccountRecord restoredAccount = mSharedPreferencesAccountCredentialCache.getAccount(accountCacheKey);
+        assertTrue(account.equals(restoredAccount));
+    }
+
+    @Test
+    public void saveAccountNoHomeAccountIdNoRealm() {
+        final AccountRecord account = new AccountRecord();
+        account.setEnvironment(ENVIRONMENT);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Synthesize a cache key for it
+        final String accountCacheKey = mDelegate.generateCacheKey(account);
+
+        // Resurrect the Account
+        final AccountRecord restoredAccount = mSharedPreferencesAccountCredentialCache.getAccount(accountCacheKey);
+        assertTrue(account.equals(restoredAccount));
+    }
+
+    @Test
+    public void saveIdToken() {
+        final IdTokenRecord idToken = new IdTokenRecord();
+        idToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        idToken.setEnvironment(ENVIRONMENT);
+        idToken.setRealm(REALM);
+        idToken.setCredentialType(CredentialType.IdToken.name());
+        idToken.setClientId(CLIENT_ID);
+        idToken.setSecret(SECRET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(idToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(idToken);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertEquals(idToken.getHomeAccountId(), restoredIdToken.getHomeAccountId());
+        assertEquals(idToken.getEnvironment(), restoredIdToken.getEnvironment());
+        assertEquals(idToken.getCredentialType(), restoredIdToken.getCredentialType());
+        assertEquals(idToken.getClientId(), restoredIdToken.getClientId());
+        assertTrue(idToken.equals(restoredIdToken));
+    }
+
+    @Test
+    public void saveCredential() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+    }
+
+    @Test
+    public void saveCredentialWithEscapeChars() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(wrapInEscapeSequenceChars(CredentialType.RefreshToken.name()));
+        refreshToken.setEnvironment(wrapInEscapeSequenceChars(ENVIRONMENT));
+        refreshToken.setHomeAccountId(wrapInEscapeSequenceChars(HOME_ACCOUNT_ID));
+        refreshToken.setClientId(wrapInEscapeSequenceChars(CLIENT_ID));
+        refreshToken.setSecret(wrapInEscapeSequenceChars(SECRET));
+        refreshToken.setTarget(wrapInEscapeSequenceChars(TARGET));
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+    }
+
+    @Test
+    public void saveCredentialNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+    }
+
+    @Test
+    public void saveCredentialNoRealmNoTarget() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessToken);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessToken.equals(restoredAccessToken));
+    }
+
+    @Test
+    public void saveCredentialNoHomeAccountIdNoRealmNoTarget() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessToken);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessToken.equals(restoredAccessToken));
+    }
+
+    @Test
+    public void saveCredentialNoHomeAccountId() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+    }
+
+    @Test
+    public void saveCredentialNoHomeAccountIdNoRealm() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessToken);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessToken.equals(restoredAccessToken));
+    }
+
+    @Test
+    public void saveCredentialNoHomeAccountIdNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertEquals(refreshToken, restoredRefreshToken);
+    }
+
+    @Test
+    public void saveCredentialNoRealm() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessToken);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessToken.equals(restoredAccessToken));
+    }
+
+    @Test
+    public void getAccounts() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Verify getAccountsFilteredBy() returns one matching element
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertTrue(accounts.size() == 1);
+        assertEquals(account, accounts.get(0));
+    }
+
+    @Test
+    public void getAccountsNullEnvironment() {
+        final AccountRecord account1 = new AccountRecord();
+        account1.setHomeAccountId(HOME_ACCOUNT_ID);
+        account1.setEnvironment(ENVIRONMENT);
+        account1.setRealm(REALM);
+        account1.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account1.setUsername(USERNAME);
+        account1.setAuthorityType(AUTHORITY_TYPE);
+
+        final AccountRecord account2 = new AccountRecord();
+        account2.setHomeAccountId(HOME_ACCOUNT_ID);
+        account2.setEnvironment(ENVIRONMENT_LEGACY);
+        account2.setRealm(REALM);
+        account2.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account2.setUsername(USERNAME);
+        account2.setAuthorityType(AUTHORITY_TYPE);
+
+        // Save the Accounts
+        mSharedPreferencesAccountCredentialCache.saveAccount(account1);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account2);
+
+        // Test retrieval
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(
+                HOME_ACCOUNT_ID,
+                null,
+                REALM
+        );
+        assertEquals(2, accounts.size());
+    }
+
+    @Test
+    public void getAccountsComplete() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(HOME_ACCOUNT_ID, ENVIRONMENT, REALM);
+        assertEquals(1, accounts.size());
+        final AccountRecord retrievedAccount = accounts.get(0);
+        assertEquals(HOME_ACCOUNT_ID, retrievedAccount.getHomeAccountId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoHomeAccountId() {
+        final AccountRecord account = new AccountRecord();
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(null, ENVIRONMENT, REALM);
+        assertEquals(1, accounts.size());
+        final AccountRecord retrievedAccount = accounts.get(0);
+        assertEquals(HOME_ACCOUNT_ID, retrievedAccount.getHomeAccountId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoHomeAccountIdNoRealm() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(null, ENVIRONMENT, null);
+        assertEquals(1, accounts.size());
+        final AccountRecord retrievedAccount = accounts.get(0);
+        assertEquals(HOME_ACCOUNT_ID, retrievedAccount.getHomeAccountId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsNoRealm() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+
+        // Save the Account
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Test retrieval
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(HOME_ACCOUNT_ID, ENVIRONMENT, null);
+        assertEquals(1, accounts.size());
+        final AccountRecord retrievedAccount = accounts.get(0);
+        assertEquals(HOME_ACCOUNT_ID, retrievedAccount.getHomeAccountId());
+        assertEquals(ENVIRONMENT, retrievedAccount.getEnvironment());
+        assertEquals(REALM, retrievedAccount.getRealm());
+    }
+
+    @Test
+    public void getAccountsWithMatchingHomeAccountIdEnvironment() {
+        final AccountRecord account1 = new AccountRecord();
+        account1.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account1.setUsername(USERNAME);
+        account1.setAuthorityType(AUTHORITY_TYPE);
+        account1.setHomeAccountId(HOME_ACCOUNT_ID);
+        account1.setEnvironment(ENVIRONMENT);
+        account1.setRealm(REALM);
+
+        final AccountRecord account2 = new AccountRecord();
+        account2.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account2.setUsername(USERNAME);
+        account2.setAuthorityType(AUTHORITY_TYPE);
+        account2.setHomeAccountId(HOME_ACCOUNT_ID);
+        account2.setEnvironment(ENVIRONMENT);
+        account2.setRealm(REALM2);
+
+        final AccountRecord account3 = new AccountRecord();
+        account3.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account3.setUsername(USERNAME);
+        account3.setAuthorityType(AUTHORITY_TYPE);
+        account3.setHomeAccountId(HOME_ACCOUNT_ID);
+        account3.setEnvironment(ENVIRONMENT);
+        account3.setRealm(REALM3);
+
+        final AccountRecord account4 = new AccountRecord();
+        account4.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account4.setUsername(USERNAME);
+        account4.setAuthorityType(AUTHORITY_TYPE);
+        account4.setHomeAccountId(HOME_ACCOUNT_ID);
+        account4.setEnvironment("Foo");
+        account4.setRealm(REALM);
+
+        // Save the Accounts
+        mSharedPreferencesAccountCredentialCache.saveAccount(account1);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account2);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account3);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account4);
+
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(HOME_ACCOUNT_ID, ENVIRONMENT, null);
+        assertEquals(3, accounts.size());
+    }
+
+    @Test
+    public void getAccountsWithMatchingEnvironmentRealm() {
+        final AccountRecord account1 = new AccountRecord();
+        account1.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account1.setUsername(USERNAME);
+        account1.setAuthorityType(AUTHORITY_TYPE);
+        account1.setHomeAccountId("Foo");
+        account1.setEnvironment(ENVIRONMENT);
+        account1.setRealm(REALM);
+
+        final AccountRecord account2 = new AccountRecord();
+        account2.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account2.setUsername(USERNAME);
+        account2.setAuthorityType(AUTHORITY_TYPE);
+        account2.setHomeAccountId("Bar");
+        account2.setEnvironment(ENVIRONMENT);
+        account2.setRealm(REALM);
+
+        final AccountRecord account3 = new AccountRecord();
+        account3.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account3.setUsername(USERNAME);
+        account3.setAuthorityType(AUTHORITY_TYPE);
+        account3.setHomeAccountId("Baz");
+        account3.setEnvironment(ENVIRONMENT);
+        account3.setRealm(REALM);
+
+        final AccountRecord account4 = new AccountRecord();
+        account4.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account4.setUsername(USERNAME);
+        account4.setAuthorityType(AUTHORITY_TYPE);
+        account4.setHomeAccountId("qux");
+        account4.setEnvironment(ENVIRONMENT);
+        account4.setRealm("quz");
+
+        // Save the Accounts
+        mSharedPreferencesAccountCredentialCache.saveAccount(account1);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account2);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account3);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account4);
+
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccountsFilteredBy(null, ENVIRONMENT, REALM);
+        assertEquals(3, accounts.size());
+    }
+
+    @Test
+    public void getCredentials() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Verify getCredentials() returns two matching elements
+        final List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertTrue(credentials.size() == 2);
+    }
+
+    @Test
+    public void getCredentialsNoEnvironment() {
+        final RefreshTokenRecord refreshToken1 = new RefreshTokenRecord();
+        refreshToken1.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken1.setEnvironment(ENVIRONMENT);
+        refreshToken1.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken1.setClientId(CLIENT_ID);
+        refreshToken1.setSecret(SECRET);
+        refreshToken1.setTarget(TARGET);
+
+        final RefreshTokenRecord refreshToken2 = new RefreshTokenRecord();
+        refreshToken2.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken2.setEnvironment(ENVIRONMENT_LEGACY);
+        refreshToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken2.setClientId(CLIENT_ID);
+        refreshToken2.setSecret(SECRET);
+        refreshToken2.setTarget(TARGET);
+
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken1);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                null, // * wildcard
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoCredentialType() {
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        final List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                null,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+
+        assertEquals(
+                2,
+                credentials.size()
+        );
+    }
+
+    @Test
+    public void getCredentialsNoClientId() {
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID + "2");
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        final List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                null,
+                null,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+
+        assertEquals(
+                2,
+                credentials.size()
+        );
+    }
+
+    @Test
+    public void getCredentialsComplete() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(1, credentials.size());
+        final Credential retrievedCredential = credentials.get(0);
+        assertEquals(
+                CredentialType.RefreshToken.name(),
+                retrievedCredential.getCredentialType()
+        );
+    }
+
+    @Test
+    public void getCredentialsCaseInsensitive() {
+        // Uppercase the value we're filtering on to assert
+        // that the match is case insensitive
+        final String searchTarget = TARGET.toUpperCase();
+
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                searchTarget,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(1, credentials.size());
+        final Credential retrievedCredential = credentials.get(0);
+        assertEquals(
+                CredentialType.RefreshToken.name(),
+                retrievedCredential.getCredentialType()
+        );
+    }
+
+    @Test
+    public void getCredentialsPartialMatch() {
+        final String[] targetScopes = TARGET.split("\\s+");
+
+        // Just in case this value changes on us, just assert that it take the expected format
+        assertEquals(3, targetScopes.length);
+
+        // Let's grab a subset of these in a different order and make sure we still get the right
+        // results back
+        final String searchTarget = targetScopes[2] + " " + targetScopes[0];
+
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                searchTarget,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(1, credentials.size());
+        final Credential retrievedCredential = credentials.get(0);
+        assertEquals(
+                CredentialType.RefreshToken.name(),
+                retrievedCredential.getCredentialType()
+        );
+    }
+
+    @Test
+    public void getCredentialsPartialMatchWithCapitalization() {
+        final String[] targetScopes = TARGET.split("\\s+");
+
+        // Just in case this value changes on us, just assert that it take the expected format
+        assertEquals(3, targetScopes.length);
+
+        // Let's grab a subset of these in a different order and make sure we still get the right
+        // results back
+        final String searchTarget = targetScopes[2].toUpperCase()
+                + " "
+                + targetScopes[0].toUpperCase();
+
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                searchTarget,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(1, credentials.size());
+        final Credential retrievedCredential = credentials.get(0);
+        assertEquals(
+                CredentialType.RefreshToken.name(),
+                retrievedCredential.getCredentialType()
+        );
+    }
+
+    @Test
+    public void getCredentialsNoHomeAccountId() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        refreshToken.setHomeAccountId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                null,
+                ENVIRONMENT,
+                CredentialType.RefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(1, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoHomeAccountIdNoRealm() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId("Baz");
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoHomeAccountIdNoRealmNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId("Foo");
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId("Bar");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId("Baz");
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget("qux");
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget("qux");
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsWhenRequestedClaimsAreNotSpecified() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+        accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsWhenRequestedClaimsAreSpecified() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+        accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName(),
+                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}",
+                mSharedPreferencesAccountCredentialCache.getCredentials()
+        );
+        assertEquals(1, credentials.size());
+    }
+
+    @Test
+    public void getCorrectCredentialWhenRequestedClaimsAreSpecified() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret("SecretA");
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":false}}}");
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret("SecretB");
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+        accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName(),
+                "{\"access_token\":{\"deviceid\":{\"essential\":true}}}",
+                mSharedPreferencesAccountCredentialCache.getCredentials()
+        );
+        assertEquals(1, credentials.size());
+        assertEquals("SecretB", credentials.get(0).getSecret());
+    }
+
+    @Test
+    public void getCredentialsNoRealm() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setSecret(SECRET);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm("Bar");
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                TARGET,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoRealmNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm("Bar");
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget("qux");
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsNoHomeAccountIdNoTarget() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        accessToken.setHomeAccountId("Quz");
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm(REALM);
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+
+        // Save the Credentials
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                null,
+                ENVIRONMENT,
+                CredentialType.AccessToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                REALM,
+                null,
+                BEARER_AUTHENTICATION_SCHEME.getName()
+        );
+        assertEquals(2, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsPRTNoClientId() {
+        final PrimaryRefreshTokenRecord primaryRefreshToken = new PrimaryRefreshTokenRecord();
+        primaryRefreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        primaryRefreshToken.setEnvironment(ENVIRONMENT);
+        primaryRefreshToken.setCredentialType(CredentialType.PrimaryRefreshToken.name().toLowerCase(Locale.US));
+        primaryRefreshToken.setClientId(CLIENT_ID);
+        primaryRefreshToken.setSessionKey(SESSION_KEY);
+
+        mSharedPreferencesAccountCredentialCache.saveCredential(primaryRefreshToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.PrimaryRefreshToken,
+                null, /* client id */
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                null,
+                null
+        );
+        assertEquals(1, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsPRTClientId() {
+        final PrimaryRefreshTokenRecord primaryRefreshToken = new PrimaryRefreshTokenRecord();
+        primaryRefreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        primaryRefreshToken.setEnvironment(ENVIRONMENT);
+        primaryRefreshToken.setCredentialType(CredentialType.PrimaryRefreshToken.name().toLowerCase(Locale.US));
+        primaryRefreshToken.setClientId(CLIENT_ID);
+        primaryRefreshToken.setSessionKey(SESSION_KEY);
+
+        mSharedPreferencesAccountCredentialCache.saveCredential(primaryRefreshToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.PrimaryRefreshToken,
+                CLIENT_ID,
+                APPLICATION_IDENTIFIER,
+                MAM_ENROLLMENT_IDENTIFIER,
+                null,
+                null,
+                null
+        );
+        assertEquals(1, credentials.size());
+    }
+
+    @Test
+    public void getCredentialsPRTAnotherClientId() {
+        final PrimaryRefreshTokenRecord primaryRefreshToken = new PrimaryRefreshTokenRecord();
+        primaryRefreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        primaryRefreshToken.setEnvironment(ENVIRONMENT);
+        primaryRefreshToken.setCredentialType(CredentialType.PrimaryRefreshToken.name().toLowerCase(Locale.US));
+        primaryRefreshToken.setClientId(CLIENT_ID);
+        primaryRefreshToken.setSessionKey(SESSION_KEY);
+
+        mSharedPreferencesAccountCredentialCache.saveCredential(primaryRefreshToken);
+
+        List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentialsFilteredBy(
+                HOME_ACCOUNT_ID,
+                ENVIRONMENT,
+                CredentialType.PrimaryRefreshToken,
+                "another-client-id",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+        assertTrue(credentials.isEmpty());
+    }
+
+    @Test
+    public void clearAccounts() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Call clearAccounts()
+        mSharedPreferencesAccountCredentialCache.removeAccount(account);
+
+        // Verify getAccounts() returns zero items
+        assertTrue(mSharedPreferencesAccountCredentialCache.getAccounts().isEmpty());
+
+        // Verify getCredentials() returns two items
+        final List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertTrue(credentials.size() == 2);
+    }
+
+    @Test
+    public void clearCredentials() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setRealm(REALM);
+        accessToken.setTarget(TARGET);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Call clearCredentials()
+        mSharedPreferencesAccountCredentialCache.removeCredential(accessToken);
+        mSharedPreferencesAccountCredentialCache.removeCredential(refreshToken);
+
+        // Verify getAccounts() returns 1 item
+        assertEquals(1, mSharedPreferencesAccountCredentialCache.getAccounts().size());
+
+        // Verify getCredentials() returns zero items
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+    }
+
+    @Test
+    public void clearAll() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Call clearAll()
+        mSharedPreferencesAccountCredentialCache.clearAll();
+
+        // Verify getAccounts() returns zero items
+        assertTrue(mSharedPreferencesAccountCredentialCache.getAccounts().isEmpty());
+
+        // Verify getCredentials() returns zero items
+        assertTrue(mSharedPreferencesAccountCredentialCache.getCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMalformedCredentialCacheKeyReturnsNull() {
+        assertNull(mSharedPreferencesAccountCredentialCache.getCredential("Malformed cache key"));
+    }
+
+    @Test
+    public void noValueForCacheKeyAccount() {
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getAccounts().size());
+        final AccountRecord account = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount("No account");
+        assertNull(account);
+    }
+
+    @Test
+    public void noValueForCacheKeyAccessToken() {
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+        final AccessTokenRecord accessToken = (AccessTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(CACHE_VALUE_SEPARATOR + CredentialType.AccessToken.name().toLowerCase() + CACHE_VALUE_SEPARATOR);
+        assertNull(accessToken);
+    }
+
+    @Test
+    public void noValueForCacheKeyRefreshToken() {
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+        final RefreshTokenRecord refreshToken = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(CACHE_VALUE_SEPARATOR + CredentialType.RefreshToken.name().toLowerCase() + CACHE_VALUE_SEPARATOR);
+        assertNull(refreshToken);
+    }
+
+    @Test
+    public void noValueForCacheKeyIdToken() {
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+        final IdTokenRecord idToken = (IdTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(CACHE_VALUE_SEPARATOR + CredentialType.IdToken.name().toLowerCase() + CACHE_VALUE_SEPARATOR);
+        assertNull(idToken);
+    }
+
+    @Test
+    public void malformedJsonCacheValueForAccount() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(account);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" \"not an account\"}");
+
+        final AccountRecord malformedAccount = mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNull(malformedAccount);
+        assertNotNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedCacheValueForAccount() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(account);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an account\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+
+        final AccountRecord malformedAccount = mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNull(malformedAccount);
+        assertNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedJsonCacheValueForAccessToken() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(accessToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" \"not an accessToken\"}");
+
+        final AccessTokenRecord malformedAccessToken = (AccessTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(malformedAccessToken);
+        assertNotNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedCacheValueForAccessToken() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(accessToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an accessToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+
+        final AccessTokenRecord malformedAccessToken = (AccessTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(malformedAccessToken);
+        assertNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedJsonCacheValueForRefreshToken() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.AccessToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" \"not a refreshToken\"}");
+
+        final RefreshTokenRecord malformedRefreshToken = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(malformedRefreshToken);
+        assertNotNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedCacheValueForRefreshToken() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setCredentialType(CredentialType.AccessToken.name());
+        refreshToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not a refreshToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+
+        final RefreshTokenRecord malformedRefreshToken = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(malformedRefreshToken);
+        assertNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedJsonCacheValueForIdToken() {
+        final IdTokenRecord idToken = new IdTokenRecord();
+        idToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        idToken.setEnvironment(ENVIRONMENT);
+        idToken.setCredentialType(CredentialType.IdToken.name());
+        idToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(idToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\"  \"not an idToken\"}");
+
+        final IdTokenRecord restoredIdToken = (IdTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(restoredIdToken);
+        assertNotNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void malformedCacheValueForIdToken() {
+        final IdTokenRecord idToken = new IdTokenRecord();
+        idToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        idToken.setEnvironment(ENVIRONMENT);
+        idToken.setCredentialType(CredentialType.IdToken.name());
+        idToken.setClientId(CLIENT_ID);
+
+        // Generate a cache key
+        final String cacheKey = mDelegate.generateCacheKey(idToken);
+
+        mSharedPreferencesFileManager.put(cacheKey, "{\"thing\" : \"not an idToken\"}");
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+
+        final IdTokenRecord restoredIdToken = (IdTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNull(restoredIdToken);
+        assertNull(mSharedPreferencesFileManager.get(cacheKey));
+    }
+
+    @Test
+    public void persistAndRestoreExtraClaimsAccount() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setMiddleName(MIDDLE_NAME);
+        account.setName(NAME);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final String secondAdditionalKey = "extra-prop-2";
+        final String secondAdditionalValue = "extra-value-2";
+        final JsonElement secondAdditionalValueElement = new JsonPrimitive(secondAdditionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+        additionalFields.put(secondAdditionalKey, secondAdditionalValueElement);
+
+        account.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(account);
+
+        // Resurrect the Credential
+        final AccountRecord restoredAccount = mSharedPreferencesAccountCredentialCache.getAccount(credentialCacheKey);
+        assertTrue(account.equals(restoredAccount));
+        assertEquals(additionalValue, restoredAccount.getAdditionalFields().get(additionalKey).getAsString());
+        assertEquals(secondAdditionalValue, restoredAccount.getAdditionalFields().get(secondAdditionalKey).getAsString());
+    }
+
+    @Test
+    public void persistAndRestoreExtraClaimsAccessToken() {
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm(REALM);
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        accessToken.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessToken);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessToken.equals(restoredAccessToken));
+        assertEquals(additionalValue, restoredAccessToken.getAdditionalFields().get(additionalKey).getAsString());
+    }
+
+    @Test
+    public void persistAndRestoreExtraClaimsRefreshToken() {
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        refreshToken.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshToken);
+
+        // Resurrect the Credential
+        final Credential restoredRefreshToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshToken.equals(restoredRefreshToken));
+        assertEquals(additionalValue, restoredRefreshToken.getAdditionalFields().get(additionalKey).getAsString());
+    }
+
+    @Test
+    public void persistAndRestoreExtraClaimsIdToken() {
+        final IdTokenRecord idToken = new IdTokenRecord();
+        idToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        idToken.setEnvironment(ENVIRONMENT);
+        idToken.setRealm(REALM);
+        idToken.setCredentialType(CredentialType.IdToken.name());
+        idToken.setClientId(CLIENT_ID);
+        idToken.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        idToken.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(idToken);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(idToken);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(idToken.equals(restoredIdToken));
+        assertEquals(additionalValue, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
+    }
+
+    @Test
+    public void testAccountMerge() {
+        final AccountRecord accountFirst = new AccountRecord();
+        accountFirst.setHomeAccountId(HOME_ACCOUNT_ID);
+        accountFirst.setEnvironment(ENVIRONMENT);
+        accountFirst.setRealm(REALM);
+        accountFirst.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        accountFirst.setUsername(USERNAME);
+        accountFirst.setAuthorityType(AUTHORITY_TYPE);
+        accountFirst.setMiddleName(MIDDLE_NAME);
+        accountFirst.setName(NAME);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        accountFirst.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveAccount(accountFirst);
+
+        // Save the second Account, with fields to merge...
+        final AccountRecord accountSecond = new AccountRecord();
+        accountSecond.setHomeAccountId(HOME_ACCOUNT_ID);
+        accountSecond.setEnvironment(ENVIRONMENT);
+        accountSecond.setRealm(REALM);
+        accountSecond.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        accountSecond.setUsername(USERNAME);
+        accountSecond.setAuthorityType(AUTHORITY_TYPE);
+        accountSecond.setMiddleName(MIDDLE_NAME);
+        accountSecond.setName(NAME);
+
+        // Create and set some additional field data...
+        final String additionalKey2 = "extra-prop-2";
+        final String additionalValue2 = "extra-value-2";
+        final JsonElement additionalValueElement2 = new JsonPrimitive(additionalValue2);
+
+        final Map<String, JsonElement> additionalFields2 = new HashMap<>();
+        additionalFields2.put(additionalKey2, additionalValueElement2);
+
+        accountSecond.setAdditionalFields(additionalFields2);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveAccount(accountSecond);
+
+        // Synthesize a cache key for it - either is fine.
+        final String credentialCacheKey = mDelegate.generateCacheKey(accountFirst);
+
+        // Resurrect the Credential
+        final AccountRecord restoredAccount = mSharedPreferencesAccountCredentialCache.getAccount(credentialCacheKey);
+        assertTrue(accountFirst.equals(restoredAccount));
+
+        // Assert the presence of both additionalFields
+        assertEquals(additionalValue, restoredAccount.getAdditionalFields().get(additionalKey).getAsString());
+        assertEquals(additionalValue2, restoredAccount.getAdditionalFields().get(additionalKey2).getAsString());
+    }
+
+    @Test
+    public void testAccessTokenMerge() {
+        final AccessTokenRecord accessTokenFirst = new AccessTokenRecord();
+        accessTokenFirst.setCredentialType(CredentialType.AccessToken.name());
+        accessTokenFirst.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessTokenFirst.setRealm(REALM);
+        accessTokenFirst.setEnvironment(ENVIRONMENT);
+        accessTokenFirst.setClientId(CLIENT_ID);
+        accessTokenFirst.setTarget(TARGET);
+        accessTokenFirst.setCachedAt(CACHED_AT);
+        accessTokenFirst.setExpiresOn(EXPIRES_ON);
+        accessTokenFirst.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        accessTokenFirst.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessTokenFirst);
+
+        final AccessTokenRecord accessTokenSecond = new AccessTokenRecord();
+        accessTokenSecond.setCredentialType(CredentialType.AccessToken.name());
+        accessTokenSecond.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessTokenSecond.setRealm(REALM);
+        accessTokenSecond.setEnvironment(ENVIRONMENT);
+        accessTokenSecond.setClientId(CLIENT_ID);
+        accessTokenSecond.setTarget(TARGET);
+        accessTokenSecond.setCachedAt(CACHED_AT);
+        accessTokenSecond.setExpiresOn(EXPIRES_ON);
+        accessTokenSecond.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey2 = "extra-prop-2";
+        final String additionalValue2 = "extra-value-2";
+        final JsonElement additionalValueElement2 = new JsonPrimitive(additionalValue2);
+
+        final Map<String, JsonElement> additionalFields2 = new HashMap<>();
+        additionalFields2.put(additionalKey2, additionalValueElement2);
+
+        accessTokenSecond.setAdditionalFields(additionalFields2);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessTokenSecond);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(accessTokenFirst);
+
+        // Resurrect the Credential
+        final Credential restoredAccessToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(accessTokenFirst.equals(restoredAccessToken));
+        assertEquals(additionalValue, restoredAccessToken.getAdditionalFields().get(additionalKey).getAsString());
+        assertEquals(additionalValue2, restoredAccessToken.getAdditionalFields().get(additionalKey2).getAsString());
+    }
+
+    @Test
+    public void testIdTokenMerge() {
+        final IdTokenRecord idTokenFirst = new IdTokenRecord();
+        idTokenFirst.setCredentialType(CredentialType.IdToken.name());
+        idTokenFirst.setHomeAccountId(HOME_ACCOUNT_ID);
+        idTokenFirst.setRealm(REALM);
+        idTokenFirst.setEnvironment(ENVIRONMENT);
+        idTokenFirst.setClientId(CLIENT_ID);
+        idTokenFirst.setCachedAt(CACHED_AT);
+        idTokenFirst.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        idTokenFirst.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(idTokenFirst);
+
+        final IdTokenRecord idTokenSecond = new IdTokenRecord();
+        idTokenSecond.setCredentialType(CredentialType.IdToken.name());
+        idTokenSecond.setHomeAccountId(HOME_ACCOUNT_ID);
+        idTokenSecond.setRealm(REALM);
+        idTokenSecond.setEnvironment(ENVIRONMENT);
+        idTokenSecond.setClientId(CLIENT_ID);
+        idTokenSecond.setCachedAt(CACHED_AT);
+        idTokenSecond.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey2 = "extra-prop-2";
+        final String additionalValue2 = "extra-value-2";
+        final JsonElement additionalValueElement2 = new JsonPrimitive(additionalValue2);
+
+        final Map<String, JsonElement> additionalFields2 = new HashMap<>();
+        additionalFields2.put(additionalKey2, additionalValueElement2);
+
+        idTokenSecond.setAdditionalFields(additionalFields2);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(idTokenSecond);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(idTokenFirst);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(idTokenFirst.equals(restoredIdToken));
+        assertEquals(additionalValue, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
+        assertEquals(additionalValue2, restoredIdToken.getAdditionalFields().get(additionalKey2).getAsString());
+    }
+
+    @Test
+    public void testRefreshTokenMerge() {
+        final RefreshTokenRecord refreshTokenFirst = new RefreshTokenRecord();
+        refreshTokenFirst.setCredentialType(CredentialType.RefreshToken.name());
+        refreshTokenFirst.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshTokenFirst.setEnvironment(ENVIRONMENT);
+        refreshTokenFirst.setClientId(CLIENT_ID);
+        refreshTokenFirst.setCachedAt(CACHED_AT);
+        refreshTokenFirst.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        refreshTokenFirst.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshTokenFirst);
+
+        final RefreshTokenRecord refreshTokenSecond = new RefreshTokenRecord();
+        refreshTokenSecond.setCredentialType(CredentialType.RefreshToken.name());
+        refreshTokenSecond.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshTokenSecond.setEnvironment(ENVIRONMENT);
+        refreshTokenSecond.setClientId(CLIENT_ID);
+        refreshTokenSecond.setCachedAt(CACHED_AT);
+        refreshTokenSecond.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey2 = "extra-prop-2";
+        final String additionalValue2 = "extra-value-2";
+        final JsonElement additionalValueElement2 = new JsonPrimitive(additionalValue2);
+
+        final Map<String, JsonElement> additionalFields2 = new HashMap<>();
+        additionalFields2.put(additionalKey2, additionalValueElement2);
+
+        refreshTokenSecond.setAdditionalFields(additionalFields2);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshTokenSecond);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshTokenFirst);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshTokenFirst.equals(restoredIdToken));
+        assertEquals(additionalValue, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
+        assertEquals(additionalValue2, restoredIdToken.getAdditionalFields().get(additionalKey2).getAsString());
+    }
+
+    @Test
+    public void testLatestMergedPropertyWins() {
+        final RefreshTokenRecord refreshTokenFirst = new RefreshTokenRecord();
+        refreshTokenFirst.setCredentialType(CredentialType.RefreshToken.name());
+        refreshTokenFirst.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshTokenFirst.setEnvironment(ENVIRONMENT);
+        refreshTokenFirst.setClientId(CLIENT_ID);
+        refreshTokenFirst.setCachedAt(CACHED_AT);
+        refreshTokenFirst.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey = "extra-prop-1";
+        final String additionalValue = "extra-value-1";
+        final JsonElement additionalValueElement = new JsonPrimitive(additionalValue);
+
+        final Map<String, JsonElement> additionalFields = new HashMap<>();
+        additionalFields.put(additionalKey, additionalValueElement);
+
+        refreshTokenFirst.setAdditionalFields(additionalFields);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshTokenFirst);
+
+        final RefreshTokenRecord refreshTokenSecond = new RefreshTokenRecord();
+        refreshTokenSecond.setCredentialType(CredentialType.RefreshToken.name());
+        refreshTokenSecond.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshTokenSecond.setEnvironment(ENVIRONMENT);
+        refreshTokenSecond.setClientId(CLIENT_ID);
+        refreshTokenSecond.setCachedAt(CACHED_AT);
+        refreshTokenSecond.setSecret(SECRET);
+
+        // Create and set some additional field data...
+        final String additionalKey2 = "extra-prop-1";
+        final String additionalValue2 = "extra-value-2";
+        final JsonElement additionalValueElement2 = new JsonPrimitive(additionalValue2);
+
+        final Map<String, JsonElement> additionalFields2 = new HashMap<>();
+        additionalFields2.put(additionalKey2, additionalValueElement2);
+
+        refreshTokenSecond.setAdditionalFields(additionalFields2);
+
+        // Save the Credential
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshTokenSecond);
+
+        // Synthesize a cache key for it
+        final String credentialCacheKey = mDelegate.generateCacheKey(refreshTokenFirst);
+
+        // Resurrect the Credential
+        final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
+        assertTrue(refreshTokenFirst.equals(restoredIdToken));
+        assertEquals(additionalValue2, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
+    }
+
+    AccountRecord buildDefaultAccountRecord() {
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        account.setMiddleName(MIDDLE_NAME);
+        account.setName(NAME);
+        return account;
+    }
+
+    RefreshTokenRecord buildDefaultRefreshToken() {
+        final RefreshTokenRecord rt = new RefreshTokenRecord();
+        rt.setCredentialType(CredentialType.RefreshToken.name());
+        rt.setHomeAccountId(HOME_ACCOUNT_ID);
+        rt.setEnvironment(ENVIRONMENT);
+        rt.setClientId(CLIENT_ID);
+        rt.setCachedAt(CACHED_AT);
+        rt.setSecret(SECRET);
+        return rt;
+    }
+
+    @Test
+    public void testSavedAccountIsCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        final String cacheKey = mDelegate.generateCacheKey(account);
+        AccountRecord retrieved = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(account, retrieved);
+        assertEquals(account, retrieved);
+
+        account.setLocalAccountId("banana");
+        retrieved = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(account, retrieved);
+        assertNotEquals(account, retrieved);
+    }
+
+    @Test
+    public void testSavedCredentialIsCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        final String cacheKey = mDelegate.generateCacheKey(rt);
+        RefreshTokenRecord retrieved = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(rt, retrieved);
+        assertEquals(rt, retrieved);
+
+        rt.setCachedAt("banana");
+        retrieved = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(rt, retrieved);
+        assertNotEquals(rt, retrieved);
+    }
+
+    @Test
+    public void testReturnedAccountIsCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        final String cacheKey = mDelegate.generateCacheKey(account);
+        AccountRecord retrieved1 = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        retrieved1.setLocalAccountId("banana");
+
+        AccountRecord retrieved2 = (AccountRecord) mSharedPreferencesAccountCredentialCache.getAccount(cacheKey);
+        assertNotSame(retrieved1, retrieved2);
+        assertNotEquals(retrieved1, retrieved2);
+    }
+
+    @Test
+    public void testReturnedCredentialIsCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        final String cacheKey = mDelegate.generateCacheKey(rt);
+        RefreshTokenRecord retrieved1 = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        retrieved1.setCachedAt("banana");
+
+        RefreshTokenRecord retrieved2 = (RefreshTokenRecord) mSharedPreferencesAccountCredentialCache.getCredential(cacheKey);
+        assertNotSame(retrieved1, retrieved2);
+        assertNotEquals(retrieved1, retrieved2);
+    }
+
+    @Test
+    public void testReturnedAllAccountsAreCloned() {
+        AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        List<AccountRecord> accounts1 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts1.size());
+
+        List<AccountRecord> accounts2 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts2.size());
+
+        assertNotSame(accounts1, accounts2);
+        assertNotSame(accounts1.get(0), accounts2.get(0));
+        assertEquals(accounts1.get(0), accounts2.get(0));
+
+        accounts1.get(0).setLocalAccountId("banana");
+        assertNotEquals(accounts1.get(0), accounts2.get(0));
+    }
+
+    @Test
+    public void testReturnedAllCredentialsAreCloned() {
+        RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        List<Credential> creds1 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds1.size());
+
+        List<Credential> creds2 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds2.size());
+
+        assertNotSame(creds1, creds2);
+        assertNotSame(creds1.get(0), creds2.get(0));
+        assertEquals(creds1.get(0), creds2.get(0));
+
+        creds1.get(0).setCachedAt("banana");
+        assertNotEquals(creds1.get(0), creds2.get(0));
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -85,9 +85,7 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * Factory method for creating an instance of MsalCppOAuth2TokenCache
-     * <p>
-     * NOTE: Currently this is configured for AAD v2 as the only IDP
+     * Factory method for creating an instance of MsalCppOAuth2TokenCache.
      *
      * @param platformComponents The Application Context
      * @return An instance of the MsalCppOAuth2TokenCache.
@@ -99,9 +97,7 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * Factory method for creating an instance of MsalCppOAuth2TokenCache
-     * <p>
-     * NOTE: Currently this is configured for AAD v2 as the only IDP
+     * Factory method for creating an instance of MsalCppOAuth2TokenCache.
      *
      * @param platformComponents The Application Context
      * @param useInMemoryCache Opt-in to caching layer that holds account and credential objects in memory

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -95,7 +95,22 @@ public class MsalCppOAuth2TokenCache
     // Suppressing unchecked warning as the return type requiring generic parameter which is not provided
     @SuppressWarnings(WarningType.unchecked_warning)
     public static MsalCppOAuth2TokenCache create(@NonNull final IPlatformComponents platformComponents) {
-        final MsalOAuth2TokenCache msalOAuth2TokenCache = MsalOAuth2TokenCache.create(platformComponents);
+        return create(platformComponents, false);
+    }
+
+    /**
+     * Factory method for creating an instance of MsalCppOAuth2TokenCache
+     * <p>
+     * NOTE: Currently this is configured for AAD v2 as the only IDP
+     *
+     * @param platformComponents The Application Context
+     * @param useInMemoryCache Opt-in to caching layer that holds account and credential objects in memory
+     * @return An instance of the MsalCppOAuth2TokenCache.
+     */
+    // Suppressing unchecked warning as the return type requiring generic parameter which is not provided
+    @SuppressWarnings(WarningType.unchecked_warning)
+    public static MsalCppOAuth2TokenCache create(@NonNull final IPlatformComponents platformComponents, boolean useInMemoryCache) {
+        final MsalOAuth2TokenCache msalOAuth2TokenCache = MsalOAuth2TokenCache.create(platformComponents, useInMemoryCache);
 
         // Suppressing unchecked warnings due to the generic types not provided while creating object of MsalCppOAuth2TokenCache
         @SuppressWarnings(WarningType.unchecked_warning)

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -127,6 +127,24 @@ public class MsalOAuth2TokenCache
             MicrosoftStsTokenResponse,
             MicrosoftAccount,
             MicrosoftRefreshToken> create(@NonNull final IPlatformComponents components) {
+        return create(components, false);
+    }
+
+    /**
+     * Factory method for creating an instance of MsalOAuth2TokenCache
+     * <p>
+     * NOTE: Currently this is configured for AAD v2 as the only IDP
+     *
+     * @param components The platform components
+     * @param useInMemoryCache Opt-in to caching layer that holds account and credential objects in memory
+     * @return An instance of the MsalOAuth2TokenCache.
+     */
+    public static MsalOAuth2TokenCache<
+            MicrosoftStsOAuth2Strategy,
+            MicrosoftStsAuthorizationRequest,
+            MicrosoftStsTokenResponse,
+            MicrosoftAccount,
+            MicrosoftRefreshToken> create(@NonNull final IPlatformComponents components, boolean useInMemoryCache) {
         final String methodName = ":create";
 
         Logger.verbose(
@@ -142,11 +160,19 @@ public class MsalOAuth2TokenCache
                         components.getStorageEncryptionManager(),
                         String.class
                 );
-        final IAccountCredentialCache accountCredentialCache =
-                new SharedPreferencesAccountCredentialCache(
-                        cacheKeyValueDelegate,
-                        sharedPreferencesFileManager
-                );
+        final IAccountCredentialCache accountCredentialCache;
+        if (useInMemoryCache) {
+            accountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                    cacheKeyValueDelegate,
+                    sharedPreferencesFileManager
+            );
+        } else {
+            accountCredentialCache = new SharedPreferencesAccountCredentialCache(
+                    cacheKeyValueDelegate,
+                    sharedPreferencesFileManager
+            );
+        }
+
         final MicrosoftStsAccountCredentialAdapter accountCredentialAdapter =
                 new MicrosoftStsAccountCredentialAdapter();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -75,13 +75,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                 + uid;
     }
 
-    private static final AccountRecord EMPTY_ACCOUNT = new AccountRecord();
-    private static final AccessTokenRecord EMPTY_AT = new AccessTokenRecord();
-    private static final RefreshTokenRecord EMPTY_RT = new RefreshTokenRecord();
-    private static final IdTokenRecord EMPTY_ID = new IdTokenRecord();
-    private static final String DESERIALIZATION_FAILED = "Deserialization failed. Skipping ";
-    private static final String ACCOUNT_RECORD_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + AccountRecord.class.getSimpleName();
-    private static final String CREDENTIAL_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + Credential.class.getSimpleName();
+    public static final AccountRecord EMPTY_ACCOUNT = new AccountRecord();
+    public static final AccessTokenRecord EMPTY_AT = new AccessTokenRecord();
+    public static final RefreshTokenRecord EMPTY_RT = new RefreshTokenRecord();
+    public static final IdTokenRecord EMPTY_ID = new IdTokenRecord();
+    public static final String DESERIALIZATION_FAILED = "Deserialization failed. Skipping ";
+    public static final String ACCOUNT_RECORD_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + AccountRecord.class.getSimpleName();
+    public static final String CREDENTIAL_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + Credential.class.getSimpleName();
 
     // SharedPreferences used to store Accounts and Credentials
     private final INameValueStorage<String> mSharedPreferencesFileManager;

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -1,0 +1,768 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.cache;
+
+import com.microsoft.identity.common.java.dto.AccessTokenRecord;
+import com.microsoft.identity.common.java.dto.AccountCredentialBase;
+import com.microsoft.identity.common.java.dto.AccountRecord;
+import com.microsoft.identity.common.java.dto.Credential;
+import com.microsoft.identity.common.java.dto.CredentialType;
+import com.microsoft.identity.common.java.dto.IdTokenRecord;
+import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.interfaces.INameValueStorage;
+import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.ported.Predicate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.NonNull;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends AbstractAccountCredentialCache {
+
+    private static final String TAG = SharedPreferencesAccountCredentialCacheWithMemoryCache.class.getSimpleName();
+
+    /**
+     * The name of the SharedPreferences file on disk.
+     */
+    public static final String DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES =
+            "com.microsoft.identity.client.account_credential_cache";
+
+    /**
+     * The name of the Broker FOCI file on disk.
+     */
+    public static final String BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES =
+            DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
+                    + ".foci-1";
+
+    /**
+     * Returns the generated filename for UID-specific caches.
+     *
+     * @param uid The uid of the current (or targeted) application.
+     * @return The uid-based cache filename.
+     */
+    public static String getBrokerUidSequesteredFilename(final int uid) {
+        return DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
+                + ".uid-"
+                + uid;
+    }
+
+    private static final AccountRecord EMPTY_ACCOUNT = new AccountRecord();
+    private static final AccessTokenRecord EMPTY_AT = new AccessTokenRecord();
+    private static final RefreshTokenRecord EMPTY_RT = new RefreshTokenRecord();
+    private static final IdTokenRecord EMPTY_ID = new IdTokenRecord();
+    private static final String DESERIALIZATION_FAILED = "Deserialization failed. Skipping ";
+    private static final String ACCOUNT_RECORD_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + AccountRecord.class.getSimpleName();
+    private static final String CREDENTIAL_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + Credential.class.getSimpleName();
+
+    // SharedPreferences used to store Accounts and Credentials
+    private final INameValueStorage<String> mSharedPreferencesFileManager;
+
+    private final ICacheKeyValueDelegate mCacheValueDelegate;
+
+    private final Object mCacheLock = new Object();
+    private boolean mLoaded = false;
+
+    private Map<String, AccountRecord> mCachedAccountRecordsWithKeys = new HashMap<>();
+    private Map<String, Credential> mCachedCredentialsWithKeys = new HashMap<>();
+
+    /**
+     * Constructor of SharedPreferencesAccountCredentialCacheWithMemoryCache.
+     *
+     * @param accountCacheValueDelegate    ICacheKeyValueDelegate
+     * @param sharedPreferencesFileManager INameValueStorage
+     */
+    public SharedPreferencesAccountCredentialCacheWithMemoryCache(
+            @NonNull final ICacheKeyValueDelegate accountCacheValueDelegate,
+            @NonNull final INameValueStorage<String> sharedPreferencesFileManager) {
+        Logger.verbose(TAG, "Init: " + TAG);
+        mSharedPreferencesFileManager = sharedPreferencesFileManager;
+        mCacheValueDelegate = accountCacheValueDelegate;
+        new Thread(() -> load()).start();
+    }
+
+    private void load() {
+        final String methodTag = TAG + ":load";
+
+        synchronized (mCacheLock) {
+            try {
+                mCachedAccountRecordsWithKeys = loadAccountsWithKeys();
+                Logger.info(methodTag, "Loaded " + mCachedAccountRecordsWithKeys.size() + " AccountRecords");
+                mCachedCredentialsWithKeys = loadCredentialsWithKeys();
+                Logger.info(methodTag, "Loaded " + mCachedCredentialsWithKeys.size() + " Credentials");
+            } catch (final Throwable t) {
+                Logger.error(methodTag, "Failed to load initial accounts or credentials from SharedPreferences", t);
+            } finally {
+                mLoaded = true;
+                mCacheLock.notifyAll();
+            }
+        }
+    }
+
+    private void waitForInitialLoad() {
+        final String methodTag = TAG + ":waitForInitialLoad";
+
+        while (!mLoaded) {
+            try {
+                mCacheLock.wait();
+            } catch (final InterruptedException e) {
+                Logger.error(methodTag, "Caught InterruptedException while waiting", e);
+            }
+        }
+    }
+
+    @Override
+    public void saveAccount(@NonNull final AccountRecord accountInput) {
+        final String methodTag = TAG + ":saveAccount";
+
+        AccountRecord accountToSave = null;
+        try {
+            accountToSave = (AccountRecord) accountInput.clone();
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone AccountRecord", e);
+            return;
+        }
+
+        Logger.verbose(methodTag, "Saving Account...");
+        Logger.verbose(methodTag, "Account type: [" + accountToSave.getClass().getSimpleName() + "]");
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToSave);
+        Logger.verbosePII(methodTag, "Generated cache key: [" + cacheKey + "]");
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+
+            // Perform any necessary field merging on the Account to save...
+            final AccountRecord existingAccount = getAccount(cacheKey);
+
+            if (null != existingAccount) {
+                accountToSave.mergeAdditionalFields(existingAccount);
+            }
+
+            final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+            mCachedAccountRecordsWithKeys.put(cacheKey, accountToSave);
+        }
+    }
+
+    @Override
+    public void saveCredential(@NonNull Credential credentialInput) {
+        final String methodTag = TAG + ":saveCredential";
+
+        Credential credentialToSave = null;
+        try {
+            credentialToSave = (Credential) credentialInput.clone();
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone Credential", e);
+            return;
+        }
+
+        Logger.verbose(methodTag, "Saving credential...");
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToSave);
+        Logger.verbosePII(methodTag, "Generated cache key: [" + cacheKey + "]");
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+
+            // Perform any necessary field merging on the Credential to save...
+            final Credential existingCredential = getCredential(cacheKey);
+
+            if (null != existingCredential) {
+                credentialToSave.mergeAdditionalFields(existingCredential);
+            }
+
+            final String cacheValue = mCacheValueDelegate.generateCacheValue(credentialToSave);
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+            mCachedCredentialsWithKeys.put(cacheKey, credentialToSave);
+        }
+    }
+
+    @Override
+    public AccountRecord getAccount(@NonNull final String cacheKey) {
+        final String methodTag = TAG + ":getAccount";
+
+        AccountRecord foundValue;
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            foundValue = mCachedAccountRecordsWithKeys.get(cacheKey);
+        }
+
+        try {
+            if (foundValue != null) {
+                foundValue = (AccountRecord) foundValue.clone();
+            }
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone AccountRecord", e);
+        }
+        return foundValue;
+    }
+
+    @Override
+    @Nullable
+    public Credential getCredential(@NonNull final String cacheKey) {
+        final String methodTag = TAG + ":getCredential";
+
+        Credential foundValue;
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            foundValue = mCachedCredentialsWithKeys.get(cacheKey);
+        }
+
+        try {
+            if (foundValue != null) {
+                foundValue = (Credential) foundValue.clone();
+            }
+        } catch (final CloneNotSupportedException e) {
+            Logger.error(methodTag, "Failed to clone Credential", e);
+        }
+
+        return foundValue;
+    }
+
+    @NonNull
+    private Map<String, AccountRecord> loadAccountsWithKeys() {
+        final String methodTag = TAG + ":loadAccountsWithKeys";
+
+        Logger.verbose(methodTag, "Loading Accounts + keys...");
+        final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
+            @Override
+            public boolean test(String value) {
+                return isAccount(value);
+            }
+        });
+        final Map<String, AccountRecord> accounts = new HashMap<>();
+        if (cacheValues != null) {
+            while (cacheValues.hasNext()) {
+                Map.Entry<String, ?> cacheValue = cacheValues.next();
+                final String cacheKey = cacheValue.getKey();
+                final AccountRecord account = mCacheValueDelegate.fromCacheValue(
+                        cacheValue.getValue().toString(),
+                        AccountRecord.class
+                );
+
+                if (null == account) {
+                    Logger.warn(methodTag, ACCOUNT_RECORD_DESERIALIZATION_FAILED);
+                } else if (EMPTY_ACCOUNT.equals(account)) {
+                    Logger.warn(methodTag, "The returned Account was uninitialized. Removing...");
+                    mSharedPreferencesFileManager.remove(cacheKey);
+                } else {
+                    accounts.put(cacheKey, account);
+                }
+            }
+        }
+
+        Logger.verbose(methodTag, "Returning [" + accounts.size() + "] Accounts w/ keys...");
+
+        return accounts;
+    }
+
+    @Override
+    @NonNull
+    public List<AccountRecord> getAccounts() {
+        final String methodTag = TAG + ":getAccounts";
+        Logger.verbose(methodTag, "Loading Accounts...(no arg)");
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            final List<AccountRecord> accounts = new ArrayList<>();
+            for (AccountRecord record : mCachedAccountRecordsWithKeys.values()) {
+                try {
+                    accounts.add((AccountRecord) record.clone());
+                } catch (final CloneNotSupportedException e) {
+                    Logger.error(methodTag, "Failed to clone AccountRecord", e);
+                }
+            }
+            Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
+            return accounts;
+        }
+    }
+
+    @Override
+    @NonNull
+    public List<AccountRecord> getAccountsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final String realm) {
+        final String methodTag = TAG + ":getAccountsFilteredBy";
+        Logger.verbose(methodTag, "Loading Accounts...");
+
+        final List<AccountRecord> allAccounts = getAccounts();
+
+        final List<AccountRecord> matchingAccounts = getAccountsFilteredByInternal(
+                homeAccountId,
+                environment,
+                realm,
+                allAccounts
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingAccounts.size() + "] matching Accounts...");
+
+        return matchingAccounts;
+    }
+
+    @NonNull
+    private Map<String, Credential> loadCredentialsWithKeys() {
+        final String methodTag = TAG + ":getCredentialsWithKeys";
+        Logger.verbose(methodTag, "Loading Credentials with keys...");
+
+        final Map<String, Credential> credentials = new HashMap<>();
+        final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
+            @Override
+            public boolean test(String value) {
+                return isCredential(value);
+            }
+        });
+
+        while (cacheValues.hasNext()) {
+            Map.Entry<String, ?> cacheValue = cacheValues.next();
+            final String cacheKey = cacheValue.getKey();
+            final Class<? extends AccountCredentialBase> clazz = credentialClassForType(cacheKey);
+            final Credential credential = mCacheValueDelegate.fromCacheValue(
+                    cacheValue.getValue().toString(),
+                    clazz
+            );
+
+            if (null == credential) {
+                Logger.warn(methodTag, CREDENTIAL_DESERIALIZATION_FAILED);
+            } else if ((AccessTokenRecord.class == clazz && EMPTY_AT.equals(credential))
+                || (RefreshTokenRecord.class == clazz && EMPTY_RT.equals(credential))
+                || (IdTokenRecord.class == clazz) && EMPTY_ID.equals(credential)) {
+                // The returned credential came back uninitialized...
+                // Remove the entry and return null...
+                Logger.warn(methodTag, "The returned Credential was uninitialized. Removing...");
+                mSharedPreferencesFileManager.remove(cacheKey);
+            }
+            else {
+                credentials.put(cacheKey, credential);
+            }
+        }
+
+        Logger.verbose(methodTag, "Loaded [" + credentials.size() + "] Credentials...");
+
+        return credentials;
+    }
+
+    @Override
+    @NonNull
+    public List<Credential> getCredentials() {
+        final String methodTag = TAG + ":getCredentials";
+        Logger.verbose(methodTag, "Loading Credentials...");
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            ArrayList<Credential> credentials = new ArrayList<>();
+            for (Credential credential : mCachedCredentialsWithKeys.values()) {
+                try {
+                    credentials.add((Credential)credential.clone());
+                } catch (final CloneNotSupportedException e) {
+                    Logger.error(methodTag, "Failed to clone Credential", e);
+                }
+            }
+            return credentials;
+        }
+    }
+
+    @Override
+    @NonNull
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+        Logger.verbose(methodTag, "getCredentialsFilteredBy()");
+
+        final List<Credential> allCredentials = getCredentials();
+
+        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                allCredentials,
+                homeAccountId,
+                environment,
+                credentialType,
+                clientId,
+                applicationIdentifier,
+                mamEnrollmentIdentifier,
+                realm,
+                target,
+                authScheme,
+                null,
+                null
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+
+        return matchingCredentials;
+    }
+
+    @Override
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @NonNull final List<Credential> inputCredentials) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+        Logger.verbose(methodTag, "getCredentialsFilteredBy() -- with input list");
+
+        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                inputCredentials,
+                homeAccountId,
+                environment,
+                credentialType,
+                clientId,
+                applicationIdentifier,
+                mamEnrollmentIdentifier,
+                realm,
+                target,
+                authScheme,
+                null,
+                null
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+
+        return matchingCredentials;
+    }
+
+    @Override
+    @NonNull
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @Nullable final String requestedClaims) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+        Logger.verbose(methodTag, "getCredentialsFilteredBy()");
+
+        final List<Credential> allCredentials = getCredentials();
+
+        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                allCredentials,
+                homeAccountId,
+                environment,
+                credentialType,
+                clientId,
+                applicationIdentifier,
+                mamEnrollmentIdentifier,
+                realm,
+                target,
+                authScheme,
+                requestedClaims,
+                null
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+
+        return matchingCredentials;
+    }
+
+    @Override
+    @NonNull
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @Nullable final String requestedClaims,
+            @Nullable final List<Credential> inputCredentials) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+        Logger.verbose(methodTag, "getCredentialsFilteredBy()");
+
+        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                inputCredentials,
+                homeAccountId,
+                environment,
+                credentialType,
+                clientId,
+                applicationIdentifier,
+                mamEnrollmentIdentifier,
+                realm,
+                target,
+                authScheme,
+                requestedClaims,
+                null
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+
+        return matchingCredentials;
+    }
+
+    @Override
+    public List<Credential> getCredentialsFilteredBy(@Nullable final String homeAccountId,
+                                                     @Nullable final String environment,
+                                                     @NonNull final Set<CredentialType> credentialTypes,
+                                                     @Nullable final String clientId,
+                                                     @Nullable final String applicationIdentifier,
+                                                     @Nullable final String mamEnrollmentIdentifier,
+                                                     @Nullable final String realm,
+                                                     @Nullable final String target,
+                                                     @Nullable final String authScheme,
+                                                     @Nullable final String requestedClaims) {
+        final List<Credential> allCredentials = getCredentials();
+
+        final List<Credential> result = new ArrayList<>();
+        for (final CredentialType type : credentialTypes) {
+            result.addAll(
+                    getCredentialsFilteredByInternal(
+                            allCredentials,
+                            homeAccountId,
+                            environment,
+                            type,
+                            clientId,
+                            applicationIdentifier,
+                            mamEnrollmentIdentifier,
+                            realm,
+                            target,
+                            authScheme,
+                            requestedClaims,
+                            null
+                    )
+            );
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable List<Credential> inputCredentials,
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @Nullable final String requestedClaims,
+            @Nullable final String kid ) {
+        final List<Credential> result = new ArrayList<>();
+        result.addAll(
+                getCredentialsFilteredByInternal(
+                        inputCredentials,
+                        homeAccountId,
+                        environment,
+                        credentialType,
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        realm,
+                        target,
+                        authScheme,
+                        requestedClaims,
+                        kid
+                )
+        );
+        return result;
+    }
+
+    @Override
+    public boolean removeAccount(@NonNull final AccountRecord accountToRemove) {
+        final String methodTag = TAG + ":removeAccount";
+        Logger.info(methodTag, "Removing Account...");
+        if (null == accountToRemove) {
+            throw new IllegalArgumentException("Param [accountToRemove] cannot be null.");
+        }
+
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToRemove);
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            boolean accountRemoved = false;
+            if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
+            {
+                mSharedPreferencesFileManager.remove(cacheKey);
+                accountRemoved = true;
+            }
+            Logger.info(methodTag, "Account was removed? [" + accountRemoved + "]");
+
+            mCachedAccountRecordsWithKeys.remove(cacheKey);
+
+            return accountRemoved;
+        }
+    }
+
+    @Override
+    public boolean removeCredential(@NonNull final Credential credentialToRemove) {
+        final String methodTag = TAG + ":removeCredential";
+        Logger.info(methodTag, "Removing Credential...");
+
+        if (null == credentialToRemove) {
+            throw new IllegalArgumentException("Param [credentialToRemove] cannot be null.");
+        }
+
+        final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToRemove);
+
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            boolean credentialRemoved = false;
+            if (mSharedPreferencesFileManager.keySet().contains(cacheKey)) {
+                mSharedPreferencesFileManager.remove(cacheKey);
+                credentialRemoved = true;
+            }
+
+            Logger.info(methodTag, "Credential was removed? [" + credentialRemoved + "]");
+
+            mCachedCredentialsWithKeys.remove(cacheKey);
+
+            return credentialRemoved;
+        }
+
+    }
+
+    @Override
+    public void clearAll() {
+        final String methodTag = TAG + ":clearAll";
+        Logger.info(methodTag, "Clearing all SharedPreferences entries...");
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            mSharedPreferencesFileManager.clear();
+            mCachedCredentialsWithKeys.clear();
+            mCachedAccountRecordsWithKeys.clear();
+        }
+        Logger.info(methodTag, "SharedPreferences cleared.");
+    }
+
+    @Nullable
+    private Class<? extends Credential> credentialClassForType(@NonNull final String cacheKey) {
+        final String methodTag = TAG + ":credentialClassForType";
+        Logger.verbose(methodTag, "Resolving class for key/CredentialType...");
+        Logger.verbosePII(methodTag, "Supplied key: [" + cacheKey + "]");
+
+        final CredentialType targetType = getCredentialTypeForCredentialCacheKey(cacheKey);
+
+        if (targetType == null) {
+            return null;
+        }
+
+        Logger.verbose(methodTag, "CredentialType matched: [" + targetType + "]");
+
+        return getTargetClassForCredentialType(cacheKey, targetType);
+    }
+
+    /**
+     * Inspects the supplied cache key to determine the target CredentialType.
+     *
+     * @param cacheKey The cache key to inspect.
+     * @return The CredentialType or null if a proper type cannot be resolved.
+     */
+    @Nullable
+    public static CredentialType getCredentialTypeForCredentialCacheKey(@NonNull final String cacheKey) {
+        final String methodTag = TAG + ":getCredentialTypeForCredentialCacheKey";
+        if (StringUtil.isNullOrEmpty(cacheKey)) {
+            throw new IllegalArgumentException("Param [cacheKey] cannot be null.");
+        }
+
+        Logger.verbosePII(methodTag, "Evaluating cache key for CredentialType [" + cacheKey + "]");
+
+        final Set<String> credentialTypesLowerCase = new HashSet<>();
+
+        for (final String credentialTypeStr : CredentialType.valueSet()) {
+            credentialTypesLowerCase.add(credentialTypeStr.toLowerCase(Locale.US));
+        }
+
+        CredentialType type = null;
+        for (final String credentialTypeStr : credentialTypesLowerCase) {
+            if (cacheKey.contains(CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR + credentialTypeStr + CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR)) {
+                Logger.verbose(methodTag, "Cache key is a Credential type...");
+
+                if (CredentialType.AccessToken.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.AccessToken;
+                    break;
+                } else if (CredentialType.AccessToken_With_AuthScheme.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.AccessToken_With_AuthScheme;
+                    break;
+                } else if (CredentialType.RefreshToken.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.RefreshToken;
+                    break;
+                } else if (CredentialType.IdToken.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.IdToken;
+                    break;
+                } else if (CredentialType.V1IdToken.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.V1IdToken;
+                    break;
+                } else if (CredentialType.PrimaryRefreshToken.name().equalsIgnoreCase(credentialTypeStr)) {
+                    type = CredentialType.PrimaryRefreshToken;
+                    break;
+                } else {
+                    // TODO Log a warning and skip this value?
+                    Logger.warn(methodTag, "Unexpected credential type.");
+                }
+            }
+        }
+
+        Logger.verbose(methodTag, "Cache key was type: [" + type + "]");
+
+        return type;
+    }
+
+    private static boolean isAccount(@NonNull final String cacheKey) {
+        final String methodTag = TAG + ":isAccount";
+        Logger.verbosePII(methodTag, "Evaluating cache key: [" + cacheKey + "]");
+        boolean isAccount = null == getCredentialTypeForCredentialCacheKey(cacheKey);
+        Logger.verbose(methodTag, "isAccount? [" + isAccount + "]");
+        return isAccount;
+    }
+
+    private static boolean isCredential(@NonNull String cacheKey) {
+        final String methodTag = TAG + ":isCredential";
+        Logger.verbosePII(methodTag, "Evaluating cache key: [" + cacheKey + "]");
+        boolean isCredential = null != getCredentialTypeForCredentialCacheKey(cacheKey);
+        Logger.verbose(methodTag, "isCredential? [" + isCredential + "]");
+        return isCredential;
+    }
+
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -46,43 +46,14 @@ import java.util.Set;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
+/**
+ * Alternative version of {@link SharedPreferencesAccountCredentialCache} that assumes all writes and reads
+ * are done through a single-instance and can thereforce be cached in memory.
+ */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends AbstractAccountCredentialCache {
 
     private static final String TAG = SharedPreferencesAccountCredentialCacheWithMemoryCache.class.getSimpleName();
-
-    /**
-     * The name of the SharedPreferences file on disk.
-     */
-    public static final String DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES =
-            "com.microsoft.identity.client.account_credential_cache";
-
-    /**
-     * The name of the Broker FOCI file on disk.
-     */
-    public static final String BROKER_FOCI_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES =
-            DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
-                    + ".foci-1";
-
-    /**
-     * Returns the generated filename for UID-specific caches.
-     *
-     * @param uid The uid of the current (or targeted) application.
-     * @return The uid-based cache filename.
-     */
-    public static String getBrokerUidSequesteredFilename(final int uid) {
-        return DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
-                + ".uid-"
-                + uid;
-    }
-
-    private static final AccountRecord EMPTY_ACCOUNT = new AccountRecord();
-    private static final AccessTokenRecord EMPTY_AT = new AccessTokenRecord();
-    private static final RefreshTokenRecord EMPTY_RT = new RefreshTokenRecord();
-    private static final IdTokenRecord EMPTY_ID = new IdTokenRecord();
-    private static final String DESERIALIZATION_FAILED = "Deserialization failed. Skipping ";
-    private static final String ACCOUNT_RECORD_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + AccountRecord.class.getSimpleName();
-    private static final String CREDENTIAL_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + Credential.class.getSimpleName();
 
     // SharedPreferences used to store Accounts and Credentials
     private final INameValueStorage<String> mSharedPreferencesFileManager;
@@ -271,8 +242,8 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 );
 
                 if (null == account) {
-                    Logger.warn(methodTag, ACCOUNT_RECORD_DESERIALIZATION_FAILED);
-                } else if (EMPTY_ACCOUNT.equals(account)) {
+                    Logger.warn(methodTag, SharedPreferencesAccountCredentialCache.ACCOUNT_RECORD_DESERIALIZATION_FAILED);
+                } else if (SharedPreferencesAccountCredentialCache.EMPTY_ACCOUNT.equals(account)) {
                     Logger.warn(methodTag, "The returned Account was uninitialized. Removing...");
                     mSharedPreferencesFileManager.remove(cacheKey);
                 } else {
@@ -353,10 +324,10 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             );
 
             if (null == credential) {
-                Logger.warn(methodTag, CREDENTIAL_DESERIALIZATION_FAILED);
-            } else if ((AccessTokenRecord.class == clazz && EMPTY_AT.equals(credential))
-                || (RefreshTokenRecord.class == clazz && EMPTY_RT.equals(credential))
-                || (IdTokenRecord.class == clazz) && EMPTY_ID.equals(credential)) {
+                Logger.warn(methodTag, SharedPreferencesAccountCredentialCache.CREDENTIAL_DESERIALIZATION_FAILED);
+            } else if ((AccessTokenRecord.class == clazz && SharedPreferencesAccountCredentialCache.EMPTY_AT.equals(credential))
+                || (RefreshTokenRecord.class == clazz && SharedPreferencesAccountCredentialCache.EMPTY_RT.equals(credential))
+                || (IdTokenRecord.class == clazz) && SharedPreferencesAccountCredentialCache.EMPTY_ID.equals(credential)) {
                 // The returned credential came back uninitialized...
                 // Remove the entry and return null...
                 Logger.warn(methodTag, "The returned Credential was uninitialized. Removing...");

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
@@ -33,7 +33,7 @@ import lombok.NonNull;
 /**
  * Base class for Objects to support the [de]/serialization of extra fields.
  */
-public abstract class AccountCredentialBase {
+public abstract class AccountCredentialBase implements Cloneable {
 
     private transient Map<String, JsonElement> mAdditionalFields = Collections.synchronizedMap(new HashMap<String, JsonElement>());
 
@@ -76,6 +76,13 @@ public abstract class AccountCredentialBase {
                 mAdditionalFields.put(entry.getKey(), entry.getValue());
             }
         }
+    }
+
+    @Override
+    public AccountCredentialBase clone() throws CloneNotSupportedException {
+        AccountCredentialBase other = (AccountCredentialBase) super.clone();
+        other.setAdditionalFields(new HashMap<>(mAdditionalFields));
+        return other;
     }
 
     //CHECKSTYLE:OFF

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
@@ -80,7 +80,7 @@ public abstract class AccountCredentialBase implements Cloneable {
 
     @Override
     public AccountCredentialBase clone() throws CloneNotSupportedException {
-        AccountCredentialBase other = (AccountCredentialBase) super.clone();
+        final AccountCredentialBase other = (AccountCredentialBase) super.clone();
         other.setAdditionalFields(new HashMap<>(mAdditionalFields));
         return other;
     }


### PR DESCRIPTION
This is a reimplementation of #1929, where the calling app needs to choose to configure its token cache for this new in-memory caching behavior.  The goal here is that MSAL.CPP will specify this for now, and other usages (broker, MSAL) could be brought over in the future in a slower or optional rollout. 

After consulting with Amit, and because the implementations here are so different, it wasn't possible to reasonably maintain a single class with forked implementation, and so instead the class itself has been forked. Similarly the tests have been forked.  I think it would be possible to instead turn those into parameterized tests, and pull some of the setup implementation as a preable to all test methods that uses that parameter to choose whether to run against the memory-backed version or not.  I think that's still a fairly messy change, but I'm open to that option if reviewers prefer it (or have a better idea).