### PR TITLE
July UI, add support for a second speed bump, new annotation to avoid running some tests on daily

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/annotations/FailsWithDailyVersions.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/annotations/FailsWithDailyVersions.java
@@ -1,0 +1,38 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation indicating that an automated End-to-End test case is failing when used with Daily Pipeline versions,
+ * but should still be attempted on Monthly Release Pipeline for validation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface FailsWithDailyVersions {
+    String value() default "";
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/GlobalConstants.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/constants/GlobalConstants.java
@@ -27,4 +27,5 @@ package com.microsoft.identity.client.ui.automation.constants;
  */
 public class GlobalConstants {
     public static final boolean IS_STAY_SIGN_IN_PAGE_EXPECTED = true;
+    public static final boolean IS_EXPECTING_SECOND_SPEED_BUMP = true;
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -140,6 +140,11 @@ public class PromptHandlerParameters {
     private final boolean howWouldYouLikeToSignInExpected;
 
     /**
+     * Denotes whether or not to except "Choose certificate" Prompt
+     */
+    private final boolean chooseCertificateExpected;
+
+    /**
      * Denotes the way in which we want to respond to the enroll page for this request.
      */
     @Builder.Default

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -105,6 +105,12 @@ public class PromptHandlerParameters {
     private final boolean speedBumpExpected;
 
     /**
+     * Denotes whether or not a second speed bump page is expected to appear during an interactive token
+     * request.
+     */
+    private final boolean secondSpeedBumpExpected;
+
+    /**
      * Denotes whether or not the register page is expected to appear during an interactive token
      * request.
      */

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/PromptHandlerParameters.java
@@ -140,7 +140,7 @@ public class PromptHandlerParameters {
     private final boolean howWouldYouLikeToSignInExpected;
 
     /**
-     * Denotes whether or not to except "Choose certificate" Prompt
+     * Denotes whether or not to expect "Choose certificate" Prompt
      */
     private final boolean chooseCertificateExpected;
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -146,7 +146,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     public void handleSpeedBump() {
         Logger.i(TAG, "Handle Speed Bump UI..");
         // Confirm On Speed Bump Screen
-        final UiObject speedBump = UiAutomatorUtils.obtainUiObjectWithResourceId("appConfirmTitle", mFindLoginUiElementTimeout);
+        final UiObject speedBump = UiAutomatorUtils.obtainUiObjectWithResourceId("idSIButton9", mFindLoginUiElementTimeout);
 
         if (!speedBump.exists()) {
             fail("Speed Bump screen did not show up");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -146,13 +146,13 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     public void handleSpeedBump() {
         Logger.i(TAG, "Handle Speed Bump UI..");
         // Confirm On Speed Bump Screen
-        final UiObject speedBump = UiAutomatorUtils.obtainUiObjectWithResourceId("idSIButton9", mFindLoginUiElementTimeout);
+        final UiObject speedBump = UiAutomatorUtils.obtainUiObjectWithResourceId("appConfirmTitle", mFindLoginUiElementTimeout);
 
         if (!speedBump.exists()) {
             fail("Speed Bump screen did not show up");
         }
 
-        handleNextButton();
+        UiAutomatorUtils.handleButtonClickForObjectWithText("Continue");
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -212,6 +212,6 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     public void handleHowWouldYouLikeToSignIn() {
         // Looks like we sometimes see this UI prompt asking "How would like to sign in?"
         // We press button1, which is "Ok" to confirm the default selection of using device certificate.
-        UiAutomatorUtils.handleButtonClick("android:id/button1", mFindLoginUiElementTimeout);
+        UiAutomatorUtils.handleButtonClickSafely("android:id/button1", mFindLoginUiElementTimeout);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -213,8 +213,11 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         // Looks like we sometimes see this UI prompt asking "How would like to sign in?"
         // We press button1, which is "Ok" to confirm the default selection of using device certificate.
         UiAutomatorUtils.handleButtonClickSafely("android:id/button1", mFindLoginUiElementTimeout);
+    }
 
-        // Sometimes need to also confirm the selection
+    @Override
+    public void handleChooseCertificate() {
+        // Choose default certificate
         UiAutomatorUtils.handleButtonClickSafely("android:id/button1", mFindLoginUiElementTimeout);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -152,7 +152,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
             fail("Speed Bump screen did not show up");
         }
 
-        UiAutomatorUtils.handleButtonClickForObjectWithText("Continue");
+        handleNextButton();
     }
 
     @Override
@@ -212,6 +212,9 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     public void handleHowWouldYouLikeToSignIn() {
         // Looks like we sometimes see this UI prompt asking "How would like to sign in?"
         // We press button1, which is "Ok" to confirm the default selection of using device certificate.
+        UiAutomatorUtils.handleButtonClickSafely("android:id/button1", mFindLoginUiElementTimeout);
+
+        // Sometimes need to also confirm the selection
         UiAutomatorUtils.handleButtonClickSafely("android:id/button1", mFindLoginUiElementTimeout);
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
@@ -69,6 +69,11 @@ public interface IMicrosoftStsLoginComponentHandler extends IOAuth2LoginComponen
     void handleVerifyYourIdentity();
 
     /**
+     * Clickes "Select" when prompted with the choose certificate prompt
+     */
+    void handleChooseCertificate();
+
+    /**
      * Handle the How would you like to sign in
      */
     void handleHowWouldYouLikeToSignIn();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -108,6 +108,10 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
             aadLoginComponentHandler.handleSpeedBump();
         }
 
+        if (parameters.isSecondSpeedBumpExpected()) {
+            aadLoginComponentHandler.handleSpeedBump();
+        }
+
         if (parameters.isRegisterPageExpected()) {
             aadLoginComponentHandler.handleRegistration();
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -83,6 +83,10 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
             aadLoginComponentHandler.handleHowWouldYouLikeToSignIn();
         }
 
+        if (parameters.isChooseCertificateExpected()) {
+            aadLoginComponentHandler.handleChooseCertificate();
+        }
+
         if (parameters.isPasswordPageExpected() || parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
             loginComponentHandler.handlePasswordField(password);
         }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -31,6 +31,9 @@ import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerPara
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.common.java.util.ThreadUtils;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Prompt Handler for Microsoft STS login flows.
@@ -113,6 +116,8 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
         }
 
         if (parameters.isSecondSpeedBumpExpected()) {
+            // Need to wait between button presses, or we might press the same button twice
+            ThreadUtils.sleepSafely(6000, TAG, "Sleep Interrupted");
             aadLoginComponentHandler.handleSpeedBump();
         }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -33,8 +33,6 @@ import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.common.java.util.ThreadUtils;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * A Prompt Handler for Microsoft STS login flows.
  */

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/LoadLabUserTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/LoadLabUserTestRule.java
@@ -46,7 +46,7 @@ public class LoadLabUserTestRule implements TestRule {
 
     private static final String TAG = LoadLabUserTestRule.class.getSimpleName();
 
-    public static final long TEMP_USER_WAIT_TIME = TimeUnit.SECONDS.toMillis(20);
+    public static final long TEMP_USER_WAIT_TIME = TimeUnit.SECONDS.toMillis(25);
 
     private LabQuery query;
     private TempUserType tempUserType;


### PR DESCRIPTION
July Ui maintentance, some cross cloud tests are experiencing a second speed bump page, also created an annotation to signify cases that would fail if ran with daily versions (due to the versions starting with 0.0).