### PR TITLE
Fix min broker protocol version value for MSA accounts in broker

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -37,7 +37,7 @@ public class BrokerProtocolVersionUtil {
     public static final String MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION = "8.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION = "9.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_POP_SCHEME_WITH_CLIENT_KEY_MINIMUM_VERSION = "11.0";
-    public static final String MSAL_TO_BROKER_PROTOCOL_BROKER_MSA_SUPPORT_MINIMUM_VERSION = "13.0";
+    public static final String MSAL_TO_BROKER_PROTOCOL_BROKER_MSA_SUPPORT_MINIMUM_VERSION = "14.0";
 
     /**
      * Verifies if negotiated broker protocol version allows to support MSA accounts in the broker.

--- a/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
@@ -28,14 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import cz.msebera.android.httpclient.NameValuePair;
-
 @RunWith(JUnit4.class)
 public class BrokerProtocolVersionUtilTest {
 
@@ -168,6 +160,34 @@ public class BrokerProtocolVersionUtilTest {
     public void testCanSendPKeyAuthHeaderToTheTokenEndpoint_NegotiatedNull(){
         Assert.assertFalse(
                 BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint(null)
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedEqualToRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("14.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedLargerThanRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("15.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedSmallerThanRequired(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("13.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedNull(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker(null)
         );
     }
 }


### PR DESCRIPTION
We recently modified maximum protocol versions in broker where default max would be 13 (updated from 12), and max with MSA support would be 14 (update from 13) and we will be used with PRTv3 release.

It was not updated at one more place where we check if negotiated protocol version supports MSA accounts (BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker). Due to this being 13, broker is acquiring token for MSA and storing MSA account (an entry can be seen in AccountManager). Subsequently, acquire token silent calls also run through broker. This is change of behavour and unintentional. We only want to support MSA accounts after PRTv3 is enabled.

Updating the min negotiated broker version for that supports MSA to 14.0. Added UTs for the method in BrokerProtocolVersionUtilTest.