### PR TITLE
Remove (dupe) application name from telemetry

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V.NEXT
 - [PATCH] Fix Error Type thrown for NO_ACCOUNT_FOUND (#2006)
 - [PATCH] Pulling device cert issuer check to beginning of OnReceivedClientCertRequest (#2010)
 - [MINOR] Add method to clear receiver concurrentHashMap in LocalBroadcaster (#1993)
+- [MINOR] Remove (dupe) application name from telemetry (#2011)
 
 V.11.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
@@ -67,7 +67,6 @@ public class InteractiveTokenCommand extends TokenCommand {
         final Span span = OTelUtility.createSpanFromParent(
                 SpanName.AcquireTokenInteractive.name(), getParameters().getSpanContext()
         );
-        span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
         span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
 
         try (final Scope scope = span.makeCurrent()) {

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -74,7 +74,6 @@ public class SilentTokenCommand extends TokenCommand {
         final Span span = OTelUtility.createSpanFromParent(
                 SpanName.AcquireTokenSilent.name(), getParameters().getSpanContext()
         );
-        span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
         span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
 
         try (final Scope scope = span.makeCurrent()) {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -106,11 +106,6 @@ public enum AttributeName {
     controller_name,
 
     /**
-     * The name of the application making the request.
-     */
-    application_name,
-
-    /**
      * Indicates if token was return from token cache
      */
     is_serviced_from_cache,


### PR DESCRIPTION
This field is a duplicate. Since we already have `calling_package_name`. Thanks @somalaya for pointing out. 

`calling_package_name` is being set directly in the broker code and is already being used in queries so we would keep that.