### PR TITLE
Fix authenticator app automation

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -400,6 +400,8 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
             UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("Continue");
             // the skip button
             UiAutomatorUtils.handleButtonClick("com.azure.authenticator:id/frx_skip_button");
+            // This is required for auth app as it has increased the compile sdk version to 34
+            UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("NOT NOW");
             shouldHandleFirstRun = false;
         }
     }


### PR DESCRIPTION
Issue : After authenticator increased its compile SDK to 34, an additional popup is coming up after the first run experience.
Fix : Made changes to skip the popup by clicking on "Not Now"