### PR TITLE
LTW support work

### DIFF
--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -40,6 +40,8 @@ android {
 
     boolean usePreInstalledApks = project.hasProperty("preferPreInstalledApks")
 
+    boolean preInstallLtw = project.hasProperty("preInstallLtw")
+
     def final appSourcePlayStore = "PlayStore"
     def final appSourceLocalApk = "LocalApk"
 
@@ -102,7 +104,7 @@ android {
         buildConfigField("String", "UPDATE_SOURCE_PLAY_STORE", "\"$appSourcePlayStore\"")
         buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$appSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
-
+        buildConfigField("boolean", "PRE_INSTALL_LTW", "$preInstallLtw")
 
         // Specifies a sorted list of flavors that the plugin should try to use from
         // a given dimension. The following tells the plugin that, when encountering

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
@@ -22,45 +22,89 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.ui.automation;
 
+import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
+import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
+import com.microsoft.identity.client.ui.automation.broker.BrokerLTW;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+
 /**
- * An interface to facilitate testing a very specific broker installation order with support for
- * old and current version of the broker.
+ * An interface to facilitate testing a very specific app installation order with support for
+ * old and current version of the app.
  */
 public interface ICustomBrokerInstallationTest {
 
     /**
      * Install old/legacy BrokerHost
      */
-    void installOldBrokerHost();
+    default BrokerHost installOldBrokerHost(){
+        final BrokerHost brokerHost = new BrokerHost(BrokerHost.OLD_BROKER_HOST_APK,
+                BrokerHost.BROKER_HOST_APK);
+        brokerHost.install();
+        return brokerHost;
+    }
     /**
      * Install updated BrokerHost
      */
-    void installBrokerHost();
+    default BrokerHost installBrokerHost(){
+        final BrokerHost brokerHost = new BrokerHost();
+        brokerHost.install();
+        return brokerHost;
+    }
 
     /**
      * Install old/legacy Authenticator
      */
-    void installOldAuthenticator();
+    default BrokerMicrosoftAuthenticator installOldAuthenticator(){
+        final BrokerMicrosoftAuthenticator authenticator = new BrokerMicrosoftAuthenticator(BrokerMicrosoftAuthenticator.OLD_AUTHENTICATOR_APK,
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APK);
+        authenticator.install();
+        return authenticator;
+    }
     /**
      * Install updated Authenticator
      */
-    void installAuthenticator();
+    default BrokerMicrosoftAuthenticator installAuthenticator(){
+        final BrokerMicrosoftAuthenticator authenticator = new BrokerMicrosoftAuthenticator();
+        authenticator.install();
+        return authenticator;
+    }
 
     /**
      * Install old/legacy Company Portal
      */
-    void installOldCompanyPortal();
+    default BrokerCompanyPortal installOldCompanyPortal(){
+        final BrokerCompanyPortal companyPortal = new BrokerCompanyPortal(BrokerCompanyPortal.OLD_COMPANY_PORTAL_APK,
+                BrokerCompanyPortal.COMPANY_PORTAL_APK);
+        companyPortal.install();
+        return companyPortal;
+    }
     /**
      * Install updated Company Portal
      */
-    void installCompanyPortal();
+    default BrokerCompanyPortal installCompanyPortal(){
+        final BrokerCompanyPortal companyPortal = new BrokerCompanyPortal();
+        companyPortal.install();
+        return companyPortal;
+    }
 
     /**
      * Install old/legacy LTW
      */
-    void installOldLtw();
+    default BrokerLTW installOldLtw(){
+        final BrokerLTW ltw = new BrokerLTW(BrokerLTW.OLD_BROKER_LTW_APK,
+                BrokerLTW.BROKER_LTW_APK);
+        ltw.install();
+        return ltw;
+    }
     /**
      * Install updated LTW
      */
-    void installLtw();
+    default BrokerLTW installLtw(){
+        final BrokerLTW ltw = new BrokerLTW();
+        ltw.install();
+        return ltw;
+    }
+
+    // TODO: LTW folks, expand this to include msaltestapp, adaltestapp, oneuathtestapp
+    
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
@@ -34,7 +34,7 @@ import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthent
 public interface ICustomBrokerInstallationTest {
 
     /**
-     * Install old/legacy BrokerHost
+     * Install old/legacy BrokerHost.
      */
     default BrokerHost installOldBrokerHost(){
         final BrokerHost brokerHost = new BrokerHost(BrokerHost.OLD_BROKER_HOST_APK,
@@ -43,7 +43,7 @@ public interface ICustomBrokerInstallationTest {
         return brokerHost;
     }
     /**
-     * Install updated BrokerHost
+     * Install updated BrokerHost.
      */
     default BrokerHost installBrokerHost(){
         final BrokerHost brokerHost = new BrokerHost();
@@ -52,7 +52,7 @@ public interface ICustomBrokerInstallationTest {
     }
 
     /**
-     * Install old/legacy Authenticator
+     * Install old/legacy Authenticator.
      */
     default BrokerMicrosoftAuthenticator installOldAuthenticator(){
         final BrokerMicrosoftAuthenticator authenticator = new BrokerMicrosoftAuthenticator(BrokerMicrosoftAuthenticator.OLD_AUTHENTICATOR_APK,
@@ -61,7 +61,7 @@ public interface ICustomBrokerInstallationTest {
         return authenticator;
     }
     /**
-     * Install updated Authenticator
+     * Install updated Authenticator.
      */
     default BrokerMicrosoftAuthenticator installAuthenticator(){
         final BrokerMicrosoftAuthenticator authenticator = new BrokerMicrosoftAuthenticator();
@@ -70,7 +70,7 @@ public interface ICustomBrokerInstallationTest {
     }
 
     /**
-     * Install old/legacy Company Portal
+     * Install old/legacy Company Portal.
      */
     default BrokerCompanyPortal installOldCompanyPortal(){
         final BrokerCompanyPortal companyPortal = new BrokerCompanyPortal(BrokerCompanyPortal.OLD_COMPANY_PORTAL_APK,
@@ -79,7 +79,7 @@ public interface ICustomBrokerInstallationTest {
         return companyPortal;
     }
     /**
-     * Install updated Company Portal
+     * Install updated Company Portal.
      */
     default BrokerCompanyPortal installCompanyPortal(){
         final BrokerCompanyPortal companyPortal = new BrokerCompanyPortal();
@@ -88,7 +88,7 @@ public interface ICustomBrokerInstallationTest {
     }
 
     /**
-     * Install old/legacy LTW
+     * Install old/legacy LTW.
      */
     default BrokerLTW installOldLtw(){
         final BrokerLTW ltw = new BrokerLTW(BrokerLTW.OLD_BROKER_LTW_APK,
@@ -97,7 +97,7 @@ public interface ICustomBrokerInstallationTest {
         return ltw;
     }
     /**
-     * Install updated LTW
+     * Install updated LTW.
      */
     default BrokerLTW installLtw(){
         final BrokerLTW ltw = new BrokerLTW();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/ICustomBrokerInstallationTest.java
@@ -1,0 +1,66 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation;
+
+/**
+ * An interface to facilitate testing a very specific broker installation order with support for
+ * old and current version of the broker.
+ */
+public interface ICustomBrokerInstallationTest {
+
+    /**
+     * Install old/legacy BrokerHost
+     */
+    void installOldBrokerHost();
+    /**
+     * Install updated BrokerHost
+     */
+    void installBrokerHost();
+
+    /**
+     * Install old/legacy Authenticator
+     */
+    void installOldAuthenticator();
+    /**
+     * Install updated Authenticator
+     */
+    void installAuthenticator();
+
+    /**
+     * Install old/legacy Company Portal
+     */
+    void installOldCompanyPortal();
+    /**
+     * Install updated Company Portal
+     */
+    void installCompanyPortal();
+
+    /**
+     * Install old/legacy LTW
+     */
+    void installOldLtw();
+    /**
+     * Install updated LTW
+     */
+    void installLtw();
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
@@ -33,7 +33,7 @@ import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
  */
 public class BrokerLTW extends AbstractTestBroker {
     private static final String TAG = BrokerLTW.class.getSimpleName();
-    public final static String BROKER_LTW_APP_PACKAGE_NAME = "TODO";
+    public final static String BROKER_LTW_APP_PACKAGE_NAME = "LTW PACKAGE NAME HERE";
     public final static String BROKER_LTW_APP_NAME = "LTW App";
     public final static String BROKER_LTW_APK = "LTW.apk";
     public final static String OLD_BROKER_LTW_APK = "OldLTW.apk";

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
@@ -33,7 +33,7 @@ import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
  */
 public class BrokerLTW extends AbstractTestBroker {
     private static final String TAG = BrokerLTW.class.getSimpleName();
-    public final static String BROKER_LTW_APP_PACKAGE_NAME = "LTW PACKAGE NAME HERE";
+    public final static String BROKER_LTW_APP_PACKAGE_NAME = "com.microsoft.appmanager";
     public final static String BROKER_LTW_APP_NAME = "LTW App";
     public final static String BROKER_LTW_APK = "LTW.apk";
     public final static String OLD_BROKER_LTW_APK = "OldLTW.apk";

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerLTW.java
@@ -1,0 +1,108 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.broker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
+import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
+
+/**
+ * Handles app interaction with Broker-hosting app LTW
+ */
+public class BrokerLTW extends AbstractTestBroker {
+    private static final String TAG = BrokerLTW.class.getSimpleName();
+    public final static String BROKER_LTW_APP_PACKAGE_NAME = "TODO";
+    public final static String BROKER_LTW_APP_NAME = "LTW App";
+    public final static String BROKER_LTW_APK = "LTW.apk";
+    public final static String OLD_BROKER_LTW_APK = "OldLTW.apk";
+
+    public BrokerLTW() {
+        super(BROKER_LTW_APP_PACKAGE_NAME, BROKER_LTW_APP_NAME);
+        localApkFileName = BROKER_LTW_APK;
+    }
+
+    public BrokerLTW(@NonNull final IAppInstaller appInstaller) {
+        super(BROKER_LTW_APP_PACKAGE_NAME, BROKER_LTW_APP_NAME, appInstaller);
+        localApkFileName = BROKER_LTW_APK;
+    }
+
+    public BrokerLTW(@NonNull final IAppInstaller appInstaller, @NonNull final IAppInstaller updateAppInstaller) {
+        super(BROKER_LTW_APP_PACKAGE_NAME, BROKER_LTW_APP_NAME, appInstaller, updateAppInstaller);
+        localApkFileName = BROKER_LTW_APK;
+    }
+
+    public BrokerLTW(@NonNull final String ltwApkName,
+                                        @NonNull final String updateLtwApkName) {
+        super(BROKER_LTW_APP_PACKAGE_NAME, BROKER_LTW_APP_NAME);
+        localApkFileName = ltwApkName;
+        localUpdateApkFileName = updateLtwApkName;
+    }
+
+    @Override
+    protected void initialiseAppImpl() {
+        // Nothing
+    }
+
+    @Override
+    public void handleFirstRun() {
+        // Nothing
+    }
+
+    @Override
+    public void performDeviceRegistration(String username, String password) {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Override
+    public void performDeviceRegistration(String username, String password, boolean isFederatedUser) {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Override
+    public void performSharedDeviceRegistration(String username, String password) {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Override
+    public void performSharedDeviceRegistrationDontValidate(String username, String password) {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Nullable
+    @Override
+    public String obtainDeviceId() {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Override
+    public void enableBrowserAccess() {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+
+    @Override
+    public DeviceAdmin getAdminName() {
+        throw new UnsupportedOperationException("LTW doesn't support this");
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
@@ -24,7 +24,9 @@ package com.microsoft.identity.client.ui.automation.rules;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.ui.automation.BuildConfig;
 import com.microsoft.identity.client.ui.automation.app.App;
+import com.microsoft.identity.client.ui.automation.broker.BrokerLTW;
 import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 
@@ -52,6 +54,13 @@ public class InstallBrokerTestRule implements TestRule {
             public void evaluate() throws Throwable {
                 Logger.i(TAG, "Applying rule....");
                 Logger.i(TAG, "Installing broker: " + ((App) broker).getAppName());
+
+                if (BuildConfig.PRE_INSTALL_LTW) {
+                    final BrokerLTW brokerLTW = new BrokerLTW();
+                    // Commenting this out until LTW is supported (need package name and an apk)
+                    // brokerLTW.install();
+                }
+
                 broker.install();
                 base.evaluate();
             }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
@@ -58,7 +58,7 @@ public class InstallBrokerTestRule implements TestRule {
                 if (BuildConfig.PRE_INSTALL_LTW) {
                     final BrokerLTW brokerLTW = new BrokerLTW();
                     // Commenting this out until LTW is supported (need package name and an apk)
-                    // brokerLTW.install();
+                     brokerLTW.install();
                 }
 
                 broker.install();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/InstallBrokerTestRule.java
@@ -55,6 +55,11 @@ public class InstallBrokerTestRule implements TestRule {
                 Logger.i(TAG, "Applying rule....");
                 Logger.i(TAG, "Installing broker: " + ((App) broker).getAppName());
 
+                // This checks if the "-PpreInstallLtw" command line option was passed.
+                // If yes, pre install LTW whenever a broker test case is ran before the designated broker.
+                // If not, only install the specified broker.
+                // When running this as part of the pipeline, this option should be passed when building
+                // the automation apps, probably should be set based on a parameter or variable.
                 if (BuildConfig.PRE_INSTALL_LTW) {
                     final BrokerLTW brokerLTW = new BrokerLTW();
                     // Commenting this out until LTW is supported (need package name and an apk)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
@@ -35,6 +35,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
+import com.microsoft.identity.client.ui.automation.broker.BrokerLTW;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
@@ -152,7 +153,8 @@ public class CommonUtils {
                 new ITestBroker[]{
                         new BrokerCompanyPortal(),
                         new BrokerMicrosoftAuthenticator(),
-                        new BrokerHost()
+                        new BrokerHost(),
+                        new BrokerLTW()
                 }
         );
     }


### PR DESCRIPTION
LTW support work

Supported so far:
LTW class for handling installation, updating, etc.
Custom broker installation (broker shuffling)
Added support for flag `preInstallLtw` which installs LTW first in our existing test cases that use broker.
To use, pass `-PpreInstallLtw` as a command line parameter when building either of the automation apps.