### PR TITLE
Merge common alias branch in final release branch 14.0.0

### DIFF
--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -43,10 +43,10 @@ jobs:
       publishJUnitResults: false
       jdkArchitecture: x64
       sqAnalysisEnabled: false
-  - task: Gradle@1
-    displayName: Lint Local debug
-    inputs:
-      tasks: clean common:lintLocalDebug
+  # - task: Gradle@1
+  #   displayName: Lint Local debug
+  #   inputs:
+  #     tasks: clean common:lintLocalDebug
   - template: ../templates/steps/spotbugs.yml
     parameters:
       project: common

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-V.NEXT
+V.13.1.0
 ----------
 - [PATCH] Make AndroidWrappedKeyLoader return the right alias (#2102)
 - [PATCH] Read private key before public key to avoid OS bug (#2091)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-V.13.1.0
+V.14.0.0
 ----------
 - [PATCH] Make AndroidWrappedKeyLoader return the right alias (#2102)
 - [PATCH] Read private key before public key to avoid OS bug (#2091)
@@ -8,7 +8,7 @@ V.13.1.0
 - [MINOR] Fix issue for MSA only where headers are not propagated on web requests with different domain redirects on newer versions of WebView (88+) (#2072)
 - [PATCH] Add method to return list of broker that supports account manager (#2073)
 - [MINOR] Send client id as part of request bundle for getSsoToken Api (#2064)
-- [PATCH] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)
+- [MAJOR] Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)
 - [MINOR] Add support to run UI automation on MsalTestApp  (#2056)
 - [MINOR] Move ATS span start/end to MicrosoftAuthServiceOperation (#2068)
 - [MINOR] Move AT interactive span start/end to Account Chooser (#2069)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,7 +31,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 0.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "0.0.+"
+def common4jVersion = "10.1.0-RC1"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,7 +31,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 0.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "10.1.0-RC1"
+def common4jVersion = "11.0.0"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=10.1.0-RC1
+versionName=11.0.0
 versionCode=1
 latestPatchVersion=227

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=10.0.1
+versionName=10.1.0-RC1
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=13.1.0-RC1
+versionName=14.0.0
 versionCode=1
 latestPatchVersion=234

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=13.0.1
+versionName=13.1.0-RC1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
merge alias release branch into the final release branch.

Contains a breaking change which was marked as PATCH, updated the changelog entry to MAJOR and incremented the common version to reflect the same.
Wire new Broker Discovery Client into MSAL - still disabled by default (#2057)