### PR TITLE
Moving FidoConstants to common4j

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
@@ -20,7 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.internal.fido
+package com.microsoft.identity.common.java.constants
 
 /**
  * Constants for FIDO related logic.


### PR DESCRIPTION
### Summary
Because a broker4j class needs to reference the Fido constants, this PR moves the FidoConstants class to common4j.

### Related PRs
- https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1895
- https://github.com/AzureAD/ad-accounts-for-android/pull/2527