### PR TITLE
Fix Access token caching

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V.NEXT
 - [PATCH] Fix NPE in OTEL code (#2018)
 - [MINOR] Updating different smartcards error message; updated string res files (#2021)
 - [PATCH] Moving ClearCertPref call to clean up method (#2025)
+- [PATCH] Fix target in token records to fix cache keys
 
 V.11.0.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ V.NEXT
 - [PATCH] Fix NPE in OTEL code (#2018)
 - [MINOR] Updating different smartcards error message; updated string res files (#2021)
 - [PATCH] Moving ClearCertPref call to clean up method (#2025)
-- [PATCH] Fix target in token records to fix cache keys
+- [PATCH] Fix target in token records to fix cache keys (#2027)
 
 V.11.0.0
 ----------

--- a/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common;
 
+import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.cache.MicrosoftStsAccountCredentialAdapter;
 import com.microsoft.identity.common.java.commands.parameters.TokenCommandParameters;
@@ -59,6 +60,7 @@ import java.security.SecureRandom;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
 import java.util.Set;
 
 import cz.msebera.android.httpclient.extras.Base64;
@@ -260,7 +262,8 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         assertEquals(MOCK_AUTHORITY, accessTokenRecord.getAuthority());
         assertEquals(MOCK_ENVIRONMENT, accessTokenRecord.getEnvironment());
         assertNotNull(accessTokenRecord.getExtendedExpiresOn());
-        assertEquals(MOCK_UID + "." + MOCK_UTID, accessTokenRecord.getHomeAccountId());;
+        assertEquals(MOCK_UID + "." + MOCK_UTID, accessTokenRecord.getHomeAccountId());
+        assertEquals(MOCK_SCOPE, accessTokenRecord.getTarget());
     }
 
     @Test
@@ -274,6 +277,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
         assertEquals(MOCK_REFRESH_TOKEN, refreshTokenRecord.getSecret());
         assertEquals(MOCK_CLIENT_ID, refreshTokenRecord.getClientId());
         assertEquals(CredentialType.RefreshToken.name(), refreshTokenRecord.getCredentialType());
+        assertEquals(MOCK_SCOPE, refreshTokenRecord.getTarget());
     }
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -361,7 +361,12 @@ public class MicrosoftStsAccountCredentialAdapter
         accessTokenRecord.setApplicationIdentifier(parameters.getApplicationIdentifier());
         accessTokenRecord.setSecret(tokenResponse.getAccessToken());
         accessTokenRecord.setAccessTokenType(tokenResponse.getTokenType());
-        accessTokenRecord.setTarget(StringUtil.join(" ", parameters.getScopes()));
+        accessTokenRecord.setTarget(
+                this.getTarget(
+                        StringUtil.join(" ", parameters.getScopes()),
+                        tokenResponse.getScope()
+                )
+        );
         setCredentialEnvironment(accessTokenRecord, parameters.getAuthority(), tokenResponse, methodTag);
 
         if (tokenResponse.getExpiresIn() != null) {
@@ -400,7 +405,12 @@ public class MicrosoftStsAccountCredentialAdapter
 
         // Optional
         refreshToken.setFamilyId(tokenResponse.getFamilyId());
-        refreshToken.setTarget(StringUtil.join(" ", parameters.getScopes()));
+        refreshToken.setTarget(
+                this.getTarget(
+                        StringUtil.join(" ", parameters.getScopes()),
+                        tokenResponse.getScope()
+                )
+        );
         refreshToken.setCachedAt(
                 String.valueOf(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()))
         );

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -64,7 +64,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
@@ -1769,16 +1771,20 @@ public class MsalOAuth2TokenCache
         return result;
     }
 
+    /**
+     * Normalizes scope values (converts to lower case)
+     * and returns as set.
+     */
     private Set<String> scopesAsSet(final AccessTokenRecord token) {
-        final Set<String> scopeSet = new HashSet<>();
         final String scopeString = token.getTarget();
-
         if (!StringUtil.isNullOrEmpty(scopeString)) {
             final String[] scopeArray = scopeString.split("\\s+");
-            scopeSet.addAll(Arrays.asList(scopeArray));
+            return Arrays.stream(scopeArray)
+                    .map(s -> s.toLowerCase(Locale.US))
+                    .collect(Collectors.toSet());
         }
 
-        return scopeSet;
+        return new HashSet<>();
     }
 
     private static boolean isSchemaCompliant(final Class<?> clazz, final String[][] params) {


### PR DESCRIPTION
**Issue:**
Steps to repro the issue
1. Acquire token interactively (Broker) with user.read
This setups up access token like this in the cache
7df0e758-afda-447e-a298-232b5d5baa12.5e930fc0-2e40-43d7-88e3-375e7f0f9d8e-login.windows.net-accesstoken-4b0db8c2-9f26-4417-8bde-3f0e3656f8e0-5e930fc0-2e40-43d7-88e3-375e7f0f9d8e-**openid User.Read profile email**-com.msft.identity.client.sample.local/1wiqxsqbj7w+h11zifsnqwgykry=
2. Acquire token interactively (broker) with user.read scope and with device claim string {\"access_token\":{\"deviceid\":{\"essential\":true}}}"
This setups up new cache value as 7df0e758-afda-447e-a298-232b5d5baa12.5e930fc0-2e40-43d7-88e3-375e7f0f9d8e-login.windows.net-accesstoken-4b0db8c2-9f26-4417-8bde-3f0e3656f8e0-5e930fc0-2e40-43d7-88e3-375e7f0f9d8e-**user.read openid offline_access profile**-com.msft.identity.client.sample.local/1wiqxsqbj7w+h11zifsnqwgykry=

There's difference between cache key values to different target strings (target strings are built from scopes).
3. New ATS call comes with the same claim string. Even though this would request a new AT from eSTS it would end up updating the 2nd entry and not the first. And then in the result, we end up choosing value stored in step 1(without device id claim).

Note: Above steps assume that the corresponding broker fix has been made.

 **Fix target in token records**
1. Fixing target string using response scopes instead of request.
2. Fixing logic where we delete any existing AT which intersect with new AT returned in response. Improved comparison by doing case-insensitive matching of scopes, so that we don't end up duplicate ATs.
Related broker PR https://github.com/AzureAD/ad-accounts-for-android/pull/2259