### PR TITLE
Add CommandDispatcher methods to stop and reset silent request executor.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add CommandDispatcher methods to stop and reset silent request executor. (#2000)
 - [PATCH] Send AT on KEY_AUTHTOKEN for ADAL Acquire token silently with Broker (#1996)
 - [PATCH] Expose Cached Credential Service request ID in tokenResponse (#1991)
 - [MINOR] Adding YubiKit remove method back in; bumping YubiKit Versions (#1994)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -753,7 +753,12 @@ public class CommandDispatcher {
             return ", with the status : " + status;
         }
 
-
+    /***
+     * Stops the SilentRequestsExecutor.
+     * Waits 1 Sec for existing silent requests to finish, before terminating them.
+     * WARN!! No new silent requests will be processed after this until the executor is reset
+     * This is expected to be called when in Shared Device Mode when global signout is performed.
+     */
     public static void stopSilentRequestExecutor() {
         final String methodTag = TAG + ":stopSilentRequestExecutor";
         Logger.info(methodTag, "shutting down..");
@@ -769,6 +774,12 @@ public class CommandDispatcher {
         }
     }
 
+    /***
+     * Resets the SilentRequestsExecutor.
+     * This creates a new Executor for the silent request.
+     * This is expected to be called after global signout is performed in Shared Device mode.
+     * This should be called if previously the Executor was stopped using 'stopSilentRequestExecutor'
+     */
     public static void resetSilentRequestExecutor() {
         Logger.info(TAG + ":resetSilentRequestExecutor", "Resetting silent Executor");
         sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);


### PR DESCRIPTION
### What 
- Adding methods in CommandDispatcher class to stop and reset the silent request executor.

### Why
- In ShareDeviceMode when signout is triggered. It is possible that there are pending silent requests in the queue.
- If this happens there is a possibility that the silent requests are completed after signout operation is complete
- This results in the silent requests populating the account information back in broker storage. resulting in the previous user data to be still available in broker even after signout
- We need to make sure that all silent requests are either complete or cancelled before we process the signout request in SDM. And also that no new silent requests are processed until signout is complete.

### How
- Added method to stop and reset the silent request executor. These methods will be called from broker signout method. (change included in [broker PR)](https://github.com/AzureAD/ad-accounts-for-android/pull/2220)

### Testing
- Added UTs to verify the new methods
- Also added a E2E test to verify this scenario ([Included in MSAL PR](https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1789))