### PR TITLE
handle broker discovery disabled on SDK side

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.NEXT
 ----------
+- [MAJOR] handle broker discovery disabled on SDK side (#2145)
 - [MAJOR] Update active broker cache upon returned result (#2140)
 - [MAJOR] Move Broker side active broker cache to broker repo (#2123)
 - [MINOR] Add span names for the BrokerOperationRequestDispatcher and PassthroughExecutor (#2100)

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheUpdater.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheUpdater.kt
@@ -27,6 +27,7 @@ import android.os.Bundle
 import com.microsoft.identity.common.internal.broker.BrokerData
 import com.microsoft.identity.common.internal.broker.BrokerValidator
 import com.microsoft.identity.common.logging.Logger
+import java.util.concurrent.TimeUnit
 
 /**
  * With the new broker selection mechanism, it is possible that the active broker that actually
@@ -43,9 +44,9 @@ import com.microsoft.identity.common.logging.Logger
  * */
 class ActiveBrokerCacheUpdater(
     private val isValidBroker: (BrokerData) -> Boolean,
-    private val cache: IActiveBrokerCache) {
+    private val cache: IClientActiveBrokerCache) {
 
-    constructor(context: Context, cache: IActiveBrokerCache): this(
+    constructor(context: Context, cache: IClientActiveBrokerCache): this(
         isValidBroker = { brokerData: BrokerData ->
             BrokerValidator(context).isSignedByKnownKeys(brokerData)
         },
@@ -62,6 +63,14 @@ class ActiveBrokerCacheUpdater(
         const val ACTIVE_BROKER_PACKAGE_NAME_KEY = "active.broker.package.name"
         const val ACTIVE_BROKER_SIGNING_CERTIFICATE_THUMBPRINT_KEY = "active.broker.signing.certificate.thumbprint"
 
+        /**
+         * Keys indicating that the "broker discovery" feature is turned off on the Broker side.
+         * (and therefore the SDK should fall back to using Account Manager to figure out which app is the active broker.)
+         *
+         * Do NOT change the value of these parameters (it's a breaking change!)
+         */
+        const val BROKER_DISCOVERY_DISABLED_KEY = "broker.discovery.disabled"
+
 
         /**
          * Adds the active broker information to the result bundle.
@@ -76,17 +85,39 @@ class ActiveBrokerCacheUpdater(
             bundle.putString(ACTIVE_BROKER_SIGNING_CERTIFICATE_THUMBPRINT_KEY,
                 activeBroker.signingCertificateThumbprint)
         }
+
+        /**
+         * Adds the "broker discovery is now disabled" to the result bundle.
+         *
+         * @param bundle       The result bundle.
+         */
+        @JvmStatic
+        fun appendBrokerDiscoveryDisabledToResultBundle(bundle: Bundle) {
+            bundle.putBoolean(BROKER_DISCOVERY_DISABLED_KEY, true)
+        }
     }
 
     /**
-     * If the active broker is returned with the result bundle,
-     * update [IActiveBrokerCache] with it.
+     * If the active broker is returned with the result bundle, update [IActiveBrokerCache] with it.
+     * If the active broker indicates that the broker discovery is disabled, wipe [IActiveBrokerCache].
      *
-     * @param bundle       The result bundle. could be null (for backward compatibility).
+     * @param bundle    The result bundle. could be null (for backward compatibility).
      */
     fun updateCachedActiveBrokerFromResultBundle(bundle: Bundle?) {
         val methodTag = "$TAG:updateCachedActiveBrokerFromResultBundle"
         if (bundle == null) {
+            return
+        }
+
+        val shouldWipeCachedActiveBroker = bundle.getBoolean(BROKER_DISCOVERY_DISABLED_KEY, false)
+        if (shouldWipeCachedActiveBroker) {
+            Logger.info(methodTag, "Got a response indicating that the broker discovery is disabled." +
+                    "Will also wipe the local active broker cache," +
+                    "and skip broker discovery via IPC (only fall back to AccountManager) for the next 60 minutes.")
+            cache.clearCachedActiveBroker()
+            cache.setShouldUseAccountManagerForTheNextMilliseconds(
+                TimeUnit.MINUTES.toMillis(60)
+            )
             return
         }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/brokeroperationexecutor/BrokerOperationExecutorTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/brokeroperationexecutor/BrokerOperationExecutorTests.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.common.internal.activebrokerdiscovery.InMemoryActi
 import com.microsoft.identity.common.internal.broker.BrokerData;
 import com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater;
 import com.microsoft.identity.common.internal.cache.IActiveBrokerCache;
+import com.microsoft.identity.common.internal.cache.IClientActiveBrokerCache;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.java.exception.ClientException;
@@ -179,7 +180,7 @@ public class BrokerOperationExecutorTests {
                 "com.microsoft.newActiveBroker",
                 "SOME_SIG_HASH");
 
-        final IActiveBrokerCache cache = new InMemoryActiveBrokerCache();
+        final IClientActiveBrokerCache cache = new InMemoryActiveBrokerCache();
         final ActiveBrokerCacheUpdater mCacheUpdater = new ActiveBrokerCacheUpdater(
                 (brokerData) -> brokerData.equals(newActiveBroker),
                 cache
@@ -222,7 +223,7 @@ public class BrokerOperationExecutorTests {
         final List<IIpcStrategy> strategyList = new ArrayList<>();
         strategyList.add(getStrategyWithValidResult());
 
-        final IActiveBrokerCache cache = new InMemoryActiveBrokerCache();
+        final IClientActiveBrokerCache cache = new InMemoryActiveBrokerCache();
         cache.setCachedActiveBroker(currentActiveBroker);
 
         expectValidResult(strategyList, cache);
@@ -234,7 +235,7 @@ public class BrokerOperationExecutorTests {
     }
 
     private void expectValidResult(final List<IIpcStrategy> strategyList,
-                                   final IActiveBrokerCache cache) {
+                                   final IClientActiveBrokerCache cache) {
         try {
             final BrokerOperationExecutor executor = new BrokerOperationExecutor(
                     strategyList,

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheUpdaterTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ActiveBrokerCacheUpdaterTest.kt
@@ -125,4 +125,23 @@ class ActiveBrokerCacheUpdaterTest {
         cacheUpdater.updateCachedActiveBrokerFromResultBundle(bundle)
         Assert.assertEquals(newActiveBroker, cache.getCachedActiveBroker())
     }
+
+    @Test
+    fun testWipeCachedActiveBroker(){
+        val cache = InMemoryActiveBrokerCache()
+        cache.setCachedActiveBroker(newActiveBroker)
+
+        val cacheUpdater = ActiveBrokerCacheUpdater ({ false }, cache)
+
+        val bundle = Bundle()
+        ActiveBrokerCacheUpdater.appendBrokerDiscoveryDisabledToResultBundle(bundle)
+
+        Assert.assertEquals(newActiveBroker, cache.getCachedActiveBroker())
+        Assert.assertFalse(cache.shouldUseAccountManager())
+
+        cacheUpdater.updateCachedActiveBrokerFromResultBundle(bundle)
+
+        Assert.assertNull(cache.getCachedActiveBroker())
+        Assert.assertTrue(cache.shouldUseAccountManager())
+    }
 }


### PR DESCRIPTION
In the scenario where we have to disable the broker discovery feature (e.g. via flighting)

We want to make sure that the SDK stops pinging the cached active broker, and go back to using AccountManager to discovery the active broker.

`ActiveBrokerCacheUpdater.appendBrokerDiscoveryDisabledToResultBundle()` will be invoked on the broker side whenever 
1. the feature is disabled on the broker side.
2. The pinged active broker is NOT the same broker that was elected by Account Manager.

Generally, this wouldn't happen (as our new broker selection logic will pick the broker with existing credentials, so it would be the same with the AccountManager-picked one).

We would only see this flag being returned to the SDK when Google regresses the broker switch bug only.

Validated with the added test.