### PR TITLE
Clear cache of access tokens with an old application identifier field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.NEXT
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#2019)
 - [MINOR] Removing thumbprint check from PKeyAuth challenge (#2045)
 - [MINOR] Add android 14 check for skipping strong box isolation in pop token (#2053)
+- [MINOR] Clear cache of access tokens with an old application identifier field (#2058)
 
 V.12.0.0
 ----------

--- a/common/src/test/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/BrokerOAuth2TokenCacheTest.java
@@ -23,7 +23,7 @@
 package com.microsoft.identity.common;
 
 import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
-import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER_SHA512;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.BEARER_AUTHENTICATION_SCHEME;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CACHED_AT;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CLIENT_ID;
@@ -161,7 +161,7 @@ public class BrokerOAuth2TokenCacheTest {
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -182,7 +182,7 @@ public class BrokerOAuth2TokenCacheTest {
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -207,7 +207,7 @@ public class BrokerOAuth2TokenCacheTest {
                             EXPIRES_ON,
                             SECRET,
                             UUID.randomUUID().toString(),
-                            APPLICATION_IDENTIFIER,
+                            APPLICATION_IDENTIFIER_SHA512,
                             MAM_ENROLLMENT_IDENTIFIER,
                             SECRET,
                             MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -552,7 +552,7 @@ public class BrokerOAuth2TokenCacheTest {
     public void testCacheMiss() {
         final ICacheRecord cacheRecord = mBrokerOAuth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 mDefaultAppUidTestBundle.mGeneratedAccount,
@@ -578,7 +578,7 @@ public class BrokerOAuth2TokenCacheTest {
 
         final ICacheRecord cacheRecord = mBrokerOAuth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 mDefaultAppUidTestBundle.mGeneratedAccount,
@@ -604,7 +604,7 @@ public class BrokerOAuth2TokenCacheTest {
 
         final ICacheRecord cacheRecord = mBrokerOAuth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 mDefaultFociTestBundle.mGeneratedAccount,

--- a/common/src/test/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MicrosoftFamilyOAuth2TokenCacheTest.java
@@ -23,7 +23,7 @@
 package com.microsoft.identity.common;
 
 import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
-import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER_SHA512;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.AUTHORITY_TYPE;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CACHED_AT;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CLIENT_ID;
@@ -120,7 +120,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -242,7 +242,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -302,7 +302,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID + "2",
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -425,7 +425,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -485,7 +485,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -557,7 +557,7 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         final String[] thread2 = {""};
         final AccountCredentialTestBundle frtTestBundle = new AccountCredentialTestBundle(
                 MicrosoftAccount.AUTHORITY_TYPE_MS_STS, localAccountId, "test.user@tenant.onmicrosoft.com",
-                randomHomeAccountId, ENVIRONMENT, realm, TARGET, CACHED_AT, EXPIRES_ON, SECRET, CLIENT_ID, APPLICATION_IDENTIFIER, MAM_ENROLLMENT_IDENTIFIER,
+                randomHomeAccountId, ENVIRONMENT, realm, TARGET, CACHED_AT, EXPIRES_ON, SECRET, CLIENT_ID, APPLICATION_IDENTIFIER_SHA512, MAM_ENROLLMENT_IDENTIFIER,
                 SECRET, MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS, "1",
                 SESSION_KEY, CredentialType.IdToken);
 
@@ -575,14 +575,14 @@ public class MicrosoftFamilyOAuth2TokenCacheTest extends MsalOAuth2TokenCacheTes
         final AccountCredentialTestBundle frtTestBundle1 = new AccountCredentialTestBundle(
                 MicrosoftAccount.AUTHORITY_TYPE_MS_STS, localAccountId, "test.user@tenant.onmicrosoft.com",
                 randomHomeAccountId, ENVIRONMENT, realm, TARGET + " client1_scope", CACHED_AT, EXPIRES_ON, SECRET, "client_1",
-                APPLICATION_IDENTIFIER, MAM_ENROLLMENT_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512, MAM_ENROLLMENT_IDENTIFIER,
                 SECRET, MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS, "1",
                 SESSION_KEY, CredentialType.IdToken);
 
         final AccountCredentialTestBundle frtTestBundle2 = new AccountCredentialTestBundle(
                 MicrosoftAccount.AUTHORITY_TYPE_MS_STS, localAccountId, "test.user@tenant.onmicrosoft.com",
                 randomHomeAccountId, ENVIRONMENT, realm, TARGET + " client2_scope", CACHED_AT, EXPIRES_ON, SECRET, "client_2",
-                APPLICATION_IDENTIFIER, MAM_ENROLLMENT_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512, MAM_ENROLLMENT_IDENTIFIER,
                 SECRET, MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS, "1", SESSION_KEY,
                 CredentialType.IdToken);
 

--- a/common/src/test/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalCppOAuth2TokenCacheTest.java
@@ -47,7 +47,7 @@ import org.robolectric.RobolectricTestRunner;
 import java.util.List;
 import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
 import static com.microsoft.identity.common.MsalOAuth2TokenCacheTest.AccountCredentialTestBundle;
-import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER_SHA512;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CACHED_AT;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CLIENT_ID;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.ENVIRONMENT;
@@ -91,7 +91,7 @@ public class MsalCppOAuth2TokenCacheTest {
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,

--- a/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -66,7 +66,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.microsoft.identity.common.MicrosoftStsAccountCredentialAdapterTest.MOCK_ID_TOKEN_WITH_CLAIMS;
-import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER;
+import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.APPLICATION_IDENTIFIER_SHA512;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.AUTHORITY_TYPE;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.BEARER_AUTHENTICATION_SCHEME;
 import static com.microsoft.identity.common.SharedPreferencesAccountCredentialCacheTest.CACHED_AT;
@@ -236,7 +236,7 @@ public class MsalOAuth2TokenCacheTest {
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -257,7 +257,7 @@ public class MsalOAuth2TokenCacheTest {
                 EXPIRES_ON,
                 SECRET,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 SECRET,
                 MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -652,7 +652,7 @@ public class MsalOAuth2TokenCacheTest {
         accessTokenToClear.setEnvironment(ENVIRONMENT);
         accessTokenToClear.setCredentialType(AccessToken.name());
         accessTokenToClear.setClientId(CLIENT_ID);
-        accessTokenToClear.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessTokenToClear.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessTokenToClear.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessTokenToClear.setTarget(TARGET);
 
@@ -711,7 +711,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord cacheRecord = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 account,
@@ -801,7 +801,7 @@ public class MsalOAuth2TokenCacheTest {
                             EXPIRES_ON,
                             SECRET,
                             CLIENT_ID,
-                            APPLICATION_IDENTIFIER,
+                            APPLICATION_IDENTIFIER_SHA512,
                             MAM_ENROLLMENT_IDENTIFIER,
                             SECRET,
                             MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -974,7 +974,7 @@ public class MsalOAuth2TokenCacheTest {
                             EXPIRES_ON,
                             SECRET,
                             CLIENT_ID,
-                            APPLICATION_IDENTIFIER,
+                            APPLICATION_IDENTIFIER_SHA512,
                             MAM_ENROLLMENT_IDENTIFIER,
                             SECRET,
                             MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -1030,7 +1030,7 @@ public class MsalOAuth2TokenCacheTest {
                             EXPIRES_ON,
                             SECRET,
                             CLIENT_ID,
-                            APPLICATION_IDENTIFIER,
+                            APPLICATION_IDENTIFIER_SHA512,
                             MAM_ENROLLMENT_IDENTIFIER,
                             SECRET,
                             MOCK_ID_TOKEN_WITH_CLAIMS,
@@ -1212,7 +1212,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount,
@@ -1233,7 +1233,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV1.mGeneratedAccount,
@@ -1255,7 +1255,7 @@ public class MsalOAuth2TokenCacheTest {
         final List<ICacheRecord> secondaryLoad =
                 mOauth2TokenCache.loadWithAggregatedAccountData(
                         CLIENT_ID,
-                        APPLICATION_IDENTIFIER,
+                        APPLICATION_IDENTIFIER_SHA512,
                         MAM_ENROLLMENT_IDENTIFIER,
                         TARGET,
                         defaultTestBundleV2.mGeneratedAccount,
@@ -1284,7 +1284,7 @@ public class MsalOAuth2TokenCacheTest {
         final List<ICacheRecord> secondaryLoad =
                 mOauth2TokenCache.loadWithAggregatedAccountData(
                         CLIENT_ID,
-                        APPLICATION_IDENTIFIER,
+                        APPLICATION_IDENTIFIER_SHA512,
                         MAM_ENROLLMENT_IDENTIFIER,
                         TARGET,
                         defaultTestBundleV1.mGeneratedAccount,
@@ -1314,7 +1314,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount,
@@ -1340,7 +1340,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount,
@@ -1366,7 +1366,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount,
@@ -1388,7 +1388,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 defaultTestBundleV2.mGeneratedAccount,
@@ -1489,7 +1489,7 @@ public class MsalOAuth2TokenCacheTest {
 
         final ICacheRecord secondaryLoad = mOauth2TokenCache.load(
                 entry.getAccessToken().getClientId(),
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 TARGET,
                 entry.getAccount(),

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -2453,27 +2453,4 @@ public class SharedPreferencesAccountCredentialCacheTest {
         );
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
-
-    @Test
-    public void testClearSha1ApplicationIdentifierAccessTokens() {
-        for (int i = 0; i < 3; i++) {
-            final AccessTokenRecord accessToken = new AccessTokenRecord();
-            accessToken.setCredentialType(CredentialType.AccessToken.name());
-
-            switch (i) {
-                case 0:
-                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
-                    assertFalse(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
-                    break;
-                case 1:
-                    accessToken.setApplicationIdentifier(null);
-                    assertFalse(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
-                    break;
-                case 2:
-                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
-                    assertTrue(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
-                    break;
-            }
-        }
-    }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -58,7 +58,6 @@ import java.util.Map;
 import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -2417,9 +2417,6 @@ public class SharedPreferencesAccountCredentialCacheTest {
         refreshToken.setTarget(TARGET);
         mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
 
-        // Verify getCredentials() returns two matching elements
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
         //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
         //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
         mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.java.authscheme.BearerAuthenticationSchemeInternal;
+import com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache;
 import com.microsoft.identity.common.java.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.java.dto.AccessTokenRecord;
@@ -56,6 +57,7 @@ import java.util.Map;
 
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -2454,9 +2456,6 @@ public class SharedPreferencesAccountCredentialCacheTest {
 
     @Test
     public void testClearSha1ApplicationIdentifierAccessTokens() {
-        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
-        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
         for (int i = 0; i < 3; i++) {
             final AccessTokenRecord accessToken = new AccessTokenRecord();
             accessToken.setCredentialType(CredentialType.AccessToken.name());
@@ -2464,19 +2463,17 @@ public class SharedPreferencesAccountCredentialCacheTest {
             switch (i) {
                 case 0:
                     accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
+                    assertFalse(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
                     break;
                 case 1:
                     accessToken.setApplicationIdentifier(null);
+                    assertFalse(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
                     break;
                 case 2:
                     accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+                    assertTrue(AbstractAccountCredentialCache.isSha1ApplicationIdentifierAccessToken(accessToken));
                     break;
             }
-            mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
         }
-        assertEquals(3, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
-        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -2381,6 +2381,9 @@ public class SharedPreferencesAccountCredentialCacheTest {
         //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
         // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
 
+        //Must clear initial sha1ClearedFlag first, in order to mock an older version.
+        mSharedPreferencesAccountCredentialCache.clearAll();
+
         // Save an Account into the cache
         final AccountRecord account = new AccountRecord();
         account.setHomeAccountId(HOME_ACCOUNT_ID);

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -49,7 +49,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -30,7 +30,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.java.authscheme.BearerAuthenticationSchemeInternal;
-import com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache;
 import com.microsoft.identity.common.java.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache;
 import com.microsoft.identity.common.java.dto.AccessTokenRecord;
@@ -70,7 +69,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
     static final String HOME_ACCOUNT_ID = "29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
     static final String ENVIRONMENT = "login.microsoftonline.com";
     static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
-    static final String APPLICATION_IDENTIFIER = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
+    static final String APPLICATION_IDENTIFIER_SHA1 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
     static final String APPLICATION_IDENTIFIER_SHA512 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIj==";
     static final String MAM_ENROLLMENT_IDENTIFIER = "UNSET";
     static final String TARGET = "user.read user.write https://graph.windows.net";
@@ -666,7 +665,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -715,7 +714,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 null, // * wildcard
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -733,7 +732,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -756,7 +755,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 null,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -778,7 +777,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -801,7 +800,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 null,
                 null,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -830,7 +829,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -846,7 +845,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -880,7 +879,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -896,7 +895,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -935,7 +934,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -951,7 +950,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -992,7 +991,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -1008,7 +1007,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -1042,7 +1041,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1055,7 +1054,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -1083,7 +1082,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1096,7 +1095,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1110,7 +1109,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -1138,7 +1137,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1151,7 +1150,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
 
@@ -1165,7 +1164,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1193,7 +1192,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1206,7 +1205,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
 
@@ -1220,7 +1219,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1248,7 +1247,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1261,7 +1260,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1276,7 +1275,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1304,7 +1303,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1317,7 +1316,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1332,7 +1331,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1362,7 +1361,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":false}}}");
@@ -1376,7 +1375,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1391,7 +1390,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1422,7 +1421,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1435,7 +1434,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1449,7 +1448,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -1474,7 +1473,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -1487,7 +1486,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setRealm("Bar");
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
         accessToken2.setCachedAt(CACHED_AT);
@@ -1504,7 +1503,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1532,7 +1531,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1545,7 +1544,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1559,7 +1558,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1584,7 +1583,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.PrimaryRefreshToken,
                 null, /* client id */
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1609,7 +1608,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
                 ENVIRONMENT,
                 CredentialType.PrimaryRefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -2400,7 +2399,7 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA1);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2379,12 +2380,9 @@ public class SharedPreferencesAccountCredentialCacheTest {
     }
 
     @Test
-    public void testSha1ToSha512AppIdentifierUpdate() {
+    public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
         //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
         // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
-
-        //Must clear initial sha1ClearedFlag first, in order to mock an older version.
-        mSharedPreferencesAccountCredentialCache.clearAll();
 
         // Save an Account into the cache
         final AccountRecord account = new AccountRecord();
@@ -2424,11 +2422,10 @@ public class SharedPreferencesAccountCredentialCacheTest {
         // Verify getCredentials() returns two matching elements
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
 
-        //Recreate cache to set off SHA-1 access token removal
-        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
-                mDelegate,
-                mSharedPreferencesFileManager
-        );
+        //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
+        //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
+        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
+        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
         assertEquals(1, mSharedPreferencesAccountCredentialCache.getCredentials().size());
 
         // Now Save an AccessToken with SHA-512 application identifier into the cache
@@ -2446,11 +2443,8 @@ public class SharedPreferencesAccountCredentialCacheTest {
         accessToken2.setSecret(SECRET);
         mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
 
-        //Recreate cache and make sure cache didn't remove the SHA-512 token
-        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCache(
-                mDelegate,
-                mSharedPreferencesFileManager
-        );
+        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
+        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -2521,6 +2521,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
         // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
 
+        //Must clear initial sha1ClearedFlag first, in order to mock an older version.
+        mSharedPreferencesAccountCredentialCache.clearAll();
+
         // Save an Account into the cache
         final AccountRecord account = new AccountRecord();
         account.setHomeAccountId(HOME_ACCOUNT_ID);
@@ -2587,34 +2590,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 mDelegate,
                 mSharedPreferencesFileManager
         );
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-    }
-
-    @Test
-    public void testClearSha1ApplicationIdentifierAccessTokens() {
-        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
-        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
-        for (int i = 0; i < 3; i++) {
-            final AccessTokenRecord accessToken = new AccessTokenRecord();
-            accessToken.setCredentialType(CredentialType.AccessToken.name());
-
-            switch (i) {
-                case 0:
-                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
-                    break;
-                case 1:
-                    accessToken.setApplicationIdentifier(null);
-                    break;
-                case 2:
-                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
-                    break;
-            }
-            mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
-        }
-        assertEquals(3, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
-        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -70,7 +70,8 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     static final String HOME_ACCOUNT_ID = "29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
     static final String ENVIRONMENT = "login.microsoftonline.com";
     static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
-    static final String APPLICATION_IDENTIFIER = "UNSET/UNSET";
+    static final String APPLICATION_IDENTIFIER = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
+    static final String APPLICATION_IDENTIFIER_SHA512 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIj==";
     static final String MAM_ENROLLMENT_IDENTIFIER = "UNSET";
     static final String TARGET = "user.read user.write https://graph.windows.net";
     // In the case of AAD, the realm is the tenantId
@@ -2513,5 +2514,107 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
         creds1.get(0).setCachedAt("banana");
         assertNotEquals(creds1.get(0), creds2.get(0));
+    }
+
+    @Test
+    public void testSha1ToSha512AppIdentifierUpdate() {
+        //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
+        // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
+
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken with SHA-1 application identifier into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Verify getCredentials() returns two matching elements
+        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+
+        //Recreate cache to set off SHA-1 access token removal
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+
+        assertEquals(1, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+
+        // Now Save an AccessToken with SHA-512 application identifier into the cache
+        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
+        accessToken2.setCredentialType(CredentialType.AccessToken.name());
+        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken2.setRealm("Foo");
+        accessToken2.setEnvironment(ENVIRONMENT);
+        accessToken2.setClientId(CLIENT_ID);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
+        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken2.setTarget(TARGET);
+        accessToken2.setCachedAt(CACHED_AT);
+        accessToken2.setExpiresOn(EXPIRES_ON);
+        accessToken2.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
+
+        //Recreate cache and make sure cache didn't remove the SHA-512 token
+        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                mDelegate,
+                mSharedPreferencesFileManager
+        );
+        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+    }
+
+    @Test
+    public void testClearSha1ApplicationIdentifierAccessTokens() {
+        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
+        assertEquals(0, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+
+        for (int i = 0; i < 3; i++) {
+            final AccessTokenRecord accessToken = new AccessTokenRecord();
+            accessToken.setCredentialType(CredentialType.AccessToken.name());
+
+            switch (i) {
+                case 0:
+                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
+                    break;
+                case 1:
+                    accessToken.setApplicationIdentifier(null);
+                    break;
+                case 2:
+                    accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+                    break;
+            }
+            mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+        }
+        assertEquals(3, mSharedPreferencesAccountCredentialCache.getCredentials().size());
+
+        mSharedPreferencesAccountCredentialCache.clearSha1ApplicationIdentifierAccessTokens();
+        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -2557,9 +2557,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         refreshToken.setTarget(TARGET);
         mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
 
-        // Verify getCredentials() returns two matching elements
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
         //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
         //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
         mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -2517,12 +2518,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     }
 
     @Test
-    public void testSha1ToSha512AppIdentifierUpdate() {
+    public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
         //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
         // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
-
-        //Must clear initial sha1ClearedFlag first, in order to mock an older version.
-        mSharedPreferencesAccountCredentialCache.clearAll();
 
         // Save an Account into the cache
         final AccountRecord account = new AccountRecord();
@@ -2562,12 +2560,10 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         // Verify getCredentials() returns two matching elements
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
 
-        //Recreate cache to set off SHA-1 access token removal
-        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
-                mDelegate,
-                mSharedPreferencesFileManager
-        );
-
+        //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
+        //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
+        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
+        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
         assertEquals(1, mSharedPreferencesAccountCredentialCache.getCredentials().size());
 
         // Now Save an AccessToken with SHA-512 application identifier into the cache
@@ -2585,11 +2581,8 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setSecret(SECRET);
         mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
 
-        //Recreate cache and make sure cache didn't remove the SHA-512 token
-        mSharedPreferencesAccountCredentialCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
-                mDelegate,
-                mSharedPreferencesFileManager
-        );
+        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
+        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
         assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -71,7 +71,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     static final String HOME_ACCOUNT_ID = "29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
     static final String ENVIRONMENT = "login.microsoftonline.com";
     static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
-    static final String APPLICATION_IDENTIFIER = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
+    static final String APPLICATION_IDENTIFIER_SHA1 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
     static final String APPLICATION_IDENTIFIER_SHA512 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIj==";
     static final String MAM_ENROLLMENT_IDENTIFIER = "UNSET";
     static final String TARGET = "user.read user.write https://graph.windows.net";
@@ -667,7 +667,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -716,7 +716,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 null, // * wildcard
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -734,7 +734,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -757,7 +757,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 null,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -779,7 +779,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -802,7 +802,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 null,
                 null,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -831,7 +831,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -847,7 +847,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -881,7 +881,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -897,7 +897,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -936,7 +936,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -952,7 +952,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -993,7 +993,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm(REALM);
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -1009,7 +1009,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 searchTarget,
@@ -1043,7 +1043,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1056,7 +1056,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.RefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 TARGET,
@@ -1084,7 +1084,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1097,7 +1097,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1111,7 +1111,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -1139,7 +1139,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1152,7 +1152,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
 
@@ -1166,7 +1166,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1194,7 +1194,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1207,7 +1207,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
 
@@ -1221,7 +1221,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1249,7 +1249,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1262,7 +1262,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1277,7 +1277,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1305,7 +1305,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1318,7 +1318,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1333,7 +1333,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1363,7 +1363,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":false}}}");
@@ -1377,7 +1377,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
         accessToken2.setRequestedClaims("{\"access_token\":{\"deviceid\":{\"essential\":true}}}");
@@ -1392,7 +1392,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1423,7 +1423,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1436,7 +1436,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1450,7 +1450,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 TARGET,
@@ -1475,7 +1475,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);
@@ -1488,7 +1488,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setRealm("Bar");
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget("qux");
         accessToken2.setCachedAt(CACHED_AT);
@@ -1505,7 +1505,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1533,7 +1533,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setCredentialType(CredentialType.AccessToken.name());
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
 
@@ -1546,7 +1546,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken2.setEnvironment(ENVIRONMENT);
         accessToken2.setCredentialType(CredentialType.AccessToken.name());
         accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
         accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken2.setTarget(TARGET);
 
@@ -1560,7 +1560,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.AccessToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 REALM,
                 null,
@@ -1585,7 +1585,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.PrimaryRefreshToken,
                 null, /* client id */
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -1610,7 +1610,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
                 ENVIRONMENT,
                 CredentialType.PrimaryRefreshToken,
                 CLIENT_ID,
-                APPLICATION_IDENTIFIER,
+                APPLICATION_IDENTIFIER_SHA512,
                 MAM_ENROLLMENT_IDENTIFIER,
                 null,
                 null,
@@ -2539,7 +2539,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         accessToken.setRealm("Foo");
         accessToken.setEnvironment(ENVIRONMENT);
         accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA1);
         accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
         accessToken.setTarget(TARGET);
         accessToken.setCachedAt(CACHED_AT);

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -49,6 +49,7 @@ import lombok.NonNull;
 public abstract class AbstractAccountCredentialCache implements IAccountCredentialCache {
 
     private static final String TAG = AbstractAccountCredentialCache.class.getSimpleName();
+    public static final String SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED = "sha1-cleared";
     private static final String NEW_LINE = "\n";
 
     @Nullable
@@ -274,25 +275,6 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
         }
 
         return matchingCredentials;
-    }
-
-    /**
-     * The application identifier field for access token records previously included a SHA-1 signing certificate hash.
-     * This method clears such tokens, as the application identifier should now contain a SHA-512 signing certificate hash.
-     */
-    public void clearSha1ApplicationIdentifierAccessTokens() {
-        final String methodTag = TAG + ":clearSha1ApplicationIdentifierAccessTokens";
-        for (final Credential credential : getCredentials()) {
-            if (credential instanceof AccessTokenRecord) {
-                final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
-                if (tokenAppIdentifier != null
-                        && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
-                    removeCredential(accessToken);
-                    Logger.info(methodTag, "Removed old access token with app identifier containing SHA-1. A new access token should be re-acquired with a SHA-512 app identifier.");
-                }
-            }
-        }
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -294,6 +294,7 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
      * This method first checks if it has been run before, and if not, removes such tokens, as application identifiers should now contain SHA-512 signing certificate hashes.
      */
     public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
+        final String methodTag = TAG + ":removeSha1ApplicationIdentifierAccessTokensIfNeeded";
         if (!isSha1Cleared()) {
             for (final Credential credential : getCredentials()) {
                 if (credential instanceof AccessTokenRecord) {
@@ -301,7 +302,7 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
                     final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
                     if (tokenAppIdentifier != null
                             && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
-                        Logger.info(TAG, "Identified old access token with app identifier containing SHA-1. This token shall be removed, and a new access token should be re-acquired with a SHA-512 app identifier.");
+                        Logger.info(methodTag, "Identified old access token with app identifier containing SHA-1. This token shall be removed, and a new access token should be re-acquired with a SHA-512 app identifier.");
                         removeCredential(credential);
                     }
                 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -278,6 +278,26 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
     }
 
     /**
+     * The application identifier field for access token records previously included a SHA-1 signing certificate hash.
+     * This method identifies such tokens, as the application identifier should now contain a SHA-512 signing certificate hash.
+     * @param credential token record.
+     * @return true if an access token containing a SHA-1 app identifier hash; false otherwise.
+     */
+    public static boolean isSha1ApplicationIdentifierAccessToken(@NonNull final Credential credential) {
+        final String methodTag = TAG + ":isSha1ApplicationIdentifierAccessToken";
+        if (credential instanceof AccessTokenRecord) {
+            final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
+            final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
+            if (tokenAppIdentifier != null
+                    && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
+                Logger.info(methodTag, "Identified old access token with app identifier containing SHA-1. This token shall be removed, and a new access token should be re-acquired with a SHA-512 app identifier.");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Can tell if an application identifier string (<package name>/<signing certificate hash>) contains a SHA-1 hash.
      * @param applicationIdentifier application identifier field string
      * @return true if contains SHA-1 hash; false otherwise.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -199,7 +199,14 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
             if (mustMatchOnApplicationIdentifier) {
                 if (credential instanceof AccessTokenRecord) {
                     final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                    matches = matches && StringUtil.equalsIgnoreCaseTrimBoth(applicationIdentifier, accessToken.getApplicationIdentifier());
+                    //Check here for an application identifier with a SHA-1 hash.
+                    final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
+                    final String[] appIdentifierArr = tokenAppIdentifier.split("/", 2);
+                    if (appIdentifierArr.length > 1
+                            && appIdentifierArr[1].length() == 28) {
+                        removeCredential(accessToken);
+                    }
+                    matches = matches && StringUtil.equalsIgnoreCaseTrimBoth(applicationIdentifier, tokenAppIdentifier);
                 } else {
                     Logger.verbose(TAG, "Query specified applicationIdentifier match, but credential type does not have application identifier");
                 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
@@ -279,5 +279,4 @@ public interface IAccountCredentialCache {
      * Clear the contents of the cache.
      */
     void clearAll();
-
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -100,6 +100,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Init: " + TAG);
         mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
+        clearSha1ApplicationIdentifierAccessTokens();
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -101,7 +101,11 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
         if (mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) == null) {
-            clearSha1ApplicationIdentifierAccessTokens();
+            for (final Credential credential : getCredentials()) {
+                if (isSha1ApplicationIdentifierAccessToken(credential)) {
+                    removeCredential(credential);
+                }
+            }
             mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
         }
     }
@@ -673,24 +677,5 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         boolean isCredential = null != getCredentialTypeForCredentialCacheKey(cacheKey);
         Logger.verbose(methodTag, "isCredential? [" + isCredential + "]");
         return isCredential;
-    }
-
-    /**
-     * The application identifier field for access token records previously included a SHA-1 signing certificate hash.
-     * This method clears such tokens, as the application identifier should now contain a SHA-512 signing certificate hash.
-     */
-    public void clearSha1ApplicationIdentifierAccessTokens() {
-        final String methodTag = TAG + ":clearSha1ApplicationIdentifierAccessTokens";
-        for (final Credential credential : getCredentials()) {
-            if (credential instanceof AccessTokenRecord) {
-                final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
-                if (tokenAppIdentifier != null
-                        && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
-                    removeCredential(accessToken);
-                    Logger.info(methodTag, "Removed old access token with app identifier containing SHA-1. A new access token should be re-acquired with a SHA-512 app identifier.");
-                }
-            }
-        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -100,14 +100,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Init: " + TAG);
         mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
-        if (mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) == null) {
-            for (final Credential credential : getCredentials()) {
-                if (isSha1ApplicationIdentifierAccessToken(credential)) {
-                    removeCredential(credential);
-                }
-            }
-            mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
-        }
+        removeSha1ApplicationIdentifierAccessTokensIfNeeded();
     }
 
     @Override
@@ -677,5 +670,22 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         boolean isCredential = null != getCredentialTypeForCredentialCacheKey(cacheKey);
         Logger.verbose(methodTag, "isCredential? [" + isCredential + "]");
         return isCredential;
+    }
+
+    /**
+     * Tells if access tokens with SHA-1 app identifiers have been cleared yet.
+     * @return true if cleared; false otherwise.
+     */
+    @Override
+    protected boolean isSha1Cleared() {
+        return mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) != null;
+    }
+
+    /**
+     * Saves the flag indicating that access tokens with SHA-1 app identifiers have been cleared.
+     */
+    @Override
+    protected void saveSha1ClearedFlag() {
+        mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -432,7 +432,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             @Nullable final String target,
             @Nullable final String authScheme,
             @Nullable final String requestedClaims,
-            @Nullable final List<Credential> inputCredentials) {
+            @NonNull final List<Credential> inputCredentials) {
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy()");
 
@@ -494,7 +494,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
 
     @Override
     public List<Credential> getCredentialsFilteredBy(
-            @Nullable List<Credential> inputCredentials,
+            @NonNull List<Credential> inputCredentials,
             @Nullable final String homeAccountId,
             @Nullable final String environment,
             @Nullable final CredentialType credentialType,

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -100,7 +100,10 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Init: " + TAG);
         mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
-        clearSha1ApplicationIdentifierAccessTokens();
+        if (mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) == null) {
+            clearSha1ApplicationIdentifierAccessTokens();
+            mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
+        }
     }
 
     @Override
@@ -672,4 +675,22 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         return isCredential;
     }
 
+    /**
+     * The application identifier field for access token records previously included a SHA-1 signing certificate hash.
+     * This method clears such tokens, as the application identifier should now contain a SHA-512 signing certificate hash.
+     */
+    public void clearSha1ApplicationIdentifierAccessTokens() {
+        final String methodTag = TAG + ":clearSha1ApplicationIdentifierAccessTokens";
+        for (final Credential credential : getCredentials()) {
+            if (credential instanceof AccessTokenRecord) {
+                final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
+                final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
+                if (tokenAppIdentifier != null
+                        && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
+                    removeCredential(accessToken);
+                    Logger.info(methodTag, "Removed old access token with app identifier containing SHA-1. A new access token should be re-acquired with a SHA-512 app identifier.");
+                }
+            }
+        }
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -82,10 +82,6 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public static final String DESERIALIZATION_FAILED = "Deserialization failed. Skipping ";
     public static final String ACCOUNT_RECORD_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + AccountRecord.class.getSimpleName();
     public static final String CREDENTIAL_DESERIALIZATION_FAILED = DESERIALIZATION_FAILED + Credential.class.getSimpleName();
-
-    // SharedPreferences used to store Accounts and Credentials
-    private final INameValueStorage<String> mSharedPreferencesFileManager;
-
     private final ICacheKeyValueDelegate mCacheValueDelegate;
 
     /**
@@ -97,10 +93,10 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public SharedPreferencesAccountCredentialCache(
             @NonNull final ICacheKeyValueDelegate accountCacheValueDelegate,
             @NonNull final INameValueStorage<String> sharedPreferencesFileManager) {
+        super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
-        mSharedPreferencesFileManager = sharedPreferencesFileManager;
         mCacheValueDelegate = accountCacheValueDelegate;
-        removeSha1ApplicationIdentifierAccessTokensIfNeeded();
+        new Thread(this::removeSha1ApplicationIdentifierAccessTokensIfNeeded).start();
     }
 
     @Override
@@ -670,22 +666,5 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         boolean isCredential = null != getCredentialTypeForCredentialCacheKey(cacheKey);
         Logger.verbose(methodTag, "isCredential? [" + isCredential + "]");
         return isCredential;
-    }
-
-    /**
-     * Tells if access tokens with SHA-1 app identifiers have been cleared yet.
-     * @return true if cleared; false otherwise.
-     */
-    @Override
-    protected boolean isSha1Cleared() {
-        return mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) != null;
-    }
-
-    /**
-     * Saves the flag indicating that access tokens with SHA-1 app identifiers have been cleared.
-     */
-    @Override
-    protected void saveSha1ClearedFlag() {
-        mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -339,14 +339,10 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 // Remove the entry and return null...
                 Logger.warn(methodTag, "The returned Credential was uninitialized. Removing...");
                 mSharedPreferencesFileManager.remove(cacheKey);
-            } else if (AccessTokenRecord.class == clazz && !mSha1Cleared) {
-                final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
-                if (tokenAppIdentifier != null
-                        && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
+            } else if (AccessTokenRecord.class == clazz
+                    && !mSha1Cleared
+                    && isSha1ApplicationIdentifierAccessToken(credential)) {
                     mSharedPreferencesFileManager.remove(cacheKey);
-                    Logger.info(methodTag, "Removed old access token with app identifier containing SHA-1. A new access token should be re-acquired with a SHA-512 app identifier.");
-                }
             }
             else {
                 credentials.put(cacheKey, credential);

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -95,6 +95,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             } finally {
                 mLoaded = true;
                 mCacheLock.notifyAll();
+                clearSha1ApplicationIdentifierAccessTokens();
             }
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -74,9 +74,18 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
         mCacheValueDelegate = accountCacheValueDelegate;
-        new Thread(() -> load()).start();
+        new Thread(() -> initialize()).start();
     }
 
+    private void initialize() {
+        final String methodTag = TAG + ":initialize";
+        try {
+            load();
+            removeSha1ApplicationIdentifierAccessTokensIfNeeded();
+        } catch (final Throwable t) {
+            Logger.error(methodTag, "Failed to load initial accounts/credentials or remove SHA-1 app identifier tokens from SharedPreferences", t);
+        }
+    }
     private void load() {
         final String methodTag = TAG + ":load";
 
@@ -86,9 +95,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 Logger.info(methodTag, "Loaded " + mCachedAccountRecordsWithKeys.size() + " AccountRecords");
                 mCachedCredentialsWithKeys = loadCredentialsWithKeys();
                 Logger.info(methodTag, "Loaded " + mCachedCredentialsWithKeys.size() + " Credentials");
-                new Thread(() -> removeSha1ApplicationIdentifierAccessTokensIfNeeded()).start();
-            } catch (final Throwable t) {
-                Logger.error(methodTag, "Failed to load initial accounts or credentials from SharedPreferences", t);
             } finally {
                 mLoaded = true;
                 mCacheLock.notifyAll();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -489,7 +489,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             @Nullable final String target,
             @Nullable final String authScheme,
             @Nullable final String requestedClaims,
-            @Nullable final List<Credential> inputCredentials) {
+            @NonNull final List<Credential> inputCredentials) {
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy()");
 
@@ -551,7 +551,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
 
     @Override
     public List<Credential> getCredentialsFilteredBy(
-            @Nullable List<Credential> inputCredentials,
+            @NonNull List<Credential> inputCredentials,
             @Nullable final String homeAccountId,
             @Nullable final String environment,
             @Nullable final CredentialType credentialType,


### PR DESCRIPTION
### Summary
_Note: A few unit tests are expected to fail until another PR which updates variables (https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2059) is merged into this one. I separated it out in order to improve the readability of this PR._

When created from the broker, access token records have an Application Identifier string field attached to them which consists of the calling app's package name and signing certificate hash:
`<Package name>/<signing certificate hash>`

The base-64 signing certificate hash is currently generated using SHA-1. As we're currently making the effort to migrate our uses of SHA-1 to SHA-512, I created a PR for the broker to now attach a SHA-512 hash to the broker parameter Signature field, replacing the SHA-1 hash, for both interactively and silently acquiring a token.

### Why this PR is also needed
Fortunately, the user shouldn't have to login again upon updating their broker app; there will be an access token cache miss, but the unaffected refresh token records will be able to reacquire an access token with the updated SHA-512 application identifier field. 
However, the access token with a SHA-1 application identifier will remain in the cache indefinitely, as it won't be explicitly removed if the broker is only searching for app identifiers including 512 hashes. 

This PR addresses this issue by removing access tokens with a SHA-1 application identifier upon instantiation of the SharedPreferencesAccountCredentialCache object (and the corresponding MemoryCache version). This ensures that the cache is cleaned of access tokens with an "old" identifier before any getCredentials() method is called. 

This logic should (in theory) run only once upon a user updating to the version which includes said logic. I added a unit test which mimics this scenario.

Related PRs:
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2059 : Will be merged into this one.
- https://github.com/AzureAD/ad-accounts-for-android/pull/2317 : The mentioned broker PR, which will be merged _after_ this one.