### PR TITLE
Moving ClearClientCertPreferences to Factory instance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ V.12.0.0
 - [MINOR] Updating different smartcards error message; updated string res files (#2021)
 - [PATCH] Moving ClearCertPref call to clean up method (#2025)
 - [PATCH] Fix target in token records to fix cache keys (#2027)
+- [PATCH] Moving ClearCertPref to Factory instance (#2035)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -29,7 +29,6 @@ import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.security.keystore.KeyProperties;
 import android.webkit.ClientCertRequest;
-import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -123,15 +122,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
      */
     @Override
     public void cleanUp() {
-        final String methodTag = TAG + ":cleanUp";
-        //For on-device CBA, we need to clear the certificate choice cache here so that
-        // the user will be able to login with multiple accounts with CBA
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            WebView.clearClientCertPreferences(null);
-        } else {
-            Logger.warn(methodTag, "Client Cert Preferences cache not cleared due to SDK version < 21 (LOLLIPOP). " +
-                    "Subsequent CBA attempts will fail due to the cached action, so the user must restart the app before attempting to login with CBA again.");
-        }
+       //nothing needed here
     }
 
     /**


### PR DESCRIPTION
### Summary
A change I made before to move ClearClientCertPreferences helped reduce the amount of this method call in the on-device CBA instance, but it introduced some regressions in user experience for smartcard CBA, as the cert preferences weren't getting cleared, which would cause CBA to always fail upon subsequent attempts  to try to login (until they restart the entire app, and broker app as well).
This PR puts the ClearClientCertPreferences method in the CertBasedAuthFactory, where a boolean helps determine if CBA was initiated, and clears if true. 

### Testing
To be extra thorough:
- tested with mfatest@vimrang1, fidlab@msidlab4, and fidlab@msidlab3. 
- tested logging in with smartcard CBA, then on-device CBA.
- tested cancelling at various stages, including the dialog prompt to select a type of CBA, within smartcard cba, within on-device cba, errors.
- tested just logging in with a password, and made sure the ClearClientCertPreferences method wasn't being called there.
- one thing to note is that with fidlab@msidlab3, the device auth invokes CBA automatically. the logic in this PR doesn't clear the cert pref in this case. this is a known thing, and in the majority of CBA scenarios we've seen so far, they won't be using this type of device auth. But this is something to investigate more in the future as we get more users.