### PR TITLE
Mapping ECDSA to EC in ClientCertRequest's keyTypes array

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V.NEXT
 - [PATCH] Fix Error Type thrown for NO_ACCOUNT_FOUND (#2006)
 - [PATCH] Pulling device cert issuer check to beginning of OnReceivedClientCertRequest (#2010)
 - [MINOR] Add method to clear receiver concurrentHashMap in LocalBroadcaster (#1993)
+- [PATCH] Mapping ECDSA to EC in ClientCertRequest's keyTypes array (#2015)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -287,6 +287,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
         final PrivateKey privateKey = session.getKeyForAuth(certDetails, pin);
         //Cert chain only needs the cert to be used for authentication.
         final X509Certificate[] chain = new X509Certificate[]{certDetails.getCertificate()};
+        mTelemetryHelper.setPublicKeyAlgoType(chain[0].getPublicKey().getAlgorithm());
         //Clear current dialog.
         mDialogHolder.dismissDialog();
         mIsCertBasedAuthProceeding = true;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandler.java
@@ -287,6 +287,7 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandler<T extends A
         final PrivateKey privateKey = session.getKeyForAuth(certDetails, pin);
         //Cert chain only needs the cert to be used for authentication.
         final X509Certificate[] chain = new X509Certificate[]{certDetails.getCertificate()};
+        //getCertificate() is annotated with NonNull.
         mTelemetryHelper.setPublicKeyAlgoType(chain[0].getPublicKey().getAlgorithm());
         //Clear current dialog.
         mDialogHolder.dismissDialog();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -88,6 +88,7 @@ public class CertBasedAuthFactory {
         final ICertBasedAuthTelemetryHelper telemetryHelper = new CertBasedAuthTelemetryHelper();
         telemetryHelper.setUserChoice(CertBasedAuthChoice.NON_APPLICABLE);
         telemetryHelper.setCertBasedAuthChallengeHandler(NON_APPLICABLE);
+        telemetryHelper.setPublicKeyAlgoType(NON_APPLICABLE);
 
         if (mUsbSmartcardCertBasedAuthManager != null
             && mUsbSmartcardCertBasedAuthManager.isDeviceConnected()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -28,7 +28,6 @@ import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.security.keystore.KeyProperties;
-import android.util.Log;
 import android.webkit.ClientCertRequest;
 
 import androidx.annotation.NonNull;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -105,7 +105,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
                         request.cancel();
                     }
                 },
-                getMappedKeyTypes(request.getKeyTypes()),
+                mapKeyTypes(request.getKeyTypes()),
                 request.getPrincipals(),
                 request.getHost(),
                 request.getPort(),
@@ -128,7 +128,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @Nullable
-    public String[] getMappedKeyTypes(@Nullable final String[] keyTypes) {
+    public String[] mapKeyTypes(@Nullable final String[] keyTypes) {
         if (keyTypes == null) {
             return null;
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -28,6 +28,7 @@ import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.security.keystore.KeyProperties;
+import android.util.Log;
 import android.webkit.ClientCertRequest;
 
 import androidx.annotation.NonNull;
@@ -86,6 +87,10 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
                         try {
                             final X509Certificate[] certChain = KeyChain.getCertificateChain(
                                     mActivity.getApplicationContext(), alias);
+                            if (certChain.length > 0) {
+                                //From my testing, the first cert (if there are more than one) is the selected one.
+                                mTelemetryHelper.setPublicKeyAlgoType(certChain[0].getPublicKey().getAlgorithm());
+                            }
                             final PrivateKey privateKey = KeyChain.getPrivateKey(
                                     mActivity, alias);
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -133,6 +133,10 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
             return null;
         }
         for (int i = 0; i < keyTypes.length; i++) {
+            //"ECDSA" isn't a constant in KeyProperties, so it should be getting mapped to "EC" via Chromium.
+            //But for some reason, Chromium's WebView bridge implementation adds "ECDSA" to the request key types String array, despite mapping it to "EC" in the web browser class.
+            //https://source.chromium.org/chromium/chromium/src/+/main:android_webview/browser/aw_contents_client_bridge.cc;l=184;bpv=1
+            //To mitigate this, we're going to map it to "EC" ourselves.
             if (keyTypes[i].equals(ECDSA_CONSTANT)) {
                 keyTypes[i] = KeyProperties.KEY_ALGORITHM_EC;
                 break;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -132,7 +132,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     @Nullable
-    public String[] mapKeyTypes(@Nullable final String[] keyTypes) {
+    static public String[] mapKeyTypes(@Nullable final String[] keyTypes) {
         if (keyTypes == null) {
             return null;
         }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/AbstractSmartcardCertBasedAuthChallengeHandlerTest.java
@@ -254,7 +254,22 @@ public abstract class AbstractSmartcardCertBasedAuthChallengeHandlerTest extends
 
             @Override
             public PublicKey getPublicKey() {
-                return null;
+                return new PublicKey() {
+                    @Override
+                    public String getAlgorithm() {
+                        return "N/A";
+                    }
+
+                    @Override
+                    public String getFormat() {
+                        return null;
+                    }
+
+                    @Override
+                    public byte[] getEncoded() {
+                        return new byte[0];
+                    }
+                };
             }
 
             @Override

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/TestCertBasedAuthTelemetryHelper.java
@@ -44,4 +44,7 @@ class TestCertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelper 
 
     @Override
     public void setUserChoice(CertBasedAuthChoice choice) {}
+
+    @Override
+    public void setPublicKeyAlgoType(String type) {}
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -81,6 +81,11 @@ public enum AttributeName {
     cert_based_auth_user_choice,
 
     /**
+     * Indicates the public key algorithm type of the selected certificate.
+     */
+    cert_based_auth_public_key_algo_type,
+
+    /**
      * The type of the error. Generally the class name of an exception.
      */
     error_type,

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/CertBasedAuthTelemetryHelper.java
@@ -117,4 +117,14 @@ public class CertBasedAuthTelemetryHelper implements ICertBasedAuthTelemetryHelp
                         "N/A");
         }
     }
+
+    /**
+     * Sets attribute that indicates the selected certificate's public key algorithm type.
+     * @param type algorithm name as a string.
+     */
+    @Override
+    public void setPublicKeyAlgoType(@NonNull final String type) {
+        mSpan.setAttribute(AttributeName.cert_based_auth_public_key_algo_type.name(),
+                type);
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/ICertBasedAuthTelemetryHelper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/ICertBasedAuthTelemetryHelper.java
@@ -74,4 +74,10 @@ public interface ICertBasedAuthTelemetryHelper {
      * @param choice enum indicating user's intended choice for CBA.
      */
     void setUserChoice(@NonNull final CertBasedAuthChoice choice);
+
+    /**
+     * Sets attribute that indicates the selected certificate's public key algorithm type.
+     * @param type algorithm name as a string.
+     */
+    void setPublicKeyAlgoType(@NonNull final String type);
 }


### PR DESCRIPTION
### Problem
The CBA team brought me an issue they were seeing with on-device CBA, specifically on Pixels. Despite installing the user certificate in the user cert store, they couldn't get the system cert picker to pop up when selecting on-device CBA, and the request would immediately fail. I was able to reproduce the issue on my Pixel 6, but not my Samsung device. The CBA team mentioned that they weren't reproducing the error on their Samsung phones either. 

### Debugging
From my experience, there are two main ways in which the system cert picker will not show up:
- No certs are in the user store.
- An issuer and/or key types filter was provided, and none of the certs installed match those filters.

I played around with the keyTypes filter, and we were receiving the string array [RSA, ECDSA]. While RSA is [an expected constant in the keyTypes array](https://developer.android.com/reference/android/security/KeyChain#choosePrivateKeyAlias(android.app.Activity,%20android.security.KeyChainAliasCallback,%20java.lang.String[],%20java.security.Principal[],%20android.net.Uri,%20java.lang.String)), ECDSA is not. After learning that the certificate being installed was of an Elliptical Curve type, I tried adding the [EC constant](https://developer.android.com/reference/android/security/keystore/KeyProperties#KEY_ALGORITHM_EC) to the array, and the cert picker finally came up. 

For some reason, [Chromium doesn't map ECDSA to EC for WebViews](https://source.chromium.org/chromium/chromium/src/+/main:android_webview/browser/aw_contents_client_bridge.cc;l=184;bpv=1), but it does for [the chromium based browsers](https://source.chromium.org/chromium/chromium/src/+/main:components/browser_ui/client_certificate/android/ssl_client_certificate_request.cc;l=172?q=clientcertrequest&ss=chromium). I'm not certain why this is inconsistent, especially since ECDSA doesn't have a literal constant like RSA does. I'm even more confused on how we haven't had an issue with this for so long (as we haven't changed this logic in years), almost as if the filters weren't really working until now (and only on Pixels).

### Patch
The medium (?) term solution that we can make on our side is to directly map "ECDSA" in the keyTypes array to the EC constant, which is what this PR does (medium, because it's not really the root of the problem in my opinion, and previous versions of common not including this change will still have the issue). 
For the long term, it would be good to know the percentage of users intending to use RSA certs vs EC certs so that we can determine impact. Since we don't know the intentions of the user (and can't query the cert store) before selection, I added an Otel span named cert_based_auth_public_key_algo_type which is populated with the algorithm name of the cert a user picks. Hopefully this will give us a general idea of the types of certs being used in successful scenarios, which may help in further identifying the scope of a future issue. 

### Testing
I confirmed the cert picker was able to come up in the Pixel 6 for both RSA and EC certificates, and no behavior changed for the Samsung phone. 

### Related PRs
- Same changes need to be made in ADAL: https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1726
- Adding new CBA Otel attribute name to broker file as well: https://github.com/AzureAD/ad-accounts-for-android/pull/2240