### PR TITLE
PBI 2516686: Add support to update OneAuthTestApp and MsalTestApp

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -105,6 +105,7 @@ public abstract class App implements IApp {
         this.updateAppInstaller = updateAppInstaller;
     }
 
+    // Use installOldApk method where available for installing old apk.
     @Override
     public void install() {
         // TODO: make it build time configurable to specify the installer that should be used.

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/App.java
@@ -105,9 +105,9 @@ public abstract class App implements IApp {
         this.updateAppInstaller = updateAppInstaller;
     }
 
-    // Use installOldApk method where available for installing old apk.
     @Override
     public void install() {
+        // Use installOldApk method where available for installing old apk.
         // TODO: make it build time configurable to specify the installer that should be used.
         // Ideally we can specify different installers on app basis
         if (appInstaller instanceof LocalApkInstaller && !TextUtils.isEmpty(localApkFileName)) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/MsalTestApp.java
@@ -50,16 +50,17 @@ public class MsalTestApp extends App {
     public MsalTestApp() {
         super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
         localApkFileName = MSAL_TEST_APP_APK;
+        localUpdateApkFileName = MSAL_TEST_APP_APK;
     }
 
-    public MsalTestApp(final boolean installOldApk) {
-        super(MSAL_TEST_APP_PACKAGE_NAME, MSAL_TEST_APP_NAME, new LocalApkInstaller());
-        if (installOldApk) {
-            localApkFileName = OLD_MSAL_TEST_APP_APK;
-        } else {
-            localApkFileName = MSAL_TEST_APP_APK;
-        }
-        localUpdateApkFileName = MSAL_TEST_APP_APK;
+    /**
+     * Use this install method,
+     * While testing for update scenario, or need to install only old Apk.
+     * Otherwise use regular install method for installing latest apk.
+     */
+    public void installOldApk() {
+        localApkFileName = OLD_MSAL_TEST_APP_APK;
+        install();
     }
 
     // click on button acquire token interactive

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneAuthTestApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneAuthTestApp.java
@@ -56,14 +56,22 @@ public class OneAuthTestApp extends App implements IFirstPartyApp {
     public final static String ONEAUTH_TESTAPP_PACKAGE_NAME = "com.microsoft.oneauth.testapp";
     public final static String ONEAUTH_TESTAPP_NAME = "OneAuth Testapp";
     public final static String ONEAUTH_TESTAPP_APK = "OneAuth.apk";
+    public final static String OLD_ONEAUTH_TESTAPP_APK = "OldOneAuth.apk";
 
     public OneAuthTestApp() {
         super(ONEAUTH_TESTAPP_PACKAGE_NAME, ONEAUTH_TESTAPP_NAME, new LocalApkInstaller());
+        localApkFileName = ONEAUTH_TESTAPP_APK;
+        localUpdateApkFileName = ONEAUTH_TESTAPP_APK;
     }
 
-    public OneAuthTestApp(@NonNull final IAppInstaller appInstaller) {
-        super(ONEAUTH_TESTAPP_PACKAGE_NAME, ONEAUTH_TESTAPP_NAME, appInstaller);
-        localApkFileName = ONEAUTH_TESTAPP_APK;
+    /**
+     * Use this install method,
+     * While testing for update scenario, or need to install only old Apk.
+     * Otherwise use regular install method for installing latest apk.
+     */
+    public void installOldApk() {
+        localApkFileName = OLD_ONEAUTH_TESTAPP_APK;
+        install();
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
@@ -70,6 +70,7 @@ public class CopyFileRule implements TestRule {
             BrokerLTW.BROKER_LTW_APK,
             BrokerLTW.OLD_BROKER_LTW_APK,
             OneAuthTestApp.ONEAUTH_TESTAPP_APK,
+            OneAuthTestApp.OLD_ONEAUTH_TESTAPP_APK,
             MsalTestApp.MSAL_TEST_APP_APK,
             MsalTestApp.OLD_MSAL_TEST_APP_APK
     };

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
@@ -70,7 +70,7 @@ public class CopyFileRule implements TestRule {
             BrokerLTW.BROKER_LTW_APK,
             BrokerLTW.OLD_BROKER_LTW_APK,
             OneAuthTestApp.ONEAUTH_TESTAPP_APK,
-            OneAuthTestApp.OLD_ONEAUTH_TESTAPP_APK,
+            // OneAuthTestApp.OLD_ONEAUTH_TESTAPP_APK,
             MsalTestApp.MSAL_TEST_APP_APK,
             MsalTestApp.OLD_MSAL_TEST_APP_APK
     };


### PR DESCRIPTION
PBI 2516686: Add support to update OneAuthTestApp and MsalTestApp

This PR adds support to update OneAuthTestApp and MsalTestApp. It exposes a method named installOldApk() which enforces to install old apk into the infrastructure.