### PR TITLE
Move ATS span start/end to MicrosoftAuthServiceOperation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ V.NEXT
 - [MINOR] Replacing SHA-1 used in broker validation with SHA-512 (#2019)
 - [MINOR] Removing thumbprint check from PKeyAuth challenge (#2045)
 - [MINOR] Add android 14 check for skipping strong box isolation in pop token (#2053)
+- [MINOR] Move ATS span start/end to MicrosoftAuthServiceOperation (#2068)
 
 V.12.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -72,9 +72,8 @@ public class SilentTokenCommand extends TokenCommand {
         AcquireTokenResult result = null;
         final String methodName = ":execute";
 
-        final Span span = OTelUtility.createSpanFromParent(
-                SpanName.AcquireTokenSilent.name(), getParameters().getSpanContext()
-        );
+        final Span span = SpanExtension.current();
+
         span.setAttribute(AttributeName.application_name.name(), getParameters().getApplicationName());
         span.setAttribute(AttributeName.public_api_id.name(), getPublicApiId());
 
@@ -145,8 +144,6 @@ public class SilentTokenCommand extends TokenCommand {
             span.setStatus(StatusCode.ERROR);
             span.recordException(throwable);
             throw throwable;
-        } finally {
-            span.end();
         }
     }
 


### PR DESCRIPTION
Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2329 

(See description in Broker PR for details. TLDR is that since we moved span start/end to `MicrosoftAuthServiceOperation` therefore we remove that code from the token command).