### PR TITLE
Added child parameters to CommandParameters for OneAuth to set them

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
@@ -80,6 +80,12 @@ public class CommandParameters {
     private String redirectUri;
 
     @Expose()
+    private String childClientId;
+
+    @Expose()
+    private String childRedirectUri;
+
+    @Expose()
     private boolean powerOptCheckEnabled;
 
     @Expose()

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/CommandParameters.java
@@ -79,9 +79,15 @@ public class CommandParameters {
     @Expose()
     private String redirectUri;
 
+    /**
+     * ClientId of a nested app
+     */
     @Expose()
     private String childClientId;
 
+    /**
+     * RedirectUri of a nested app
+     */
     @Expose()
     private String childRedirectUri;
 


### PR DESCRIPTION
In nested app authentication flow, broker needs to query ESTS with nested app's clientid and redirectUri. To allow OneAuth to set this, we have added child parameters to command parameters. 