### PR TITLE
also clear cached timestamp in ClientActiveClientBrokerCache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] also clear cached timestamp in ActiveClientBrokerCache (#2075)
 - [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)
 - [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCache.kt
@@ -118,10 +118,14 @@ open class ActiveBrokerCache
     override fun clearCachedActiveBroker() {
         return runBlocking {
             lock.withLock {
-                storage.remove(ACTIVE_BROKER_CACHE_PACKAGE_NAME_KEY)
-                storage.remove(ACTIVE_BROKER_CACHE_SIGHASH_KEY)
-                inMemoryCachedValue = null
+                clearCachedActiveBrokerWithoutLock()
             }
         }
+    }
+
+    protected fun clearCachedActiveBrokerWithoutLock(){
+        storage.remove(ACTIVE_BROKER_CACHE_PACKAGE_NAME_KEY)
+        storage.remove(ACTIVE_BROKER_CACHE_SIGHASH_KEY)
+        inMemoryCachedValue = null
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -114,4 +114,14 @@ internal constructor(private val storage: INameValueStorage<String>,
             }
         }
     }
+
+    override fun clearCachedActiveBroker() {
+        return runBlocking {
+            lock.withLock {
+                clearCachedActiveBrokerWithoutLock()
+                storage.remove(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY)
+                cachedTimeStamp = null
+            }
+        }
+    }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
@@ -310,6 +310,27 @@ class ActiveBrokerCacheTest {
         Assert.assertNull(cache.cachedTimeStamp)
     }
 
+    @Test
+    fun testSetSkipToAccountManager_ClearValue(){
+        val cache = ClientActiveBrokerCache(InMemoryStorage(), Mutex())
+        Assert.assertNull(cache.getCachedActiveBroker())
+
+        Assert.assertFalse(cache.shouldUseAccountManager())
+        Assert.assertNull(cache.cachedTimeStamp)
+
+        cache.setShouldUseAccountManagerForTheNextMilliseconds(
+            TimeUnit.SECONDS.toMillis(2)
+        )
+        Assert.assertTrue(cache.shouldUseAccountManager())
+        Assert.assertNotNull(cache.cachedTimeStamp)
+
+        cache.clearCachedActiveBroker()
+
+        Assert.assertFalse(cache.shouldUseAccountManager())
+        Assert.assertNull(cache.cachedTimeStamp)
+    }
+
+
     private fun getStorageSupplier() : IStorageSupplier {
         return InMemoryStorageSupplier()
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheTest.kt
@@ -329,8 +329,7 @@ class ActiveBrokerCacheTest {
         Assert.assertFalse(cache.shouldUseAccountManager())
         Assert.assertNull(cache.cachedTimeStamp)
     }
-
-
+    
     private fun getStorageSupplier() : IStorageSupplier {
         return InMemoryStorageSupplier()
     }


### PR DESCRIPTION
As the name implies..

ClientActiveClientBrokerCache is a subclass of ActiveClientBrokerCache