### PR TITLE
Added command line flag to enable broker discovery

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,6 +36,8 @@ if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion !=
     common4jVersion = project.distCommon4jVersion
 }
 
+boolean newBrokerDiscoveryEnabledFlag = project.hasProperty("newBrokerDiscoveryEnabledFlag")
+
 android {
 
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -54,6 +56,7 @@ android {
                 "eu", "fi", "fr", "gl", "he", "hi", "hr", "hu", "in", "it", "iw", "ja",
                 "kk", "ko", "lt", "lv", "ms", "nb", "nl", "pl", "pt-rBR", "pt-rPT", "ro",
                 "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-rCN", "zh-rTW"
+        buildConfigField("boolean", "newBrokerDiscoveryEnabledFlag", "$newBrokerDiscoveryEnabledFlag")
     }
 
     buildTypes {

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 import android.content.Context
+import com.microsoft.identity.common.BuildConfig
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -62,7 +63,7 @@ class BrokerDiscoveryClientFactory {
          **/
         @JvmStatic
         fun isNewBrokerDiscoveryEnabled(): Boolean {
-            return IS_NEW_DISCOVERY_ENABLED;
+            return BuildConfig.newBrokerDiscoveryEnabledFlag || IS_NEW_DISCOVERY_ENABLED;
         }
 
         /**
@@ -75,7 +76,7 @@ class BrokerDiscoveryClientFactory {
                 runBlocking {
                     lock.withLock {
                         if (instance == null) {
-                            instance = if (IS_NEW_DISCOVERY_ENABLED) {
+                            instance = if (isNewBrokerDiscoveryEnabled()) {
                                 BrokerDiscoveryClient(context, platformComponents)
                             } else {
                                 LegacyBrokerDiscoveryClient(context)


### PR DESCRIPTION
Description : Same as title

Testing : When -PnewBrokerDiscoveryEnabledFlag is added, below picture shows that the "Enable new discovery" switch is ENABLED.

![Screenshot_20230622_094504](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/assets/69237821/6c616113-0194-4602-85f1-7216f9004c65)


When -PnewBrokerDiscoveryEnabledFlag is NOT sent

![Screenshot_20230622_094607](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/assets/69237821/bc0c80fa-ea6a-47a8-b1d0-593a5737c55c)
