### PR TITLE
Add support to run UI automation on MsalTestApp - 2516682

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V.NEXT
 - [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)
 - [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)
+- [MINOR] Add support to run UI automation on MsalTestApp  (#2056)
 
 V.13.0.1
 ----------

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -52,16 +52,21 @@ public class MsalTestApp extends App{
         localApkFileName = MSAL_TEST_APP_APK;
     }
 
-    public MsalTestApp(boolean updateApk) {
+    public MsalTestApp(final boolean installOldApk) {
         super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
-        localApkFileName = MSAL_TEST_APP_APK;
-        localUpdateApkFileName = OLD_MSAL_TEST_APP_APK;
+        if (installOldApk) {
+            localApkFileName = OLD_MSAL_TEST_APP_APK;
+        } else {
+            localApkFileName = MSAL_TEST_APP_APK;
+        }
+        localUpdateApkFileName = MSAL_TEST_APP_APK;
     }
 
     // click on button acquire token interactive
     public String acquireToken(@NonNull final String username,
                                         @NonNull final String password,
                                         final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
+        // handle loginHint input if needed
         if (promptHandlerParameters != null) {
             UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
         }
@@ -70,7 +75,7 @@ public class MsalTestApp extends App{
         scrollToElement(acquireTokenButton);
         acquireTokenButton.click();
 
-        // handle prompt
+        // handle prompt if needed
         if (promptHandlerParameters != null) {
             final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
             microsoftStsPromptHandler.handlePrompt(username, password);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -1,0 +1,99 @@
+package com.microsoft.identity.client.ui.automation.app;
+
+import androidx.annotation.NonNull;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+
+import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.providers.oauth2.IDToken;
+
+import org.junit.Assert;
+
+import java.util.Map;
+
+/**
+ * A model for interacting with the Msal Test App for MSAL Android during UI Test.
+ */
+
+public class MsalTestApp extends App{
+
+    private final static String TAG = MsalTestApp.class.getSimpleName();
+    private static final String MSAL_TEST_APP_PACKAGE_NAME = "com.microsoft.identity.client.testapp";
+    private static final String MSAL_TEST_APP_NAME = "MSAL Test App";
+    public static final String MSAL_TEST_APP_APK = "MsalTestApp.apk";
+    public static final String OLD_MSAL_TEST_APP_APK = "OldMsalTestApp.apk";
+
+
+
+    // constructors
+    public MsalTestApp() {
+        super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
+        localApkFileName = MSAL_TEST_APP_APK;
+    }
+
+    public MsalTestApp(@NonNull final String msalTestAppApk, @NonNull final String updateMsalTestAppApk) {
+        super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
+        localApkFileName = msalTestAppApk;
+        localUpdateApkFileName = updateMsalTestAppApk;
+    }
+
+    // click on button acquire token interactive
+    public String acquireToken(@NonNull final String username,
+                                        @NonNull final String password,
+                                        @NonNull final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
+        Logger.i(TAG, "Acquiring Token..");
+        UiAutomatorUtils.handleInput("com.microsoft.identity.client.testapp:id/loginHint", username);
+        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_acquiretoken");
+        final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
+        microsoftStsPromptHandler.handlePrompt(username, password);
+
+        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
+
+        return result.getText();
+    }
+
+
+    // click on button acquire token silent
+    public String acquireTokenSilent(@NonNull final String username,
+                               @NonNull final String password,
+                               @NonNull final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
+        Logger.i(TAG, "Acquiring Token Silent..");
+        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_acquiretokensilent");
+
+        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
+
+        return result.getText();
+    }
+
+    // click on button getUsers
+    public String getUsers() throws UiObjectNotFoundException {
+        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_getUsers");
+        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
+        return result.getText();
+    }
+
+    // validate acquired token
+    public Map<String, ?> validateToken(String resultToken) throws ServiceException {
+        Logger.i(TAG, "Confirming Valid Result..");
+        Map<String, ?> tokens = IDToken.parseJWT(resultToken);
+        Assert.assertNotNull(tokens);
+        return tokens;
+    }
+
+    @Override
+    protected void initialiseAppImpl() {
+
+    }
+
+    @Override
+    public void handleFirstRun() {
+        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btnStartTask");
+    }
+
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -52,10 +52,10 @@ public class MsalTestApp extends App{
         localApkFileName = MSAL_TEST_APP_APK;
     }
 
-    public MsalTestApp(@NonNull final String msalTestAppApk, @NonNull final String updateMsalTestAppApk) {
+    public MsalTestApp(boolean updateApk) {
         super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
-        localApkFileName = msalTestAppApk;
-        localUpdateApkFileName = updateMsalTestAppApk;
+        localApkFileName = MSAL_TEST_APP_APK;
+        localUpdateApkFileName = OLD_MSAL_TEST_APP_APK;
     }
 
     // click on button acquire token interactive

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -116,9 +116,7 @@ public class MsalTestApp extends App {
     }
 
     @Override
-    protected void initialiseAppImpl() {
-
-    }
+    protected void initialiseAppImpl() {}
 
     @Override
     public void handleFirstRun() {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -16,7 +16,6 @@ import java.util.List;
 /**
  * A model for interacting with the Msal Test App for MSAL Android during UI Test.
  */
-
 public class MsalTestApp extends App{
 
     private final static String TAG = MsalTestApp.class.getSimpleName();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -123,5 +123,4 @@ public class MsalTestApp extends App {
     public void handleFirstRun() {
         UiAutomatorUtils.handleButtonClick("com.msft.identity.client.sample.local:id/btnStartTask");
     }
-
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -64,10 +64,11 @@ public class MsalTestApp extends App {
 
     // click on button acquire token interactive
     public String acquireToken(@NonNull final String username,
-                                        @NonNull final String password,
-                                        final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
+                               @NonNull final String password,
+                               @NonNull final PromptHandlerParameters promptHandlerParameters,
+                               @NonNull final boolean shouldHandlePrompt) throws UiObjectNotFoundException {
         // handle loginHint input if needed
-        if (promptHandlerParameters != null) {
+        if (shouldHandlePrompt) {
             UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
         }
 
@@ -76,7 +77,7 @@ public class MsalTestApp extends App {
         acquireTokenButton.click();
 
         // handle prompt if needed
-        if (promptHandlerParameters != null) {
+        if (shouldHandlePrompt) {
             final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
             microsoftStsPromptHandler.handlePrompt(username, password);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client.ui.automation.app;
 
 import androidx.annotation.NonNull;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -3,19 +3,15 @@ package com.microsoft.identity.client.ui.automation.app;
 import androidx.annotation.NonNull;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
-
+import androidx.test.uiautomator.UiScrollable;
+import androidx.test.uiautomator.UiSelector;
 import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
-import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
-import com.microsoft.identity.common.java.exception.ServiceException;
-import com.microsoft.identity.common.java.providers.oauth2.IDToken;
-
-import org.junit.Assert;
-
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A model for interacting with the Msal Test App for MSAL Android during UI Test.
@@ -24,12 +20,10 @@ import java.util.Map;
 public class MsalTestApp extends App{
 
     private final static String TAG = MsalTestApp.class.getSimpleName();
-    private static final String MSAL_TEST_APP_PACKAGE_NAME = "com.microsoft.identity.client.testapp";
+    private static final String MSAL_TEST_APP_PACKAGE_NAME = "com.msft.identity.client.sample.local";
     private static final String MSAL_TEST_APP_NAME = "MSAL Test App";
     public static final String MSAL_TEST_APP_APK = "MsalTestApp.apk";
     public static final String OLD_MSAL_TEST_APP_APK = "OldMsalTestApp.apk";
-
-
 
     // constructors
     public MsalTestApp() {
@@ -47,43 +41,48 @@ public class MsalTestApp extends App{
     public String acquireToken(@NonNull final String username,
                                         @NonNull final String password,
                                         @NonNull final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
-        Logger.i(TAG, "Acquiring Token..");
-        UiAutomatorUtils.handleInput("com.microsoft.identity.client.testapp:id/loginHint", username);
-        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_acquiretoken");
+        UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
+
+        UiObject acquireTokenButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretoken");
+        scrollToElement(acquireTokenButton);
+        acquireTokenButton.click();
+
+        // handle prompt
         final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
         microsoftStsPromptHandler.handlePrompt(username, password);
 
-        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
-
+        // get token and return
+        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/txt_result");
         return result.getText();
     }
 
 
     // click on button acquire token silent
-    public String acquireTokenSilent(@NonNull final String username,
-                               @NonNull final String password,
-                               @NonNull final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
-        Logger.i(TAG, "Acquiring Token Silent..");
-        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_acquiretokensilent");
-
-        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
-
+    public String acquireTokenSilent() throws UiObjectNotFoundException {
+        UiObject acquireTokenSilentButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretokensilent");
+        scrollToElement(acquireTokenSilentButton);
+        acquireTokenSilentButton.click();
+        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/txt_result");
         return result.getText();
     }
 
     // click on button getUsers
-    public String getUsers() throws UiObjectNotFoundException {
-        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btn_getUsers");
-        final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.identity.client.testapp:id/txt_result");
-        return result.getText();
+    public List<String> getUsers() throws UiObjectNotFoundException {
+        UiAutomatorUtils.handleButtonClick("com.msft.identity.client.sample.local:id/btn_getUsers");
+
+        // get each user information in the user list
+        List<String> users = new ArrayList<>();
+        final UiObject userList = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/user_list");
+        for (int i = 0; i < userList.getChildCount(); i++) {
+            UiObject user = userList.getChild(new UiSelector().index(i));
+            users.add(user.getText());
+        }
+        return users;
     }
 
-    // validate acquired token
-    public Map<String, ?> validateToken(String resultToken) throws ServiceException {
-        Logger.i(TAG, "Confirming Valid Result..");
-        Map<String, ?> tokens = IDToken.parseJWT(resultToken);
-        Assert.assertNotNull(tokens);
-        return tokens;
+    private void scrollToElement(UiObject obj) throws UiObjectNotFoundException {
+        UiScrollable scrollable = new UiScrollable(new UiSelector().scrollable(true));
+        scrollable.scrollIntoView(obj);
     }
 
     @Override
@@ -93,7 +92,7 @@ public class MsalTestApp extends App{
 
     @Override
     public void handleFirstRun() {
-        UiAutomatorUtils.handleButtonClick("com.microsoft.identity.client.testapp:id/btnStartTask");
+        UiAutomatorUtils.handleButtonClick("com.msft.identity.client.sample.local:id/btnStartTask");
     }
 
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -61,16 +61,20 @@ public class MsalTestApp extends App{
     // click on button acquire token interactive
     public String acquireToken(@NonNull final String username,
                                         @NonNull final String password,
-                                        @NonNull final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
-        UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
+                                        final PromptHandlerParameters promptHandlerParameters) throws UiObjectNotFoundException {
+        if (promptHandlerParameters != null) {
+            UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
+        }
 
         UiObject acquireTokenButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretoken");
         scrollToElement(acquireTokenButton);
         acquireTokenButton.click();
 
         // handle prompt
-        final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
-        microsoftStsPromptHandler.handlePrompt(username, password);
+        if (promptHandlerParameters != null) {
+            final MicrosoftStsPromptHandler microsoftStsPromptHandler = new MicrosoftStsPromptHandler((MicrosoftStsPromptHandlerParameters) promptHandlerParameters);
+            microsoftStsPromptHandler.handlePrompt(username, password);
+        }
 
         // get token and return
         final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/txt_result");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  * A model for interacting with the Msal Test App for MSAL Android during UI Test.
  */
-public class MsalTestApp extends App{
+public class MsalTestApp extends App {
 
     private final static String TAG = MsalTestApp.class.getSimpleName();
     private static final String MSAL_TEST_APP_PACKAGE_NAME = "com.msft.identity.client.sample.local";
@@ -71,7 +71,7 @@ public class MsalTestApp extends App{
             UiAutomatorUtils.handleInput("com.msft.identity.client.sample.local:id/loginHint", username);
         }
 
-        UiObject acquireTokenButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretoken");
+        final UiObject acquireTokenButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretoken");
         scrollToElement(acquireTokenButton);
         acquireTokenButton.click();
 
@@ -89,7 +89,7 @@ public class MsalTestApp extends App{
 
     // click on button acquire token silent
     public String acquireTokenSilent() throws UiObjectNotFoundException {
-        UiObject acquireTokenSilentButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretokensilent");
+        final UiObject acquireTokenSilentButton = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/btn_acquiretokensilent");
         scrollToElement(acquireTokenSilentButton);
         acquireTokenSilentButton.click();
         final UiObject result = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/txt_result");
@@ -101,10 +101,10 @@ public class MsalTestApp extends App{
         UiAutomatorUtils.handleButtonClick("com.msft.identity.client.sample.local:id/btn_getUsers");
 
         // get each user information in the user list
-        List<String> users = new ArrayList<>();
+        final List<String> users = new ArrayList<>();
         final UiObject userList = UiAutomatorUtils.obtainUiObjectWithResourceId("com.msft.identity.client.sample.local:id/user_list");
         for (int i = 0; i < userList.getChildCount(); i++) {
-            UiObject user = userList.getChild(new UiSelector().index(i));
+            final UiObject user = userList.getChild(new UiSelector().index(i));
             users.add(user.getText());
         }
         return users;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.client.ui.automation.rules;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
+import com.microsoft.identity.client.ui.automation.app.MsalTestApp;
 import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.app.TeamsApp;
 import com.microsoft.identity.client.ui.automation.app.WordApp;
@@ -66,7 +67,9 @@ public class CopyFileRule implements TestRule {
             WordApp.WORD_APK,
             BrowserEdge.EDGE_APK,
             BrokerLTW.BROKER_LTW_APK,
-            BrokerLTW.OLD_BROKER_LTW_APK
+            BrokerLTW.OLD_BROKER_LTW_APK,
+            MsalTestApp.MSAL_TEST_APP_APK,
+            MsalTestApp.OLD_MSAL_TEST_APP_APK
     };
 
     public CopyFileRule() {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.ui.automation.rules;
 
 import android.util.Log;
 
+import com.microsoft.identity.client.ui.automation.app.MsalTestApp;
 import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.app.TeamsApp;
 import com.microsoft.identity.client.ui.automation.app.WordApp;
@@ -51,6 +52,7 @@ public class RemoveFirstPartyAppsTestRule implements TestRule {
                 new TeamsApp().uninstall();
                 new WordApp().uninstall();
                 new BrowserEdge().uninstall();
+                new MsalTestApp().uninstall();
 
                 base.evaluate();
             }


### PR DESCRIPTION
Product Backlog Item 2516683: Add support to run UI automation on MsalTestApp

This PR adds infrastructure for testing MsalTestApp.

Add MsalTestApp.java with methods like acquireTokenInteractively/acquireTokenSilently/getUsers to the MsalAutomationApp, these three methods can simulate user interaction.