### PR TITLE
Add method to return list of broker that supports account manager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)
 - [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -236,6 +236,7 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                     "Will skip broker discovery via IPC and fall back to AccountManager " +
                             "for the next 60 minutes."
                 )
+                cache.clearCachedActiveBroker()
                 cache.setShouldUseAccountManagerForTheNextMilliseconds(
                     TimeUnit.MINUTES.toMillis(
                         60

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -106,6 +106,15 @@ data class BrokerData(val packageName : String,
             }
         }
 
+        /**
+         * Returns true if the owner of the [Context] is a broker app
+         * which relies on AccountManager as a broker discovery mechanism.
+         * */
+        @JvmStatic
+        fun isAccountManagerSupported(context: Context): Boolean {
+            return accountManagerBrokers.contains(context.packageName)
+        }
+
         @JvmStatic
         val debugMicrosoftAuthenticator = BrokerData(
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME,
@@ -159,6 +168,18 @@ data class BrokerData(val packageName : String,
             AuthenticationConstants.Broker.LTW_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.LTW_APP_SHA512_DEBUG_SIGNATURE
         )
+
+        @JvmStatic
+        val accountManagerBrokers: Set<String> =
+            Collections.unmodifiableSet(object : HashSet<String>() {
+                init {
+                    add(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
+                    add(AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME)
+                    add(AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME)
+                    add(AuthenticationConstants.Broker.MOCK_AUTH_APP_PACKAGE_NAME)
+                    add(AuthenticationConstants.Broker.MOCK_CP_PACKAGE_NAME)
+                }
+            })
 
         @JvmStatic
         val debugBrokers: Set<BrokerData> =

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -67,54 +67,6 @@ data class BrokerData(val packageName : String,
          */
         val sShouldTrustDebugBrokers = BuildConfig.DEBUG
 
-        /**
-         * Returns the list of known broker apps (which SDK should make requests to).
-         * see [sShouldTrustDebugBrokers] for more info regarding testing.
-         **/
-        fun getKnownBrokerApps() : Set<BrokerData> {
-            return if (sShouldTrustDebugBrokers) allBrokers else prodBrokers
-        }
-
-        /**
-         * Validate that the installed counterpart of the given [BrokerData] is signed by known keys.
-         * @return true if the validation succeeds. False otherwise.
-         **/
-        fun isSignedByKnownKeys(brokerData: BrokerData, context: Context): Boolean {
-            val methodTag = "$TAG:isSignedByKnownKeys"
-            return try {
-                // Read all the certificates associated with the package name. In higher version of
-                // android sdk, package manager will only returned the cert that is used to sign the
-                // APK. Even a cert is claimed to be issued by another certificates, sdk will return
-                // the signing cert. However, for the lower version of android, it will return all the
-                // certs in the chain. We need to verify that the cert chain is correctly chained up.
-                val certs: List<X509Certificate> =
-                    PackageUtils.readCertDataForApp(brokerData.packageName, context)
-
-                // Verify the cert list contains the cert we trust.
-                PackageUtils.verifySignatureHash(certs, setOf(brokerData.signatureHash).iterator())
-
-                // Perform the certificate chain validation. If there is only one cert returned,
-                // no need to perform certificate chain validation.
-                if (certs.size > 1) {
-                    PackageUtils.verifyCertificateChain(certs)
-                }
-
-                true
-            } catch (t: Throwable) {
-                Logger.error(methodTag, "Failed to validate broker app $this", t)
-                return false
-            }
-        }
-
-        /**
-         * Returns true if the owner of the [Context] is a broker app
-         * which relies on AccountManager as a broker discovery mechanism.
-         * */
-        @JvmStatic
-        fun isAccountManagerSupported(context: Context): Boolean {
-            return accountManagerBrokers.contains(context.packageName)
-        }
-
         @JvmStatic
         val debugMicrosoftAuthenticator = BrokerData(
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME,
@@ -211,5 +163,53 @@ data class BrokerData(val packageName : String,
                     addAll(prodBrokers)
                 }
             })
+
+        /**
+         * Returns the list of known broker apps (which SDK should make requests to).
+         * see [sShouldTrustDebugBrokers] for more info regarding testing.
+         **/
+        fun getKnownBrokerApps() : Set<BrokerData> {
+            return if (sShouldTrustDebugBrokers) allBrokers else prodBrokers
+        }
+
+        /**
+         * Validate that the installed counterpart of the given [BrokerData] is signed by known keys.
+         * @return true if the validation succeeds. False otherwise.
+         **/
+        fun isSignedByKnownKeys(brokerData: BrokerData, context: Context): Boolean {
+            val methodTag = "$TAG:isSignedByKnownKeys"
+            return try {
+                // Read all the certificates associated with the package name. In higher version of
+                // android sdk, package manager will only returned the cert that is used to sign the
+                // APK. Even a cert is claimed to be issued by another certificates, sdk will return
+                // the signing cert. However, for the lower version of android, it will return all the
+                // certs in the chain. We need to verify that the cert chain is correctly chained up.
+                val certs: List<X509Certificate> =
+                    PackageUtils.readCertDataForApp(brokerData.packageName, context)
+
+                // Verify the cert list contains the cert we trust.
+                PackageUtils.verifySignatureHash(certs, setOf(brokerData.signatureHash).iterator())
+
+                // Perform the certificate chain validation. If there is only one cert returned,
+                // no need to perform certificate chain validation.
+                if (certs.size > 1) {
+                    PackageUtils.verifyCertificateChain(certs)
+                }
+
+                true
+            } catch (t: Throwable) {
+                Logger.error(methodTag, "Failed to validate broker app $this", t)
+                return false
+            }
+        }
+
+        /**
+         * Returns true if the owner of the [Context] is a broker app
+         * which relies on AccountManager as a broker discovery mechanism.
+         * */
+        @JvmStatic
+        fun isAccountManagerSupported(packageName: String): Boolean {
+            return accountManagerBrokers.contains(packageName)
+        }
     }
 }


### PR DESCRIPTION
Related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2339