### PR TITLE
Separate Broker API and Client SDK Active Broker caches

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MAJOR] Separate Broker API and Client SDK Active Broker caches (#2164)
 - [MINOR] Deprecate Common logger wrapper (#2157)
 - [PATCH] Fix NPE in OTEL code for DCF flow (#2139)
 - [PATCH] Fixed debug apps not recognized as active broker issue (#2138)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -31,11 +31,9 @@ import com.microsoft.identity.common.internal.broker.PackageHelper
 import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle
 import com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy
 import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
-import com.microsoft.identity.common.internal.cache.ClientActiveBrokerCache
 import com.microsoft.identity.common.internal.cache.IClientActiveBrokerCache
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.exception.ClientException.ONLY_SUPPORTS_ACCOUNT_MANAGER_ERROR_CODE
-import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.java.logging.Logger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
@@ -167,13 +165,14 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         }
     }
 
-    constructor(context: Context, components: IPlatformComponents): this(
+    constructor(context: Context,
+                cache: IClientActiveBrokerCache): this(
         brokerCandidates = BrokerData.getKnownBrokerApps(),
         getActiveBrokerFromAccountManager = {
             AccountManagerBrokerDiscoveryUtil(context).getActiveBrokerFromAccountManager()
         },
         ipcStrategy = ContentProviderStrategy(context),
-        cache = ClientActiveBrokerCache.getCache(components.storageSupplier),
+        cache = cache,
         isPackageInstalled = { brokerData ->
             PackageHelper(context).
                 isPackageInstalledAndEnabled(brokerData.packageName)

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -147,7 +147,7 @@ public class BrokerMsalController extends BaseController {
         mBrokerOperationExecutor = new BrokerOperationExecutor(
                 ipcStrategies,
                 new ActiveBrokerCacheUpdater(applicationContext,
-                        ClientActiveBrokerCache.getCache(components.getStorageSupplier())));
+                        ClientActiveBrokerCache.getClientSdkCache(components.getStorageSupplier())));
         mHelloCache = getHelloCache();
     }
 


### PR DESCRIPTION
In broker apps - MSAL and Broker might use different encryption/decryption keys.

This means the same active broker cache cannot be shared by MSAL, and the Broker API/WPJ API **_under the same app_**.

as each library will write data encrypted by its own key, and the other party will not be able to decrypt.

As a solution - we're having them write to different storage files.

--

The issue was discovered by @somalaya (thanks!) and the fix is already validated.