### PR TITLE
Capture broker_operation_name on MSAL_PerformIpcStrategy span

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerOperationExecutor.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerOperationExecutor.java
@@ -230,6 +230,7 @@ public class BrokerOperationExecutor {
 
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             span.setAttribute(AttributeName.ipc_strategy.name(), strategy.getType().name());
+            span.setAttribute(AttributeName.broker_operation_name.name(), operation.getMethodName());
             operation.performPrerequisites(strategy);
             final BrokerOperationBundle brokerOperationBundle = operation.getBundle();
             final Bundle resultBundle = strategy.communicateToBroker(brokerOperationBundle);

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -394,7 +394,7 @@ public class ClientException extends BaseException {
     public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
 
     /**
-     * The android version used does not support the operation.
+     * The workplacejoin data is null.
      */
     public static final String WORKPLACE_JOIN_DATA_NULL = "workplace_join_data_null";
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -394,6 +394,11 @@ public class ClientException extends BaseException {
     public static final String UNSUPPORTED_ANDROID_API_VERSION = "unsupported_android_api_version";
 
     /**
+     * The android version used does not support the operation.
+     */
+    public static final String WORKPLACE_JOIN_DATA_NULL = "workplace_join_data_null";
+
+    /**
      * Error code to be returned when the broker determines that only account manager can be used
      * in the Broker Discovery process.
      **/

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -247,5 +247,10 @@ public enum AttributeName {
     /**
      * The time (in milliseconds) spent on network when acquiring AT.
      */
-    elapsed_time_network_acquire_at;
+    elapsed_time_network_acquire_at,
+
+    /**
+     * The broker operation name.
+     */
+    broker_operation_name;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -55,5 +55,7 @@ public enum SpanName {
     BrokerDiscoveryManagerPerformDiscoveryProcess,
     BrokerDiscoveryMetadataAggregator,
     BrokerSelectionProtocolManager,
-    BrokerDiscoveryV1ProtocolBroadcastResult
+    BrokerDiscoveryV1ProtocolBroadcastResult,
+
+    MultipleWpjDataStore
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -55,7 +55,5 @@ public enum SpanName {
     BrokerDiscoveryManagerPerformDiscoveryProcess,
     BrokerDiscoveryMetadataAggregator,
     BrokerSelectionProtocolManager,
-    BrokerDiscoveryV1ProtocolBroadcastResult,
-
-    MultipleWpjDataStore
+    BrokerDiscoveryV1ProtocolBroadcastResult
 }


### PR DESCRIPTION
### Why

We have multiple entries of this error:
 "Attempt to invoke virtual method 'boolean com.microsoft.identity.broker4j.workplacejoin.data.WorkplaceJoinData.isSharedDevice()' on a null object reference"

android_spans
| where PipelineInfo_IngestionTime between (ago(7d) .. now())
| where error_message == "Attempt to invoke virtual method 'boolean com.microsoft.identity.broker4j.workplacejoin.data.WorkplaceJoinData.isSharedDevice()' on a null object reference"
| where broker_version == "11.2.1"

to identify the operation that is failing we start capturing the broker_operation_name 


Note:
In addition we also add 2 const used int this PR