### PR TITLE
Invert check so SSL check method name matches its behavior

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -177,7 +177,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 processInvalidRedirectUri(view, url);
             } else if (isBlankPageRequest(formattedURL)) {
                 Logger.info(methodTag,"It is an blank page request");
-            } else if (isUriSSLProtected(formattedURL)) {
+            } else if (!isUriSSLProtected(formattedURL)) {
                 Logger.info(methodTag,"Check for SSL protection");
                 processSSLProtectionCheck(view, url);
             } else {
@@ -195,7 +195,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     private boolean isUriSSLProtected(@NonNull final String url) {
-        return !(url.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX));
+        return url.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX);
     }
 
     private boolean isBlankPageRequest(@NonNull final String url) {


### PR DESCRIPTION
The function `isUriSSLProtected` actually does the _opposite_ check currently. Flipping the logic around so this makes sense.