### PR TITLE
Capture perf telemetry for cache & network operations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ V.NEXT
 - [MAJOR] Tidy up BrokerValidator (#2107)
 - [PATCH] Adding null checks for CancelHelper (CBA) (#2105)
 - [MINOR] Update YubiKit version to 2.3.0 (#2112)
+- [MINOR] Capture perf telemetry for cache & network operations (#2124)
 
 V.14.0.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.cache;
+
+import com.microsoft.identity.common.java.WarningType;
+import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.java.dto.AccountRecord;
+import com.microsoft.identity.common.java.dto.Credential;
+import com.microsoft.identity.common.java.dto.CredentialType;
+import com.microsoft.identity.common.java.dto.IdTokenRecord;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAccount;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftRefreshToken;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenResponse;
+import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
+import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.NonNull;
+
+/**
+ * A wrapper around {@link BrokerOAuth2TokenCache} to facilitate capturing telemery around cache operations.
+ * <p>
+ * This class today only captures performance data for each operation in this class and puts it on the current span.
+ * For token operations, a current span is present and therefore these attributes will go on that span.
+ */
+// Suppressing rawtype warnings due to the generic type OAuth2Strategy, AuthorizationRequest, MicrosoftFamilyOAuth2TokenCache, MsalOAuth2TokenCache and OAuth2TokenCache
+@SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", WarningType.rawtype_warning})
+public class BrokerOAuth2TokenCacheTelemetryWrapper
+        <GenericOAuth2Strategy extends OAuth2Strategy,
+                GenericAuthorizationRequest extends AuthorizationRequest,
+                GenericTokenResponse extends MicrosoftTokenResponse,
+                GenericAccount extends MicrosoftAccount,
+                GenericRefreshToken extends MicrosoftRefreshToken> extends BrokerOAuth2TokenCache<GenericOAuth2Strategy, GenericAuthorizationRequest, GenericTokenResponse, GenericAccount, GenericRefreshToken> {
+
+    private final BrokerOAuth2TokenCache mCacheToWrap;
+
+    public BrokerOAuth2TokenCacheTelemetryWrapper(@NonNull final IPlatformComponents mPlatformComponents,
+                                                  int uid,
+                                                  @NonNull IBrokerApplicationMetadataCache applicationMetadataCache,
+                                                  @NonNull final BrokerOAuth2TokenCache cacheToWrap) {
+        super(mPlatformComponents, uid, applicationMetadataCache);
+        mCacheToWrap = cacheToWrap;
+    }
+
+    @Override
+    public ICacheRecord save(@NonNull GenericOAuth2Strategy oAuth2Strategy, @NonNull GenericAuthorizationRequest request, @NonNull GenericTokenResponse response) throws ClientException {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.save(oAuth2Strategy, request, response);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_save.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<ICacheRecord> saveAndLoadAggregatedAccountData(@NonNull GenericOAuth2Strategy oAuth2Strategy, @NonNull GenericAuthorizationRequest request, @NonNull GenericTokenResponse response) throws ClientException {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.saveAndLoadAggregatedAccountData(oAuth2Strategy, request, response);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_save_and_load_aggregated_account_data.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public ICacheRecord save(AccountRecord accountRecord, IdTokenRecord idTokenRecord) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.save(accountRecord, idTokenRecord);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_save.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public ICacheRecord load(String clientId, String applicationIdentifier, String mamEnrollmentIdentifier, String target, AccountRecord account, AbstractAuthenticationScheme authScheme) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.load(clientId, applicationIdentifier, mamEnrollmentIdentifier, target, account, authScheme);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_load.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<ICacheRecord> loadWithAggregatedAccountData(String clientId, String applicationIdentifier, String mamEnrollmentIdentifier, String target, AccountRecord account, AbstractAuthenticationScheme authenticationScheme) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.loadWithAggregatedAccountData(clientId, applicationIdentifier, mamEnrollmentIdentifier, target, account, authenticationScheme);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_load_aggregated_account_data.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public boolean removeCredential(Credential credential) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.removeCredential(credential);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_remove_credential.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public AccountRecord getAccount(String environment, String clientId, String homeAccountId, String realm) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccount(environment, clientId, homeAccountId, realm);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_account.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId, String homeAccountId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccountsWithAggregatedAccountData(environment, clientId, homeAccountId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_accounts_with_aggregated_account_data.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccountByLocalAccountId(environment, clientId, localAccountId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_account_by_local_account_id.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public ICacheRecord getAccountWithAggregatedAccountDataByLocalAccountId(String environment, String clientId, String localAccountId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccountWithAggregatedAccountDataByLocalAccountId(environment, clientId, localAccountId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_account_with_aggregated_account_data_by_local_account_id.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<AccountRecord> getAccounts(String environment, String clientId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccounts(environment, clientId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_accounts.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<AccountRecord> getAllTenantAccountsForAccountByClientId(String clientId, AccountRecord accountRecord) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAllTenantAccountsForAccountByClientId(clientId, accountRecord);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_all_tenant_accounts_for_account_by_client_id.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<ICacheRecord> getAccountsWithAggregatedAccountData(String environment, String clientId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccountsWithAggregatedAccountData(environment, clientId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_accounts_with_aggregated_account_data.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public List<IdTokenRecord> getIdTokensForAccountRecord(String clientId, AccountRecord accountRecord) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getIdTokensForAccountRecord(clientId, accountRecord);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_id_tokens_for_account_record.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.removeAccount(environment, clientId, homeAccountId, realm);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_remove_account.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public AccountDeletionRecord removeAccount(String environment, String clientId, String homeAccountId, String realm, CredentialType... typesToRemove) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.removeAccount(environment, clientId, homeAccountId, realm, typesToRemove);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_remove_account.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public void clearAll() {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            mCacheToWrap.clearAll();
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_clear_all.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    protected Set<String> getAllClientIds() {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAllClientIds();
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_all_client_ids.name(),
+                    elapsedTime
+            );
+        }
+    }
+
+    @Override
+    public AccountRecord getAccountByHomeAccountId(@Nullable String environment, @NonNull String clientId, @NonNull String homeAccountId) {
+        final long startTime = System.currentTimeMillis();
+
+        try {
+            return mCacheToWrap.getAccountByHomeAccountId(environment, clientId, homeAccountId);
+        } finally {
+            final long endTime = System.currentTimeMillis();
+            final long elapsedTime = endTime - startTime;
+            SpanExtension.current().setAttribute(
+                    AttributeName.elapsed_time_cache_get_account_by_home_account_id.name(),
+                    elapsedTime
+            );
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -232,5 +232,20 @@ public enum AttributeName {
     /**
      * The time (in milliseconds) spent in executing the getAllClientIds method in OAuth2TokenCache.
      */
-    elapsed_time_cache_get_all_client_ids;
+    elapsed_time_cache_get_all_client_ids,
+
+    /**
+     * The time (in milliseconds) spent on network when acquiring PRT.
+     */
+    elapsed_time_network_acquire_prt,
+
+    /**
+     * The time (in milliseconds) spent on network when acquiring nonce.
+     */
+    elapsed_time_network_acquire_nonce,
+
+    /**
+     * The time (in milliseconds) spent on network when acquiring AT.
+     */
+    elapsed_time_network_acquire_at;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -147,5 +147,90 @@ public enum AttributeName {
     /**
      * The size of the silent command executor queue when starting to process an ATS request.
      */
-    num_concurrent_silent_requests;
+    num_concurrent_silent_requests,
+
+    /**
+     * The time (in milliseconds) spent in executing the save method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_save,
+
+    /**
+     * The time (in milliseconds) spent in executing the load method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_load,
+
+    /**
+     * The time (in milliseconds) spent in executing the loadAggregatedAccountData method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_load_aggregated_account_data,
+
+    /**
+     * The time (in milliseconds) spent in executing the loadWithAggregatedAccountData method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_load_with_aggregated_account_data,
+
+    /**
+     * The time (in milliseconds) spent in executing the saveAndLoadAggregatedAccountData method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_save_and_load_aggregated_account_data,
+
+    /**
+     * The time (in milliseconds) spent in executing the removeCredential method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_remove_credential,
+
+    /**
+     * The time (in milliseconds) spent in executing the get account method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_account,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAccountWithAggregatedAccountData method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_accounts_with_aggregated_account_data,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAccountByLocalAccountId method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_account_by_local_account_id,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAccountWithAggregatedAccountDataByLocalAccountId method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_account_with_aggregated_account_data_by_local_account_id,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAccounts method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_accounts,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAllTenantAccountsForAccountByClientId method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_all_tenant_accounts_for_account_by_client_id,
+
+    /**
+     * The time (in milliseconds) spent in executing the getIdTokensForAccountRecord method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_id_tokens_for_account_record,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAccountByHomeAccountId method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_account_by_home_account_id,
+
+    /**
+     * The time (in milliseconds) spent in executing the removeAccount method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_remove_account,
+
+    /**
+     * The time (in milliseconds) spent in executing the clearAll method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_clear_all,
+
+    /**
+     * The time (in milliseconds) spent in executing the getAllClientIds method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_all_client_ids;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -39,6 +39,8 @@ import com.microsoft.identity.common.java.net.HttpClient;
 import com.microsoft.identity.common.java.net.HttpConstants;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenRequest;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
@@ -229,11 +231,17 @@ public abstract class OAuth2Strategy
         }
 
         final URL requestUrl = new URL(getTokenEndpoint());
+
+        final long networkStartTime = System.currentTimeMillis();
         final HttpResponse response = httpClient.post(
                 requestUrl,
                 headers,
                 requestBody.getBytes(ObjectMapper.ENCODING_SCHEME)
         );
+        final long networkEndTime = System.currentTimeMillis();
+        final long networkTime = networkEndTime - networkStartTime;
+        SpanExtension.current().setAttribute(AttributeName.elapsed_time_network_acquire_at.name(), networkTime);
+
 
         // Record the clock skew between *this device* and EVO...
         if (null != response.getDate()) {


### PR DESCRIPTION
Capture elapsed time for each cache & network operation and put that on the current span.

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2428

This is needed to help us further understand the breakdown of latency in Broker and continue to troubleshoot perf issues.