### PR TITLE
Nichbop/release/12.0.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,10 @@ V.12.0.2
 ----------
 - [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)
 
+V.12.0.1
+=======
+- [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041/#2042)
+
 V.12.0.0
 ----------
 - [MINOR] make getCurrentActiveBrokerPackageName case insensitive and trims the authenticator type (#2026)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.12.0.3
+----------
+- [PATCH] Read private key before public key to avoid OS bug (#2091)
+
 V.12.0.2
 ----------
 - [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
-V.12.0.1
-=======
-- [PATCH] Revert "Getting rid of account manager strategy in MSAL/OneAuth (#1988)" (#2041/#2042)
+V.12.0.2
+----------
+- [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)
 
 V.12.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -239,6 +239,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             public void run() {
                 Logger.info(methodTag, "Launching embedded WebView for acquiring auth code.");
                 Logger.infoPII(methodTag, "The start url is " + mAuthorizationRequestUrl);
+
+                mAADWebViewClient.setRequestHeaders(mRequestHeaders);
                 mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
 
                 // The first page load could take time, and we do not want to just show a blank page.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -57,6 +57,7 @@ import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URISyntaxException;
 import java.security.Principal;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -84,6 +85,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private final String mRedirectUrl;
     private final CertBasedAuthFactory mCertBasedAuthFactory;
     private AbstractCertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
+
+    private HashMap<String, String> mRequestHeaders;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -126,6 +129,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public boolean shouldOverrideUrlLoading(final WebView view, final WebResourceRequest request) {
         final Uri requestUrl = request.getUrl();
         return handleUrl(view, requestUrl.toString());
+    }
+
+    public void setRequestHeaders(final HashMap<String, String> requestHeaders) {
+        mRequestHeaders = requestHeaders;
     }
 
     /**
@@ -180,9 +187,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (!isUriSSLProtected(formattedURL)) {
                 Logger.info(methodTag,"Check for SSL protection");
                 processSSLProtectionCheck(view, url);
+            } else if (isHeaderForwardingRequiredUri(url)) {
+                processHeaderForwardingRequiredUri(view, url);
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
+
                 return false;
             }
         } catch (final ClientException exception) {
@@ -240,6 +250,17 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isWebCpUrl(@NonNull final String url) {
         return url.startsWith(AuthenticationConstants.Broker.BROWSER_EXT_WEB_CP);
+    }
+
+    private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
+        // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
+        // This drops all the headers, which can have credentials useful for SSO and correlationIds useful for
+        // investigations.
+        // Old Chromium versions <88 did this behavior by default, but it was removed in more recent versions.
+        // For now, reproduce this only for MSA, and consider adding more trusted ESTS endpoints in the future.
+        final boolean urlIsTrustedToReceiveHeaders =  url.startsWith("https://login.live.com/");
+        final boolean originalRequestHasHeaders = mRequestHeaders != null && !mRequestHeaders.isEmpty();
+        return urlIsTrustedToReceiveHeaders && originalRequestHasHeaders;
     }
 
     // This function is only called when the client received a redirect that starts with the apps
@@ -434,6 +455,15 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
         Logger.infoPII(methodTag,"We are declining to override loading and redirect to invalid URL: '"
                 + removeQueryParametersOrRedact(url) + "' the user's url pattern is '" + mRedirectUrl + "'");
+    }
+
+    private void processHeaderForwardingRequiredUri(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processHeaderForwardingRequiredUri";
+
+        Logger.infoPII(methodTag,"We are loading this new URL: '"
+                + removeQueryParametersOrRedact(url) + "' with original requestHeaders appended.");
+
+        view.loadUrl(url, mRequestHeaders);
     }
 
     private String removeQueryParametersOrRedact(@NonNull final String url) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -202,10 +202,25 @@ public class AndroidKeyStoreUtil {
         final String errCode;
         try {
             final KeyStore keyStore = getKeyStore();
-            final Certificate cert = keyStore.getCertificate(keyAlias);
+
+            if (!keyStore.containsAlias(keyAlias)) {
+                Logger.verbose(methodTag, "Alias doesn't exist.");
+                return null;
+            }
+
+            // We intentionally check the private key first, due to crash stacks hit in the wild
+            // when checking for the public certificate when it does not exist.
+            // `KeyStore exception android.os.ServiceSpecificException: (code 7)`
+            // https://stackoverflow.com/questions/52024752/android-9-keystore-exception-android-os-servicespecificexception
             final Key privateKey = keyStore.getKey(keyAlias, null);
-            if (cert == null || privateKey == null) {
-                Logger.verbose(methodTag, "Key entry doesn't exist.");
+            if (privateKey == null) {
+                Logger.verbose(methodTag, "Private key entry doesn't exist.");
+                return null;
+            }
+
+            final Certificate cert = keyStore.getCertificate(keyAlias);
+            if (cert == null) {
+                Logger.verbose(methodTag, "Public key entry doesn't exist.");
                 return null;
             }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -45,6 +45,8 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+
 
 @RunWith(RobolectricTestRunner.class)
 public class AzureActiveDirectoryWebViewClientTest {
@@ -74,6 +76,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_PKEY_AUTH_URL = "urn:http-auth:PKeyAuth/xyz";
     private static final String TEST_WEB_CP_URL = "companyportal://abc/123";
     private static final String TEST_INVALID_URL = "https://play.google.com/store/apps/details?id=com.azure.authenticator";
+    private static final String TEST_MSA_HEADER_FORWARDING_POSITIVE_URL = "https://login.live.com/oauth20_authorize.srf";
+    private static final String TEST_MSA_HEADER_FORWARDING_NEGATIVE_URL = "https://login.blah.com/oauth20_authorize.srf";
 
     @Before
     public void setup() {
@@ -100,6 +104,9 @@ public class AzureActiveDirectoryWebViewClientTest {
                     }
                 },
                 TEST_REDIRECT_URI);
+        HashMap<String, String> dummyHeaders = new HashMap<>();
+        dummyHeaders.put("key", "value");
+        mWebViewClient.setRequestHeaders(dummyHeaders);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -169,6 +176,12 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testUrlOverrideHandlesInvalidUrl() {
         assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INVALID_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesHeaderForwardingRequiredUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_MSA_HEADER_FORWARDING_POSITIVE_URL));
+        assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_MSA_HEADER_FORWARDING_NEGATIVE_URL));
     }
 
 

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=12.0.2
+versionName=12.0.3
 versionCode=1
 latestPatchVersion=234

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=12.0.1
+versionName=12.0.2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
This shows changes for 12.0.2 as well because origin/release/12.0.3 is currently pointed at v12.0.1.

Only the last two commits to change AndroidKeystoreUtil.java and update the version are actually new.