### PR TITLE
Separate constants for max client and broker protocol versions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.NEXT
 ----------
 - [PATCH] Fix Error Type thrown for NO_ACCOUNT_FOUND (#2006)
+- [MINOR] Separate constants for max client and broker protocol versions (#2008)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -605,7 +605,19 @@ public final class AuthenticationConstants {
          *
          * @see <a href="https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md">Android Auth Broker Protocol Versions</a>
          */
-        public static final String MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "12.0";
+        public static final String LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "13.0";
+
+        /**
+         * The maximum msal-to-broker protocol version known by clients such as MSAL Android.
+         */
+        public static final String CLIENT_MAX_PROTOCOL_VERSION = LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
+
+        /**
+         * The maximum broker protocol version known by Broker. This is a default value that can be
+         * used by the broker, however, broker may choose to override this value and use a higher
+         * value during handshake based on a flight.
+         */
+        public static final String DEFAULT_MAX_BROKER_PROTOCOL_VERSION = "12.0";
 
         /**
          * A client id for requesting the SSO token.

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -230,6 +230,7 @@ public class BrokerMsalController extends BaseController {
      *
      * @param strategy            an {@link IIpcStrategy}
      * @param minRequestedVersion the minimum allowed broker protocol version, may be null.
+     * @param clientMaxProtocolVersion the maximum broker protocol version known by client.
      * @return a protocol version negotiated by MSAL and Broker.
      */
     @VisibleForTesting

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -24,8 +24,9 @@ package com.microsoft.identity.common.internal.controllers;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_MAX_PROTOCOL_VERSION;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_NAME;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GENERATE_SHR;
@@ -208,7 +209,7 @@ public class BrokerMsalController extends BaseController {
                  final @Nullable String minRequestedVersion) throws BaseException {
 
         final String cachedProtocolVersion = mHelloCache.tryGetNegotiatedProtocolVersion(
-                minRequestedVersion, MSAL_TO_BROKER_PROTOCOL_VERSION_CODE);
+                minRequestedVersion, CLIENT_MAX_PROTOCOL_VERSION);
 
         if (!StringUtil.isEmpty(cachedProtocolVersion)) {
             return cachedProtocolVersion;
@@ -217,7 +218,7 @@ public class BrokerMsalController extends BaseController {
         final Bundle bundle = new Bundle();
         bundle.putString(
                 CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY,
-                MSAL_TO_BROKER_PROTOCOL_VERSION_CODE
+                CLIENT_MAX_PROTOCOL_VERSION
         );
 
         if (!StringUtil.isEmpty(minRequestedVersion)) {
@@ -239,7 +240,7 @@ public class BrokerMsalController extends BaseController {
 
         mHelloCache.saveNegotiatedProtocolVersion(
                 minRequestedVersion,
-                MSAL_TO_BROKER_PROTOCOL_VERSION_CODE,
+                CLIENT_MAX_PROTOCOL_VERSION,
                 negotiatedProtocolVersion);
 
         return negotiatedProtocolVersion;

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -33,8 +33,9 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CAN_FOCI_APPS_CONSTRUCT_ACCOUNTS_FROM_PRT_ID_TOKEN_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_CONFIGURED_MINIMUM_BP_VERSION_KEY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.CLIENT_MAX_PROTOCOL_VERSION;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.REQUEST_AUTHORITY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.SHOULD_SEND_PKEYAUTH_HEADER_TO_THE_TOKEN_ENDPOINT;
@@ -196,7 +197,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         final Bundle requestBundle = new Bundle();
         requestBundle.putString(
                 CLIENT_ADVERTISED_MAXIMUM_BP_VERSION_KEY,
-                MSAL_TO_BROKER_PROTOCOL_VERSION_CODE
+                CLIENT_MAX_PROTOCOL_VERSION
         );
 
         if (!StringUtil.isNullOrEmpty(parameters.getRequiredBrokerProtocolVersion())) {


### PR DESCRIPTION
The changes here are needed to enable flight for MSA accounts in Broker. See related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2235

The following changes have been made:

- Rename the constant for holding latest msal-to-broker protocol version from `MSAL_TO_BROKER_PROTOCOL_VERSION_CODE` to `LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE`
- Bump the `LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE` to `13.0` as this is the version that supports MSA accounts in Broker.
- Add a new constant for MAX Protocol Version known by clients such as MSAL. This is the same as LATEST MSAL BROKER protocol version (and references that constant) but having its own constant makes it cleaner to know what's being used in MSAL as parameter to CLIENT MAX.
- Add a new constant for MAX protocol Version known by Broker. This is currently being to `12.0` because in the Broker we want the max to be `12.0` as we will control this with a flight. For now we want MSA flight disabled and therefore the default max is 12.0. The actual max used by Broker is either this or 13.0 based on flight. See the tagged Broker PR for more details.
- Also added a new constructor to BrokerMsalController for test purposes. See broker PR for details.