### PR TITLE
Moving ClearCertPref call to clean up method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.NEXT
 - [MINOR] Add method to clear receiver concurrentHashMap in LocalBroadcaster (#1993)
 - [PATCH] Mapping ECDSA to EC in ClientCertRequest's keyTypes array (#2015)
 - [PATCH] Fix NPE in OTEL code (#2018)
+- [PATCH] Moving ClearCertPref call to clean up method (#2025)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -145,27 +145,30 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mAADWebViewClient = new AzureActiveDirectoryWebViewClient(
                 activity,
                 new AuthorizationCompletionCallback(),
-                url -> {
-                    final String[] javascriptToExecute = new String[1];
-                    mProgressBar.setVisibility(View.INVISIBLE);
-                    try {
-                        javascriptToExecute[0] = String.format("window.expectedUrl = '%s';%n%s",
-                                URLEncoder.encode(url, "UTF-8"),
-                                mPostPageLoadedJavascript);
-                    } catch (final UnsupportedEncodingException e) {
-                        // Encode url component failed, fallback.
-                        Logger.warn(methodTag, "Inject expectedUrl failed.");
-                    }
-                    // Inject the javascript string from testing. This should only be evaluated if we haven't sent
-                    // an auth result already.
-                    if (!mAuthResultSent && !StringExtensions.isNullOrBlank(javascriptToExecute[0])) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                            mWebView.evaluateJavascript(javascriptToExecute[0], null);
-                        } else {
-                            // On earlier versions of Android, javascript has to be loaded with a custom scheme.
-                            // In these cases, Android will helpfully unescape any octects it finds. Unfortunately,
-                            // our javascript may contain the '%' character, so we escape it again, to undo that.
-                            mWebView.loadUrl("javascript:" + javascriptToExecute[0].replace("%", "%25"));
+                new OnPageLoadedCallback() {
+                    @Override
+                    public void onPageLoaded(final String url) {
+                        final String[] javascriptToExecute = new String[1];
+                        mProgressBar.setVisibility(View.INVISIBLE);
+                        try {
+                            javascriptToExecute[0] = String.format("window.expectedUrl = '%s';%n%s",
+                                    URLEncoder.encode(url, "UTF-8"),
+                                    mPostPageLoadedJavascript);
+                        } catch (final UnsupportedEncodingException e) {
+                            // Encode url component failed, fallback.
+                            Logger.warn(methodTag, "Inject expectedUrl failed.");
+                        }
+                        // Inject the javascript string from testing. This should only be evaluated if we haven't sent
+                        // an auth result already.
+                        if (!mAuthResultSent && !StringExtensions.isNullOrBlank(javascriptToExecute[0])) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                                mWebView.evaluateJavascript(javascriptToExecute[0], null);
+                            } else {
+                                // On earlier versions of Android, javascript has to be loaded with a custom scheme.
+                                // In these cases, Android will helpfully unescape any octects it finds. Unfortunately,
+                                // our javascript may contain the '%' character, so we escape it again, to undo that.
+                                mWebView.loadUrl("javascript:" + javascriptToExecute[0].replace("%", "%25"));
+                            }
                         }
                     }
                 },

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -129,7 +129,8 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             WebView.clearClientCertPreferences(null);
         } else {
-            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP). " +
+                    "Subsequent CBA attempts will fail due to the cached action, so the user must restart the app before attempting to login with CBA again.");
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -29,6 +29,7 @@ import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.security.keystore.KeyProperties;
 import android.webkit.ClientCertRequest;
+import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -122,7 +123,14 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
      */
     @Override
     public void cleanUp() {
-        //Nothing needed at the moment.
+        final String methodTag = TAG + ":cleanUp";
+        //For on-device CBA, we need to clear the certificate choice cache here so that
+        // the user will be able to login with multiple accounts with CBA
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            WebView.clearClientCertPreferences(null);
+        } else {
+            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP)");
+        }
     }
 
     /**


### PR DESCRIPTION
### Summary
The C++ team mentioned that they're still seeing some ERR_CERT_DATABASE_CHANGED errors pop up in a few apps, which we attributed last time to the [WebView.ClearClientCertPreferences](https://developer.android.com/reference/android/webkit/WebView#clearClientCertPreferences(java.lang.Runnable)) call that we have to make to allow CBA users to add more than one account without having to restart the app.
This PR moves the one ClearClientCertPreferences call we have to the cleanUp method of the OnDevice challenge handler. The good thing about this move is that it will only get called if on-device CBA was ever initiated, instead of every time the WebView gets initialized. (This option has more recently been easily accessible due to the multiple rounds of refactoring that have been done to CBA in the previous few months :) ). 
If this change doesn't improve the hit rate of the error the OneAuth folks are seeing, I'll talk to the CBA team regarding the customer impact of removing/keeping this method call.

### Testing
Tested logging in with CBA and making sure the clearClientCertPreferences call isn't causing any abnormal behavior. Was able to add another account without closing the app, and I was also able to cancel out of the CBA flow, but then successfully add an account upon restart of the WebView.  Made sure that the method call wasn't being made in a regular password login flow.
Also asked the C++ team if they can run this branch through their automated tests to catch any issues on their side early.