### PR TITLE
Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.NEXT
 ----------
-- [PATCH] Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe (#2049)
+- [PATCH] Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe (#2050)
 - [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041)
 - [MINOR] Add BrokerDiscoveryClient + Tests (#2039)
 - [MAJOR] Consolidate IStorageSupplier logic (#2033)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe (#2049)
 - [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041)
 - [MINOR] Add BrokerDiscoveryClient + Tests (#2039)
 - [MAJOR] Consolidate IStorageSupplier logic (#2033)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -141,6 +141,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.java.logging.Logger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 
 /**
@@ -167,8 +168,7 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         val methodTag = "$TAG:getActiveBroker"
 
         return runBlocking {
-            classLevelLock.lock()
-            try {
+            classLevelLock.withLock {
                 if (!shouldSkipCache) {
                     val cachedData = cache.getCachedActiveBroker()
                     cachedData?.let {
@@ -203,8 +203,6 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                 )
 
                 return@runBlocking accountManagerResult
-            } finally {
-                classLevelLock.unlock()
             }
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -72,11 +72,6 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         const val ERROR_BUNDLE_KEY = "ERROR_BUNDLE_KEY"
 
         /**
-         * Error code to be returned when the broker determines that only account manager can be used.
-         **/
-        const val ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE = "ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE"
-
-        /**
          * Per-process Thread-safe, coroutine-safe Mutex of this class.
          * This is to prevent the IPC mechanism from being unnecessarily triggered due to race condition.
          *

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -206,7 +206,8 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                     isPackageInstalled = isPackageInstalled,
                     shouldStopQueryForAWhile = {
                         Logger.info(
-                            methodTag,"Will skip broker discovery for the next 60 minutes."
+                            methodTag,"Will skip broker discovery via IPC and fall back to AccountManager " +
+                                    "for the next 60 minutes."
                         )
                         cache.setShouldUseAccountManagerForTheNextMilliseconds(TimeUnit.MINUTES.toMillis(60))
                     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -185,7 +185,6 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                     if(cache.shouldUseAccountManager()) {
                         return@runBlocking getActiveBrokerFromAccountManager()
                     }
-
                     cache.getCachedActiveBroker()?.let {
                         if (isPackageInstalled(it)) {
                             Logger.info(methodTag, "Returning cached broker: $it")

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
@@ -37,7 +37,7 @@ import kotlin.concurrent.write
  * A cache for storing the active broker as known by the caller.
  **/
 @ThreadSafe
-class ActiveBrokerCache
+open class ActiveBrokerCache
     internal constructor(private val storage: INameValueStorage<String>,
                          private val lock: Mutex) : IActiveBrokerCache {
 
@@ -58,25 +58,12 @@ class ActiveBrokerCache
         private const val BROKER_METADATA_CACHE_STORE_ON_BROKER_SIDE_STORAGE_NAME = "BROKER_METADATA_CACHE_STORE_ON_BROKER_SIDE"
 
         /**
-         * File name of [ActiveBrokerCache] used by the SDK code.
-         **/
-        private const val BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE_STORAGE_NAME = "BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE"
-
-        /**
          * The Mutex for all [ActiveBrokerCache] instances used by the broker code.
          * (As of May 24, 2023... Kotlin has yet to officially support ReadWriteMutex.
          *  I don't think it's worth implementing our own (for now).
          *  If we eventually are seeing a perf hit, sure...)
          **/
         private val sBrokerSideLock = Mutex()
-
-        /**
-         * The Mutex for all [ActiveBrokerCache] instances used by the SDK code.
-         * (As of May 24, 2023... Kotlin has yet to officially support ReadWriteMutex.
-         *  I don't think it's worth implementing our own (for now).
-         *  If we eventually are seeing a perf hit, sure...)
-         **/
-        private val sSdkSideLock = Mutex()
 
         /**
          * If the caller is the broker, invoke this function.
@@ -90,21 +77,6 @@ class ActiveBrokerCache
                 storage = storageSupplier.getEncryptedNameValueStore(
                     BROKER_METADATA_CACHE_STORE_ON_BROKER_SIDE_STORAGE_NAME, String::class.java),
                 lock = sBrokerSideLock
-            )
-        }
-
-        /**
-         * If the caller is an SDK, invoke this function.
-         *
-         * @param storageSupplier an [IStorageSupplier] component.
-         * @return a thread-safe [IActiveBrokerCache].
-         */
-        fun getBrokerMetadataStoreOnSdkSide(storageSupplier: IStorageSupplier)
-                : IActiveBrokerCache {
-            return ActiveBrokerCache(
-                storage = storageSupplier.getEncryptedNameValueStore(
-                    BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE_STORAGE_NAME, String::class.java),
-                lock = sSdkSideLock
             )
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
@@ -71,6 +71,9 @@ class ActiveBrokerCache
 
         /**
          * The Mutex for all [ActiveBrokerCache] instances used by the SDK code.
+         * (As of May 24, 2023... Kotlin has yet to officially support ReadWriteMutex.
+         *  I don't think it's worth implementing our own (for now).
+         *  If we eventually are seeing a perf hit, sure...)
          **/
         private val sSdkSideLock = Mutex()
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -41,9 +41,9 @@ internal constructor(private val storage: INameValueStorage<String>,
         }
 
         /**
-         * Returns true if the time has passed the given expiry date.
+         * Returns true if the time has NOT passed the given expiry date.
          */
-        fun isExpired(expiryDate: Long?): Boolean{
+        fun isNotExpired(expiryDate: Long?): Boolean{
             if (expiryDate == null) {
                 return false
             }
@@ -73,7 +73,7 @@ internal constructor(private val storage: INameValueStorage<String>,
                     }
                 }
 
-                if (isExpired(cachedTimeStamp)){
+                if (isNotExpired(cachedTimeStamp)){
                     cachedTimeStamp = null
                     return@runBlocking true
                 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -1,0 +1,71 @@
+package com.microsoft.identity.common.internal.cache
+
+import com.microsoft.identity.common.java.interfaces.INameValueStorage
+import com.microsoft.identity.common.java.interfaces.IStorageSupplier
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+
+class ClientActiveBrokerCache
+internal constructor(private val storage: INameValueStorage<String>,
+                     private val lock: Mutex): ActiveBrokerCache(storage, lock), IClientActiveBrokerCache {
+
+    companion object {
+        /**
+         * File name of [ActiveBrokerCache] used by the SDK code.
+         **/
+        private const val BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE_STORAGE_NAME = "BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE"
+
+        /**
+         * The Mutex for all [ActiveBrokerCache] instances used by the SDK code.
+         * (As of May 24, 2023... Kotlin has yet to officially support ReadWriteMutex.
+         *  I don't think it's worth implementing our own (for now).
+         *  If we eventually are seeing a perf hit, sure...)
+         **/
+        private val sSdkSideLock = Mutex()
+
+        /**
+         * If the caller is an SDK, invoke this function.
+         *
+         * @param storageSupplier an [IStorageSupplier] component.
+         * @return a thread-safe [IActiveBrokerCache].
+         */
+        fun getBrokerMetadataStoreOnSdkSide(storageSupplier: IStorageSupplier)
+                : IClientActiveBrokerCache {
+            return ClientActiveBrokerCache(
+                storage = storageSupplier.getEncryptedNameValueStore(
+                    BROKER_METADATA_CACHE_STORE_ON_SDK_SIDE_STORAGE_NAME, String::class.java),
+                lock = sSdkSideLock
+            )
+        }
+
+        /**
+         * Key for storing time which the client discovery should use AccountManager.
+         **/
+        const val SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY =
+            "SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY"
+    }
+
+    override fun shouldUseAccountManager(): Boolean {
+        return runBlocking {
+            lock.withLock {
+                storage.get(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY)?.let { rawValue ->
+                    rawValue.toLongOrNull()?.let { expiryDate ->
+                        return@runBlocking Instant.now().toEpochMilli() < expiryDate
+                    }
+                }
+                return@runBlocking false
+            }
+        }
+    }
+
+    override fun setShouldUseAccountManagerForTheNextMilliseconds(time: Long) {
+        return runBlocking {
+            lock.withLock {
+                storage.put(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY,
+                    (Instant.now().toEpochMilli() + time).toString())
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -40,11 +40,13 @@ internal constructor(private val storage: INameValueStorage<String>,
             )
         }
 
-
         /**
          * Returns true if the time has passed the given expiry date.
          */
-        private fun isExpired(expiryDate: Long): Boolean{
+        fun isExpired(expiryDate: Long?): Boolean{
+            if (expiryDate == null) {
+                return false
+            }
             return Instant.now().toEpochMilli() < expiryDate
         }
 
@@ -71,11 +73,9 @@ internal constructor(private val storage: INameValueStorage<String>,
                     }
                 }
 
-                cachedTimeStamp?.let {
-                    if (isExpired(it)){
-                        cachedTimeStamp = null
-                        return@runBlocking true
-                    }
+                if (isExpired(cachedTimeStamp)){
+                    cachedTimeStamp = null
+                    return@runBlocking true
                 }
 
                 return@runBlocking false

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -83,10 +83,10 @@ internal constructor(private val storage: INameValueStorage<String>,
         }
     }
 
-    override fun setShouldUseAccountManagerForTheNextMilliseconds(time: Long) {
+    override fun setShouldUseAccountManagerForTheNextMilliseconds(timeInMillis: Long) {
         return runBlocking {
             lock.withLock {
-                val timeStamp = Instant.now().toEpochMilli() + time
+                val timeStamp = Instant.now().toEpochMilli() + timeInMillis
                 storage.put(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY, timeStamp.toString())
                 cachedTimeStamp = timeStamp
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.common.internal.cache
 
 import com.microsoft.identity.common.java.interfaces.INameValueStorage

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -74,10 +74,10 @@ internal constructor(private val storage: INameValueStorage<String>,
                 }
 
                 if (isNotExpired(cachedTimeStamp)){
-                    cachedTimeStamp = null
                     return@runBlocking true
                 }
 
+                cachedTimeStamp = null
                 return@runBlocking false
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/IClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/IClientActiveBrokerCache.kt
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache
+
+import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClient
+
+/**
+ * An extension of [IActiveBrokerCache].
+ * This will allow [BrokerDiscoveryClient] to fall back to AccountManager immediately if it's aware that the broker side
+ * Does not support account manager (as opposed to trying to make unnecessary IPC call every time).
+ * */
+interface IClientActiveBrokerCache: IActiveBrokerCache {
+
+    /**
+     * Returns true if [BrokerDiscoveryClient] should still use AccountManager.
+     **/
+    fun shouldUseAccountManager(): Boolean
+
+    /**
+     * Set the time span when [BrokerDiscoveryClient] should just rely on AccountManager.
+     *
+     * @param timeInMillis Time in milliseconds (from now)
+     **/
+    fun setShouldUseAccountManagerForTheNextMilliseconds(timeInMillis: Long)
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -339,7 +339,7 @@ class BrokerDiscoveryClientTests {
 
     /**
      * Create 3 clients. Try to make requests from multiple coroutines (same thread).
-     * Only 1 IPC call should be made. Value should be read from cache.
+     * Only 1 IPC call should be made. The rest should read from cache.
      **/
     @Test
     fun testRaceCondition_MultiCoroutines(){
@@ -381,7 +381,7 @@ class BrokerDiscoveryClientTests {
 
     /**
      * Create 3 clients. Try to make requests from multiple threads.
-     * Only 1 IPC call should be made. Value should be read from cache.
+     * Only 1 IPC call should be made. The rest should read from cache.
      **/
     @Test
     fun testRaceCondition_MultiThread(){

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -24,13 +24,13 @@ package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import android.os.Bundle
 import com.microsoft.identity.common.exception.BrokerCommunicationException
-import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClient.Companion.ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.prodCompanyPortal
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.prodMicrosoftAuthenticator
 import com.microsoft.identity.common.internal.broker.ipc.AbstractIpcStrategyWithServiceValidation
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle
 import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
 import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.exception.ClientException.ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
@@ -39,8 +39,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.locks.ReentrantLock
 
 @RunWith(RobolectricTestRunner::class)
 class BrokerDiscoveryClientTests {

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -24,16 +24,22 @@ package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import android.os.Bundle
 import com.microsoft.identity.common.exception.BrokerCommunicationException
+import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClient.Companion.ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.prodCompanyPortal
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.prodMicrosoftAuthenticator
+import com.microsoft.identity.common.internal.broker.ipc.AbstractIpcStrategyWithServiceValidation
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle
 import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
+import com.microsoft.identity.common.java.exception.ClientException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 
 @RunWith(RobolectricTestRunner::class)
@@ -122,11 +128,12 @@ class BrokerDiscoveryClientTests {
     }
 
     /**
-     * The brokers returns an error.
-     * Account Manager is used instead.
+     * If we get an ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE error.
+     * AccountManager shall be used (but not cached).
      **/
     @Test
-    fun testQuery_ErrorReturned(){
+    fun testQuery_V0ProtocolErrorReturned(){
+        val cache = InMemoryActiveBrokerCache()
         val client = BrokerDiscoveryClient(
             brokerCandidates = setOf(
                 prodMicrosoftAuthenticator, prodCompanyPortal
@@ -136,20 +143,58 @@ class BrokerDiscoveryClientTests {
             },
             ipcStrategy = object : IIpcStrategy {
                 override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle {
-                    throw UnsupportedOperationException()
+                    throw ClientException(ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE)
                 }
                 override fun getType(): IIpcStrategy.Type {
                     return IIpcStrategy.Type.CONTENT_PROVIDER
                 }
             },
-            cache = InMemoryActiveBrokerCache(),
+            cache = cache,
+            isPackageInstalled =  {
+                it == prodMicrosoftAuthenticator || it == prodCompanyPortal
+            }
+        )
+        Assert.assertEquals(prodCompanyPortal, client.getActiveBroker())
+        Assert.assertNull(cache.getCachedActiveBroker())
+    }
+
+    /**
+     * If we ping the broker that doesn't support the new broker election logic,
+     * an error shall be returned. AccountManager shall be used (but not cached).
+     **/
+    @Test
+    fun testQuery_UnsupportedBrokerErrorReturned(){
+        val cache = InMemoryActiveBrokerCache()
+        val client = BrokerDiscoveryClient(
+            brokerCandidates = setOf(
+                prodMicrosoftAuthenticator, prodCompanyPortal
+            ),
+            getActiveBrokerFromAccountManager = {
+                return@BrokerDiscoveryClient prodMicrosoftAuthenticator
+            },
+            ipcStrategy = object : AbstractIpcStrategyWithServiceValidation() {
+                override fun communicateToBrokerAfterValidation(bundle: BrokerOperationBundle): Bundle? {
+                    throw IllegalStateException()
+                }
+
+                override fun isSupportedByTargetedBroker(targetedBrokerPackageName: String): Boolean {
+                    return false
+                }
+
+                override fun getType(): IIpcStrategy.Type {
+                    return IIpcStrategy.Type.CONTENT_PROVIDER
+                }
+            },
+            cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
             }
         )
 
-        Assert.assertEquals(prodCompanyPortal, client.getActiveBroker())
+        Assert.assertEquals(prodMicrosoftAuthenticator, client.getActiveBroker())
+        Assert.assertNull(cache.getCachedActiveBroker())
     }
+
 
     /**
      * No Broker is installed.
@@ -295,82 +340,123 @@ class BrokerDiscoveryClientTests {
     }
 
     /**
-     * Create 3 clients. Try to make concurrent request.
-     * Only 1 IPC call should be made.
+     * Create 3 clients. Try to make requests from multiple coroutines (same thread).
+     * Only 1 IPC call should be made. Value should be read from cache.
      **/
     @Test
-    fun testRaceCondition(){
+    fun testRaceCondition_MultiCoroutines(){
+        val queriedAuthenticator = AtomicBoolean(false)
+        val queriedCompanyPortal = AtomicBoolean(false)
         val cache = InMemoryActiveBrokerCache()
-        val lock = ReentrantLock()
-        var count = 0
 
-        fun getClient(): IBrokerDiscoveryClient {
-            return BrokerDiscoveryClient(
-                brokerCandidates = setOf(
-                    prodMicrosoftAuthenticator, prodCompanyPortal
-                ),
-                getActiveBrokerFromAccountManager = {
-                    throw IllegalStateException()
-                },
-                ipcStrategy = object : IIpcStrategy {
-                    override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle {
-                        lock.lock()
-                        count++
-                        if (count == 2) {
-                            // Throw an exception if this is being invoked twice.
-                            // The value should be read from cache.
-                            throw IllegalStateException()
-                        }
-                        lock.unlock()
+        val countDownLatch = CountDownLatch(3)
 
-                        if (bundle.targetBrokerAppPackageName == prodMicrosoftAuthenticator.packageName ||
-                            bundle.targetBrokerAppPackageName == prodCompanyPortal.packageName) {
-                            val returnBundle = Bundle()
-                            returnBundle.putString(
-                                BrokerDiscoveryClient.ACTIVE_BROKER_PACKAGE_NAME_BUNDLE_KEY,
-                                prodCompanyPortal.packageName
-                            )
-                            returnBundle.putString(
-                                BrokerDiscoveryClient.ACTIVE_BROKER_SIGNATURE_HASH_BUNDLE_KEY,
-                                prodCompanyPortal.signatureHash
-                            )
-                            return returnBundle
-                        }
+        val client1 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
+        val client2 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
+        val client3 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
 
-                        throw IllegalStateException()
-                    }
-                    override fun getType(): IIpcStrategy.Type {
-                        return IIpcStrategy.Type.CONTENT_PROVIDER
-                    }
-                },
-                cache = cache,
-                isPackageInstalled =  {
-                    it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-                },
-                lock = lock
-            )
-        }
 
-        val client1 = getClient()
-        val client2 = getClient()
-        val client3 = getClient()
-
+        // Coroutine (Same thread, multiple coroutines)
         runBlocking {
             launch {
-                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker(shouldSkipCache = true))
+                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+                countDownLatch.countDown()
             }
             launch {
-                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker(shouldSkipCache = true))
+                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+                countDownLatch.countDown()
             }
             launch {
-                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker(shouldSkipCache = true))
-                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker(shouldSkipCache = true))
+                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+                countDownLatch.countDown()
             }
         }
+
+        countDownLatch.await()
+    }
+
+    /**
+     * Create 3 clients. Try to make requests from multiple threads.
+     * Only 1 IPC call should be made. Value should be read from cache.
+     **/
+    @Test
+    fun testRaceCondition_MultiThread(){
+        val queriedAuthenticator = AtomicBoolean(false)
+        val queriedCompanyPortal = AtomicBoolean(false)
+        val cache = InMemoryActiveBrokerCache()
+
+        val countDownLatch = CountDownLatch(3)
+
+        val client1 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
+        val client2 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
+        val client3 = getClientForConcurrencyTest(queriedAuthenticator, queriedCompanyPortal, cache)
+
+        Thread().run {
+            Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+            countDownLatch.countDown()
+        }
+        Thread().run {
+            Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+            countDownLatch.countDown()
+        }
+        Thread().run {
+            Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+            countDownLatch.countDown()
+        }
+
+        countDownLatch.await()
+    }
+
+    // Returns a client which will throw an error if
+    // AuthApp/CP is queried via IPC more than once - each.
+    private fun getClientForConcurrencyTest(queriedAuthenticator: AtomicBoolean,
+                                            queriedCompanyPortal: AtomicBoolean,
+                                            cache: InMemoryActiveBrokerCache) : BrokerDiscoveryClient {
+        return BrokerDiscoveryClient(
+            brokerCandidates = setOf(
+                prodMicrosoftAuthenticator, prodCompanyPortal
+            ),
+            getActiveBrokerFromAccountManager = {
+                throw IllegalStateException("Result shouldn't be obtained from AccountManager")
+            },
+            ipcStrategy = object : IIpcStrategy {
+                override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle {
+                    if (bundle.targetBrokerAppPackageName == prodMicrosoftAuthenticator.packageName) {
+                        if (!queriedAuthenticator.compareAndSet(false,true)) {
+                            throw IllegalStateException("AuthApp shouldn't be invoked more than once.")
+                        }
+
+                        val returnBundle = Bundle()
+                        returnBundle.putString(
+                            BrokerDiscoveryClient.ACTIVE_BROKER_PACKAGE_NAME_BUNDLE_KEY,
+                            prodCompanyPortal.packageName
+                        )
+                        returnBundle.putString(
+                            BrokerDiscoveryClient.ACTIVE_BROKER_SIGNATURE_HASH_BUNDLE_KEY,
+                            prodCompanyPortal.signatureHash
+                        )
+                        return returnBundle
+                    }
+
+                    if (bundle.targetBrokerAppPackageName == prodCompanyPortal.packageName) {
+                        if (!queriedCompanyPortal.compareAndSet(false, true)) {
+                            throw IllegalStateException("CP shouldn't be invoked more than once.")
+                        }
+
+                        // Let's say if this guy throws an error.
+                        throw UnsupportedOperationException("CP error.")
+                    }
+
+                    throw UnsupportedOperationException("Unknown broker app.")
+                }
+                override fun getType(): IIpcStrategy.Type {
+                    return IIpcStrategy.Type.CONTENT_PROVIDER
+                }
+            },
+            cache = cache,
+            isPackageInstalled =  {
+                it == prodMicrosoftAuthenticator || it == prodCompanyPortal
+            }
+        )
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -153,6 +153,7 @@ class BrokerDiscoveryClientTests {
             }
         )
         Assert.assertEquals(prodCompanyPortal, client.getActiveBroker())
+        Assert.assertTrue(cache.shouldUseAccountManager())
         Assert.assertNull(cache.getCachedActiveBroker())
     }
 
@@ -190,6 +191,7 @@ class BrokerDiscoveryClientTests {
         )
 
         Assert.assertEquals(prodMicrosoftAuthenticator, client.getActiveBroker())
+        Assert.assertTrue(cache.shouldUseAccountManager())
         Assert.assertNull(cache.getCachedActiveBroker())
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -360,14 +360,20 @@ class BrokerDiscoveryClientTests {
         runBlocking {
             launch {
                 Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
                 countDownLatch.countDown()
             }
             launch {
                 Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
                 countDownLatch.countDown()
             }
             launch {
                 Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
                 countDownLatch.countDown()
             }
         }
@@ -393,14 +399,20 @@ class BrokerDiscoveryClientTests {
 
         Thread().run {
             Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
             countDownLatch.countDown()
         }
         Thread().run {
             Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
             countDownLatch.countDown()
         }
         Thread().run {
             Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
+            Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
             countDownLatch.countDown()
         }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
@@ -30,7 +30,7 @@ import com.microsoft.identity.common.internal.cache.IActiveBrokerCache
  **/
 class InMemoryActiveBrokerCache: IActiveBrokerCache {
 
-    var activeBroker: BrokerData? = null
+    private var activeBroker: BrokerData? = null
 
     @Synchronized
     override fun getCachedActiveBroker(): BrokerData? {

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.cache.ClientActiveBrokerCache.Companion.isExpired
 import com.microsoft.identity.common.internal.cache.IActiveBrokerCache
 import com.microsoft.identity.common.internal.cache.IClientActiveBrokerCache
 import java.time.Instant
@@ -52,10 +53,7 @@ class InMemoryActiveBrokerCache: IClientActiveBrokerCache {
 
     @Synchronized
     override fun shouldUseAccountManager(): Boolean {
-        shouldUseAccountManagerUntil?.let {
-            return Instant.now().toEpochMilli() < it
-        }
-        return false
+        return isExpired(shouldUseAccountManagerUntil)
     }
 
     @Synchronized

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
@@ -23,7 +23,7 @@
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import com.microsoft.identity.common.internal.broker.BrokerData
-import com.microsoft.identity.common.internal.cache.ClientActiveBrokerCache.Companion.isExpired
+import com.microsoft.identity.common.internal.cache.ClientActiveBrokerCache.Companion.isNotExpired
 import com.microsoft.identity.common.internal.cache.IActiveBrokerCache
 import com.microsoft.identity.common.internal.cache.IClientActiveBrokerCache
 import java.time.Instant
@@ -53,7 +53,7 @@ class InMemoryActiveBrokerCache: IClientActiveBrokerCache {
 
     @Synchronized
     override fun shouldUseAccountManager(): Boolean {
-        return isExpired(shouldUseAccountManagerUntil)
+        return isNotExpired(shouldUseAccountManagerUntil)
     }
 
     @Synchronized

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/InMemoryActiveBrokerCache.kt
@@ -24,13 +24,16 @@ package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import com.microsoft.identity.common.internal.broker.BrokerData
 import com.microsoft.identity.common.internal.cache.IActiveBrokerCache
+import com.microsoft.identity.common.internal.cache.IClientActiveBrokerCache
+import java.time.Instant
 
 /**
  * An [IActiveBrokerCache] which stores values in-memory.
  **/
-class InMemoryActiveBrokerCache: IActiveBrokerCache {
+class InMemoryActiveBrokerCache: IClientActiveBrokerCache {
 
     private var activeBroker: BrokerData? = null
+    private var shouldUseAccountManagerUntil: Long? = null
 
     @Synchronized
     override fun getCachedActiveBroker(): BrokerData? {
@@ -45,5 +48,18 @@ class InMemoryActiveBrokerCache: IActiveBrokerCache {
     @Synchronized
     override fun clearCachedActiveBroker() {
         activeBroker = null
+    }
+
+    @Synchronized
+    override fun shouldUseAccountManager(): Boolean {
+        shouldUseAccountManagerUntil?.let {
+            return Instant.now().toEpochMilli() < it
+        }
+        return false
+    }
+
+    @Synchronized
+    override fun setShouldUseAccountManagerForTheNextMilliseconds(time: Long) {
+        shouldUseAccountManagerUntil = Instant.now().toEpochMilli() + time
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.java.util.ported.Predicate
 import kotlinx.coroutines.sync.Mutex
 import org.junit.Assert
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 class ActiveBrokerCacheTest {
 
@@ -46,7 +47,7 @@ class ActiveBrokerCacheTest {
         val storageSupplier = getStorageSupplier()
 
         val brokerCache = ActiveBrokerCache.getBrokerMetadataStoreOnBrokerSide(storageSupplier)
-        val sdkCache = ActiveBrokerCache.getBrokerMetadataStoreOnSdkSide(storageSupplier)
+        val sdkCache = ClientActiveBrokerCache.getBrokerMetadataStoreOnSdkSide(storageSupplier)
 
         Assert.assertNull(brokerCache.getCachedActiveBroker())
         Assert.assertNull(sdkCache.getCachedActiveBroker())
@@ -287,6 +288,22 @@ class ActiveBrokerCacheTest {
         cache.clearCachedActiveBroker()
         Assert.assertNull(cache.getCachedActiveBroker())
         Assert.assertNull(cache.inMemoryCachedValue)
+    }
+
+    @Test
+    fun testSetSkipToAccountManager(){
+        val cache = ClientActiveBrokerCache(InMemoryStorage(), Mutex())
+        Assert.assertNull(cache.getCachedActiveBroker())
+        Assert.assertFalse(cache.shouldUseAccountManager())
+
+        cache.setShouldUseAccountManagerForTheNextMilliseconds(
+            TimeUnit.SECONDS.toMillis(2)
+        )
+        Assert.assertTrue(cache.shouldUseAccountManager())
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(2))
+
+        Assert.assertFalse(cache.shouldUseAccountManager())
     }
 
     private fun getStorageSupplier() : IStorageSupplier {

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
@@ -294,16 +294,20 @@ class ActiveBrokerCacheTest {
     fun testSetSkipToAccountManager(){
         val cache = ClientActiveBrokerCache(InMemoryStorage(), Mutex())
         Assert.assertNull(cache.getCachedActiveBroker())
+
         Assert.assertFalse(cache.shouldUseAccountManager())
+        Assert.assertNull(cache.cachedTimeStamp)
 
         cache.setShouldUseAccountManagerForTheNextMilliseconds(
             TimeUnit.SECONDS.toMillis(2)
         )
         Assert.assertTrue(cache.shouldUseAccountManager())
+        Assert.assertNotNull(cache.cachedTimeStamp)
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(2))
 
         Assert.assertFalse(cache.shouldUseAccountManager())
+        Assert.assertNull(cache.cachedTimeStamp)
     }
 
     private fun getStorageSupplier() : IStorageSupplier {

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
@@ -28,9 +28,9 @@ import com.microsoft.identity.common.components.InMemoryStorageSupplier
 import com.microsoft.identity.common.java.interfaces.INameValueStorage
 import com.microsoft.identity.common.java.util.ported.InMemoryStorage
 import com.microsoft.identity.common.java.util.ported.Predicate
+import kotlinx.coroutines.sync.Mutex
 import org.junit.Assert
 import org.junit.Test
-import java.util.concurrent.locks.ReentrantReadWriteLock
 
 class ActiveBrokerCacheTest {
 
@@ -65,7 +65,7 @@ class ActiveBrokerCacheTest {
      **/
     @Test
     fun testReadWriteAcrossInstances(){
-        val lock = ReentrantReadWriteLock()
+        val lock = Mutex()
         val storage = InMemoryStorage<String>()
 
         val cache1 = ActiveBrokerCache(storage, lock)
@@ -123,7 +123,7 @@ class ActiveBrokerCacheTest {
             }
         }
 
-        val cache = ActiveBrokerCache(writeOnlyStorage, ReentrantReadWriteLock())
+        val cache = ActiveBrokerCache(writeOnlyStorage, Mutex())
         val mockData = BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH)
         cache.setCachedActiveBroker(mockData)
 
@@ -172,7 +172,7 @@ class ActiveBrokerCacheTest {
             }
         }
 
-        val cache = ActiveBrokerCache(readOnlyStorage, ReentrantReadWriteLock())
+        val cache = ActiveBrokerCache(readOnlyStorage, Mutex())
         Assert.assertEquals(BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH), cache.getCachedActiveBroker())
         Assert.assertEquals(BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH), cache.inMemoryCachedValue)
     }
@@ -222,7 +222,7 @@ class ActiveBrokerCacheTest {
             }
         }
 
-        val cache = ActiveBrokerCache(readOnlyStorage, ReentrantReadWriteLock())
+        val cache = ActiveBrokerCache(readOnlyStorage, Mutex())
         val mockData = BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH)
         cache.setCachedActiveBroker(mockData)
 
@@ -265,7 +265,7 @@ class ActiveBrokerCacheTest {
             }
         }
 
-        val cache = ActiveBrokerCache(clearOnlyStorage, ReentrantReadWriteLock())
+        val cache = ActiveBrokerCache(clearOnlyStorage, Mutex())
         cache.inMemoryCachedValue = BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH)
 
         cache.clearCachedActiveBroker()
@@ -275,7 +275,7 @@ class ActiveBrokerCacheTest {
 
     @Test
     fun testE2EWriteReadClear(){
-        val cache = ActiveBrokerCache(InMemoryStorage(), ReentrantReadWriteLock())
+        val cache = ActiveBrokerCache(InMemoryStorage(), Mutex())
         Assert.assertNull(cache.getCachedActiveBroker())
 
         val mockData = BrokerData(MOCK_PACKAGE_NAME, MOCK_HASH)

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -387,7 +387,7 @@ public class ClientException extends BaseException {
      * The android version used does not support the operation.
      */
     public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
-    
+
     /**
      * Error code to be returned when the broker determines that only account manager can be used
      * in the Broker Discovery process.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -387,6 +387,12 @@ public class ClientException extends BaseException {
      * The android version used does not support the operation.
      */
     public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
+    
+    /**
+     * Error code to be returned when the broker determines that only account manager can be used
+     * in the Broker Discovery process.
+     **/
+    public static final String ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE = "ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE";
 
     /**
      * Constructor of ClientException.


### PR DESCRIPTION
1. Parallelize IPC requests in BrokerDiscoveryRequests.

2. Stop caching account manager values.... because if broker switch happens, then the cached value here could be blocking. we will always get a fresh value.

3. Introduce `IClientActiveBrokerCache.shouldUseAccountManager()`, which, if returns true, will just fall back to account manager. This is an optimization for the phase where we're flighting the new mechanism. Without it, the SDK might end up making unnecessary IPC requests to unsupported broker. 

4. Make the class coroutine safe. 

Given the code below, each coroutines would be triggered in the same thread (In this case, main thread).
```
runBlocking {
            launch {
                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
                countDownLatch.countDown()
            }
            launch {
                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
                countDownLatch.countDown()
            }
            launch {
                Assert.assertEquals(prodCompanyPortal, client3.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client1.getActiveBroker())
                Assert.assertEquals(prodCompanyPortal, client2.getActiveBroker())
                countDownLatch.countDown()
            }
        }
```
Therefore, we cannot use Java's Lock (which only protects in thread level). We need to use coroutine's lock.

coroutine's lock needs to be in... a coroutine, so i'm wrapping them with runBlocking.