### PR TITLE
Revive and Expand Consumer Pipeline check

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -13,8 +13,6 @@ parameters:
     displayName: Should skip long running test?
     type: boolean
     default: true
-pool:
-  vmImage: 'ubuntu-latest'
 
 variables:
 - name: shouldSkipLongRunningTest
@@ -124,6 +122,8 @@ stages:
     dependsOn: setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: broker
@@ -184,6 +184,8 @@ stages:
     dependsOn: setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
       - checkout: broker
         displayName: Checkout broker repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -224,11 +224,7 @@ stages:
             eval $(dbus-launch --sh-syntax)
             sudo apt install gnome-keyring
             /usr/bin/gnome-keyring-daemon --start --components=secrets
-            ./gradlew LinuxBroker:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-      - task: Gradle@2
-        displayName: Run broker Unit tests
-        inputs:
-          tasks: LinuxBroker:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+            ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
   # adal
   - job: adalValidation
     displayName: ADAL

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -124,6 +124,8 @@ stages:
     dependsOn: setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    pool:
+      name: 1ES-AndroidPool-EOC-Test
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: broker
@@ -141,35 +143,6 @@ stages:
           git status
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: PowerShell@2
-      displayName: Install Flatbuffers Compiler
-      enabled: False
-      inputs:
-        targetType: inline
-        script: >-
-          Write-Output "Downloading flatbuffers"
-
-          $downloadLink = "https://github.com/google/flatbuffers/releases/download/v1.12.0/flatc_windows.zip"
-
-          Write-Output "Using download link: $downloadLink"
-
-          $dest = "$env:Temp\FlatBufferInstaller.zip"
-
-          (New-Object Net.WebClient).DownloadFile($downloadLink, $dest)
-
-          Write-Output "Extracting flatbuffers archive on machine...."
-
-          Expand-Archive -Path $dest -DestinationPath .\flatc-extracted
-
-          Write-Output "Finished extracting flatbuffers archive on machine...."
-
-          Write-Output "Run flatc"
-
-          .\flatc-extracted\flatc
-
-          echo '##vso[task.setvariable variable=path]$(PATH):$(CWD)\flatc-extracted\'
-
-          flatc
     - task: Gradle@2
       displayName: Assemble broker
       inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -13,6 +13,8 @@ parameters:
     displayName: Should skip long running test?
     type: boolean
     default: true
+pool:
+  vmImage: 'ubuntu-latest'
 
 variables:
 - name: shouldSkipLongRunningTest
@@ -188,8 +190,6 @@ stages:
         clean: true
         submodules: recursive
         persistCredentials: True
-      - bash: lsb_release -d
-        displayName: ubuntu version
       - task: CmdLine@1
         displayName: Set MVN Access Token in Environment
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -164,6 +164,37 @@ stages:
       displayName: Run broker Unit tests
       inputs:
         tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+  # Linux broker
+  - job: linuxBrokerValidation
+    displayName: Linux Broker
+    dependsOn: setupBranch
+    variables:
+      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    steps:
+      - template: ../templates/steps/automation-cert.yml
+      - checkout: broker
+        displayName: Checkout broker repository
+        clean: true
+        submodules: recursive
+        persistCredentials: True
+      - task: CmdLine@2
+        displayName: Checkout common submodule $(commonBranch)
+        inputs:
+          script: |
+            git fetch
+            git checkout $(commonBranch)
+            git pull
+            git status
+            git rev-parse HEAD
+          workingDirectory: $(Agent.BuildDirectory)/s/common
+      - task: Gradle@2
+        displayName: Assemble broker
+        inputs:
+          tasks: clean LinuxBroker:assembleLocal
+      - task: Gradle@2
+        displayName: Run broker Unit tests
+        inputs:
+          tasks: LinuxBroker:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # adal
   - job: adalValidation
     displayName: ADAL

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -173,11 +173,14 @@ stages:
     - task: Gradle@2
       displayName: Assemble broker
       inputs:
-        tasks: clean AADAuthenticator:assembleLocal
+        tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
+        publishJUnitResults: false
+        jdkArchitecture: x86
+        sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
       inputs:
-        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) ${{variables.shouldSkipLongRunningTest}}
+        tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -183,25 +183,26 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:
-      - template: ../templates/steps/automation-cert.yml
       - checkout: broker
         displayName: Checkout broker repository
         clean: true
         submodules: recursive
         persistCredentials: True
-      - task: CmdLine@2
-        displayName: Checkout common submodule $(commonBranch)
+      - bash: lsb_release -d
+        displayName: ubuntu version
+      - task: CmdLine@1
+        displayName: Set MVN Access Token in Environment
         inputs:
-          script: |
-            git fetch
-            git checkout $(commonBranch)
-            git pull
-            git status
-            git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/common
+          filename: echo
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
+      - task: CmdLine@1
+        displayName: Set Office MVN Access Token in Environment
+        inputs:
+          filename: echo
+          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_OFFICE_ACCESSTOKEN]$(System.AccessToken)'
       - task: Gradle@1
         name: Gradle1
-        displayName: Assemble
+        displayName: Assemble Linux Broker
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -8,9 +8,21 @@ name: $(date:yyyyMMdd)$(rev:.r)
 
 trigger: none
 
+parameters:
+  - name: shouldSkipLongRunningTest
+    displayName: Should skip long running test?
+    type: boolean
+    default: true
+
 variables:
+- name: shouldSkipLongRunningTest
+  ${{ if parameters.shouldSkipLongRunningTest }}:
+    value: "-PshouldSkipLongRunningTest"
+  ${{ else }}:
+    value: ""
 - name: robolectricSdkVersion
   value: 28
+- group: AndroidAuthClientVariables
 
 resources:
   repositories:
@@ -163,7 +175,7 @@ stages:
     - task: Gradle@2
       displayName: Run broker Unit tests
       inputs:
-        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey)
+        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker
@@ -187,10 +199,15 @@ stages:
             git status
             git rev-parse HEAD
           workingDirectory: $(Agent.BuildDirectory)/s/common
-      - task: Gradle@2
-        displayName: Assemble Linux broker
+      - task: Gradle@1
+        name: Gradle1
+        displayName: Assemble
         inputs:
-          tasks: LinuxBroker:clean LinuxBroker:assemble
+          cwd: $(Build.SourcesDirectory)/broker-java-root
+          tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
+          publishJUnitResults: false
+          jdkArchitecture: x86
+          sqAnalysisBreakBuildIfQualityGateFailed: false
       - task: Bash@3
         retryCountOnTaskFailure: 3
         displayName: Execute tests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -163,7 +163,7 @@ stages:
     - task: Gradle@2
       displayName: Run broker Unit tests
       inputs:
-        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+        tasks: AADAuthenticator:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey)
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker
@@ -188,9 +188,25 @@ stages:
             git rev-parse HEAD
           workingDirectory: $(Agent.BuildDirectory)/s/common
       - task: Gradle@2
-        displayName: Assemble broker
+        displayName: Assemble Linux broker
         inputs:
-          tasks: clean LinuxBroker:assemble
+          tasks: LinuxBroker:clean LinuxBroker:assemble
+      - task: Bash@3
+        retryCountOnTaskFailure: 3
+        displayName: Execute tests
+        inputs:
+          workingDirectory: $(Build.SourcesDirectory)/broker-java-root
+          targetType: 'inline'
+          script: |
+            sudo apt-get install -y dbus-x11
+            sudo apt-get install -y dos2unix
+            dos2unix gradlew
+            chmod +x gradlew
+            export DISPLAY=:0.0
+            eval $(dbus-launch --sh-syntax)
+            sudo apt install gnome-keyring
+            /usr/bin/gnome-keyring-daemon --start --components=secrets
+            ./gradlew LinuxBroker:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
       - task: Gradle@2
         displayName: Run broker Unit tests
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -190,7 +190,7 @@ stages:
       - task: Gradle@2
         displayName: Assemble broker
         inputs:
-          tasks: clean LinuxBroker:assembleLocal
+          tasks: clean LinuxBroker:assemble
       - task: Gradle@2
         displayName: Run broker Unit tests
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -119,6 +119,8 @@ stages:
   # broker
   - job: brokerValidation
     displayName: Broker
+    cancelTimeoutInMinutes: 1
+    timeoutInMinutes: 120
     dependsOn: setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -162,6 +162,7 @@ stages:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
       vmImage: 'ubuntu-latest'
+    retryCountOnTaskFailure: 2
     steps:
       - checkout: broker
         displayName: Checkout broker repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -122,8 +122,6 @@ stages:
     dependsOn: setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    pool:
-      vmImage: 'ubuntu-latest'
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: broker

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -29,11 +29,6 @@ resources:
     name: AzureAD/azure-activedirectory-library-for-android
     ref: dev
     endpoint: ANDROID_GITHUB
-  - repository: OneAuth
-    type: git
-    name: OneAuth/OneAuthAndroidCommonWrapper
-    ref: main
-    endpoint: OneAuthServiceConnection_2
 
 stages:
 - stage: validateConsumers
@@ -199,80 +194,3 @@ stages:
       displayName: Run adal Unit tests
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
-  # OneAuth
-  - job: oneAuthValidation
-    displayName: OneAuth
-    dependsOn: setupBranch
-    variables:
-      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    steps:
-      - checkout: OneAuth
-        displayName: Checkout OneAuth repository
-        clean: true
-        submodules: true
-        persistCredentials: True
-      - task: CmdLine@2
-        displayName: Checkout OneAuthAndroidCommonWrapper
-        inputs:
-          script: |
-            git fetch
-            git checkout main
-            git pull
-            git status
-            git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/
-      - task: CmdLine@2
-        displayName: Checkout common submodule $(commonBranch)
-        inputs:
-          script: |
-            git fetch
-            git checkout $(commonBranch)
-            git pull
-            git status
-            git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/common
-      - task: CmdLine@2
-        displayName: Checkout OneAuth submodule $(oneAuthBranchName)
-        inputs:
-          script: |
-            git fetch
-            git checkout $(oneAuthBranchName)
-            git pull
-            git status
-            git rev-parse HEAD
-          workingDirectory: $(Agent.BuildDirectory)/s/OneAuth
-
-      - task: MavenAuthenticate@0
-        displayName: Authenticate to the IdentityDivision Android Maven feed
-        inputs:
-          MavenServiceConnections: IdentityDivision
-
-      - task: MavenAuthenticate@0
-        displayName: Authenticate to the Intune_App_SDK feed
-        inputs:
-          MavenServiceConnections: Intune_App_SDK
-
-      - task: Bash@3
-        displayName: Install ninja
-        inputs:
-          targetType: inline
-          script: |
-            if [[ "$AGENT_OS" == "Darwin" ]]; then
-              HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
-            elif [[ "$AGENT_OS" == "Windows_NT" ]]; then
-              choco install -y ninja
-            elif [[ "$AGENT_OS" == "Linux" ]]; then
-              sudo apt-get install -y ninja-build
-            fi
-      - task: Gradle@2
-        displayName: Assemble OneAuth
-        inputs:
-          cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
-          tasks: clean OneAuth:assembleLocalDebug
-      - task: Gradle@2
-        displayName: Run OneAuth Unit tests
-        inputs:
-          cwd: $(Agent.BuildDirectory)/s/
-          gradleWrapperFile: $(Agent.BuildDIrectory)/s/gradlew.bat
-          tasks: OneAuth:testLocalDebugUnitTest

--- a/azure-pipelines/templates/steps/automation-cert.yml
+++ b/azure-pipelines/templates/steps/automation-cert.yml
@@ -9,7 +9,7 @@ steps:
   displayName: Set MVN Access Token in Environment
   inputs:
     filename: echo
-    arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAt }}]$(mvnAccessToken)'
+    arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAt }}]$(System.AccessToken)'
 - task: AzureKeyVault@1
   displayName: 'Azure Key Vault: Download Cert for Automation'
   inputs:


### PR DESCRIPTION
This Pr is aimed to fix the common consumer pipeline, which runs UTs for MSAL, ADAL, Broker to validate that common changes are not breaking anything in those libraries. Also expand the pipeline to include linux broker in this validation.

Successful run https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1138440&view=results