### PR TITLE
Stop logging thread name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MINOR] Stop logging thread name (#2185)
 - [MINOR] Add LTW as prod broker app (#2179)
 
 V.16.0.0

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.java
@@ -35,7 +35,7 @@ import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.events.UiStartEvent;
 import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.util.ProcessUtil;
-import com.microsoft.identity.common.logging.DiagnosticContext;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
 
 import java.util.HashMap;
 
@@ -46,6 +46,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
+import static com.microsoft.identity.common.java.logging.DiagnosticContext.CORRELATION_ID;
 
 /**
  * Constructs intents and/or fragments for interactive requests based on library configuration and current request.
@@ -94,7 +95,7 @@ public class AuthorizationActivityFactory {
         intent.putExtra(AUTHORIZATION_AGENT, authorizationAgent);
         intent.putExtra(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         intent.putExtra(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
-        intent.putExtra(DiagnosticContext.CORRELATION_ID, DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
+        intent.putExtra(CORRELATION_ID, DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
         return intent;
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -39,7 +39,7 @@ import com.microsoft.identity.common.java.logging.RequestContext;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
-import com.microsoft.identity.common.logging.DiagnosticContext;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.logging.Logger;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.CANCEL_AUTHORIZATION_REQUEST;
@@ -166,7 +166,7 @@ public abstract class AuthorizationFragment extends Fragment {
         final String methodTag = TAG + ":setDiagnosticContextForAuthorizationActivity";
         final RequestContext rc = new RequestContext();
         rc.put(DiagnosticContext.CORRELATION_ID, correlationId);
-        DiagnosticContext.setRequestContext(rc);
+        DiagnosticContext.INSTANCE.setRequestContext(rc);
         Logger.verbose(
                 methodTag,
                 "Initializing diagnostic context for AuthorizationActivity"

--- a/common/src/main/java/com/microsoft/identity/common/logging/DiagnosticContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/logging/DiagnosticContext.java
@@ -32,10 +32,6 @@ import com.microsoft.identity.common.java.logging.IRequestContext;
 // TODO @Deprecate
 public class DiagnosticContext{
 
-    public static final String CORRELATION_ID = com.microsoft.identity.common.java.logging.DiagnosticContext.CORRELATION_ID;
-    public static final String THREAD_ID = com.microsoft.identity.common.java.logging.DiagnosticContext.THREAD_ID;
-    public static final String THREAD_NAME = com.microsoft.identity.common.java.logging.DiagnosticContext.THREAD_NAME;
-
     /**
      * Set the request context.
      *

--- a/common4j/src/main/com/microsoft/identity/common/java/logging/DiagnosticContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/logging/DiagnosticContext.java
@@ -29,7 +29,6 @@ public enum DiagnosticContext {
 
     public static final String CORRELATION_ID = "correlation_id";
     public static final String THREAD_ID = "thread_id";
-    public static final String THREAD_NAME = "thread_name";
 
     // This is thread-safe.
     @SuppressFBWarnings("SE_BAD_FIELD_STORE")
@@ -39,7 +38,6 @@ public enum DiagnosticContext {
                 protected RequestContext initialValue() {
                     final RequestContext defaultRequestContext = new RequestContext();
                     defaultRequestContext.put(THREAD_ID, String.valueOf(Thread.currentThread().getId()));
-                    defaultRequestContext.put(THREAD_NAME, Thread.currentThread().getName());
                     defaultRequestContext.put(CORRELATION_ID, "UNSET");
                     return defaultRequestContext;
                 }
@@ -57,7 +55,6 @@ public enum DiagnosticContext {
         }
 
         requestContext.put(THREAD_ID, String.valueOf(Thread.currentThread().getId()));
-        requestContext.put(THREAD_NAME, Thread.currentThread().getName());
         REQUEST_CONTEXT_THREAD_LOCAL.set(requestContext);
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
@@ -442,10 +442,10 @@ public class Logger {
      */
     private static String getDiagnosticContextMetadata(@Nullable String correlationId) {
         final IRequestContext requestContext = DiagnosticContext.INSTANCE.getRequestContext();
-        String threadName = requestContext.get(DiagnosticContext.THREAD_NAME);
+        String threadId = requestContext.get(DiagnosticContext.THREAD_ID);
 
-        if (StringUtil.isNullOrEmpty(threadName)) {
-            threadName = UNSET;
+        if (StringUtil.isNullOrEmpty(threadId)) {
+            threadId = UNSET;
         }
         if (StringUtil.isNullOrEmpty(correlationId)) {
             correlationId = requestContext.get(DiagnosticContext.CORRELATION_ID);
@@ -455,6 +455,6 @@ public class Logger {
         }
 
         return String.format("%s: %s, %s: %s",
-                DiagnosticContext.THREAD_NAME, threadName, DiagnosticContext.CORRELATION_ID, correlationId);
+                DiagnosticContext.THREAD_ID, threadId, DiagnosticContext.CORRELATION_ID, correlationId);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/logging/LoggerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/logging/LoggerTest.java
@@ -135,14 +135,14 @@ public class LoggerTest {
         final Logger.LogLevel logLevel = Logger.LogLevel.VERBOSE;
         final boolean containsPII = false;
         final String newCorrelationId = "NEW_CORRELATION_ID";
-        final String newThreadName = Thread.currentThread().getName();
+        final String newThreadId = String.valueOf(Thread.currentThread().getId());
 
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, newCorrelationId);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
         Logger.setAllowPii(false);
-        testLogger(tag, logLevel, newCorrelationId, newThreadName, containsPII, new IOperationToTest() {
+        testLogger(tag, logLevel, newCorrelationId, newThreadId, containsPII, new IOperationToTest() {
             @Override
             public void execute() {
                 Logger.verbose(tag, "");
@@ -158,27 +158,27 @@ public class LoggerTest {
 
         final String correlationId_1 = "CORRELATIONID_1";
         final String correlationId_2 = "CORRELATIONID_2";
-        final String threadName_1 = Thread.currentThread().getName();
+        final String threadId_1 = String.valueOf(Thread.currentThread().getId());
 
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, correlationId_1);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final String[] threadName_2 = {null};
+        final String[] threadId_2 = {null};
 
         // Spin a background thread.
         new Thread(new Runnable() {
             @SneakyThrows
             @Override
             public void run() {
-                threadName_2[0] = Thread.currentThread().getName();
+                threadId_2[0] = String.valueOf(Thread.currentThread().getId());
 
                 final RequestContext requestContext = new RequestContext();
                 requestContext.put(DiagnosticContext.CORRELATION_ID, correlationId_2);
                 DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
-                testLogger(tag, logLevel, correlationId_2, threadName_2[0], containsPII, new IOperationToTest() {
+                testLogger(tag, logLevel, correlationId_2, threadId_2[0], containsPII, new IOperationToTest() {
                     @Override
                     public void execute() {
                         Logger.verbose(tag, "");
@@ -189,14 +189,14 @@ public class LoggerTest {
         }).start();
 
         countDownLatch.await();
-        testLogger(tag, logLevel, correlationId_1, threadName_1, containsPII, new IOperationToTest() {
+        testLogger(tag, logLevel, correlationId_1, threadId_1, containsPII, new IOperationToTest() {
             @Override
             public void execute() {
                 Logger.verbose(tag, "");
             }
         }, false);
 
-        Assert.assertNotEquals(threadName_2[0], threadName_1);
+        Assert.assertNotEquals(threadId_2[0], threadId_1);
     }
 
     private interface IOperationToTest {

--- a/common4j/src/test/com/microsoft/identity/common/java/telemetry/TelemetryTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/telemetry/TelemetryTest.java
@@ -52,7 +52,6 @@ public class TelemetryTest {
         if (DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID) == null) {
             final RequestContext defaultRequestContext = new RequestContext();
             defaultRequestContext.put(DiagnosticContext.THREAD_ID, String.valueOf(Thread.currentThread().getId()));
-            defaultRequestContext.put(DiagnosticContext.THREAD_NAME, Thread.currentThread().getName());
             defaultRequestContext.put(DiagnosticContext.CORRELATION_ID, "UNSET");
             DiagnosticContext.INSTANCE.setRequestContext(defaultRequestContext);
 


### PR DESCRIPTION
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2691762

tl;dr Thread name could contain PII.

We'll log thread id instead.
(was planning to log if a thread is a main thread, but it seems like there's no official way to do so in 4j. Looper is an Android class)