### PR TITLE
Add more log statements to the getValidActiveBrokerPackageName and add more details on the client exceptions 

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.broker;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 import static com.microsoft.identity.common.java.exception.ClientException.ACCOUNT_MANAGER_FAILED;
+import static com.microsoft.identity.common.java.exception.ClientException.BROKER_VERIFICATION_FAILED_ERROR;
 import static com.microsoft.identity.common.java.exception.ClientException.NOT_VALID_BROKER_FOUND;
 import static com.microsoft.identity.common.java.exception.ClientException.NO_SUCH_ALGORITHM;
 import static com.microsoft.identity.common.java.exception.ErrorStrings.APP_PACKAGE_NAME_NOT_FOUND;
@@ -111,11 +112,11 @@ public class BrokerValidator {
 
             return signatureHash;
         } catch (NameNotFoundException e) {
-            throw new ClientException(APP_PACKAGE_NAME_NOT_FOUND, e.getMessage(), e);
+            throw new ClientException(BROKER_VERIFICATION_FAILED_ERROR, APP_PACKAGE_NAME_NOT_FOUND + " "+ e.getMessage(), e);
         } catch (NoSuchAlgorithmException e) {
             throw new ClientException(NO_SUCH_ALGORITHM, e.getMessage(), e);
         } catch (final IOException | GeneralSecurityException e) {
-            throw new ClientException(BROKER_VERIFICATION_FAILED, e.getMessage(), e);
+            throw new ClientException(BROKER_VERIFICATION_FAILED_ERROR, e.getMessage(), e);
         }
     }
 
@@ -248,23 +249,27 @@ public class BrokerValidator {
     public String getValidActiveBrokerPackageName() throws ClientException {
         final String methodTag = TAG + ":getValidActiveBrokerPackageName";
 
-        final int numberOfAuthenticators;
+        final AuthenticatorDescription[] authenticators;
         try {
-            final AuthenticatorDescription[] authenticators = AccountManager.get(mContext).getAuthenticatorTypes();
-            numberOfAuthenticators = authenticators.length;
-            Logger.info(methodTag, numberOfAuthenticators + " Authenticators registered.");
-            for (final AuthenticatorDescription authenticator : authenticators) {
-                Logger.info(methodTag, "Authenticator: " + authenticator.packageName + " type: " + authenticator.type );
-                if (BROKER_ACCOUNT_TYPE.equals(authenticator.type)) {
-                    verifySignatureAndThrow(authenticator.packageName);
-                    return authenticator.packageName;
-                }
-            }
+            authenticators = AccountManager.get(mContext).getAuthenticatorTypes();
         } catch (final Exception exception) {
             final ClientException clientException = new ClientException(ACCOUNT_MANAGER_FAILED, exception.getMessage());
             Logger.error(methodTag, exception.getMessage(), exception);
             throw clientException;
         }
+
+        final int numberOfAuthenticators = authenticators.length;
+        Logger.info(methodTag, numberOfAuthenticators + " Authenticators registered.");
+        for (final AuthenticatorDescription authenticator : authenticators) {
+            // TODO: remove or change to verbose once we're confident this is working.
+            Logger.info(methodTag, "Authenticator: " + authenticator.packageName + ",  type: " + authenticator.type );
+            if (BROKER_ACCOUNT_TYPE.equals(authenticator.type)) {
+                Logger.info(methodTag, "Verify: " + authenticator.packageName);
+                verifySignatureAndThrow(authenticator.packageName);
+                return authenticator.packageName;
+            }
+        }
+
         final String errorMessage = "None of the " + numberOfAuthenticators + " authenticators, is type: " + BROKER_ACCOUNT_TYPE;
         final ClientException clientException = new ClientException(NOT_VALID_BROKER_FOUND, errorMessage);
         Logger.error(methodTag, errorMessage, clientException);

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.broker;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+import static com.microsoft.identity.common.java.exception.ClientException.ACCOUNT_MANAGER_FAILED;
 import static com.microsoft.identity.common.java.exception.ClientException.NOT_VALID_BROKER_FOUND;
 import static com.microsoft.identity.common.java.exception.ClientException.NO_SUCH_ALGORITHM;
 import static com.microsoft.identity.common.java.exception.ErrorStrings.APP_PACKAGE_NAME_NOT_FOUND;
@@ -253,13 +254,14 @@ public class BrokerValidator {
             numberOfAuthenticators = authenticators.length;
             Logger.info(methodTag, numberOfAuthenticators + " Authenticators registered.");
             for (final AuthenticatorDescription authenticator : authenticators) {
+                Logger.info(methodTag, "Authenticator: " + authenticator.packageName + " type: " + authenticator.type );
                 if (BROKER_ACCOUNT_TYPE.equals(authenticator.type)) {
                     verifySignatureAndThrow(authenticator.packageName);
                     return authenticator.packageName;
                 }
             }
         } catch (final Exception exception) {
-            final ClientException clientException = new ClientException(NOT_VALID_BROKER_FOUND, exception.getMessage());
+            final ClientException clientException = new ClientException(ACCOUNT_MANAGER_FAILED, exception.getMessage());
             Logger.error(methodTag, exception.getMessage(), exception);
             throw clientException;
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
@@ -59,6 +59,7 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import static com.microsoft.identity.common.java.exception.ClientException.BROKER_VERIFICATION_FAILED_ERROR;
 import static com.microsoft.identity.common.java.exception.ErrorStrings.BROKER_APP_VERIFICATION_FAILED;
 
 /**
@@ -168,7 +169,7 @@ public final class PackageUtils {
             }
         }
 
-        throw new ClientException(BROKER_APP_VERIFICATION_FAILED, "SignatureHashes: " + hashListStringBuilder.toString());
+        throw new ClientException(BROKER_VERIFICATION_FAILED_ERROR, BROKER_APP_VERIFICATION_FAILED + "SignatureHashes: " + hashListStringBuilder.toString());
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -309,6 +309,11 @@ public class ClientException extends BaseException {
     public static final String NOT_VALID_BROKER_FOUND = "not_valid_broker_found";
 
     /**
+     * Account manager failed to query for the Authenticator types.
+     */
+    public static final String ACCOUNT_MANAGER_FAILED = "account_manager_failed";
+
+    /**
      * An account manager operation failed.
      */
     public static final String ACCOUNT_MANAGER_OPERATION_ERROR = "account_manager_operation_error";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -309,6 +309,11 @@ public class ClientException extends BaseException {
     public static final String NOT_VALID_BROKER_FOUND = "not_valid_broker_found";
 
     /**
+     * The broker verification failed.
+     */
+    public static final String BROKER_VERIFICATION_FAILED_ERROR = "broker_app_verification_failed";
+
+    /**
      * Account manager failed to query for the Authenticator types.
      */
     public static final String ACCOUNT_MANAGER_FAILED = "account_manager_failed";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
@@ -273,7 +273,7 @@ public final class ErrorStrings {
     /**
      * App package name is not found in the package manager.
      */
-    public static final String APP_PACKAGE_NAME_NOT_FOUND = "App package name is not found in the package manager";
+    public static final String APP_PACKAGE_NAME_NOT_FOUND = "App package name is not found in the package manager.";
 
     /**
      * Signature could not be verified.


### PR DESCRIPTION
ClientExceptions require an error code and error message, so we are adding the code, and improving the message, to identify root cause of MWPJ failing on initialization.