### PR TITLE
Remove Unneeded Modifier in Consumers Pipeline

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -204,6 +204,7 @@ stages:
             /usr/bin/gnome-keyring-daemon --start --components=secrets
             ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
       - task: PublishTestResults@2
+        condition: succeededOrFailed()
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/TEST-*.xml'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -204,10 +204,10 @@ stages:
             /usr/bin/gnome-keyring-daemon --start --components=secrets
             ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
       - task: PublishTestResults@2
-          inputs:
-            testResultsFormat: 'JUnit'
-            testResultsFiles: '**/TEST-*.xml'
-            searchFolder: 'LinuxBroker'
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/TEST-*.xml'
+          searchFolder: 'LinuxBroker'
   # adal
   - job: adalValidation
     displayName: ADAL

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -203,6 +203,11 @@ stages:
             sudo apt install gnome-keyring
             /usr/bin/gnome-keyring-daemon --start --components=secrets
             ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
+      - task: PublishTestResults@2
+          inputs:
+            testResultsFormat: 'JUnit'
+            testResultsFiles: '**/TEST-*.xml'
+            searchFolder: 'LinuxBroker'
   # adal
   - job: adalValidation
     displayName: ADAL

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -162,7 +162,6 @@ stages:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
       vmImage: 'ubuntu-latest'
-    retryCountOnTaskFailure: 2
     steps:
       - checkout: broker
         displayName: Checkout broker repository


### PR DESCRIPTION
Incorrectly added retryCountOnTaskFailure: 2 when it was not needed, it also caused a syntax error that's stopping pipeline from running.