### PR TITLE
Change to incorporate the Java class primitives

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/components/AndroidStorageSupplier.kt
+++ b/common/src/main/java/com/microsoft/identity/common/components/AndroidStorageSupplier.kt
@@ -43,9 +43,9 @@ class AndroidStorageSupplier(private val context: Context,
                                           storageEncryptionManager: StorageEncryptionManager?): INameValueStorage<T> {
             val mgr: IMultiTypeNameValueStorage =
                 SharedPreferencesFileManager.getSharedPreferences(context, storeName, storageEncryptionManager)
-            if (Long::class.java.isAssignableFrom(clazz)) {
+            if (Long::class.java.isAssignableFrom(clazz)|| java.lang.Long::class.java.isAssignableFrom(clazz)) {
                 return (SharedPreferenceLongStorage(mgr) as INameValueStorage<T>)
-            } else if (String::class.java.isAssignableFrom(clazz)) {
+            } else if (String::class.java.isAssignableFrom(clazz)|| java.lang.String::class.java.isAssignableFrom(clazz)) {
                 return (SharedPrefStringNameValueStorage(mgr) as INameValueStorage<T>)
             }
 


### PR DESCRIPTION
Similar to https://github.com/AzureAD/ad-accounts-for-android/pull/2277/files

WHAT?
Updated  AndroidStorageSupplier.kt.kt to add java primitives.

WHY?
Kotlin treats primitives in a different way than Java, hence we have added the check for both the types.

Based of : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2033