### PR TITLE
Update YubiKit versions to 2.3.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [MINOR] Update YubiKit version to 2.3.0 (#2112)
 
 V.14.0.0
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -66,8 +66,8 @@ ext {
     tokenShare = "1.6.5"
     intuneAppSdkVersion = "8.6.3"
     javaAssistVersion = "3.27.0-GA"
-    yubikitAndroidVersion = "2.2.0"
-    yubikitPivVersion = "2.2.0"
+    yubikitAndroidVersion = "2.3.0"
+    yubikitPivVersion = "2.3.0"
     powerliftAndroidVersion="1.0.0"
 
     // microsoft-diagnostics-uploader app versions


### PR DESCRIPTION
### Summary
Android 14 brings a change relating to [context-registered receivers regarding a flag that is now required](https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported), and this affected the USB connection experience for smartcard CBA. YubiKit's latest release addresses this change ([2.3.0](https://github.com/Yubico/yubikit-android/releases/tag/2.3.0)).

Tested the smartcard CBA experience with brokerHost and msaltestapp running on an Android 14 device and an Android 13 device. Validated the USB and NFC experience was consistent. 

### Other PRs
- Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2398/files
- MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1854/files
- ADAL: https://github.com/AzureAD/azure-activedirectory-library-for-android/pull/1744/files
- Android Complete: https://github.com/AzureAD/android-complete/pull/235/files