### PR TITLE
Undeprecate Logger wrapper

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ----------
-- [MINOR] Deprecate Common logger wrappers (#2157)
+- [MINOR] Deprecate Common logger wrapper (#2157)
 - [PATCH] Fix NPE in OTEL code for DCF flow (#2139)
 - [PATCH] Fixed debug apps not recognized as active broker issue (#2138)
 - [MAJOR] Update active broker cache upon returned result (#2140)

--- a/common/src/main/java/com/microsoft/identity/common/logging/Logger.java
+++ b/common/src/main/java/com/microsoft/identity/common/logging/Logger.java
@@ -31,10 +31,7 @@ import androidx.annotation.Nullable;
 
 /**
  * Android's Logger. Wraps around common4j's logger (with an addition of Logcat).
- * <p>
- * Deprecated: Broker partners should use {@link com.microsoft.identity.common.java.logging.Logger}
  */
-@Deprecated
 public class Logger {
 
     private static final String ANDROID_LOGCAT_LOGGER_IDENTIFIER = "ANDROID_LOGCAT_LOGGER";


### PR DESCRIPTION
We didn't really need to deprecate this in the first place, as we'd already asked CP to use the correct logger. This is causing a warning (treated as error) in oneauth test app build, so i'm un-deprecating it.