### PR TITLE
Add android 14 check for skipping strong box isolation in pop token

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.NEXT
 - [MAJOR] Added support for DeviceCodeFlow with device id claims. New API is only available in version 13 or higher (#2044)
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#2019)
 - [MINOR] Removing thumbprint check from PKeyAuth challenge (#2045)
+- [MINOR] Add android 14 check for skipping strong box isolation in pop token (#2053)
 
 V.12.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -215,6 +215,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                         // Android 14 specific error where strong box is failing, most likely because of IAR requirement in android 14
                         // https://android.googlesource.com/platform/compatibility/cdd/+/e2fee2f/9_security-model/9_11_keys-and-credentials.md
                         // Had to check code name, as android 14 device in beta seems to still show 33 as SDK int
+                        // TO-DO : https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2574078
                         Logger.error(TAG, "Android 14 Internal Key store error with strongbox. Skipping strongbox", e);
                         tryStrongBox = false;
                         continue;


### PR DESCRIPTION
Created the PR on Fadi's behalf

Issue description  :  When a device is newly Intune enrolled in A14, the user is able to login to Defender, but unable to retrieve the pop access token. As a fallback, Defender allows onboarding without pop token (which is why you were able to onboard fully to Defender). However, in absence of the correct token Defender backend does not acknowledge heartbeat calls we send every few hours to maintain device compliance. Heartbeat failure subsequently fails the signals being sent to Intune backend marking the device non-compliant (Device_Threat_Health_Not_Reported reported by Intune).


This is an issue especially when policies are setup to make the device noncompliant if Defender is not setup (this is what Microsoft has setup internally).

Bug link : https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2574078

Fix : There is  new IAR requirement introduced for Android 14 that is failing for Strong box isolation to work as expected. Skipping strong box until a fix for this is made. We are still investigating on what could be the long term fix. But until then, we will go ahead with this temporary fix.

Testing : Shared the new broker build with CP team and they tested that defender is working as expected after taking this fix.

