### PR TITLE
Adding null checks for CancelHelper (CBA)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [PATCH] Adding null checks for CancelHelper (CBA) (#2105)
 - [PATCH] Make AndroidWrappedKeyLoader return the right alias (#2102)
 - [PATCH] Read private key before public key to avoid OS bug (#2091)
 - [PATCH] Add new CryptoFactoryName and ClientException error code (#2094)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactory.java
@@ -75,8 +75,8 @@ public class CertBasedAuthFactory {
      */
     @VisibleForTesting
     protected CertBasedAuthFactory(@NonNull final Activity activity,
-                                   @NonNull final AbstractUsbSmartcardCertBasedAuthManager usbManager,
-                                   @NonNull final AbstractNfcSmartcardCertBasedAuthManager nfcManager,
+                                   final AbstractUsbSmartcardCertBasedAuthManager usbManager,
+                                   final AbstractNfcSmartcardCertBasedAuthManager nfcManager,
                                    @NonNull final IDialogHolder dialogHolder) {
         mActivity = activity;
         mUsbSmartcardCertBasedAuthManager = usbManager;
@@ -143,8 +143,12 @@ public class CertBasedAuthFactory {
                                 @NonNull final ICertBasedAuthTelemetryHelper telemetryHelper) {
         mDialogHolder.dismissDialog();
         telemetryHelper.setResultFailure(USER_CANCEL_MESSAGE);
-        mNfcSmartcardCertBasedAuthManager.clearConnectionCallback();
-        mUsbSmartcardCertBasedAuthManager.clearConnectionCallback();
+        if (mNfcSmartcardCertBasedAuthManager != null) {
+            mNfcSmartcardCertBasedAuthManager.clearConnectionCallback();
+        }
+        if (mUsbSmartcardCertBasedAuthManager != null) {
+            mUsbSmartcardCertBasedAuthManager.clearConnectionCallback();
+        }
         callback.onReceived(null);
     }
 
@@ -252,9 +256,13 @@ public class CertBasedAuthFactory {
      * Clears all connection and disconnection callbacks for smartcard managers.
      */
     public void clearAllSmartcardConnectionAndDisconnectionCallbacks() {
-        mUsbSmartcardCertBasedAuthManager.clearConnectionCallback();
-        mUsbSmartcardCertBasedAuthManager.clearDisconnectionCallback();
-        mNfcSmartcardCertBasedAuthManager.clearConnectionCallback();
+        if (mUsbSmartcardCertBasedAuthManager != null) {
+            mUsbSmartcardCertBasedAuthManager.clearConnectionCallback();
+            mUsbSmartcardCertBasedAuthManager.clearDisconnectionCallback();
+        }
+        if (mNfcSmartcardCertBasedAuthManager != null) {
+            mNfcSmartcardCertBasedAuthManager.clearConnectionCallback();
+        }
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/CertBasedAuthFactoryTest.java
@@ -101,6 +101,21 @@ public class CertBasedAuthFactoryTest extends AbstractCertBasedAuthTest {
     }
 
     @Test
+    public void testCancelAtPromptDialogNullManagers() {
+        mFactory = new CertBasedAuthFactory(mActivity, null, null, mDialogHolder);
+        challengeHandlerHelper(ExpectedChallengeHandler.NULL);
+        checkIfCorrectDialogIsShowing(TestDialog.user_choice);
+        final UserChoiceDialog.PositiveButtonListener listener = mDialogHolder.getUserChoicePositiveButtonListener();
+        assertNotNull(listener);
+        listener.onClick(1);
+        checkIfCorrectDialogIsShowing(TestDialog.prompt);
+        final ICancelCbaCallback callback = mDialogHolder.getCancelCbaCallback();
+        assertNotNull(callback);
+        callback.onCancel();
+        checkIfCorrectDialogIsShowing(null);
+    }
+
+    @Test
     public void testChooseSmartcardAndProceedWithUsb() {
         challengeHandlerHelper(ExpectedChallengeHandler.USB);
         checkIfCorrectDialogIsShowing(TestDialog.user_choice);


### PR DESCRIPTION
## Summary
The OneAuth team let me know about some crashes associated with CBA. A NPE is coming from `CertBasedAuthFactory.onCancelHelper` on the line `mNfcSmartcardCertBasedAuthManager.clearConnectionCallback();`. The case where `mNfcSmartcardCertBasedAuthManager` would be null is when a device that is incapable of NFC initiates CBA. I missed putting a null check here for the NFC and USB managers, as well in one other method (though that one was protected by a null check before it's called, so it didn't have a chance of causing issues in prod).
This PR adds in those null checks, as well as a unit test focusing on null managers.