### PR TITLE
Fix adal tests

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -255,7 +255,7 @@ public class AndroidKeyStoreUtil {
     /**
      * See: https://issuetracker.google.com/issues/37095309
      */
-    private static synchronized void applyKeyStoreLocaleWorkarounds(@NonNull final Locale currentLocale) {
+    public static synchronized void applyKeyStoreLocaleWorkarounds(@NonNull final Locale currentLocale) {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M
                 && DateUtilities.isLocaleCalendarNonGregorian(currentLocale)) {
             Locale.setDefault(Locale.ENGLISH);

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -709,7 +709,7 @@ public class MsalOAuth2TokenCache
 
     @Override
     public ICacheRecord load(@NonNull final String clientId,
-                             @NonNull final String applicationIdentifier,
+                             @Nullable final String applicationIdentifier,
                              @Nullable final String mamEnrollmentIdentifier,
                              @Nullable final String target,
                              @NonNull final AccountRecord account,


### PR DESCRIPTION
One ADAL test is failing because it's passing a null in a nonnull parameter. 

Looking into the method, it seems that the parameter should indeed be nullable.

---

I also made another method public for https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1725