### PR TITLE
Deprecate logger wrappers and update comments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,19 @@
+V.Next
+----------
+- [MINOR] Deprecate Common logger wrappers (#2157)
+- [PATCH] Fix NPE in OTEL code for DCF flow (#2139)
+- [PATCH] Fixed debug apps not recognized as active broker issue (#2138)
+- [MAJOR] Update active broker cache upon returned result (#2140)
+- [MINOR] Update TokenRequest.java with NAA params (#2143)
+- [MAJOR] handle broker discovery disabled on SDK side (#2145)
+- [MINOR] Refactored OneAuthTestApp infra in order to process LTW test cases (#2136)
+- [MINOR] Add checkMode method to msaltestapp infra (#2141)
+- [MINOR] Updated target, compile sdk, AGP and gradle versions  (#2142)
+- [MINOR] Add new apk name to BrokerHost infra (#2152)
+- [MINOR] Send key to request broker data in all BrokerOperationBundle (#2159)
+
 V.15.0.0
 ----------
-- [MINOR] Send key to request broker data in all BrokerOperationBundle (#2159)
-- [MAJOR] handle broker discovery disabled on SDK side (#2145)
-- [MAJOR] Update active broker cache upon returned result (#2140)
 - [MAJOR] Move Broker side active broker cache to broker repo (#2123)
 - [MINOR] Add span names for the BrokerOperationRequestDispatcher and PassthroughExecutor (#2100)
 - [PATCH] Add key derivation method that takes SecretKey object as argument (#2113)
@@ -13,13 +24,6 @@ V.15.0.0
 - [MINOR] Capture perf telemetry for cache & network operations (#2124)
 - [MINOR] Add method to flush shared preference file manager (#2130)
 - [PATCH] Improve logging in BrokerMsalController.verifyBrokerVersionIsSupported (#2132)
-- [MINOR] Refactored OneAuthTestApp infra in order to process LTW test cases (#2136)
-- [PATCH] Fix NPE in OTEL code for DCF flow (#2139)
-- [PATCH] Fixed debug apps not recognized as active broker issue (#2138)
-- [MINOR] Updated target, compile sdk, AGP and gradle versions  (#2142)
-- [MINOR] Add checkMode method to msaltestapp infra (#2141)
-- [MINOR] Update TokenRequest.java with NAA params (#2143)
-- [MINOR] Add new apk name to BrokerHost infra (#2152)
 
 V.14.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
@@ -31,11 +31,12 @@ import com.microsoft.identity.common.java.telemetry.events.DeprecatedApiUsageEve
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Deprecated.
- * <p>
  * This is now acting as an adapter for {@link com.microsoft.identity.common.java.logging.Logger}.
+ * <p>
+ * Deprecated: Broker partners should use {@link com.microsoft.identity.common.java.logging.Logger}
  **/
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+@Deprecated
 public class Logger extends com.microsoft.identity.common.logging.Logger {
 
     private static boolean sEmitDeprecationEvent = true;

--- a/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/logging/Logger.java
@@ -33,7 +33,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * This is now acting as an adapter for {@link com.microsoft.identity.common.java.logging.Logger}.
  * <p>
- * Deprecated: Broker partners should use {@link com.microsoft.identity.common.java.logging.Logger}
+ * Deprecated: Broker partners should use class linked above.
  **/
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 @Deprecated

--- a/common/src/main/java/com/microsoft/identity/common/logging/Logger.java
+++ b/common/src/main/java/com/microsoft/identity/common/logging/Logger.java
@@ -28,7 +28,13 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-// Android's Logger. Wraps around common4j's logger (with an addition of Logcat).
+
+/**
+ * Android's Logger. Wraps around common4j's logger (with an addition of Logcat).
+ * <p>
+ * Deprecated: Broker partners should use {@link com.microsoft.identity.common.java.logging.Logger}
+ */
+@Deprecated
 public class Logger {
 
     private static final String ANDROID_LOGCAT_LOGGER_IDENTIFIER = "ANDROID_LOGCAT_LOGGER";


### PR DESCRIPTION
Deprecate logger wrappers in common to notify partners to use `com.microsoft.identity.common.java.logging.Logger` instead.

Not sure if this needs a changelog entry...