### PR TITLE
Eliminate logging noise

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java
@@ -164,7 +164,7 @@ public class PackageHelper {
                 enabled = applicationInfo.enabled;
             }
         } catch (NameNotFoundException e) {
-            Logger.error(methodTag, "Package is not found. Package name: " + packageName, e);
+            Logger.warn(methodTag, "Package is not found. Package name: " + packageName);
         }
 
         Logger.info(methodTag, " Is package installed and enabled? [" + enabled + "]");

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -44,7 +44,7 @@ import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Typ
 
 
 public class BrokerOperationBundle {
-    private static final String TAG = BrokerOperationBundle.class.getName();
+    private static final String TAG = BrokerOperationBundle.class.getSimpleName();
 
     @Getter
     @Accessors(prefix = "m")

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
@@ -50,7 +50,7 @@ import java.util.List;
  */
 public class ContentProviderStrategy extends AbstractIpcStrategyWithServiceValidation {
 
-    private static final String TAG = ContentProviderStrategy.class.getName();
+    private static final String TAG = ContentProviderStrategy.class.getSimpleName();
     private final Context mContext;
 
     public ContentProviderStrategy(final Context context) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenMigrationUtility.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/migration/TokenMigrationUtility.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Executors;
 
 public class TokenMigrationUtility<T extends BaseAccount, U extends RefreshToken> {
 
-    private static final String TAG = TokenMigrationUtility.class.getName();
+    private static final String TAG = TokenMigrationUtility.class.getSimpleName();
 
     /**
      * ExecutorService to handle background computation.

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -83,7 +83,7 @@ import java.util.List;
 
 public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
 
-    private static final String TAG = MsalBrokerRequestAdapter.class.getName();
+    private static final String TAG = MsalBrokerRequestAdapter.class.getSimpleName();
 
     @Override
     public BrokerRequest brokerRequestFromAcquireTokenParameters(@NonNull final InteractiveTokenCommandParameters parameters) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/AdalBrokerResultAdapter.java
@@ -55,7 +55,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 
 public class AdalBrokerResultAdapter implements IBrokerResultAdapter {
 
-    private static final String TAG = AdalBrokerResultAdapter.class.getName();
+    private static final String TAG = AdalBrokerResultAdapter.class.getSimpleName();
 
     @Override
     public @NonNull Bundle bundleFromAuthenticationResult(@NonNull final ILocalAuthenticationResult authenticationResult,

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryContext.java
@@ -44,7 +44,7 @@ import lombok.NonNull;
  */
 public class AndroidTelemetryContext extends AbstractTelemetryContext {
 
-    private static final String TAG = AndroidTelemetryContext.class.getName();
+    private static final String TAG = AndroidTelemetryContext.class.getSimpleName();
 
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "Lombok inserts nullchecks")

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryB2CAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryB2CAuthority.java
@@ -38,7 +38,7 @@ import lombok.NonNull;
 
 public class AzureActiveDirectoryB2CAuthority extends Authority {
 
-    private static final String TAG = AzureActiveDirectoryB2CAuthority.class.getName();
+    private static final String TAG = AzureActiveDirectoryB2CAuthority.class.getSimpleName();
 
     public AzureActiveDirectoryB2CAuthority(String authorityUrl) {
         mAuthorityTypeString = "B2C";

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -67,7 +67,7 @@ public class MsalCppOAuth2TokenCache
         GenericAccount,
         GenericRefreshToken> {
 
-    private static final String TAG = MsalCppOAuth2TokenCache.class.getName();
+    private static final String TAG = MsalCppOAuth2TokenCache.class.getSimpleName();
 
     /**
      * Constructor of MsalOAuth2TokenCache.

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -82,7 +82,7 @@ import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.X
 @AllArgsConstructor
 @ThreadSafe
 public class UrlConnectionHttpClient extends AbstractHttpClient {
-    private static final Object TAG = UrlConnectionHttpClient.class.getName();
+    private static final String TAG = UrlConnectionHttpClient.class.getSimpleName();
 
     protected static final int RETRY_TIME_WAITING_PERIOD_MSEC = 1000;
     protected static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
@@ -47,7 +47,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public class IDToken {
 
-    private static final String TAG = IDToken.class.getName();
+    private static final String TAG = IDToken.class.getSimpleName();
 
     /**
      * Subject - Identifier for the End-User at the Issuer.

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -59,7 +59,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
     private String mCorrelationId;
     private final List<Map<String, String>> mTelemetry = new ArrayList<>();
 
-    private static final String TAG = LocalAuthenticationResult.class.getName();
+    private static final String TAG = LocalAuthenticationResult.class.getSimpleName();
 
     public LocalAuthenticationResult(@NonNull final ICacheRecord lastAuthorized,
                                      @NonNull final List<ICacheRecord> completeResultFromCache,


### PR DESCRIPTION
As opposed to logging the full class name.... a simple name is enough.

e.g.

INFO  [**_com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy_**:communicateToBroker] [2023-06-20 17:48:05 - thread_name: DefaultDispatcher-worker-5, correlation_id: UNSET - Android 33] Broker operation name: BROKER_API_HELLO brokerPackage: com.microsoft.mockauthapp

It'll look like this with simple name

INFO  [**_BrokerOperationExecutor_**:BROKER_GET_FLIGHTS] [2023-06-20 17:48:05 - thread_name: DefaultDispatcher-worker-5, correlation_id: UNSET - Android 33] Executing with IIpcStrategy: ContentProviderStrategy

I also made change to not pollute logs with stack trace when a package is not installed (which is quite common...)
