### PR TITLE
Use System.Accesstoken for vsts-publish task

### DIFF
--- a/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
+++ b/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAndroidAccessTokenVar }}]$(mvnAccessToken)'
+      arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAndroidAccessTokenVar }}]$(System.AccessToken)'
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble Release


### PR DESCRIPTION
Using [system.accesstoken](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#systemaccesstoken) for the vsts-publish task. This will remove the dependency on the updating the PAT when it expires.