### PR TITLE
Revert "Getting rid of account manager strategy in MSAL/OneAuth" on 12.0.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.12.0.1
+=======
+- [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041/#2042)
+
 V.12.0.0
 ----------
 - [MINOR] make getCurrentActiveBrokerPackageName case insensitive and trims the authenticator type (#2026)
@@ -13,6 +17,10 @@ V.12.0.0
 - [PATCH] Moving ClearCertPref call to clean up method (#2025)
 - [PATCH] Fix target in token records to fix cache keys (#2027)
 - [PATCH] Moving ClearCertPref to Factory instance (#2035)
+
+V.11.0.1
+=======
+- [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041/#2042)
 
 V.11.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker.ipc;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.util.ProcessUtil;
+import com.microsoft.identity.common.logging.Logger;
+
+import java.io.IOException;
+
+import static com.microsoft.identity.common.exception.BrokerCommunicationException.Category.CONNECTION_ERROR;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.ACCOUNT_MANAGER_ADD_ACCOUNT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+
+/**
+ * A strategy for communicating with the targeted broker via AccountManager's addAccount().
+ * <p>
+ * NOTE: SuppressLint is added because this API requires MANAGE_ACCOUNTS for API<= 22.
+ * AccountManagerUtil.canUseAccountManagerOperation() will validate that.
+ */
+
+@SuppressLint("MissingPermission")
+public class AccountManagerAddAccountStrategy implements IIpcStrategy {
+    private static final String TAG = AccountManagerAddAccountStrategy.class.getSimpleName();
+
+    private final Context mContext;
+
+    public AccountManagerAddAccountStrategy(final Context context) {
+        mContext = context;
+    }
+
+    @Override
+    @Nullable
+    public Bundle communicateToBroker(final @NonNull BrokerOperationBundle brokerOperationBundle)
+            throws BrokerCommunicationException {
+        final String methodTag = TAG + ":communicateToBroker";
+        final String operationName = brokerOperationBundle.getOperation().name();
+        Logger.info(methodTag, "Broker operation: " + operationName+" brokerPackage: "+brokerOperationBundle.getTargetBrokerAppPackageName());
+        try {
+            final AccountManagerFuture<Bundle> resultBundle =
+                    AccountManager.get(mContext)
+                            .addAccount(
+                                    BROKER_ACCOUNT_TYPE,
+                                    AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                                    null,
+                                    brokerOperationBundle.getAccountManagerBundle(),
+                                    null,
+                                    null,
+                                    ProcessUtil.getPreferredHandler());
+
+            Logger.verbose(methodTag, "Received result from broker");
+            return resultBundle.getResult();
+        } catch (final AuthenticatorException | IOException | OperationCanceledException e) {
+            Logger.error(methodTag, e.getMessage(), e);
+            throw new BrokerCommunicationException(CONNECTION_ERROR, getType(), "Failed to connect to AccountManager", e);
+        }
+    }
+
+    @Override
+    public Type getType() {
+        return ACCOUNT_MANAGER_ADD_ACCOUNT;
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -93,6 +93,39 @@ public class BrokerOperationBundle {
     @Getter
     @Nullable final private Bundle bundle;
 
+    /**
+     * Packs the response bundle with the account manager key.
+     */
+    public Bundle getAccountManagerBundle()
+            throws BrokerCommunicationException {
+        Bundle requestBundle = bundle;
+        if (requestBundle == null) {
+            requestBundle = new Bundle();
+        }
+
+        requestBundle.putString(
+                AuthenticationConstants.Broker.BROKER_ACCOUNT_MANAGER_OPERATION_KEY,
+                getAccountManagerAddAccountOperationKey());
+
+        return requestBundle;
+    }
+
+    private String getAccountManagerAddAccountOperationKey() throws BrokerCommunicationException{
+        final String methodTag = TAG + ":getAccountManagerAddAccountOperationKey";
+
+        String accountManagerKey = operation.getAccountManagerOperation();
+        if (accountManagerKey == null) {
+            final String errorMessage = "Operation " + operation.name() + " is not supported by AccountManager addAccount().";
+            Logger.warn(methodTag, errorMessage);
+            throw new BrokerCommunicationException(
+                    OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                    ACCOUNT_MANAGER_ADD_ACCOUNT,
+                    errorMessage,
+                    null);
+        }
+        return accountManagerKey;
+    }
+
     public String getContentProviderPath() throws BrokerCommunicationException {
         final String methodTag = TAG + ":getContentProviderUriPath";
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -58,6 +58,7 @@ import com.microsoft.identity.common.internal.broker.BrokerActivity;
 import com.microsoft.identity.common.internal.broker.BrokerResult;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerAddAccountStrategy;
 import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy;
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
 import com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy;
@@ -70,6 +71,7 @@ import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
 import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
+import com.microsoft.identity.common.internal.util.AccountManagerUtil;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience;
@@ -200,6 +202,11 @@ public class BrokerMsalController extends BaseController {
         if (client.isBoundServiceSupported(activeBrokerPackageName)) {
             sb.append("BoundServiceStrategy, ");
             strategies.add(new BoundServiceStrategy<>(client));
+        }
+
+        if (AccountManagerUtil.canUseAccountManagerOperation(applicationContext)) {
+            sb.append("AccountManagerStrategy.");
+            strategies.add(new AccountManagerAddAccountStrategy(applicationContext));
         }
 
         Logger.info(methodTag, sb.toString());

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerAddAccountStrategyTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/AccountManagerAddAccountStrategyTest.java
@@ -1,0 +1,118 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc;
+
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerAddAccountStrategy;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowAccountManagerAddAccountConnectionFailed;
+import com.microsoft.identity.common.internal.ipc.mock.ShadowAccountManagerAddAccountWithSuccessResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.BROKER_GET_KEY_FROM_INACTIVE_BROKER;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_DEVICE_MODE;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_HELLO;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_REMOVE_ACCOUNT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SIGN_OUT_FROM_SHARED_DEVICE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.N}, shadows = {ShadowAccountManagerAddAccountWithSuccessResult.class})
+public class AccountManagerAddAccountStrategyTest extends IpcStrategyTests {
+    @Override
+    protected IIpcStrategy getStrategy() {
+        return new AccountManagerAddAccountStrategy(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    @Override
+    public void testMsalHello() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_HELLO));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetIntentForInteractiveRequest() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST));
+    }
+
+    @Test
+    @Override
+    public void testMsalAcquireTokenSilent() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_ACQUIRE_TOKEN_SILENT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_ACCOUNTS));
+    }
+
+    @Test
+    @Override
+    public void testMsalRemoveAccounts() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_REMOVE_ACCOUNT));
+    }
+
+    @Test
+    @Override
+    public void testMsalGetDeviceMode() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_DEVICE_MODE));
+    }
+
+    @Test
+    @Override
+    public void testGetCurrentAccountInSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testMsalSignOutFromSharedDevice() {
+        testOperationSucceeds(getMockRequestBundle(MSAL_SIGN_OUT_FROM_SHARED_DEVICE));
+    }
+
+    @Test
+    @Override
+    public void testBrokerGetKeyFromInactiveBroker() {
+        testOperationNotSupportedOnClientSide(getMockRequestBundle(BROKER_GET_KEY_FROM_INACTIVE_BROKER));
+    }
+
+    @Test
+    @Override
+    @Config(shadows = {ShadowAccountManagerAddAccountConnectionFailed.class})
+    public void testIpcFailed() {
+        testIpcConnectionFailed(getMockRequestBundle(MSAL_HELLO));
+    }
+}
+

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountConnectionFailed.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountConnectionFailed.java
@@ -1,0 +1,68 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Implements(AccountManager.class)
+public class ShadowAccountManagerAddAccountConnectionFailed {
+
+    public AccountManagerFuture<Bundle> addAccount(final String accountType,
+                                                   final String authTokenType, final String[] requiredFeatures,
+                                                   final Bundle addAccountOptions,
+                                                   final Activity activity, AccountManagerCallback<Bundle> callback, Handler handler) {
+        return new AccountManagerFuture<Bundle>() {
+            @Override public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override public boolean isCancelled() {
+                return true;
+            }
+
+            @Override public boolean isDone() {
+                return false;
+            }
+
+            @Override public Bundle getResult() throws AuthenticatorException, IOException, OperationCanceledException {
+                throw new AuthenticatorException("Failed to bind");
+            }
+
+            @Override public Bundle getResult(long timeout, TimeUnit unit) throws AuthenticatorException, IOException, OperationCanceledException {
+                throw new AuthenticatorException("Failed to bind");
+            }
+        };
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountWithSuccessResult.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/mock/ShadowAccountManagerAddAccountWithSuccessResult.java
@@ -1,0 +1,70 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.ipc.mock;
+
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Handler;
+
+import com.microsoft.identity.common.internal.ipc.IpcStrategyTests;
+
+import org.robolectric.annotation.Implements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Implements(AccountManager.class)
+public class ShadowAccountManagerAddAccountWithSuccessResult {
+
+    public AccountManagerFuture<Bundle> addAccount(final String accountType,
+                                                   final String authTokenType, final String[] requiredFeatures,
+                                                   final Bundle addAccountOptions,
+                                                   final Activity activity, AccountManagerCallback<Bundle> callback, Handler handler) {
+        return new AccountManagerFuture<Bundle>() {
+            @Override public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override public boolean isCancelled() {
+                return false;
+            }
+
+            @Override public boolean isDone() {
+                return true;
+            }
+
+            @Override public Bundle getResult() throws AuthenticatorException, IOException, OperationCanceledException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+
+            @Override public Bundle getResult(long timeout, TimeUnit unit) throws AuthenticatorException, IOException, OperationCanceledException {
+                return IpcStrategyTests.getMockIpcResultBundle();
+            }
+        };
+    }
+}

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=12.0.0
+versionName=12.0.1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
cherry-pick
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2041 onto 12.0.0.