### PR TITLE
[cherry-pick] Use ESRP to publish maven release for common and common4j (#2188)

### DIFF
--- a/azure-pipelines/maven-release/common.yml
+++ b/azure-pipelines/maven-release/common.yml
@@ -26,7 +26,7 @@ jobs:
     gradleGeneratePomFiletask: common:generatePomFileForDistReleasePublication
     aarSourceFolder: common/build/outputs/aar
     jarSourceFolder: common/build/outputs/jar
-    pomSourceFolder: common/build/publications/distRelease
+    pomSourceFolder: common/build/poms
     gpgAar: true
     gpgSourcesJar: true
     gpgJavadocJar: false

--- a/azure-pipelines/maven-release/common4j.yml
+++ b/azure-pipelines/maven-release/common4j.yml
@@ -18,10 +18,10 @@ jobs:
   parameters:
     project: common4j
     projectVersion: $(common4jVersion)
-    gradleAssembleReleaseTask: common4j:clean common4j:assemble common4j:test -Psugar=true
+    gradleAssembleReleaseTask: common4j:clean common4j:assemble -Psugar=true
     gradleGeneratePomFiletask: common4j:generatePomFileForAarPublication
     jarSourceFolder: common4j/build/outputs/jars
-    pomSourceFolder: common4j/build/publications/aar
+    pomSourceFolder: common4j/build/poms
     extraSourceFolder: common4j/build/libs
     extraContents: '**/*.jar'
     gpgAar: false

--- a/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
+++ b/azure-pipelines/templates/steps/maven-release/gpg-signing.sh
@@ -73,15 +73,15 @@ if [ $JAVADOCJAR == "true" ]; then
     fi
 fi
 
-gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign pom-default.xml
+gpg --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_SECUREFILEPATH --armor --detach-sign $PROJECT-$PROJECTVERSION.pom
 signed=$?
 
 if [ $signed -ne 0 ]; then
-    echo "GPG signing failed with for pom-default.xml with error code $signed"
+    echo "GPG signing failed with for $PROJECT-$PROJECTVERSION.pom with error code $signed"
     exit $signed
 fi
-if [ ! -f pom-default.xml.asc ]; then
-    exit "Signature file for pom-default.xml not found."
+if [ ! -f $PROJECT-$PROJECTVERSION.pom.asc ]; then
+    exit "Signature file for $PROJECT-$PROJECTVERSION.pom not found."
 fi
 
 for file in *; do

--- a/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
+++ b/azure-pipelines/templates/steps/maven-release/maven-release-jobs.yml
@@ -37,7 +37,6 @@ parameters:
 - name: gpgJavadocJar
   default: false
 
-
 jobs:
 - job: sdl_maven
   displayName: SDL and Maven Tasks
@@ -95,7 +94,7 @@ jobs:
       displayName: Copy pom to Artifact Staging Directory
       inputs:
         SourceFolder: ${{ parameters.pomSourceFolder }}
-        Contents: '**/*.xml'
+        Contents: '**/*.pom'
         TargetFolder: $(Build.ArtifactStagingDirectory)
   - task: PublishPipelineArtifact@1
     name: PublishPipelineArtifact1
@@ -164,16 +163,17 @@ jobs:
     displayName: Download Python Requests Library
     inputs:
       script: pip install requests
-  - task: DownloadSecureFile@1
-    name: credentials
-    displayName: Download Nexus Sonatype Login Credentials
+  - task: EsrpRelease@4
     inputs:
-      secureFile: NugetADDSonatypeCredentials.json
-      retryCount: 5
-  - task: PythonScript@0
-    displayName: Upload to Nexus Sonatype Staging Directory
-    inputs:
-      arguments: ${{ parameters.project }} ${{ parameters.projectVersion }}
-      scriptSource: filePath
-      scriptPath: azure-pipelines/templates/steps/maven-release/upload-to-nexus-sonatype.py
+      ConnectedServiceName: 'AndroidAuth_ESRP_Release'
+      Intent: 'PackageDistribution'
+      ContentType: 'Maven'
+      ContentSource: 'Folder'
+      FolderLocation: '$(Build.ArtifactStagingDirectory)'
+      WaitForReleaseCompletion: true
+      Owners: '$(releaseOwners)'
+      Approvers: '$(releaseApprovers)'
+      ServiceEndpointUrl: '$(esrpServiceEndpointUrl)'
+      MainPublisher: '$(esrpMainPublisher)'
+      DomainTenantId: '$(esrpDomainTenantId)'
 ...

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -349,3 +349,8 @@ tasks.configureEach { task ->
         task.dependsOn 'sourcesJar'
     }
 }
+
+// This is used to generate the pom file for publishing to external maven in maven-release-jobs.yml
+tasks.withType(GenerateMavenPom).all {
+    destination = layout.buildDirectory.file("poms/${project.name}-${project.version}.pom").get().asFile
+}

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -245,3 +245,8 @@ afterEvaluate {
     // above in the plugins block.
     compileJava.dependsOn generateBuildConfig, generateTestBuildConfig
 }
+
+// This is used to generate the pom file for publishing to external maven in maven-release-jobs.yml
+tasks.withType(GenerateMavenPom).all {
+    destination = layout.buildDirectory.file("poms/${project.name}-${project.version}.pom").get().asFile
+}


### PR DESCRIPTION
### What
Use ESRP to publish maven release for common and common4j

### Why

To unblock our maven releases we need to move to using [ESRP ](https://microsoft.sharepoint.com/teams/prss/esrp/info/SitePages/Home.aspx)

### How
We have already onboarded to ESRP for our maven release. In this PR I am updating our maven release pipeline and other corresponding files to enable releasing via ESRP.

The changes includes
- adding ESRP release task to our maven release pipeline
- removing publish to Sonatype task
- update to publish pom file in projectname-projectversion.pom (maven) format, as that is what ESRP expects

### Testing
Verified running a test pipeline and publishing common4j under a test groupid

https://releaseui-wus-esrp-prod.azurewebsites.net/Release/Search/#21943ed9-9c60-4106-aed7-0d190cfe305e