### PR TITLE
Removing token removal logic

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+V.14.0.1
+- [PATCH] Reverting token removal logic (#2117)
+
 V.14.0.0
 ----------
 - [PATCH] Make AndroidWrappedKeyLoader return the right alias (#2102)

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -2375,71 +2374,5 @@ public class SharedPreferencesAccountCredentialCacheTest {
         final Credential restoredIdToken = mSharedPreferencesAccountCredentialCache.getCredential(credentialCacheKey);
         assertTrue(refreshTokenFirst.equals(restoredIdToken));
         assertEquals(additionalValue2, restoredIdToken.getAdditionalFields().get(additionalKey).getAsString());
-    }
-
-    @Test
-    public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
-        //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
-        // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
-
-        // Save an Account into the cache
-        final AccountRecord account = new AccountRecord();
-        account.setHomeAccountId(HOME_ACCOUNT_ID);
-        account.setEnvironment(ENVIRONMENT);
-        account.setRealm(REALM);
-        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
-        account.setUsername(USERNAME);
-        account.setAuthorityType(AUTHORITY_TYPE);
-        mSharedPreferencesAccountCredentialCache.saveAccount(account);
-
-        // Save an AccessToken with SHA-1 application identifier into the cache
-        final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setCredentialType(CredentialType.AccessToken.name());
-        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
-        accessToken.setRealm("Foo");
-        accessToken.setEnvironment(ENVIRONMENT);
-        accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA1);
-        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
-        accessToken.setTarget(TARGET);
-        accessToken.setCachedAt(CACHED_AT);
-        accessToken.setExpiresOn(EXPIRES_ON);
-        accessToken.setSecret(SECRET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
-
-        // Save a RefreshToken into the cache
-        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
-        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
-        refreshToken.setEnvironment(ENVIRONMENT);
-        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
-        refreshToken.setClientId(CLIENT_ID);
-        refreshToken.setSecret(SECRET);
-        refreshToken.setTarget(TARGET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
-
-        //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
-        //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
-        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
-        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
-        assertEquals(1, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
-        // Now Save an AccessToken with SHA-512 application identifier into the cache
-        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
-        accessToken2.setCredentialType(CredentialType.AccessToken.name());
-        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
-        accessToken2.setRealm("Foo");
-        accessToken2.setEnvironment(ENVIRONMENT);
-        accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
-        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
-        accessToken2.setTarget(TARGET);
-        accessToken2.setCachedAt(CACHED_AT);
-        accessToken2.setExpiresOn(EXPIRES_ON);
-        accessToken2.setSecret(SECRET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
-
-        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
-        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -2515,71 +2514,5 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
         creds1.get(0).setCachedAt("banana");
         assertNotEquals(creds1.get(0), creds2.get(0));
-    }
-
-    @Test
-    public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
-        //Mimics the scenario where the cache has access tokens with a SHA-1 app identifier,
-        // and then the user updates their app to a version where access tokens should now have a SHA-512 app identifier.
-
-        // Save an Account into the cache
-        final AccountRecord account = new AccountRecord();
-        account.setHomeAccountId(HOME_ACCOUNT_ID);
-        account.setEnvironment(ENVIRONMENT);
-        account.setRealm(REALM);
-        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
-        account.setUsername(USERNAME);
-        account.setAuthorityType(AUTHORITY_TYPE);
-        mSharedPreferencesAccountCredentialCache.saveAccount(account);
-
-        // Save an AccessToken with SHA-1 application identifier into the cache
-        final AccessTokenRecord accessToken = new AccessTokenRecord();
-        accessToken.setCredentialType(CredentialType.AccessToken.name());
-        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
-        accessToken.setRealm("Foo");
-        accessToken.setEnvironment(ENVIRONMENT);
-        accessToken.setClientId(CLIENT_ID);
-        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA1);
-        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
-        accessToken.setTarget(TARGET);
-        accessToken.setCachedAt(CACHED_AT);
-        accessToken.setExpiresOn(EXPIRES_ON);
-        accessToken.setSecret(SECRET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
-
-        // Save a RefreshToken into the cache
-        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
-        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
-        refreshToken.setEnvironment(ENVIRONMENT);
-        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
-        refreshToken.setClientId(CLIENT_ID);
-        refreshToken.setSecret(SECRET);
-        refreshToken.setTarget(TARGET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
-
-        //Remove the flag entry, as initialization of the cache calls removeSha1ApplicationIdentifierAccessTokensIfNeeded on a different thread.
-        //Thread should have run by now... but if not, it's harmless, as it should only take out SHA1 identifier access tokens.
-        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
-        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
-        assertEquals(1, mSharedPreferencesAccountCredentialCache.getCredentials().size());
-
-        // Now Save an AccessToken with SHA-512 application identifier into the cache
-        final AccessTokenRecord accessToken2 = new AccessTokenRecord();
-        accessToken2.setCredentialType(CredentialType.AccessToken.name());
-        accessToken2.setHomeAccountId(HOME_ACCOUNT_ID);
-        accessToken2.setRealm("Foo");
-        accessToken2.setEnvironment(ENVIRONMENT);
-        accessToken2.setClientId(CLIENT_ID);
-        accessToken2.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
-        accessToken2.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
-        accessToken2.setTarget(TARGET);
-        accessToken2.setCachedAt(CACHED_AT);
-        accessToken2.setExpiresOn(EXPIRES_ON);
-        accessToken2.setSecret(SECRET);
-        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken2);
-
-        mSharedPreferencesFileManager.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
-        mSharedPreferencesAccountCredentialCache.removeSha1ApplicationIdentifierAccessTokensIfNeeded();
-        assertEquals(2, mSharedPreferencesAccountCredentialCache.getCredentials().size());
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/AbstractAccountCredentialCache.java
@@ -50,7 +50,6 @@ import lombok.NonNull;
 public abstract class AbstractAccountCredentialCache implements IAccountCredentialCache {
 
     private static final String TAG = AbstractAccountCredentialCache.class.getSimpleName();
-    public static final String SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED = "sha1-cleared";
     private static final String NEW_LINE = "\n";
 
     // SharedPreferences used to store Accounts and Credentials
@@ -287,53 +286,6 @@ public abstract class AbstractAccountCredentialCache implements IAccountCredenti
         }
 
         return matchingCredentials;
-    }
-
-    /**
-     * The application identifier field for access token records previously included a SHA-1 signing certificate hash.
-     * This method first checks if it has been run before, and if not, removes such tokens, as application identifiers should now contain SHA-512 signing certificate hashes.
-     */
-    public void removeSha1ApplicationIdentifierAccessTokensIfNeeded() {
-        final String methodTag = TAG + ":removeSha1ApplicationIdentifierAccessTokensIfNeeded";
-        if (!isSha1Cleared()) {
-            for (final Credential credential : getCredentials()) {
-                if (credential instanceof AccessTokenRecord) {
-                    final AccessTokenRecord accessToken = (AccessTokenRecord) credential;
-                    final String tokenAppIdentifier = accessToken.getApplicationIdentifier();
-                    if (tokenAppIdentifier != null
-                            && applicationIdentifierContainsSha1(tokenAppIdentifier)) {
-                        Logger.info(methodTag, "Identified old access token with app identifier containing SHA-1. This token shall be removed, and a new access token should be re-acquired with a SHA-512 app identifier.");
-                        removeCredential(credential);
-                    }
-                }
-            }
-            saveSha1ClearedFlag();
-        }
-    }
-
-    /**
-     * Can tell if an application identifier string (<package name>/<signing certificate hash>) contains a SHA-1 hash.
-     * @param applicationIdentifier application identifier field string
-     * @return true if contains SHA-1 hash; false otherwise.
-     */
-    static boolean applicationIdentifierContainsSha1(@NonNull final String applicationIdentifier) {
-        final String[] appIdentifierArr = applicationIdentifier.split("/", 2);
-        return (appIdentifierArr.length > 1 && appIdentifierArr[1].length() == 28);
-    }
-
-    /**
-     * Tells if access tokens with SHA-1 app identifiers have been cleared yet.
-     * @return true if cleared; false otherwise.
-     */
-    protected boolean isSha1Cleared() {
-        return mSharedPreferencesFileManager.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED) != null;
-    }
-
-    /**
-     * Saves the flag indicating that access tokens with SHA-1 app identifiers have been cleared.
-     */
-    protected void saveSha1ClearedFlag() {
-        mSharedPreferencesFileManager.put(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED, String.valueOf(true));
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -96,7 +96,6 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
         mCacheValueDelegate = accountCacheValueDelegate;
-        new Thread(this::removeSha1ApplicationIdentifierAccessTokensIfNeeded).start();
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -74,18 +74,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
         mCacheValueDelegate = accountCacheValueDelegate;
-        new Thread(() -> initialize()).start();
+        new Thread(() -> load()).start();
     }
 
-    private void initialize() {
-        final String methodTag = TAG + ":initialize";
-        try {
-            load();
-            removeSha1ApplicationIdentifierAccessTokensIfNeeded();
-        } catch (final Throwable t) {
-            Logger.error(methodTag, "Failed to load initial accounts/credentials or remove SHA-1 app identifier tokens from SharedPreferences", t);
-        }
-    }
     private void load() {
         final String methodTag = TAG + ":load";
 
@@ -95,6 +86,8 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 Logger.info(methodTag, "Loaded " + mCachedAccountRecordsWithKeys.size() + " AccountRecords");
                 mCachedCredentialsWithKeys = loadCredentialsWithKeys();
                 Logger.info(methodTag, "Loaded " + mCachedCredentialsWithKeys.size() + " Credentials");
+            } catch (final Throwable t) {
+                Logger.error(methodTag, "Failed to load initial accounts or credentials from SharedPreferences", t);
             } finally {
                 mLoaded = true;
                 mCacheLock.notifyAll();


### PR DESCRIPTION
### Summary
Going to remove the token clearing logic from this PR for now: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2058
In the future we'll look into doing a more thorough cleaning in a different manner. 