### PR TITLE
Fix Error Type thrown for NO_ACCOUNT_FOUND

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.NEXT
+----------
+- [PATCH] Fix Error Type thrown for NO_ACCOUNT_FOUND (#2006)
+
 V.11.0.0
 ----------
 - [MINOR] Add CommandDispatcher methods to stop and reset silent request executor. (#2000)

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -383,6 +383,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (OAuth2ErrorCode.INTERACTION_REQUIRED.equalsIgnoreCase(errorCode) ||
                 OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(errorCode) ||
                 ErrorStrings.INVALID_BROKER_REFRESH_TOKEN.equalsIgnoreCase(errorCode) ||
+                ErrorStrings.NO_ACCOUNT_FOUND.equalsIgnoreCase(errorCode) ||
                 ErrorStrings.NO_TOKENS_FOUND.equalsIgnoreCase(errorCode)) {
 
             Logger.warn(methodTag, "Received a UIRequired exception from Broker : " + errorCode);


### PR DESCRIPTION
Found a bug where NO_ACCOUNT_FOUND was thrown as a ClientException. This is wrong because NO_ACCOUNT_FOUND should be a UiRequiredException so that apps can respond to that by starting interactive request and be able to recover.

Steps to Repro:
- Add an MSA account to MSAL
- Install Broker with MSA support
- Try ATS it should work
- Now change account password
- Expire the AT by advancing the clock more than an hour
- Try ATS (MSAL will throw a ClientException with NO_ACCOUNT_FOUND error)
(This is because MSAL tries LocalController, this fails with UiRequiredException then MSAL tries BrokerMsalController and this fails with the mentioned client exception because the account is not in broker)

The expectation is that a UiRequiredException is ultimately thrown so the user can do interactive auth and recover.

Please note that I tried with MSA account but issue should also be happening to AAD accounts as well since this is not anything specific to MSA but this is just about broker installation order and password change.
