### PR TITLE
Catch strongbox exception on Android 14

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ V.15.0.0
 - [MINOR] Add checkMode method to msaltestapp infra (#2141)
 - [MINOR] Update TokenRequest.java with NAA params (#2143)
 - [MINOR] Add new apk name to BrokerHost infra (#2152)
+- [MINOR] Catch strongbox exception on Android 14 (#2158)
 
 V.14.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -217,8 +217,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                         trySetAttestationChallenge = false;
 
                         continue;
-                    } else if (tryStrongBox && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-                            && (Build.VERSION.RELEASE_OR_CODENAME.equals("UpsideDownCake") || Build.VERSION.RELEASE_OR_CODENAME.equals("14"))
+                    } else if (tryStrongBox && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
                             && (null != e.getCause()) && isNegativeInternalError(e.getCause())) {
                         // Android 14 specific error where strong box is failing, most likely because of IAR requirement in android 14
                         // https://android.googlesource.com/platform/compatibility/cdd/+/e2fee2f/9_security-model/9_11_keys-and-credentials.md


### PR DESCRIPTION
**Issue** : This is related to the fix we did in the PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2053

The fix we did previously worked and Defender team confirmed the same. They were unblocked on Andorid 14. But, I started seeing the same issue again on Android 14 because the "Build.VERSION.RELEASE_OR_CODENAME" is different now. This is happening only on some devices (I think.. because, Defender team is not seeing this issue). Build.VERSION.RELEASE_OR_CODENAME was previously UpsideDownCake. Now it is coming as "14". 

**Fix** : 

- I have added a new condition to check for Build.VERSION.RELEASE_OR_CODENAME as 14 as well. 
- Build.VERSION.RELEASE_OR_CODENAME was only available on Android API level 30, so added a check for this.
- Also added some null checks.