### PR TITLE
remove in-memory cached value in ClientActiveBrokerCache

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCache.kt
@@ -79,27 +79,15 @@ internal constructor(private val storage: INameValueStorage<String>,
             "SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY"
     }
 
-    /**
-     * Cached value of [SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY]
-     **/
-    var cachedTimeStamp: Long? = null
-
     override fun shouldUseAccountManager(): Boolean {
         return runBlocking {
             lock.withLock {
-                if (cachedTimeStamp == null){
-                    storage.get(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY)?.let { rawValue ->
-                        rawValue.toLongOrNull()?.let { expiryDate ->
-                            cachedTimeStamp = expiryDate
-                        }
+                storage.get(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY)?.let { rawValue ->
+                    rawValue.toLongOrNull()?.let { expiryDate ->
+                        return@runBlocking isNotExpired(expiryDate)
                     }
                 }
 
-                if (isNotExpired(cachedTimeStamp)){
-                    return@runBlocking true
-                }
-
-                cachedTimeStamp = null
                 return@runBlocking false
             }
         }
@@ -110,7 +98,6 @@ internal constructor(private val storage: INameValueStorage<String>,
             lock.withLock {
                 val timeStamp = System.currentTimeMillis() + timeInMillis
                 storage.put(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY, timeStamp.toString())
-                cachedTimeStamp = timeStamp
             }
         }
     }
@@ -120,7 +107,6 @@ internal constructor(private val storage: INameValueStorage<String>,
             lock.withLock {
                 clearCachedActiveBrokerWithoutLock()
                 storage.remove(SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY)
-                cachedTimeStamp = null
             }
         }
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCacheTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/ClientActiveBrokerCacheTest.kt
@@ -36,18 +36,15 @@ class ClientActiveBrokerCacheTest {
         Assert.assertNull(cache.getCachedActiveBroker())
 
         Assert.assertFalse(cache.shouldUseAccountManager())
-        Assert.assertNull(cache.cachedTimeStamp)
 
         cache.setShouldUseAccountManagerForTheNextMilliseconds(
             TimeUnit.SECONDS.toMillis(2)
         )
         Assert.assertTrue(cache.shouldUseAccountManager())
-        Assert.assertNotNull(cache.cachedTimeStamp)
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(2))
 
         Assert.assertFalse(cache.shouldUseAccountManager())
-        Assert.assertNull(cache.cachedTimeStamp)
     }
 
     @Test
@@ -56,17 +53,14 @@ class ClientActiveBrokerCacheTest {
         Assert.assertNull(cache.getCachedActiveBroker())
 
         Assert.assertFalse(cache.shouldUseAccountManager())
-        Assert.assertNull(cache.cachedTimeStamp)
 
         cache.setShouldUseAccountManagerForTheNextMilliseconds(
             TimeUnit.SECONDS.toMillis(2)
         )
         Assert.assertTrue(cache.shouldUseAccountManager())
-        Assert.assertNotNull(cache.cachedTimeStamp)
 
         cache.clearCachedActiveBroker()
 
         Assert.assertFalse(cache.shouldUseAccountManager())
-        Assert.assertNull(cache.cachedTimeStamp)
     }
 }


### PR DESCRIPTION
Remove the per-instance cache because there could be multiple instances in one app (and the in-memory cached data could be out of date)

This is a good example of premature optimization :/

Later down the line, if we want to optimize this, we could add this back as a "global static" variable.