### PR TITLE
Add method to flush shared preference file manager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.NEXT
 - [PATCH] Adding null checks for CancelHelper (CBA) (#2105)
 - [MINOR] Update YubiKit version to 2.3.0 (#2112) Note: This version of YubiKit contains new logging libraries. Projects using the SLF4j and/or logback-android dependencies must bump their versions to at least 2.0.7 and 3.0.0, respectively.
 - [MINOR] Capture perf telemetry for cache & network operations (#2124)
+- [MINOR] Add method to flush shared preference file manager (#2130)
 
 V.14.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -354,7 +354,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     /**
      * This method performs a commit() to ensure that all outstanding apply() calls are completed.
      * This should be called after any putX() call where we need to ensure that apply() is not delayed or missed.
-     * @return 
+     * @return true if the commit is successful.
      */
     public boolean flushSharedPreference(){
         synchronized (cacheLock) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -351,4 +351,16 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         return result;
     }
 
+    /**
+     * This method performs a commit() to ensure that all outstanding apply() calls are completed.
+     * This should be called after any putX() call where we need to ensure that apply() is not delayed or missed.
+     * @return 
+     */
+    public boolean flushSharedPreference(){
+        synchronized (cacheLock) {
+            final SharedPreferences.Editor editor = mSharedPreferences.edit();
+            return editor.commit();
+        }
+    }
+
 }


### PR DESCRIPTION
AB#2596635
We have seen that when trying to sign out an account from PowerApps, OneAuth-MSAL marks the force prompt flag on account and that makes a call to SharedPreferencesFileManager.putString() to update the account properties.
After this PowerApps makes a call to MAM API to unregister account and this causes the PowerApps to get force closed. 
Since the application is killed, the SharedPreferece apply() could not complete and the account properties are not properly stored.
Proposed solution is to have a flush method which will be called by OneAuth-MSAL when critical account properties such as sign out flag need to be updated.