### PR TITLE
Wire new Broker Discovery Client into MSAL - still disabled by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)
 - [PATCH] Stop caching account manager values. Make BrokerDiscoveryClient coroutine-safe (#2050)
 - [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041)
 - [MINOR] Add BrokerDiscoveryClient + Tests (#2039)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
@@ -1,0 +1,79 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.activebrokerdiscovery
+
+import android.content.Context
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A class for initializing a new [IBrokerDiscoveryClient] object.
+ **/
+class BrokerDiscoveryClientFactory {
+    companion object {
+        @Volatile
+        private var IS_NEW_DISCOVERY_ENABLED = false
+
+        @Volatile
+        private var instance: IBrokerDiscoveryClient? = null
+
+        private val lock = Mutex()
+
+        /**
+         * If set to true, the new Broker discovery mechanism will be enabled.
+         * This is currently turned off by default - until we're ready to ship the feature.
+         **/
+        @JvmStatic
+        fun setNewBrokerDiscoveryEnabled(isEnabled: Boolean){
+            if (isEnabled != IS_NEW_DISCOVERY_ENABLED) {
+                instance = null
+                IS_NEW_DISCOVERY_ENABLED = isEnabled
+            }
+        }
+
+        /**
+         * Initializes a new [IBrokerDiscoveryClient] object.
+         **/
+        @JvmStatic
+        fun getInstance(context: Context,
+                        platformComponents: IPlatformComponents) : IBrokerDiscoveryClient{
+            if (instance == null){
+                runBlocking {
+                    lock.withLock {
+                        if (instance == null) {
+                            instance = if (IS_NEW_DISCOVERY_ENABLED) {
+                                BrokerDiscoveryClient(context, platformComponents)
+                            } else {
+                                LegacyBrokerDiscoveryClient(context)
+                            }
+                        }
+                    }
+                }
+            }
+            return instance!!
+        }
+    }
+}
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
@@ -39,6 +39,9 @@ class BrokerDiscoveryClientFactory {
         @Volatile
         private var instance: IBrokerDiscoveryClient? = null
 
+        /**
+         * Coroutine-level lock.
+         **/
         private val lock = Mutex()
 
         /**
@@ -47,6 +50,7 @@ class BrokerDiscoveryClientFactory {
          **/
         @JvmStatic
         fun setNewBrokerDiscoveryEnabled(isEnabled: Boolean){
+            // If the flag changes, wipe the existing singleton.
             if (isEnabled != IS_NEW_DISCOVERY_ENABLED) {
                 instance = null
                 IS_NEW_DISCOVERY_ENABLED = isEnabled
@@ -76,4 +80,3 @@ class BrokerDiscoveryClientFactory {
         }
     }
 }
-

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
@@ -29,6 +29,9 @@ import com.microsoft.identity.common.internal.broker.BrokerValidator
 import com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE
 import com.microsoft.identity.common.logging.Logger
 
+/**
+ * An [IBrokerDiscoveryClient] which is based on AccountManager.
+ **/
 class LegacyBrokerDiscoveryClient(val context: Context): IBrokerDiscoveryClient {
 
     companion object {

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
@@ -1,0 +1,88 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.activebrokerdiscovery
+
+import android.accounts.AccountManager
+import android.content.Context
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.BrokerValidator
+import com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE
+import com.microsoft.identity.common.logging.Logger
+
+class LegacyBrokerDiscoveryClient(val context: Context): IBrokerDiscoveryClient {
+
+    companion object {
+        private val TAG = LegacyBrokerDiscoveryClient::class.simpleName
+
+        /**
+         * Determines which app is the broker based on having the work account registration in Account Manager.
+         *
+         * Known issue: When we're in an AccountManager callback (Especially on older Android devices, i.e. Android 10)
+         * Android For Work throws a SecurityException when we're calling AccountManager.getAuthenticatorTypes()
+         *
+         * E.g. Company Portal main process can call this freely, broker process can call this freely,
+         * but once running in AccountManager on the work profile (user != 0),
+         * apparently sometimes it tries to get accounts from user 0 (personal profile) and fails.
+         *
+         * @return Package Name of the broker
+         */
+        private fun getActiveBrokerPackageName(context: Context): String? {
+            val methodTag = "$TAG:getActiveBrokerPackageName"
+
+            val authenticators = AccountManager.get(context).authenticatorTypes
+
+            Logger.info(methodTag, "${authenticators.size} Authenticators registered.")
+            val brokerValidator = BrokerValidator(context)
+            for (authenticator in authenticators) {
+                Logger.info(methodTag,
+                    "Authenticator: ${authenticator.packageName} type: ${authenticator.type}")
+                if (BROKER_ACCOUNT_TYPE.equals(authenticator.type.trim { it <= ' ' }, ignoreCase = true)) {
+                    Logger.info(methodTag, "Verify: " + authenticator.packageName)
+                    brokerValidator.verifySignatureAndThrow(authenticator.packageName)
+                    return authenticator.packageName
+                }
+            }
+
+            Logger.info(methodTag,
+                "None of the authenticators, is type: $BROKER_ACCOUNT_TYPE")
+            return null
+        }
+    }
+
+    override fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
+        val methodTag = "$TAG:getActiveBroker"
+        return try {
+            val activeBrokerPkgName =
+                getActiveBrokerPackageName(context) ?:
+                return null
+
+            BrokerData.getKnownBrokerApps().firstOrNull {
+                it.packageName == activeBrokerPkgName
+            }
+        } catch (e: Exception) {
+            Logger.error(methodTag, "Failed to get active broker", e)
+            null
+        }
+    }
+
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
@@ -87,5 +87,4 @@ class LegacyBrokerDiscoveryClient(val context: Context): IBrokerDiscoveryClient 
             null
         }
     }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -168,7 +168,7 @@ public class BrokerMsalController extends BaseController {
                                                final String activeBrokerPackageName) {
         final String methodTag = TAG + ":getIpcStrategies";
         final List<IIpcStrategy> strategies = new ArrayList<>();
-        final StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder(100);
         sb.append("Broker Strategies added : ");
 
         final ContentProviderStrategy contentProviderStrategy = new ContentProviderStrategy(applicationContext);

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -28,8 +28,8 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.MSAL_TO_BROKER_PROTOCOL_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_DCF;
-import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_FETCH_DCF_AUTH_RESULT;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_ACQUIRE_TOKEN_SILENT;
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_FETCH_DCF_AUTH_RESULT;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GENERATE_SHR;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_ACCOUNTS;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_GET_CURRENT_ACCOUNT_IN_SHARED_DEVICE;
@@ -54,10 +54,8 @@ import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.PropertyBagUtil;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.internal.broker.BrokerActivity;
 import com.microsoft.identity.common.internal.broker.BrokerResult;
-import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
 import com.microsoft.identity.common.internal.broker.ipc.AccountManagerAddAccountStrategy;
 import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy;
@@ -133,10 +131,8 @@ public class BrokerMsalController extends BaseController {
     private final BrokerOperationExecutor mBrokerOperationExecutor;
     private final HelloCache mHelloCache;
     private final IPlatformComponents mComponents;
-
     private final Context mApplicationContext;
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public BrokerMsalController(@NonNull final Context applicationContext,
                                 @NonNull final IPlatformComponents components,
                                 @NonNull final String activeBrokerPackageName,
@@ -144,29 +140,17 @@ public class BrokerMsalController extends BaseController {
         mComponents = components;
         mApplicationContext = applicationContext;
         mActiveBrokerPackageName = activeBrokerPackageName;
-        if (StringUtil.isEmpty(mActiveBrokerPackageName)) {
-            throw new IllegalStateException("Active Broker not found. This class should not be initialized.");
-        }
-
         mBrokerOperationExecutor = new BrokerOperationExecutor(ipcStrategies);
         mHelloCache = getHelloCache();
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public BrokerMsalController(@NonNull final Context applicationContext, @NonNull final IPlatformComponents components) {
-        mComponents = components;
-        mApplicationContext = applicationContext;
-        mActiveBrokerPackageName = getActiveBrokerPackageName();
-        mBrokerOperationExecutor = new BrokerOperationExecutor(getIpcStrategies(mApplicationContext, mActiveBrokerPackageName));
-        mHelloCache = getHelloCache();
-    }
-
-    public BrokerMsalController(@NonNull final Context applicationContext) {
-        mComponents = AndroidPlatformComponentsFactory.createFromContext(applicationContext);
-        mApplicationContext = applicationContext;
-        mActiveBrokerPackageName = getActiveBrokerPackageName();
-        mBrokerOperationExecutor = new BrokerOperationExecutor(getIpcStrategies(mApplicationContext, mActiveBrokerPackageName));
-        mHelloCache = getHelloCache();
+    public BrokerMsalController(@NonNull final Context applicationContext,
+                                @NonNull final IPlatformComponents components,
+                                @NonNull final String activeBrokerPackageName) {
+        this(applicationContext,
+                components,
+                activeBrokerPackageName,
+                getIpcStrategies(applicationContext, activeBrokerPackageName));
     }
 
     @VisibleForTesting
@@ -175,25 +159,16 @@ public class BrokerMsalController extends BaseController {
                 mComponents);
     }
 
-    @VisibleForTesting
-    public String getActiveBrokerPackageName() throws IllegalStateException{
-        try {
-            return new BrokerValidator(mApplicationContext).getCurrentActiveBrokerPackageName();
-        } catch (final ClientException e) {
-            throw new IllegalStateException("Active Broker not found. This class should not be initialized.", e);
-        }
-    }
-
     /**
      * Gets a list of communication strategies.
      * Order of objects in the list will reflects the order of strategies that will be used.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     @NonNull
-    protected List<IIpcStrategy> getIpcStrategies(final Context applicationContext, final String activeBrokerPackageName) {
+    static List<IIpcStrategy> getIpcStrategies(final Context applicationContext,
+                                               final String activeBrokerPackageName) {
         final String methodTag = TAG + ":getIpcStrategies";
         final List<IIpcStrategy> strategies = new ArrayList<>();
-        final StringBuilder sb = new StringBuilder(100);
+        final StringBuilder sb = new StringBuilder();
         sb.append("Broker Strategies added : ");
 
         final ContentProviderStrategy contentProviderStrategy = new ContentProviderStrategy(applicationContext);

--- a/common/src/test/java/com/microsoft/identity/common/internal/controllers/BrokerMsalControllerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/controllers/BrokerMsalControllerTest.java
@@ -66,52 +66,48 @@ public class BrokerMsalControllerTest {
         final String ssoUrl = "https://a.url.that.we.need/that/has/a/path?one_useless_param&sso_nonce=aNonceToUse&anotherUselessParam=foo";
         final String aCookie = "aCookie";
         final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
-        BrokerMsalController controller = new BrokerMsalController(InstrumentationRegistry.getInstrumentation().getContext(), components) {
+        final IIpcStrategy strategy = new IIpcStrategy() {
             @Override
-            public String getActiveBrokerPackageName() {
-                return "aBrokerPackage";
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) {
+                Bundle retBundle = new Bundle();
+                if (bundle.getOperation().equals(BrokerOperationBundle.Operation.MSAL_HELLO)) {
+                    retBundle.putString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY, "7.0");
+                } else if (bundle.getOperation().equals(BrokerOperationBundle.Operation.MSAL_SSO_TOKEN)) {
+                    AcquirePrtSsoTokenResult result = AcquirePrtSsoTokenResult.builder()
+                            .accountName(anAccountName)
+                            .localAccountId(aLocalAccountId)
+                            .homeAccountId(aHomeAccountId)
+                            .accountAuthority(accountAuthority)
+                            .cookieName("x-ms-RefreshTokenCredential")
+                            .cookieContent(aCookie)
+                            .telemetry(Collections.<String, Object>emptyMap())
+                            .build();
+
+                    retBundle.putString(AuthenticationConstants.Broker.BROKER_GENERATE_SSO_TOKEN_RESULT, new Gson().toJson(result));
+                }
+                return retBundle;
             }
 
-            @NonNull
             @Override
-            protected List<IIpcStrategy> getIpcStrategies(Context applicationContext, String activeBrokerPackageName) {
-                return Collections.<IIpcStrategy>singletonList(new IIpcStrategy() {
-                    @Nullable
-                    @Override
-                    public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
-                        Bundle retBundle = new Bundle();
-                        if (bundle.getOperation().equals(BrokerOperationBundle.Operation.MSAL_HELLO)) {
-                            retBundle.putString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY, "7.0");
-                        } else if (bundle.getOperation().equals(BrokerOperationBundle.Operation.MSAL_SSO_TOKEN)) {
-                            AcquirePrtSsoTokenResult result = AcquirePrtSsoTokenResult.builder()
-                                    .accountName(anAccountName)
-                                    .localAccountId(aLocalAccountId)
-                                    .homeAccountId(aHomeAccountId)
-                                    .accountAuthority(accountAuthority)
-                                    .cookieName("x-ms-RefreshTokenCredential")
-                                    .cookieContent(aCookie)
-                                    .telemetry(Collections.<String, Object>emptyMap())
-                                    .build();
-
-                            retBundle.putString(AuthenticationConstants.Broker.BROKER_GENERATE_SSO_TOKEN_RESULT, new Gson().toJson(result));
-                        }
-                        return retBundle;
-                    }
-
-                    @Override
-                    public Type getType() {
-                        return Type.CONTENT_PROVIDER;
-                    }
-                });
+            public Type getType() {
+                return Type.CONTENT_PROVIDER;
             }
         };
-        AcquirePrtSsoTokenCommandParameters params = AcquirePrtSsoTokenCommandParameters.builder()
+
+        final BrokerMsalController controller = new BrokerMsalController(
+                InstrumentationRegistry.getInstrumentation().getContext(),
+                components,
+                "aBrokerPackage",
+                Collections.singletonList(strategy));
+
+        final AcquirePrtSsoTokenCommandParameters params = AcquirePrtSsoTokenCommandParameters.builder()
                 .platformComponents(components)
                 .correlationId(aCorrelationId)
                 .accountName(anAccountName)
                 .requestAuthority(accountAuthority)
                 .ssoUrl(ssoUrl)
                 .build();
+
         final AcquirePrtSsoTokenResult ssoTokenResult = controller.getSsoToken(params);
         Assert.assertEquals(accountAuthority, ssoTokenResult.getAccountAuthority());
         Assert.assertEquals(anAccountName, ssoTokenResult.getAccountName());

--- a/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ipc/HelloCacheTests.java
@@ -185,16 +185,14 @@ public class HelloCacheTests {
 
         class MockController extends BrokerMsalController {
             public MockController(Context applicationContext) {
-                super(applicationContext);
+                super(applicationContext,
+                        AndroidPlatformComponentsFactory.createFromContext(applicationContext),
+                        brokerAppName);
             }
 
             @Override
             public HelloCache getHelloCache() {
                 return HelloCacheTests.this.getHelloCache(protocolA);
-            }
-
-            @Override public String getActiveBrokerPackageName() {
-                return brokerAppName;
             }
         }
 


### PR DESCRIPTION
MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1835
Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2315

## Changes

1. Created `BrokerDiscoveryClientFactory`, which provides either 
     - BrokerDiscoveryClient : The new Broker Discovery Mechanism
     - LegacyBrokerDiscoveryClient: The current mechanism based on AccountManager.
2. By default, `BrokerDiscoveryClientFactory` would return `LegacyBrokerDiscoveryClient`. If anyone wants to test the new mechanism (not yet wired on broker as of now), they could invoke `BrokerDiscoveryClientFactory.setNewBrokerDiscoveryEnabled(true)`
3. Make changes to the `BrokerMsalController`'s constructor. 