### PR TITLE
[dev] Fix min broker protocol version value for MSA accounts in broker

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V.NEXT
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#2019)
 - [MINOR] Removing thumbprint check from PKeyAuth challenge (#2045)
 - [MINOR] Add android 14 check for skipping strong box isolation in pop token (#2053)
+- [PATCH] Fix min broker protocol version value for MSA accounts in broker(#2062)
 
 V.12.0.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@ V.NEXT
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#2019)
 - [MINOR] Removing thumbprint check from PKeyAuth challenge (#2045)
 - [MINOR] Add android 14 check for skipping strong box isolation in pop token (#2053)
-- [PATCH] Fix min broker protocol version value for MSA accounts in broker(#2062)
+- [PATCH] Fix min broker protocol version value for MSA accounts in broker (#2062)
 
 V.12.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -37,7 +37,7 @@ public class BrokerProtocolVersionUtil {
     public static final String MSAL_TO_BROKER_PROTOCOL_ACCOUNT_FROM_PRT_CHANGES_MINIMUM_VERSION = "8.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_PKEYAUTH_HEADER_CHANGES_MINIMUM_VERSION = "9.0";
     public static final String MSAL_TO_BROKER_PROTOCOL_POP_SCHEME_WITH_CLIENT_KEY_MINIMUM_VERSION = "11.0";
-    public static final String MSAL_TO_BROKER_PROTOCOL_BROKER_MSA_SUPPORT_MINIMUM_VERSION = "13.0";
+    public static final String MSAL_TO_BROKER_PROTOCOL_BROKER_MSA_SUPPORT_MINIMUM_VERSION = "14.0";
 
     /**
      * Verifies if negotiated broker protocol version allows to support MSA accounts in the broker.

--- a/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtilTest.java
@@ -170,4 +170,33 @@ public class BrokerProtocolVersionUtilTest {
                 BrokerProtocolVersionUtil.canSendPKeyAuthHeaderToTheTokenEndpoint(null)
         );
     }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedEqualToRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("14.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedLargerThanRequired(){
+        Assert.assertTrue(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("15.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedSmallerThanRequired(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker("13.0")
+        );
+    }
+
+    @Test
+    public void testcanSupportMsaAccountsInBroker_NegotiatedNull(){
+        Assert.assertFalse(
+                BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker(null)
+        );
+    }
+
 }


### PR DESCRIPTION
We recently modified maximum protocol versions in broker where default max would be 13 (updated from 12), and max with MSA support would be 14 (update from 13) and we will be used with PRTv3 release.

It was not updated at one more place where we check if negotiated protocol version supports MSA accounts (BrokerProtocolVersionUtil.canSupportMsaAccountsInBroker). Due to this being 13, broker is acquiring token for MSA and storing MSA account (an entry can be seen in AccountManager). Subsequently, acquire token silent calls also run through broker. This is change of behavour and unintentional. We only want to support MSA accounts after PRTv3 is enabled.

Updating the min negotiated broker version for that supports MSA to 14.0. Added UTs for the method in BrokerProtocolVersionUtilTest.

June release PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2061 