### PR TITLE
remove storage helper usage

### DIFF
--- a/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/DefaultSharedPrefsFileManagerReencrypterTest.java
@@ -113,7 +113,7 @@ public class DefaultSharedPrefsFileManagerReencrypterTest {
         @Override
         public String decrypt(@NonNull final String input) throws Exception {
             try {
-                // This is a workaround for some really clunky global state management
+                AuthenticationSettings.INSTANCE.setSecretKey(mMockLegacyKey);
                 final IKeyAccessorStringAdapter encryptionManager =
                         new KeyAccessorStringAdapter(
                                 new AndroidAuthSdkStorageEncryptionManager(mContext));

--- a/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/adal/internal/cache/StorageHelperTests.java
@@ -198,6 +198,7 @@ public class StorageHelperTests extends AndroidSecretKeyEnabledHelper {
     public void testKeyChange() throws GeneralSecurityException, IOException {
         Context context = getInstrumentation().getTargetContext();
         StorageHelper.LAST_KNOWN_THUMBPRINT.set("");
+        StorageHelper.FIRST_TIME.set(true);
         final StorageHelper storageHelper = new StorageHelper(context);
         Assert.assertTrue(storageHelper.testKeyChange());
         for (int i = 0; i < 500; i++) {

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/cache/StorageHelper.java
@@ -102,7 +102,7 @@ public class StorageHelper implements IStorageHelper {
     private static final String TAG = "StorageHelper";
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     public static final AtomicReference<String> LAST_KNOWN_THUMBPRINT = new AtomicReference<>("");
-    private static final AtomicBoolean FIRST_TIME = new AtomicBoolean(false);
+    public static final AtomicBoolean FIRST_TIME = new AtomicBoolean(false);
 
     /**
      * A flag to turn on/off keystore encryption on Broker apps.

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.platform;
 
-import static com.microsoft.identity.common.adal.internal.cache.StorageHelper.applyKeyStoreLocaleWorkarounds;
+import static com.microsoft.identity.common.internal.util.AndroidKeyStoreUtil.applyKeyStoreLocaleWorkarounds;
 import static com.microsoft.identity.common.java.WarningType.NewApi;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.LOCALE_CHANGE_LOCK;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.isLocaleCalendarNonGregorian;


### PR DESCRIPTION
StorageHelper itself seems to be used by OneAuth still - so i'm keeping it for now.

In our codebase however, there should be no more usage of StorageHelper after this PR and another Broker PR.