### PR TITLE
Pulling device cert issuer check to beginning of OnReceivedClientCertRequest

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.NEXT
 ----------
 - [PATCH] Fix Error Type thrown for NO_ACCOUNT_FOUND (#2006)
+- [PATCH] Pulling device cert issuer check to beginning of OnReceivedClientCertRequest (#2010)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -69,7 +69,6 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     @Override
     public Void processChallenge(ClientCertRequest request) {
         final String methodTag = TAG + ":processChallenge";
-
         KeyChain.choosePrivateKeyAlias(mActivity, new KeyChainAliasCallback() {
                     @Override
                     public void alias(String alias) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -35,7 +35,6 @@ import androidx.annotation.RequiresApi;
 import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 
-import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
@@ -45,7 +44,6 @@ import java.security.cert.X509Certificate;
  */
 public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuthChallengeHandler {
     private static final String TAG = OnDeviceCertBasedAuthChallengeHandler.class.getSimpleName();
-    private static final String ACCEPTABLE_ISSUER = "CN=MS-Organization-Access";
     private final Activity mActivity;
 
     /**
@@ -71,21 +69,6 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     @Override
     public Void processChallenge(ClientCertRequest request) {
         final String methodTag = TAG + ":processChallenge";
-        final Principal[] acceptableCertIssuers = request.getPrincipals();
-
-        // When ADFS server sends null or empty issuers, we'll continue with cert prompt.
-        if (acceptableCertIssuers != null) {
-            for (final Principal issuer : acceptableCertIssuers) {
-                if (issuer.getName().contains(ACCEPTABLE_ISSUER)) {
-                    //Checking if received acceptable issuers contain "CN=MS-Organization-Access"
-                    final String message = "Cancelling the TLS request, not respond to TLS challenge triggered by device authentication.";
-                    Logger.info(methodTag, message);
-                    mTelemetryHelper.setResultFailure(message);
-                    request.cancel();
-                    return null;
-                }
-            }
-        }
 
         KeyChain.choosePrivateKeyAlias(mActivity, new KeyChainAliasCallback() {
                     @Override


### PR DESCRIPTION
## Summary
The C++ team let me know that some of their OneAuth UX automation tests were timing out due to the new user choice dialog I added as a part of the CBA support. These tests were ADFS related, but not CBA. The expected result was to not see any sort of CBA dialog at all.

The particular account that is being used here is related to an ADFS server that has its deviceAuthenticationMethod set to ClientTLS, so the ClientCertRequest coming in is for device authentication. A check was made a while back (when initial CBA support was first added) to account for this particular ClientCertRequest, and it immediately cancels the request once it determines it's for device auth, I mistakenly kept this check in the challenge handler for on-device CBA, when the check should actually be run before any sort of CBA logic can run. 

This PR pulls the cert issuer check to the very beginning of OnReceivedClientCertRequest, as there's no reason to create CBA challenge handlers for a request that isn't for CBA. I was able to first reproduce the issue with the test account OneAuth was using, and then I confirmed that the changes in this PR would suppress the user choice dialog, fixing the issue. 

