### PR TITLE
perform sighash validation when the value is read from cache

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -57,13 +57,14 @@ import java.util.concurrent.TimeUnit
  * @param ipcStrategy                       An [IIpcStrategy] to aggregate data with.
  * @param cache                             A local cache for storing active broker discovery results.
  * @param isPackageInstalled                a function to determine if any given broker app is installed.
- * @param lock                              a lock for preventing race condition of the operations in this class.
+ * @param isValidBroker                     a function to determine if the installed broker app contains a matching signature hash.
  **/
 class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                             private val getActiveBrokerFromAccountManager: () -> BrokerData?,
                             private val ipcStrategy: IIpcStrategy,
                             private val cache: IClientActiveBrokerCache,
-                            private val isPackageInstalled: (BrokerData) -> Boolean) : IBrokerDiscoveryClient {
+                            private val isPackageInstalled: (BrokerData) -> Boolean,
+                            private val isValidBroker: (BrokerData) -> Boolean) : IBrokerDiscoveryClient {
 
     companion object {
         val TAG = BrokerDiscoveryClient::class.simpleName
@@ -174,6 +175,16 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         isPackageInstalled = { brokerData ->
             PackageHelper(context).
                 isPackageInstalledAndEnabled(brokerData.packageName)
+        },
+        isValidBroker = { brokerData ->
+            val methodTag = "$TAG:isValidBroker"
+            val installedHash = PackageHelper(context).getSha512SignatureForPackage(brokerData.packageName)
+            val isHashMatch = installedHash == brokerData.signatureHash
+            if (!isHashMatch) {
+                Logger.warn(methodTag, "Hash does not match for app ${brokerData.packageName}. " +
+                        "Expected: ${brokerData.signatureHash} but get: $installedHash")
+            }
+            isHashMatch
         })
 
     override fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
@@ -184,23 +195,32 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
 
     private suspend fun getActiveBrokerAsync(shouldSkipCache:Boolean): BrokerData?{
         val methodTag = "$TAG:getActiveBrokerAsync"
-
         classLevelLock.withLock {
             if (!shouldSkipCache) {
                 if (cache.shouldUseAccountManager()) {
                     return getActiveBrokerFromAccountManager()
                 }
                 cache.getCachedActiveBroker()?.let {
-                    if (isPackageInstalled(it)) {
-                        Logger.info(methodTag, "Returning cached broker: $it")
-                        return it
-                    } else {
+                    if (!isPackageInstalled(it)) {
                         Logger.info(
                             methodTag,
                             "There is a cached broker: $it, but the app is no longer installed."
                         )
                         cache.clearCachedActiveBroker()
+                        return@let
                     }
+
+                    if (!isValidBroker(it)) {
+                        Logger.info(
+                            methodTag,
+                            "Clearing cache as the installed app does not have a matching signature hash."
+                        )
+                        cache.clearCachedActiveBroker()
+                        return@let
+                    }
+
+                    Logger.info(methodTag, "Returning cached broker: $it")
+                    return it
                 }
             }
 
@@ -235,4 +255,5 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
             return accountManagerResult
         }
     }
+
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -296,6 +296,38 @@ class BrokerDiscoveryClientTests {
         Assert.assertNull(client.getActiveBroker())
         Assert.assertNull(cache.getCachedActiveBroker())
     }
+
+    /**
+     * There is no a cached active broker, but the installed app is a malicious app (signed by unknown key)
+     **/
+    @Test
+    fun test_ReplacedByMaliciousApp() {
+        val cache = InMemoryActiveBrokerCache()
+
+        val client = BrokerDiscoveryClient(
+            brokerCandidates = setOf(
+                prodMicrosoftAuthenticator, prodCompanyPortal
+            ),
+            getActiveBrokerFromAccountManager = {
+                return@BrokerDiscoveryClient null
+            },
+            ipcStrategy = object : IIpcStrategy {
+                override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle {
+                    throw IllegalStateException()
+                }
+                override fun getType(): IIpcStrategy.Type {
+                    return IIpcStrategy.Type.CONTENT_PROVIDER
+                }
+            },
+            cache = InMemoryActiveBrokerCache(),
+            isPackageInstalled =  { it == prodMicrosoftAuthenticator },
+            isValidBroker = { false }
+        )
+
+        Assert.assertNull(client.getActiveBroker())
+        Assert.assertNull(cache.getCachedActiveBroker())
+    }
+
     /**
      * There is already a cached active broker, but the installed app is a malicious app (signed by unknown key)
      **/

--- a/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientTests.kt
@@ -84,7 +84,8 @@ class BrokerDiscoveryClientTests {
             cache = InMemoryActiveBrokerCache(),
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertEquals(prodMicrosoftAuthenticator, client.getActiveBroker())
@@ -119,7 +120,8 @@ class BrokerDiscoveryClientTests {
             cache = InMemoryActiveBrokerCache(),
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertEquals(prodCompanyPortal, client.getActiveBroker())
@@ -150,7 +152,8 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
         Assert.assertEquals(prodCompanyPortal, client.getActiveBroker())
         Assert.assertTrue(cache.shouldUseAccountManager())
@@ -187,7 +190,8 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertEquals(prodMicrosoftAuthenticator, client.getActiveBroker())
@@ -219,7 +223,8 @@ class BrokerDiscoveryClientTests {
             cache = InMemoryActiveBrokerCache(),
             isPackageInstalled =  {
                 return@BrokerDiscoveryClient false
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertNull(client.getActiveBroker())
@@ -251,7 +256,8 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertEquals(prodMicrosoftAuthenticator, client.getActiveBroker())
@@ -283,7 +289,39 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 return@BrokerDiscoveryClient false
-            }
+            },
+            isValidBroker = { true }
+        )
+
+        Assert.assertNull(client.getActiveBroker())
+        Assert.assertNull(cache.getCachedActiveBroker())
+    }
+    /**
+     * There is already a cached active broker, but the installed app is a malicious app (signed by unknown key)
+     **/
+    @Test
+    fun testCache_ReplacedByMaliciousApp() {
+        val cache = InMemoryActiveBrokerCache()
+        cache.setCachedActiveBroker(prodMicrosoftAuthenticator)
+
+        val client = BrokerDiscoveryClient(
+            brokerCandidates = setOf(
+                prodMicrosoftAuthenticator, prodCompanyPortal
+            ),
+            getActiveBrokerFromAccountManager = {
+                return@BrokerDiscoveryClient null
+            },
+            ipcStrategy = object : IIpcStrategy {
+                override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle {
+                    throw IllegalStateException()
+                }
+                override fun getType(): IIpcStrategy.Type {
+                    return IIpcStrategy.Type.CONTENT_PROVIDER
+                }
+            },
+            cache = cache,
+            isPackageInstalled =  { it == prodMicrosoftAuthenticator },
+            isValidBroker = { false }
         )
 
         Assert.assertNull(client.getActiveBroker())
@@ -332,7 +370,8 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
 
         Assert.assertEquals(prodCompanyPortal, client.getActiveBroker(shouldSkipCache = true))
@@ -468,7 +507,8 @@ class BrokerDiscoveryClientTests {
             cache = cache,
             isPackageInstalled =  {
                 it == prodMicrosoftAuthenticator || it == prodCompanyPortal
-            }
+            },
+            isValidBroker = { true }
         )
     }
 }


### PR DESCRIPTION
If the active broker is read from cache - we want to double check if the installed package name still has a valid signature hash before making a request.
