### PR TITLE
Reset silent request executor after test steps

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -387,6 +387,8 @@ public class CommandDispatcherTest {
             // Should be rejected to get scheduled
             Assert.assertTrue(e instanceof RejectedExecutionException);
         }
+        // Restart the silentRequestExecutor again
+        CommandDispatcher.resetSilentRequestExecutor();
     }
 
     @Test


### PR DESCRIPTION
Resetting silent request executor after test steps to stop it. To keep other tests unblocked when tests are run together.
This should fix the instrumented test pipeline for common [![Build Status](https://identitydivision.visualstudio.com/Engineering/_apis/build/status%2FAndroid%2FPull%20Request%20Pipelines%2FInstrumented%20Tests%2FCommon%20instrumented%20test?repoName=AzureAD%2Fmicrosoft-authentication-library-common-for-android&branchName=refs%2Fpull%2F1976%2Fmerge)](https://identitydivision.visualstudio.com/Engineering/_build/latest?definitionId=1859&repoName=AzureAD%2Fmicrosoft-authentication-library-common-for-android&branchName=refs%2Fpull%2F1976%2Fmerge)

Passing now
[![Build Status](https://identitydivision.visualstudio.com/Engineering/_apis/build/status%2FAndroid%2FPull%20Request%20Pipelines%2FInstrumented%20Tests%2FCommon%20instrumented%20test?repoName=AzureAD%2Fmicrosoft-authentication-library-common-for-android&branchName=refs%2Fpull%2F2007%2Fmerge)](https://identitydivision.visualstudio.com/Engineering/_build/latest?definitionId=1859&repoName=AzureAD%2Fmicrosoft-authentication-library-common-for-android&branchName=refs%2Fpull%2F2007%2Fmerge)