### PR TITLE
Update CopyFileRule.java with broker host apk with broker selection disabled 

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
@@ -57,6 +57,7 @@ public class CopyFileRule implements TestRule {
     private final String[] mApkFileNames = {
             BrokerHost.BROKER_HOST_APK,
             BrokerHost.OLD_BROKER_HOST_APK,
+            BrokerHost.BROKER_HOST_WITHOUT_BROKER_SELECTION_APK,
             AzureSampleApp.AZURE_SAMPLE_APK,
             AzureSampleApp.OLD_AZURE_SAMPLE_APK,
             BrokerMicrosoftAuthenticator.AUTHENTICATOR_APK,


### PR DESCRIPTION
We hav recently added downloading broker host apk with broker selection disabled in the pipeline. But, the apk should also be pushed to /sdcard  location of firebase. The change made in this PR is to copy the new apk to /sdcard location like all other apks