### PR TITLE
Avoid NPE when Content-Type header is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Fix NPE when Content-Type header is missing in HTTP response (#2079)
 - [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)
 - [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -369,7 +369,7 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
             if (response.getHeaders() != null && response.getHeaders().size() > 0) {
                 span.setAttribute(
                         AttributeName.response_content_type.name(),
-                        response.getHeaders().get(CONTENT_TYPE).get(0)
+                        response.getHeaderValue(CONTENT_TYPE, 0)
                 );
 
                 span.setAttribute(


### PR DESCRIPTION
Ingesting 13.0.1, I hit NPEs in MSAL.CPP tests. We have a PoP test that involves some test endpoint, and that endpoint is not setting a Content-Type header. It looks like there is new telemetry code in 13.X that isn't accounting for that header being missing in the way it does others, and is generating an NPE.