### PR TITLE
Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
@@ -30,7 +30,7 @@ import com.microsoft.identity.common.internal.cache.IActiveBrokerCache
  **/
 class InMemoryActiveBrokerCache: IActiveBrokerCache {
 
-    var activeBroker: BrokerData? = null
+    private var activeBroker: BrokerData? = null
 
     @Synchronized
     override fun getCachedActiveBroker(): BrokerData? {


### PR DESCRIPTION
Parallelize IPC requests in BrokerDiscoveryRequests.

Stop caching account manager values.... because if broker switch happens, then the cached value here could be blocking. we will always get a fresh value.