### PR TITLE
Replace the usage of Arrays.stream to use non-Java8 APIs in common

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ V.15.0.0
 - [MINOR] Add checkMode method to msaltestapp infra (#2141)
 - [MINOR] Update TokenRequest.java with NAA params (#2143)
 - [MINOR] Add new apk name to BrokerHost infra (#2152)
+- [MINOR] Replace the usage of Arrays.stream to use non-Java8 APIs in common (#2162)
 
 V.14.0.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1783,7 +1783,6 @@ public class MsalOAuth2TokenCache
                 scopesAsSet.add(s.toLowerCase(Locale.US));
             }
             return scopesAsSet;
-
         }
 
         return new HashSet<>();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1779,8 +1779,8 @@ public class MsalOAuth2TokenCache
         if (!StringUtil.isNullOrEmpty(scopeString)) {
             final String[] scopeArray = scopeString.split("\\s+");
             final Set<String> scopesAsSet = new HashSet<>();
-            for (String s : scopeArray) {
-                scopesAsSet.add(s.toLowerCase(Locale.US));
+            for (final String scope : scopeArray) {
+                scopesAsSet.add(scope.toLowerCase(Locale.US));
             }
             return scopesAsSet;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1778,9 +1778,12 @@ public class MsalOAuth2TokenCache
         final String scopeString = token.getTarget();
         if (!StringUtil.isNullOrEmpty(scopeString)) {
             final String[] scopeArray = scopeString.split("\\s+");
-            return Arrays.stream(scopeArray)
-                    .map(s -> s.toLowerCase(Locale.US))
-                    .collect(Collectors.toSet());
+            final Set<String> scopesAsSet = new HashSet<>();
+            for (String s : scopeArray) {
+                scopesAsSet.add(s.toLowerCase(Locale.US));
+            }
+            return scopesAsSet;
+
         }
 
         return new HashSet<>();


### PR DESCRIPTION
**WHAT?**
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2674888

**WHY?**
To avoid : Android 22 Runtime MissingMethodException - Arrays.stream uses desugaring library not included faced by OneAuth-MSAL.


**Testing :**
Testcase : com.microsoft.identity.common.MsalOAuth2TokenCacheTest#saveTokensWithIntersect
Ran the test on this part of code, and results with arrays.stream and after the change look the same

![image](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/assets/65260743/dd498995-7093-46af-86ab-913ff3433088)
