### PR TITLE
Improve logging in BrokerMsalController.verifyBrokerVersionIsSupported

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.NEXT
 - [MINOR] Update YubiKit version to 2.3.0 (#2112) Note: This version of YubiKit contains new logging libraries. Projects using the SLF4j and/or logback-android dependencies must bump their versions to at least 2.0.7 and 3.0.0, respectively.
 - [MINOR] Capture perf telemetry for cache & network operations (#2124)
 - [MINOR] Add method to flush shared preference file manager (#2130)
+- [PATCH] Improve logging in BrokerMsalController.verifyBrokerVersionIsSupported (#2132)
 
 V.14.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -1189,7 +1189,8 @@ public class BrokerMsalController extends BaseController {
                 throw new UnsupportedBrokerException(mActiveBrokerPackageName);
             }
         } catch (final ClientException e) {
-            Logger.error(methodTag, "Unable to read broker result from result bundle", e);
+            Logger.info(methodTag, "ResultBundle does not contain BrokerResult." +
+                    "So, this is not likely a broker version supported issue. Continuing.");
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -1189,7 +1189,7 @@ public class BrokerMsalController extends BaseController {
                 throw new UnsupportedBrokerException(mActiveBrokerPackageName);
             }
         } catch (final ClientException e) {
-            Logger.info(methodTag, "ResultBundle does not contain BrokerResult." +
+            Logger.info(methodTag, "ResultBundle does not contain BrokerResult. " +
                     "So, this is not likely a broker version supported issue. Continuing.");
         }
     }


### PR DESCRIPTION
Result bundle returned from Broker may or may not contain BrokerResult. 

After call returns from broker in BrokerMsalController, we attempt to check if the error is unsupported_broker_version. To do so we try to look for BrokerResult in the returned bundle, as the above error would be returned as BrokerResult object.

But if it's not unsupported broker version error, then the returned bundle may or may not contain BrokerResult object (depending on which broker operation is executed). eg GetAccounts.. if BrokerResult is not returned parsing result bundle raises exception (brokerResultFromBundle method in MsalBrokerResultAdapter).

This exception is getting logged in verifyBrokerVersionIsSupported and making the logs noisy with exception stack, even though the request continues and is successful/failure based the code logic that follows.

Fix:
Updating the log statement to not log exception. We still log a message.