### PR TITLE
Fixing common consumers pipeline

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -129,10 +129,12 @@ stages:
         jdkArchitecture: x64
         jdkVersionOption: "1.11"
         tasks: clean msal:assembleLocal
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Run msal Unit tests
       inputs:
         tasks: msal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"
   # broker
   - job: brokerValidation
     displayName: Broker
@@ -169,10 +171,12 @@ stages:
         publishJUnitResults: false
         jdkArchitecture: x64
         jdkVersionOption: "1.11"
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Run broker Unit tests
       inputs:
         tasks: AADAuthenticator:localDebugAADAuthenticatorUnitTestCoverageReport --build-cache --info -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PpowerLiftApiKey=$(powerliftApiKey) -PcodeCoverageEnabled=true ${{variables.shouldSkipLongRunningTest}}
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"
   # Linux broker
   - job: linuxBrokerValidation
     displayName: Linux Broker
@@ -199,8 +203,8 @@ stages:
         inputs:
           filename: echo
           arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_OFFICE_ACCESSTOKEN]$(System.AccessToken)'
-      - task: Gradle@1
-        name: Gradle1
+      - task: Gradle@3
+        name: Gradle3
         displayName: Assemble Linux Broker
         inputs:
           cwd: $(Build.SourcesDirectory)/broker-java-root
@@ -260,7 +264,9 @@ stages:
         tasks: clean adal:assembleLocal
         jdkArchitecture: x64
         jdkVersionOption: "1.11"
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Run adal Unit tests
       inputs:
         tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -123,9 +123,11 @@ stages:
           git status
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Assemble msal
       inputs:
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"
         tasks: clean msal:assembleLocal
     - task: Gradle@2
       displayName: Run msal Unit tests

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -162,13 +162,13 @@ stages:
           git status
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Assemble broker
       inputs:
         tasks: AADAuthenticator:clean AADAuthenticator:assembleLocal --build-cache --info
         publishJUnitResults: false
-        jdkArchitecture: x86
-        sqAnalysisBreakBuildIfQualityGateFailed: false
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"
     - task: Gradle@2
       displayName: Run broker Unit tests
       inputs:
@@ -206,8 +206,8 @@ stages:
           cwd: $(Build.SourcesDirectory)/broker-java-root
           tasks: LinuxBroker:clean LinuxBroker:assemble --build-cache --info
           publishJUnitResults: false
-          jdkArchitecture: x86
-          sqAnalysisBreakBuildIfQualityGateFailed: false
+          jdkArchitecture: x64
+          jdkVersionOption: "1.11"
       - task: Bash@3
         retryCountOnTaskFailure: 3
         displayName: Execute tests
@@ -254,10 +254,12 @@ stages:
           git status
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
-    - task: Gradle@2
+    - task: Gradle@3
       displayName: Assemble adal
       inputs:
         tasks: clean adal:assembleLocal
+        jdkArchitecture: x64
+        jdkVersionOption: "1.11"
     - task: Gradle@2
       displayName: Run adal Unit tests
       inputs:


### PR DESCRIPTION
Issue : This PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2142 caused a break in common consumers pipeline. The stages that consume common need to have JDK 11 installed after updating the gradle version to 7.5.
This was not caught in the pipeline run of the PR because MSAL and Broker PRs were merged after common was merged.

Fix : Updated the jdk version on the pipeline