### PR TITLE
Add a label to skip common consumer validation

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -92,7 +92,7 @@ stages:
     steps:
     - bash: |
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-check"'
+        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
         then
           echo "##vso[task.setvariable variable=prWithCILabel;isOutput=true]true"
           echo "fullci label found!"

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -57,12 +57,13 @@ stages:
   dependsOn: checkLabel
   pool:
     name: Hosted Windows 2019 with VS2019
+  variables:
+    prLabels: $[ dependencies.checkLabel.outputs['fetchPrCILabel.prLabels'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup
   - job: setupBranch
     displayName: Setup branch
-    condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
     steps:
     - checkout: none
     - task: PowerShell@2

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: ${{ eq(variables['validationOptional'], 'true') }}
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -128,13 +127,13 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
@@ -170,7 +169,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
@@ -179,7 +178,7 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
@@ -213,7 +212,7 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
-        ${{ if variables.validationOptional }}:
+        ${{ if eq(variables.validationOptional, 'true') }}:
           continueOnError: true
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
@@ -224,7 +223,7 @@ stages:
       - task: Bash@3
         retryCountOnTaskFailure: 3
         displayName: Execute tests
-        ${{ if variables.validationOptional }}:
+        ${{ if eq(variables.validationOptional, 'true') }}:
           continueOnError: true
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
@@ -272,13 +271,13 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
-      ${{ if variables.validationOptional }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -145,7 +145,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: ${{ eq($(validationOptional), 'true') }}
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -185,7 +184,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: ${{ eq($(checkPrCILabelvalidationOptional), 'true') }}
     pool:
       vmImage: 'ubuntu-latest'
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -169,7 +169,9 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      ${{ if eq(variables.validationOptional, 'true') }}:
+      variables:
+        pleaseStop: $('validationOptional')
+      ${{ if eq(variables.pleaseStop, 'true') }}:
         continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
@@ -271,7 +273,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
-      ${{ if eq(variables.validationOptional, 'true') }}:
+      ${{ if eq(variables['validationOptional'], 'true') }}:
         continueOnError: true
       inputs:
         tasks: clean adal:assembleLocal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,6 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: not(eq(stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'], ''))
   jobs:
   # setup
   - job: setupBranch
@@ -105,6 +104,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    condition: not(eq(variables['prLabels'], ''))
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -127,7 +127,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble c$(validationOptional) msal
-      ${{ if eq(variables.validationOptional, 'true') }}:
+      ${{ if eq($(validationOptional), 'true') }}:
         continueOnError: true
       inputs:
         tasks: clean msal:assembleLocal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -60,6 +60,8 @@ stages:
   variables:
     prLabels2: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
     prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
+    prLabels2: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
+    prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -105,7 +105,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    condition: and( succeeded(), not(contains(variables['prLabels'], '{')) )
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -58,10 +58,10 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    prLabels1: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
-    prLabels2: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-    prLabels3: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
-    prLabels4: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
+    prLabels1: $[ stageDependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
+    prLabels2: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
+    prLabels3: $[ stageDependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
+    prLabels4: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq($(skipValidation), 'true')) )
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - pwsh: |
         Write-Host "Should skip validation: $(skipValidation)"

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: and(succeeded(), not(contains(variables['prLabels'], '}')))
+  condition: and(succeeded(), not(contains(variables['prLabels'], '{')))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -100,6 +100,7 @@ stages:
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: checkPrCILabel
     - pwsh: |
+        Write-Host "Setting version to: $env:LABEL_FOUND"
         Write-Host "Setting version to: $env:LABELFOUND"
         Write-Host "##vso[task.setvariable variable=labelFound;isOutput=true]$env:LABELFOUND"
       displayName: 'Set variable'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: not(contains(stageVariables['prLabels'], '{'))
+  condition: not(contains(variables.prLabels, '{'))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: and(succeeded(), not(contains($(prLabels), '{')))
+  condition: not(contains(stageVariables['prLabels'], '{'))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnFailure: variables['validationOptional']
+    continueOnError: variables['validationOptional']
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -145,7 +145,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnFailure: variables['validationOptional']
+    continueOnError: variables['validationOptional']
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -185,7 +185,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnFailure: variables['validationOptional']
+    continueOnError: variables['validationOptional']
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -244,7 +244,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnFailure: variables['validationOptional']
+    continueOnError: variables['validationOptional']
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -62,6 +62,7 @@ stages:
   # setup
   - job: setupBranch
     displayName: Setup branch
+    condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
     steps:
     - checkout: none
     - task: PowerShell@2

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -58,10 +58,10 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    prLabels2: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
-    prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-    prLabels2: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
-    prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
+    prLabels1: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
+    prLabels2: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
+    prLabels3: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
+    prLabels4: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -102,7 +102,7 @@ stages:
     - pwsh: |
         Write-Host "Setting version to: $env:LABEL_FOUND"
         Write-Host "Setting version to: $env:LABELFOUND"
-        Write-Host "$(labelfound)"
+        Write-Host "$(checkPrCILabel.labelfound)"
         Write-Host "##vso[task.setvariable variable=skipValidation;isOutput=true]$env:LABELFOUND"
       displayName: 'Set variable'
       name: set_variable

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
+  condition: and(succeeded(), not(contains(variables['prLabels'], '}')))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -58,10 +58,7 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    prLabels1: $[ stageDependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
-    prLabels2: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-    prLabels3: $[ stageDependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels2'] ]
-    prLabels4: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels2'] ]
+    prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -128,10 +128,12 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # broker
@@ -145,7 +147,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: eq(variables['validationOptional'], 'true')
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -167,6 +168,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
@@ -174,6 +176,7 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
@@ -185,7 +188,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: eq(variables['validationOptional'], 'true')
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -207,6 +209,7 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
+        continueOnError: eq(variables['validationOptional'], 'true')
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
@@ -215,6 +218,7 @@ stages:
           sqAnalysisBreakBuildIfQualityGateFailed: false
       - task: Bash@3
         retryCountOnTaskFailure: 3
+        continueOnError: eq(variables['validationOptional'], 'true')
         displayName: Execute tests
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
@@ -244,7 +248,6 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: eq(variables['validationOptional'], 'true')
     steps:
     - checkout: adal
       displayName: Checkout adal repository
@@ -263,9 +266,11 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
+      continueOnError: eq(variables['validationOptional'], 'true')
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -100,10 +100,8 @@ stages:
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: checkPrCILabel
     - pwsh: |
-        Write-Host "Setting version to: $env:LABEL_FOUND"
-        Write-Host "Setting version to: $env:LABELFOUND"
-        Write-Host "$(checkPrCILabel.labelfound)"
-        Write-Host "##vso[task.setvariable variable=skipValidation;isOutput=true]$env:LABELFOUND"
+        Write-Host "Should skip validation: $(checkPrCILabel.labelfound)"
+        Write-Host "##vso[task.setvariable variable=skipValidation;isOutput=true]$(checkPrCILabel.labelfound)"
       displayName: 'Set variable'
       name: set_variable
   # msal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -60,7 +60,8 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    skipConsumerValidation: contains(variables.prLabels, variables.skipConsumerValidationLabel)
+    test: variables['prLabels']
+    skipConsumerValidation: contains(variables['prLabels'], variables['skipConsumerValidationLabel'])
   condition: and(succeeded(), not(eq(variables['skipConsumerValidation'], 'true')) )
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -169,7 +169,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      ${{ if eq($(validationOptional), 'true') }}:
+      ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -51,7 +51,8 @@ stages:
     name: Hosted Windows 2019 with VS2019
   jobs:
     job: getLabelsJob
-    - template: ../templates/steps/fetch-pr-labels.yml
+      steps:
+        template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers
   # Validate Consumers
   displayName: 'Validate'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -110,10 +110,12 @@ stages:
     dependsOn:
       - setupBranch
       - checkLabel
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+    condition: and(succeeded(), not(eq($(skipValidation), 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:
+    - pwsh: |
+        Write-Host "Should skip validation: $(skipValidation)"
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
       displayName: Checkout msal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -94,18 +94,23 @@ stages:
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
         then
-          echo "##vso[task.setvariable variable=prWithCILabel;isOutput=true]true"
-          echo "fullci label found!"
+          echo "##vso[task.setvariable variable=labelFound;isOutput=true]true"
+          echo "Skip-Consumers-Check label found"
         fi
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: checkPrCILabel
+    - pwsh: |
+        Write-Host "Setting version to: $env:LABELFOUND"
+        Write-Host "##vso[task.setvariable variable=labelFound;isOutput=true]$env:LABELFOUND"
+      displayName: 'Set variable'
+      name: set_variable
   # msal
   - job: msalValidation
     displayName: MSAL
     dependsOn:
       - setupBranch
       - checkLabel
-    condition: and(succeeded(), not(eq(variables['prWithCILabel'], 'true')) )
+    condition: and(succeeded(), not(eq(variables['labelFound'], 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,10 +59,7 @@ stages:
   dependsOn: checkLabel
   pool:
     name: Hosted Windows 2019 with VS2019
-  variables:
-    test: variables['prLabels']
-    skipConsumerValidation: contains(variables['prLabels'], variables['skipConsumerValidationLabel'])
-  condition: and(succeeded(), not(eq(variables['skipConsumerValidation'], 'true')) )
+  condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -48,6 +48,7 @@ stages:
   displayName: Check for PR Label
   pool:
     name: Hosted Windows 2019 with VS2019
+  jobs:
   - job: checkLabel
     steps:
       - template: ../templates/steps/fetch-pr-labels.yml
@@ -56,7 +57,7 @@ stages:
   displayName: 'Validate'
   pool:
     name: Hosted Windows 2019 with VS2019
-  condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+  condition: and(succeeded(), not(eq(variables['skipConsumerValidation'], 'true')) )
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -110,7 +110,6 @@ stages:
     dependsOn:
       - setupBranch
       - checkLabel
-    condition: and(succeeded(), not(eq($(skipValidation), 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,8 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: ${{ eq(variables['validationOptional'], 'true') }}
+    ${{ if variables.validationOptional }}:
+      continueOnError: true
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -128,12 +129,10 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
-      continueOnError: $(validationOptional)
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
-      continueOnError: $(validationOptional)
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # broker
@@ -168,7 +167,6 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      continueOnError: $(validationOptional)
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
@@ -176,7 +174,6 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
-      continueOnError: $(validationOptional)
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
@@ -209,7 +206,6 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
-        continueOnError: $(validationOptional)
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
@@ -218,7 +214,6 @@ stages:
           sqAnalysisBreakBuildIfQualityGateFailed: false
       - task: Bash@3
         retryCountOnTaskFailure: 3
-        continueOnError: $(validationOptional)
         displayName: Execute tests
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
@@ -266,11 +261,9 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
-      continueOnError: $(validationOptional)
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
-      continueOnError: $(validationOptional)
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: variables['validationOptional']
+    continueOnError: eq(variables['validationOptional'], 'true')
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -145,7 +145,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: variables['validationOptional']
+    continueOnError: eq(variables['validationOptional'], 'true')
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -185,7 +185,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: variables['validationOptional']
+    continueOnError: eq(variables['validationOptional'], 'true')
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -244,7 +244,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: variables['validationOptional']
+    continueOnError: eq(variables['validationOptional'], 'true')
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -110,8 +110,6 @@ stages:
       skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
     condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
-    - pwsh: |
-        Write-Host "Should skip validation: $(skipValidation)"
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
       displayName: Checkout msal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -92,9 +92,9 @@ stages:
     steps:
     - bash: |
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Consumer-Validation-Optional"'
+        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
         then
-          echo "##vso[task.setvariable variable=validationOptional;isOutput=true]true"
+          echo "##vso[task.setvariable variable=skipValidation;isOutput=true]true"
           echo "Skip-Consumers-Check label found, skip validation"
         fi
       condition: eq(variables['Build.Reason'], 'PullRequest')
@@ -107,7 +107,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -126,15 +127,11 @@ stages:
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
-      displayName: Assemble c$(validationOptional) msal
-      ${{ if eq(variables.validationOptional, 'true') }}:
-        continueOnError: true
+      displayName: Assemble msal
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
-      ${{ if eq(variables.validationOptional, 'true') }}:
-        continueOnError: true
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # broker
@@ -147,7 +144,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -169,8 +167,6 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      ${{ if eq(variables.validationOptional, 'true') }}:
-        continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
@@ -178,8 +174,6 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
-      ${{ if eq(variables.validationOptional, 'true') }}:
-        continueOnError: true
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
@@ -190,7 +184,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -212,8 +207,6 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
-        ${{ if eq(variables.validationOptional, 'true') }}:
-          continueOnError: true
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
@@ -223,8 +216,6 @@ stages:
       - task: Bash@3
         retryCountOnTaskFailure: 3
         displayName: Execute tests
-        ${{ if eq(variables.validationOptional, 'true') }}:
-          continueOnError: true
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
           targetType: 'inline'
@@ -252,7 +243,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - checkout: adal
       displayName: Checkout adal repository
@@ -271,13 +263,9 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
-      ${{ if eq(variables['validationOptional'], 'true') }}:
-        continueOnError: true
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
-      ${{ if eq(variables.validationOptional, 'true') }}:
-        continueOnError: true
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -89,6 +89,7 @@ stages:
   - job: msalValidation
     displayName: MSAL
     dependsOn: setupBranch
+    condition: and(succeeded(), notContains( github.event.pull_request.labels.*.name, 'Skip-Consumers-Check' ))
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -102,7 +102,9 @@ stages:
   # msal
   - job: msalValidation
     displayName: MSAL
-    dependsOn: setupBranch, checkLabel
+    dependsOn:
+      - setupBranch
+      - checkLabel
     condition: and(succeeded(), not(eq(variables['prWithCILabel'], 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
@@ -136,7 +138,9 @@ stages:
     displayName: Broker
     cancelTimeoutInMinutes: 1
     timeoutInMinutes: 120
-    dependsOn: setupBranch, checkLabel
+    dependsOn:
+      - setupBranch
+      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -172,7 +176,9 @@ stages:
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker
-    dependsOn: setupBranch, checkLabel
+    dependsOn:
+      - setupBranch
+      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -227,7 +233,9 @@ stages:
   # adal
   - job: adalValidation
     displayName: ADAL
-    dependsOn: setupBranch, checkLabel
+    dependsOn:
+      - setupBranch
+      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -43,13 +43,24 @@ resources:
     endpoint: ANDROID_GITHUB
 
 stages:
+- stage:
+  # Check PR Label
+  displayName: Check for PR Label
+  pool:
+    name: Hosted Windows 2019 with VS2019
+  - job: checkLabel
+    steps:
+      - template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers
+  # Validate Consumers
   displayName: 'Validate'
   pool:
     name: Hosted Windows 2019 with VS2019
+  condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
   jobs:
   # setup
   - job: setupBranch
+    dependsOn: checkLabel
     displayName: Setup branch
     steps:
     - checkout: none
@@ -85,20 +96,6 @@ stages:
         }
       name: echovar
       displayName: Echo branch name
-  # Check PR Label
-  - job: checkLabel
-    displayName: Check for PR Label
-    dependsOn: setupBranch
-    steps:
-    - bash: |
-        echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
-        then
-          echo "##vso[task.setvariable variable=skipValidation;isOutput=true]true"
-          echo "Skip-Consumers-Check label found, skip validation"
-        fi
-      condition: eq(variables['Build.Reason'], 'PullRequest')
-      name: checkPrCILabel
   # msal
   - job: msalValidation
     displayName: MSAL
@@ -107,8 +104,6 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -144,8 +139,6 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -184,8 +177,6 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -243,8 +234,6 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -169,9 +169,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      variables:
-        pleaseStop: $('validationOptional')
-      ${{ if eq(variables.pleaseStop, 'true') }}:
+      ${{ if eq($(validationOptional), 'true') }}:
         continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -94,16 +94,11 @@ stages:
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
         then
-          echo "##vso[task.setvariable variable=labelfound;isOutput=true]true"
-          echo "Skip-Consumers-Check label found"
+          echo "##vso[task.setvariable variable=skipValidation;isOutput=true]true"
+          echo "Skip-Consumers-Check label found, skip validation"
         fi
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: checkPrCILabel
-    - pwsh: |
-        Write-Host "Should skip validation: $(checkPrCILabel.labelfound)"
-        Write-Host "##vso[task.setvariable variable=skipValidation;isOutput=true]$(checkPrCILabel.labelfound)"
-      displayName: 'Set variable'
-      name: set_variable
   # msal
   - job: msalValidation
     displayName: MSAL
@@ -112,6 +107,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq($(skipValidation), 'true')) )
     steps:
     - pwsh: |
         Write-Host "Should skip validation: $(skipValidation)"

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -55,13 +55,13 @@ stages:
 - stage: validateConsumers
   # Validate Consumers
   displayName: 'Validate'
+  dependsOn: checkLabel
   pool:
     name: Hosted Windows 2019 with VS2019
   condition: and(succeeded(), not(eq(variables['skipConsumerValidation'], 'true')) )
   jobs:
   # setup
   - job: setupBranch
-    dependsOn: checkLabel
     displayName: Setup branch
     steps:
     - checkout: none
@@ -102,7 +102,6 @@ stages:
     displayName: MSAL
     dependsOn:
       - setupBranch
-      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:
@@ -137,7 +136,6 @@ stages:
     timeoutInMinutes: 120
     dependsOn:
       - setupBranch
-      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -175,7 +173,6 @@ stages:
     displayName: Linux Broker
     dependsOn:
       - setupBranch
-      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -232,7 +229,6 @@ stages:
     displayName: ADAL
     dependsOn:
       - setupBranch
-      - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -50,9 +50,7 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   jobs:
-  - job:
-    steps:
-      - template: ../templates/steps/fetch-pr-labels.yml
+    - template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers
   # Validate Consumers
   displayName: 'Validate'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -128,10 +128,14 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # broker

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -63,6 +63,7 @@ stages:
   # setup
   - job: setupBranch
     displayName: Setup branch
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     steps:
     - checkout: none
     - task: PowerShell@2
@@ -104,7 +105,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
+    condition: and( succeeded(), not(contains(variables['prLabels'], '{')) )
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -89,7 +89,7 @@ stages:
   - job: msalValidation
     displayName: MSAL
     dependsOn: setupBranch
-    condition: and(succeeded(), notContains( github.event.pull_request.labels.*.name, 'Skip-Consumers-Check' ))
+    condition: and(succeeded(), not(contains( github.event.pull_request.labels.*.name, 'Skip-Consumers-Check' )) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -43,13 +43,13 @@ resources:
     endpoint: ANDROID_GITHUB
 
 stages:
-- stage:
+- stage: checkLabel
   # Check PR Label
   displayName: Check for PR Label
   pool:
     name: Hosted Windows 2019 with VS2019
   jobs:
-  - job: checkLabel
+  - job:
     steps:
       - template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -44,21 +44,24 @@ resources:
     endpoint: ANDROID_GITHUB
 
 stages:
-- stage: checkLabel
+- stage: getLabel
   # Check PR Label
   displayName: Check for PR Label
   pool:
     name: Hosted Windows 2019 with VS2019
   jobs:
+    job: getLabelsJob
     - template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers
   # Validate Consumers
   displayName: 'Validate'
-  dependsOn: checkLabel
+  dependsOn: getLabel
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    prLabels: $[ dependencies.checkLabel.outputs['fetchPrCILabel.prLabels'] ]
+    test1: $[ dependencies.getLabel.getLabelsJob.outputs ]
+    test2: $[ dependencies.getLabel.outputs ]
+    prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -85,11 +85,25 @@ stages:
         }
       name: echovar
       displayName: Echo branch name
+  # Check PR Label
+  - job: checkLabel
+    displayName: Check for PR Label
+    dependsOn: setupBranch
+    steps:
+    - bash: |
+        echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-check"'
+        then
+          echo "##vso[task.setvariable variable=prWithCILabel;isOutput=true]true"
+          echo "fullci label found!"
+        fi
+      condition: eq(variables['Build.Reason'], 'PullRequest')
+      name: checkPrCILabel
   # msal
   - job: msalValidation
     displayName: MSAL
-    dependsOn: setupBranch
-    condition: and(succeeded(), not(contains( github.event.pull_request.labels.*.name, 'Skip-Consumers-Check' )) )
+    dependsOn: setupBranch, checkLabel
+    condition: and(succeeded(), not(eq(variables['prWithCILabel'], 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:
@@ -122,7 +136,7 @@ stages:
     displayName: Broker
     cancelTimeoutInMinutes: 1
     timeoutInMinutes: 120
-    dependsOn: setupBranch
+    dependsOn: setupBranch, checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -158,7 +172,7 @@ stages:
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker
-    dependsOn: setupBranch
+    dependsOn: setupBranch, checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     pool:
@@ -213,7 +227,7 @@ stages:
   # adal
   - job: adalValidation
     displayName: ADAL
-    dependsOn: setupBranch
+    dependsOn: setupBranch, checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -4,6 +4,7 @@
 # Variable: 'mvnAccessToken' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 # Variable: 'commonBranchName' common branch to be used when running the pipeline manually
+# Variable: 'skipConsumerValidationLabel' PR label used to skip the checks in this pipeline
 name: $(date:yyyyMMdd)$(rev:.r)
 
 trigger: none
@@ -58,6 +59,8 @@ stages:
   dependsOn: checkLabel
   pool:
     name: Hosted Windows 2019 with VS2019
+  variables:
+    skipConsumerValidation: contains(variables.prLabels, variables.skipConsumerValidationLabel)
   condition: and(succeeded(), not(eq(variables['skipConsumerValidation'], 'true')) )
   jobs:
   # setup

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -58,8 +58,7 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   variables:
-    test1: $[ dependencies.getLabel.getLabelsJob.outputs ]
-    test2: $[ dependencies.getLabel.outputs ]
+    prLabels2: $[ dependencies.getLabel.outputs['getLabelsJob.fetchPrCILabel.prLabels'] ]
     prLabels: $[ dependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
   condition: and(succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])))
   jobs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,7 +108,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    continueOnError: eq(variables['validationOptional'], 'true')
+    continueOnError: ${{ eq(variables['validationOptional'], 'true') }}
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -128,7 +128,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: eq($(validationOptional), 'true')
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -108,8 +108,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
-    ${{ if variables.validationOptional }}:
-      continueOnError: true
+    continueOnError: ${{ eq(variables['validationOptional'], 'true') }}
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -146,6 +145,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnError: ${{ eq($(validationOptional), 'true') }}
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -185,6 +185,7 @@ stages:
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
       validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnError: ${{ eq($(checkPrCILabelvalidationOptional), 'true') }}
     pool:
       vmImage: 'ubuntu-latest'
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: and(succeeded(), not(contains(variables['prLabels'], '{')))
+  condition: and(succeeded(), not(contains($(prLabels), '{')))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -92,9 +92,9 @@ stages:
     steps:
     - bash: |
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
+        if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Consumer-Validation-Optional"'
         then
-          echo "##vso[task.setvariable variable=skipValidation;isOutput=true]true"
+          echo "##vso[task.setvariable variable=validationOptional;isOutput=true]true"
           echo "Skip-Consumers-Check label found, skip validation"
         fi
       condition: eq(variables['Build.Reason'], 'PullRequest')
@@ -107,8 +107,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnFailure: variables['validationOptional']
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -144,8 +144,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnFailure: variables['validationOptional']
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -184,8 +184,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnFailure: variables['validationOptional']
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -243,8 +243,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
-    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
+      validationOptional: $[ dependencies.checkLabel.outputs['checkPrCILabel.validationOptional'] ]
+    continueOnFailure: variables['validationOptional']
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: not(contains(stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'], '{'))
+  condition: not(eq(stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'], ''))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -126,7 +126,7 @@ stages:
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
-      displayName: Assemble msal
+      displayName: Assemble c$(validationOptional) msal
       ${{ if eq(variables.validationOptional, 'true') }}:
         continueOnError: true
       inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -50,9 +50,7 @@ stages:
   pool:
     name: Hosted Windows 2019 with VS2019
   jobs:
-    job: getLabelsJob
-      steps:
-        template: ../templates/steps/fetch-pr-labels.yml
+    - template: ../templates/steps/fetch-pr-labels.yml
 - stage: validateConsumers
   # Validate Consumers
   displayName: 'Validate'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -104,7 +104,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    condition: not(eq(variables['prLabels'], ''))
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     steps:
     - template: ../templates/steps/automation-cert.yml
     - checkout: msal
@@ -139,6 +139,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -176,6 +177,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -232,6 +234,7 @@ stages:
       - setupBranch
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -94,7 +94,7 @@ stages:
         echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
         then
-          echo "##vso[task.setvariable variable=labelFound;isOutput=true]true"
+          echo "##vso[task.setvariable variable=labelfound;isOutput=true]true"
           echo "Skip-Consumers-Check label found"
         fi
       condition: eq(variables['Build.Reason'], 'PullRequest')
@@ -102,7 +102,8 @@ stages:
     - pwsh: |
         Write-Host "Setting version to: $env:LABEL_FOUND"
         Write-Host "Setting version to: $env:LABELFOUND"
-        Write-Host "##vso[task.setvariable variable=labelFound;isOutput=true]$env:LABELFOUND"
+        Write-Host "$(labelfound)"
+        Write-Host "##vso[task.setvariable variable=skipValidation;isOutput=true]$env:LABELFOUND"
       displayName: 'Set variable'
       name: set_variable
   # msal
@@ -111,7 +112,7 @@ stages:
     dependsOn:
       - setupBranch
       - checkLabel
-    condition: and(succeeded(), not(eq(variables['labelFound'], 'true')) )
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
     steps:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -128,12 +128,12 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble msal
-      continueOnError: eq($(validationOptional), 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
   # broker
@@ -168,7 +168,7 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
@@ -176,7 +176,7 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
@@ -209,7 +209,7 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
-        continueOnError: eq(variables['validationOptional'], 'true')
+        continueOnError: $(validationOptional)
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
@@ -218,7 +218,7 @@ stages:
           sqAnalysisBreakBuildIfQualityGateFailed: false
       - task: Bash@3
         retryCountOnTaskFailure: 3
-        continueOnError: eq(variables['validationOptional'], 'true')
+        continueOnError: $(validationOptional)
         displayName: Execute tests
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
@@ -266,11 +266,11 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
-      continueOnError: eq(variables['validationOptional'], 'true')
+      continueOnError: $(validationOptional)
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -59,7 +59,7 @@ stages:
     name: Hosted Windows 2019 with VS2019
   variables:
     prLabels: $[ stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
-  condition: not(contains(variables.prLabels, '{'))
+  condition: not(contains(stageDependencies.getLabel.getLabelsJob.outputs['fetchPrCILabel.prLabels'], '{'))
   jobs:
   # setup
   - job: setupBranch

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -146,6 +146,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       name: 1ES-AndroidPool-EOC-Test
     steps:
@@ -184,6 +186,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -241,6 +245,8 @@ stages:
       - checkLabel
     variables:
       commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
+      skipValidation: $[ dependencies.checkLabel.outputs['checkPrCILabel.skipValidation'] ]
+    condition: and(succeeded(), not(eq(variables['skipValidation'], 'true')) )
     steps:
     - checkout: adal
       displayName: Checkout adal repository

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -170,6 +170,8 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble broker
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
@@ -177,6 +179,8 @@ stages:
         sqAnalysisBreakBuildIfQualityGateFailed: false
     - task: Gradle@2
       displayName: Run broker Unit tests
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
   # Linux broker
@@ -209,6 +213,8 @@ stages:
       - task: Gradle@1
         name: Gradle1
         displayName: Assemble Linux Broker
+        ${{ if variables.validationOptional }}:
+          continueOnError: true
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
@@ -218,6 +224,8 @@ stages:
       - task: Bash@3
         retryCountOnTaskFailure: 3
         displayName: Execute tests
+        ${{ if variables.validationOptional }}:
+          continueOnError: true
         inputs:
           workingDirectory: $(Build.SourcesDirectory)/broker-java-root
           targetType: 'inline'
@@ -264,9 +272,13 @@ stages:
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - task: Gradle@2
       displayName: Assemble adal
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: clean adal:assembleLocal
     - task: Gradle@2
       displayName: Run adal Unit tests
+      ${{ if variables.validationOptional }}:
+        continueOnError: true
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -2,18 +2,20 @@ steps:
   - bash: |
       echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
       curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-
       if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
       then
         echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"
         echo "Skip-Consumers-Check label found, skip validation"
       fi
-
-      echo "##vso[task.setvariable variable=labelz]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
       echo $(skipConsumerValidation)
       echo "$(labelz)"
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
   - bash: |
-      echo "$(skipConsumerValidation)"
-      echo "$(labelz)"
+      echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      test1=curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'
+      echo "##vso[task.setvariable variable=labelz]$test1"
+      echo "$test1"
+  - bash: |
+      echo "$skipConsumerValidation"
+      echo "$labelz"

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -2,11 +2,14 @@ steps:
   - bash: |
       echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
       curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'
+
       if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
       then
         echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"
         echo "Skip-Consumers-Check label found, skip validation"
       fi
+
+      echo "##vso[task.setvariable variable=labels]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
+      echo "$(labels)"
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,20 +1,7 @@
 steps:
   - bash: |
-      echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
-      then
-        echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"
-        echo "Skip-Consumers-Check label found, skip validation"
-      fi
-      echo $(skipConsumerValidation)
+      echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
+      echo "##vso[task.setvariable variable=prLabels]$temp"
     condition: eq(variables['Build.Reason'], 'PullRequest')
-    name: checkPrCILabel
-  - bash: |
-      echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      test1=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
-      echo "##vso[task.setvariable variable=labelz]$test1"
-      echo "$test1"
-  - bash: |
-      echo "$skipConsumerValidation"
-      echo "$labelz"
+    name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,4 +1,5 @@
-job: getLabelsJob
+jobs:
+- job: getLabelsJob
   displayName: Fetch PR Labels
   steps:
     - bash: |

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -4,7 +4,7 @@ jobs:
   steps:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -jr '.[] | {name}')
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -jc '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -10,10 +10,10 @@ steps:
       fi
 
       echo "##vso[task.setvariable variable=labelz]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
-      echo $(labelz)
       echo $(skipConsumerValidation)
+      echo "$(labelz)"
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
   - bash: |
-      echo $(labelz)
-      echo $(skipConsumerValidation)
+      echo "$(skipConsumerValidation)"
+      echo "$(labelz)"

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,10 +1,7 @@
-jobs:
-- job:
-  displayName: Fetch PR Labels
-  steps:
-    - bash: |
-        echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
-        echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
-      condition: eq(variables['Build.Reason'], 'PullRequest')
-      name: fetchPrCILabel
+steps:
+  - bash: |
+      echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
+      echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -2,6 +2,7 @@ steps:
   - bash: |
       echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
       curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[].name'
       if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
       then
         echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,0 +1,11 @@
+steps:
+  - bash: |
+      echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+      if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
+      then
+        echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"
+        echo "Skip-Consumers-Check label found, skip validation"
+      fi
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    name: checkPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -4,7 +4,7 @@ jobs:
   steps:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -c '.[] | {name}')
         echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -6,6 +6,5 @@ jobs:
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
         echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
-        echo "##vso[task.setvariable variable=prLabels2;isOutput=true]why?"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,7 +1,9 @@
-steps:
-  - bash: |
-      echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
-      echo "##vso[task.setvariable variable=prLabels]$temp"
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    name: fetchPrCILabel
+- job:
+  displayName: Fetch PR Labels
+  - steps:
+    - bash: |
+        echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
+        echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+      condition: eq(variables['Build.Reason'], 'PullRequest')
+      name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -2,7 +2,7 @@ steps:
   - bash: |
       echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
       curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[].name'
+      curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'
       if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "Skip-Consumers-Check"'
       then
         echo "##vso[task.setvariable variable=skipConsumerValidation;isOutput=true]true"

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -5,7 +5,7 @@ jobs:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -c '.[] | {name}')
-        echo "##vso[task.setvariable variable=prLabels;isOutput=true]'$temp'"
+        echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,7 +1,9 @@
-steps:
-  - bash: |
-      echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
-      echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    name: fetchPrCILabel
+job: getLabelsJob
+  displayName: Fetch PR Labels
+  steps:
+    - bash: |
+        echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
+        echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+      condition: eq(variables['Build.Reason'], 'PullRequest')
+      name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -4,7 +4,7 @@ jobs:
   steps:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -j '.[] | {name}')
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -jr '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -9,7 +9,11 @@ steps:
         echo "Skip-Consumers-Check label found, skip validation"
       fi
 
-      echo "##vso[task.setvariable variable=labels]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
-      echo $(labels)
+      echo "##vso[task.setvariable variable=labelz]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
+      echo $(labelz)
+      echo $(skipConsumerValidation)
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
+  - bash: |
+      echo $(labelz)
+      echo $(skipConsumerValidation)

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -5,7 +5,7 @@ jobs:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -c '.[] | {name}')
-        echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+        echo "##vso[task.setvariable variable=prLabels;isOutput=true]'$temp'"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -8,12 +8,11 @@ steps:
         echo "Skip-Consumers-Check label found, skip validation"
       fi
       echo $(skipConsumerValidation)
-      echo "$(labelz)"
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel
   - bash: |
       echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-      test1=curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'
+      test1=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
       echo "##vso[task.setvariable variable=labelz]$test1"
       echo "$test1"
   - bash: |

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -6,5 +6,6 @@ jobs:
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')
         echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+        echo "##vso[task.setvariable variable=prLabels2;isOutput=true]why?"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -10,6 +10,6 @@ steps:
       fi
 
       echo "##vso[task.setvariable variable=labels]curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}'"
-      echo "$(labels)"
+      echo $(labels)
     condition: eq(variables['Build.Reason'], 'PullRequest')
     name: checkPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -6,5 +6,6 @@ jobs:
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -c '.[] | {name}')
         echo "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
+        echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -4,7 +4,7 @@ jobs:
   steps:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -c '.[] | {name}')
+        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -j '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -1,6 +1,7 @@
+jobs:
 - job:
   displayName: Fetch PR Labels
-  - steps:
+  steps:
     - bash: |
         echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq '.[] | {name}')

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -63,7 +63,7 @@ public final class AuthenticationConstants {
     /**
      * The Constant CHARSET_UTF8.
      */
-    private static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
+    public static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
     /**
      * The Constant CHARSET_ASCII.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -63,7 +63,7 @@ public final class AuthenticationConstants {
     /**
      * The Constant CHARSET_UTF8.
      */
-    public static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
+    private static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
     /**
      * The Constant CHARSET_ASCII.


### PR DESCRIPTION
Add a label to skip consumer validation.

The label is named `Skip-Consumers-Check`, and should only be used when creating PRs that purposefully break common consumers, and must be accompanied by Respective PRs in the other repos to address the breaks. It would be impossible to make this check required without a mechanism like this to enable bypassing it in the scenario outlined above.
