### PR TITLE
June Ui Maintenance

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -57,9 +57,8 @@ import lombok.NonNull;
 public class LabClient implements ILabClient {
 
     private final LabApiAuthenticationClient mLabApiAuthenticationClient;
-    private final long PASSWORD_RESET_WAIT_DURATION = TimeUnit.SECONDS.toMillis(90);
-    private final long LAB_API_RETRY_WAIT = TimeUnit.SECONDS.toMillis(5);
-    private final long TEMP_USER_CREATION_WAIT = TimeUnit.SECONDS.toMillis(30);
+    private final long PASSWORD_RESET_WAIT_DURATION = TimeUnit.SECONDS.toMillis(65);
+    private final long LAB_API_RETRY_WAIT = TimeUnit.SECONDS.toMillis(2);
 
     /**
      * Temp users API provided by Lab team can often take more than 10 seconds to return...hence, we
@@ -212,13 +211,6 @@ public class LabClient implements ILabClient {
         }
 
         final String password = getPassword(tempUser);
-
-        // Adding a wait to finish temp user creation
-        try {
-            Thread.sleep(TEMP_USER_CREATION_WAIT);
-        } catch (final InterruptedException e) {
-            e.printStackTrace();
-        }
 
         return new LabAccount.LabAccountBuilder()
                 .username(tempUser.getUpn())

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -22,6 +22,7 @@ android {
         dependencies {
             coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
         }
+        animationsDisabled = true
     }
     //Commenting out until the next major version of common/msal/etc...
     /*
@@ -106,7 +107,7 @@ android {
         buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$appSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
         buildConfigField("boolean", "PRE_INSTALL_LTW", "$preInstallLtw")
-        buildConfigField("boolean", "SEND_POWERLIFT_FAILURES", "$sendPowerLiftLogs")
+        buildConfigField("boolean", "SEND_POWERLIFT_LOGS", "$sendPowerLiftLogs")
 
         // Specifies a sorted list of flavors that the plugin should try to use from
         // a given dimension. The following tells the plugin that, when encountering

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -41,6 +41,7 @@ android {
     boolean usePreInstalledApks = project.hasProperty("preferPreInstalledApks")
 
     boolean preInstallLtw = project.hasProperty("preInstallLtw")
+    boolean sendPowerLiftLogs = project.hasProperty("sendPowerLiftLogs")
 
     def final appSourcePlayStore = "PlayStore"
     def final appSourceLocalApk = "LocalApk"
@@ -105,6 +106,7 @@ android {
         buildConfigField("String", "UPDATE_SOURCE_LOCAL_APK", "\"$appSourceLocalApk\"")
         buildConfigField("boolean", "PREFER_PRE_INSTALLED_APKS", "$usePreInstalledApks")
         buildConfigField("boolean", "PRE_INSTALL_LTW", "$preInstallLtw")
+        buildConfigField("boolean", "SEND_POWERLIFT_FAILURES", "$sendPowerLiftLogs")
 
         // Specifies a sorted list of flavors that the plugin should try to use from
         // a given dimension. The following tells the plugin that, when encountering

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -209,8 +209,6 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
 
         handleFirstRun(); // handle CP first run
 
-        // Company portal password page is somewhat inconsistent, found out turning off battery optimization helps in UI testing
-        turnOffBatteryOptimization();
         signInThroughFrontPage(username, password, isFederated);
 
         // click the activate device admin btn

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
@@ -33,39 +33,30 @@ public class PowerLiftIncidentRule implements TestRule {
                 try {
                     base.evaluate();
                 } catch (final Throwable originalThrowable) {
-                    if (BuildConfig.SEND_POWERLIFT_FAILURES) {
-                        String powerLiftIncidentDetails = null;
-                        try {
-                            Logger.e(
-                                    TAG,
-                                    "Encountered error during test....creating PowerLift incident.",
-                                    originalThrowable
-                            );
-                            powerLiftIncidentDetails = powerLiftIntegratedApp.createPowerLiftIncident();
-                        } catch (final Throwable powerLiftError) {
-                            Logger.e(
-                                    TAG,
-                                    "Oops...something went wrong...unable to create PowerLift incident.",
-                                    powerLiftError
-                            );
-                        }
-                        if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
-                            throw originalThrowable;
-                        } else {
-                            assert powerLiftIncidentDetails != null;
-                            throw new ThrowableWithPowerLiftIncident(
-                                    powerLiftIntegratedApp,
-                                    powerLiftIncidentDetails,
-                                    originalThrowable
-                            );
-                        }
-                    }
-                    else {
-                        Logger.i(
+                    String powerLiftIncidentDetails = null;
+                    try {
+                        Logger.e(
                                 TAG,
-                                "Skipping PowerLift Incident creation."
+                                "Encountered error during test....creating PowerLift incident.",
+                                originalThrowable
                         );
+                        powerLiftIncidentDetails = powerLiftIntegratedApp.createPowerLiftIncident();
+                    } catch (final Throwable powerLiftError) {
+                        Logger.e(
+                                TAG,
+                                "Oops...something went wrong...unable to create PowerLift incident.",
+                                powerLiftError
+                        );
+                    }
+                    if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
                         throw originalThrowable;
+                    } else {
+                        assert powerLiftIncidentDetails != null;
+                        throw new ThrowableWithPowerLiftIncident(
+                                powerLiftIntegratedApp,
+                                powerLiftIncidentDetails,
+                                originalThrowable
+                        );
                     }
                 }
             }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
@@ -2,7 +2,6 @@ package com.microsoft.identity.client.ui.automation.rules;
 
 import android.text.TextUtils;
 
-import com.microsoft.identity.client.ui.automation.BuildConfig;
 import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.powerlift.ThrowableWithPowerLiftIncident;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -26,6 +26,7 @@ import android.util.Log;
 
 import androidx.annotation.Nullable;
 
+import com.microsoft.identity.client.ui.automation.BuildConfig;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
@@ -109,7 +110,7 @@ public class RulesHelper {
             Log.i(TAG, "Adding InstallBrokerTestRule");
             ruleChain = ruleChain.around(new InstallBrokerTestRule(broker));
 
-            if (broker instanceof IPowerLiftIntegratedApp) {
+            if (broker instanceof IPowerLiftIntegratedApp && BuildConfig.SEND_POWERLIFT_LOGS) {
                 Log.i(TAG, "Adding PowerLiftIncidentRule");
                 ruleChain = ruleChain.around(new PowerLiftIncidentRule((IPowerLiftIntegratedApp) broker));
             }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/CommonUtils.java
@@ -48,8 +48,8 @@ import java.util.concurrent.TimeUnit;
 public class CommonUtils {
 
     private final static String TAG = CommonUtils.class.getSimpleName();
-    public final static long FIND_UI_ELEMENT_TIMEOUT = TimeUnit.SECONDS.toMillis(20);
-    public final static long FIND_UI_ELEMENT_TIMEOUT_LONG = TimeUnit.SECONDS.toMillis(40);
+    public final static long FIND_UI_ELEMENT_TIMEOUT = TimeUnit.SECONDS.toMillis(15);
+    public final static long FIND_UI_ELEMENT_TIMEOUT_LONG = TimeUnit.SECONDS.toMillis(30);
 
     private final static String SD_CARD = "/sdcard";
 


### PR DESCRIPTION
Some Ui Maintenance Work

Bypass creating powerlift incidents for failed tests by default and add a build parameter to enable them `-PsendPowerLiftLogs` (I don't find these particularly useful, and last time checked they were visible in powerlift, but this could have changed. Saves a little bit of cost in case of retries/failures.)

I feel that we've had excesive waiting in our UI automation. We originally did this to improve reliability of the test cases, but i've attempted to run it for 2 days with these changes and didn't see much impact on relibaility, so i'm reducing the amount of time we wait for certain things (temp user creation, timeout until UI element is found, Password reset wait, etc.)

Also removed step when we were turning off battery optimization in CP, added extra time cost but didn't seem to give much benefit overall.