### PR TITLE
Make AndroidWrappedKeyLoader return the right alias

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Make AndroidWrappedKeyLoader return the right alias (#2102)
 - [PATCH] Read private key before public key to avoid OS bug (#2091)
 - [PATCH] Add new CryptoFactoryName and ClientException error code (#2094)
 - [PATCH] also clear cached timestamp in ActiveClientBrokerCache (#2075)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -70,11 +70,6 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     public static boolean sSkipKeyInvalidationCheck = false;
 
     /**
-     * Alias for this type of key.
-     */
-    /* package */ static final String KEYSTORE_KEY_ALIAS = "KEYSTORE_KEY";
-
-    /**
      * Algorithm for key wrapping.
      */
     private static final String WRAP_ALGORITHM = "RSA/ECB/PKCS1Padding";
@@ -140,7 +135,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     @Override
     @NonNull
     public String getAlias() {
-        return KEYSTORE_KEY_ALIAS;
+        return mAlias;
     }
 
     @Override


### PR DESCRIPTION
It seems like getAlias() is being used for logging purpose only, so we should be safe.