### PR TITLE
Update RemoveFirstPartyAppsTestRule.java 

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
@@ -52,7 +52,8 @@ public class RemoveFirstPartyAppsTestRule implements TestRule {
                 new TeamsApp().uninstall();
                 new WordApp().uninstall();
                 new BrowserEdge().uninstall();
-//                 new MsalTestApp().uninstall();
+                // Commenting this until new msalAutomationApp name is added               
+                // new MsalTestApp().uninstall();
 
                 base.evaluate();
             }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
@@ -52,7 +52,7 @@ public class RemoveFirstPartyAppsTestRule implements TestRule {
                 new TeamsApp().uninstall();
                 new WordApp().uninstall();
                 new BrowserEdge().uninstall();
-                new MsalTestApp().uninstall();
+//                 new MsalTestApp().uninstall();
 
                 base.evaluate();
             }


### PR DESCRIPTION
Issue : This PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2056/files introduced an uninstall for MsalTestApp. But the pkgName for this is same as the pkgName for msalAutomationAPp. So, this may break the existing tests. 

Fix : Commenting out the MsalTestAPp uninstall statement until the pkg name is changed.