### PR TITLE
Initial dependencies for passkey work

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -145,6 +145,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
 
     implementation "androidx.datastore:datastore-preferences:1.0.0"
 
@@ -159,6 +160,10 @@ dependencies {
     //For Executive Order work
     implementation "com.yubico.yubikit:android:$rootProject.ext.yubikitAndroidVersion"
     implementation "com.yubico.yubikit:piv:$rootProject.ext.yubikitPivVersion"
+    //For passkeys
+    implementation "androidx.credentials:credentials:1.2.0-beta01"
+    // Needed for credentials support from play services, for devices running Android 13 and below.
+    implementation "androidx.credentials:credentials-play-services-auth:1.2.0-beta01"
 
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.3.0'
 

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -23,3 +23,8 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,12 +6,12 @@ ext {
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
     targetSdkVersion = 30
-    compileSdkVersion = 30
+    compileSdkVersion = 34
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '4.2.2'
-    kotlinVersion = '1.7.21'
+    gradleVersion = '7.4.2'
+    kotlinVersion = '1.8.22'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip


### PR DESCRIPTION
## Summary
This brings in the necessary dependencies (that I know of so far) into the common build.gradle, along with a few other changes.
- `androidx.credentials:credentials` and `androidx.credentials:credentials-play-services-auth` are the [Credential Manager] (https://developer.android.com/jetpack/androidx/releases/credentials) dependencies needed to interact with Google Password Manager and other 3P passkey providers. The most stable version is a beta version, so I expect the version to change a few times in the next few months. 
    - I'll create actual variables to hold the dependency versions in a future PR (before the feature branch gets merged into dev). 
- `androidx.lifecycle:lifecycle-runtime-ktx` in order to make use of the lifecycle scope. The main methods from CredMan need to run in a coroutine, and the lifecycle scope fits what we need there.
- CredMan documentation suggests adding directives to the proguard-rules.pro file to not optimize `androidx.credentials.playservices` right away.
- Changes to the gradle, kotlin, and compileSdk versions are expected to be merged directly into dev with separate PRs. For now this means that all common checks are probably going to fail.

I was able to make some test calls with CredMan to create a demo passkey and sign a challenge with the passkey.