### PR TITLE
Pass Lab Secret to Linux Broker Testing step in consumer pipeline

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -226,7 +226,7 @@ stages:
             eval $(dbus-launch --sh-syntax)
             sudo apt install gnome-keyring
             /usr/bin/gnome-keyring-daemon --start --components=secrets
-            ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
+            ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
       - task: PublishTestResults@2
         condition: succeededOrFailed()
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -23,6 +23,7 @@ variables:
 - name: robolectricSdkVersion
   value: 28
 - group: AndroidAuthClientVariables
+- group: AndroidAuthClientAutomationSecrets
 
 resources:
   repositories:


### PR DESCRIPTION
Consumer pipeline has been failing due to a recent addition of lab account tests in Linux, which require the lab secret to be passed as part of the pipeline run for them to pass successfully. This PR makes that change in the consumer pipeline.

Succesful run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1179073&view=results