### PR TITLE
Forward request headers on redirects

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)
 - [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)
 - [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -239,6 +239,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             public void run() {
                 Logger.info(methodTag, "Launching embedded WebView for acquiring auth code.");
                 Logger.infoPII(methodTag, "The start url is " + mAuthorizationRequestUrl);
+
+                mAADWebViewClient.setRequestHeaders(mRequestHeaders);
                 mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
 
                 // The first page load could take time, and we do not want to just show a blank page.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -258,7 +258,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Old Chromium versions <88 did this behavior by default, but it was removed in more recent versions.
         // For now, reproduce this only for MSA, and consider adding more trusted ESTS endpoints in the future.
         final boolean urlIsTrustedToReceiveHeaders =  url.startsWith("https://login.live.com/");
-        boolean originalRequestHasHeaders = mRequestHeaders != null && !mRequestHeaders.isEmpty();
+        final boolean originalRequestHasHeaders = mRequestHeaders != null && !mRequestHeaders.isEmpty();
         return urlIsTrustedToReceiveHeaders && originalRequestHasHeaders;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -257,7 +257,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // investigations.
         // Old Chromium versions <88 did this behavior by default, but it was removed in more recent versions.
         // For now, reproduce this only for MSA, and consider adding more trusted ESTS endpoints in the future.
-        boolean urlIsTrustedToReceiveHeaders =  url.startsWith("https://login.live.com/");
+        final boolean urlIsTrustedToReceiveHeaders =  url.startsWith("https://login.live.com/");
         boolean originalRequestHasHeaders = mRequestHeaders != null && !mRequestHeaders.isEmpty();
         return urlIsTrustedToReceiveHeaders && originalRequestHasHeaders;
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -56,6 +56,7 @@ import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URISyntaxException;
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -83,6 +84,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private final String mRedirectUrl;
     private final CertBasedAuthFactory mCertBasedAuthFactory;
     private AbstractCertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
+
+    private HashMap<String, String> mRequestHeaders;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -125,6 +128,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public boolean shouldOverrideUrlLoading(final WebView view, final WebResourceRequest request) {
         final Uri requestUrl = request.getUrl();
         return handleUrl(view, requestUrl.toString());
+    }
+
+    public void setRequestHeaders(final HashMap<String, String> requestHeaders) {
+        mRequestHeaders = requestHeaders;
     }
 
     /**
@@ -179,9 +186,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (!isUriSSLProtected(formattedURL)) {
                 Logger.info(methodTag,"Check for SSL protection");
                 processSSLProtectionCheck(view, url);
+            } else if (isHeaderForwardingRequiredUri(url)) {
+                processHeaderForwardingRequiredUri(view, url);
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
+
                 return false;
             }
         } catch (final ClientException exception) {
@@ -239,6 +249,17 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isWebCpUrl(@NonNull final String url) {
         return url.startsWith(AuthenticationConstants.Broker.BROWSER_EXT_WEB_CP);
+    }
+
+    private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
+        // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
+        // This drops all the headers, which can have credentials useful for SSO and correlationIds useful for
+        // investigations.
+        // Old Chromium versions <88 did this behavior by default, but it was removed in more recent versions.
+        // For now, reproduce this only for MSA, and consider adding more trusted ESTS endpoints in the future.
+        boolean urlIsTrustedToReceiveHeaders =  url.startsWith("https://login.live.com/");
+        boolean originalRequestHasHeaders = mRequestHeaders != null && !mRequestHeaders.isEmpty();
+        return urlIsTrustedToReceiveHeaders && originalRequestHasHeaders;
     }
 
     // This function is only called when the client received a redirect that starts with the apps
@@ -432,6 +453,15 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
         Logger.infoPII(methodTag,"We are declining to override loading and redirect to invalid URL: '"
                 + removeQueryParametersOrRedact(url) + "' the user's url pattern is '" + mRedirectUrl + "'");
+    }
+
+    private void processHeaderForwardingRequiredUri(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processHeaderForwardingRequiredUri";
+
+        Logger.infoPII(methodTag,"We are loading this new URL: '"
+                + removeQueryParametersOrRedact(url) + "' with original requestHeaders appended.");
+
+        view.loadUrl(url, mRequestHeaders);
     }
 
     private String removeQueryParametersOrRedact(@NonNull final String url) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -45,6 +45,8 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+
 
 @RunWith(RobolectricTestRunner.class)
 public class AzureActiveDirectoryWebViewClientTest {
@@ -74,6 +76,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_PKEY_AUTH_URL = "urn:http-auth:PKeyAuth/xyz";
     private static final String TEST_WEB_CP_URL = "companyportal://abc/123";
     private static final String TEST_INVALID_URL = "https://play.google.com/store/apps/details?id=com.azure.authenticator";
+    private static final String TEST_MSA_HEADER_FORWARDING_POSITIVE_URL = "https://login.live.com/oauth20_authorize.srf";
+    private static final String TEST_MSA_HEADER_FORWARDING_NEGATIVE_URL = "https://login.blah.com/oauth20_authorize.srf";
 
     @Before
     public void setup() {
@@ -100,6 +104,9 @@ public class AzureActiveDirectoryWebViewClientTest {
                     }
                 },
                 TEST_REDIRECT_URI);
+        HashMap<String, String> dummyHeaders = new HashMap<>();
+        dummyHeaders.put("key", "value");
+        mWebViewClient.setRequestHeaders(dummyHeaders);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -169,6 +176,12 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testUrlOverrideHandlesInvalidUrl() {
         assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INVALID_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesHeaderForwardingRequiredUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_MSA_HEADER_FORWARDING_POSITIVE_URL));
+        assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_MSA_HEADER_FORWARDING_NEGATIVE_URL));
     }
 
 


### PR DESCRIPTION
What
Catch request headers in the original loadUrl request, and forward them to handleUrl so request headers are not dropped.

Why
On API31+ devices, OneAuth's MSA interactive SSO tests started failing consistently. Upon further investigation, this is because on API31+ (loaded with WebView 88+), Webview shipped a security fix that prevents request headers from being forwarded if the domain doesn't match the original URL. OneAuth-MSAL appends the refresh token in the request header, but in Fiddler traces, this is dropped when browser redirects from login.microsoftonline.com to login.live.com. This results in other telemetry information like correlation ID being dropped.

Reference: https://infosecwriteups.com/leakage-of-sensitive-data-through-android-webviews-3b0b86486a28

How
Capture request header in original loadURL request, and then in handleUrl, override the current request and append original request headers there.

Testing
Confirmed OneAuth's MSA interactive SSO tests are working again with this fix.