### PR TITLE
Add a hub app's redirectURI to an Allowlist of valid redirectURIs

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -215,7 +215,7 @@ public class AndroidPlatformUtil implements IPlatformUtil {
         // Below redirectURI is being used in our automation tests and also by OneAuth tests for NAA
         return BuildConfig.DEBUG && (redirectUri.equals("msauth://com.microsoft.teams/VCpKgbYCXucoq1mZ4BZPsh5taNE=")
                         || redirectUri.equals("msauth://com.microsoft.teams/fcg80qvoM1YMKJZibjBwQcDfOno=")
-                        || redirectUri.equals("msauth://com.microsoft.teams/fcg80qvoM1YMKJZibjBwQcDfOno%3D"));
+                        || redirectUri.equals("https://login.microsoftonline.com/common/oauth2/nativeclient"));
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -448,9 +448,9 @@ public abstract class BaseController {
                     methodTag,
                     "Token request was successful"
             );
-            List<ICacheRecord> acquireTokenResultRecords = null;
+            List<ICacheRecord> acquireTokenResultRecords;
             if (parameters.hasNestedAppParameters()) {
-                // Do not save the token in naa flow. This is because, NAA is curerntly only supported with OneAuth and OneAuth already caches AT until it is expired.
+                // Do not save the token in naa flow. This is because, NAA is currently only supported with OneAuth and OneAuth already caches AT until it is expired.
                 // Design doc : https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/7876
                 acquireTokenResultRecords = getAcquireTokenResultRecords(
                         (MicrosoftStsTokenResponse) tokenResult.getTokenResponse(),
@@ -564,20 +564,25 @@ public abstract class BaseController {
                     "Token request was successful"
             );
 
-            // Remove old Access Token
-            Logger.info(
-                    methodTag,
-                    "Access token is refresh-expired. Removing from cache..."
-            );
-            final AccessTokenRecord accessTokenRecord = cacheRecord.getAccessToken();
-            cache.removeCredential(accessTokenRecord);
+            List<ICacheRecord> savedRecords;
+            if (!parameters.hasNestedAppParameters()) {
+                // Remove old Access Token
+                Logger.info(
+                        methodTag,
+                        "Access token is refresh-expired. Removing from cache..."
+                );
+                final AccessTokenRecord accessTokenRecord = cacheRecord.getAccessToken();
+                cache.removeCredential(accessTokenRecord);
 
-            // Suppressing unchecked warnings due to casting of rawtypes to generic types of OAuth2TokenCache's instance tokenCache while calling method saveAndLoadAggregatedAccountData
-            @SuppressWarnings(WarningType.unchecked_warning) final List<ICacheRecord> savedRecords = cache.saveAndLoadAggregatedAccountData(
-                    strategy,
-                    getAuthorizationRequest(strategy, parameters),
-                    tokenResult.getTokenResponse()
-            );
+                // Suppressing unchecked warnings due to casting of rawtypes to generic types of OAuth2TokenCache's instance tokenCache while calling method saveAndLoadAggregatedAccountData
+                savedRecords = cache.saveAndLoadAggregatedAccountData(
+                        strategy,
+                        getAuthorizationRequest(strategy, parameters),
+                        tokenResult.getTokenResponse()
+                );
+            } else {
+                savedRecords = getAcquireTokenResultRecords((MicrosoftStsTokenResponse) tokenResult.getTokenResponse(), (MicrosoftStsOAuth2Strategy) strategy, (MicrosoftStsAuthorizationRequest) getAuthorizationRequest(strategy, parameters));
+            }
 
             final ICacheRecord savedRecord = savedRecords.get(0);
             finalizeCacheRecordForResult(savedRecord, parameters.getAuthenticationScheme());

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/IAcquireMicrosoftStsTokenStrategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/IAcquireMicrosoftStsTokenStrategy.java
@@ -41,7 +41,7 @@ public interface IAcquireMicrosoftStsTokenStrategy<T extends TokenCommandParamet
     /**
      * Create a token request
      * @param parameters Silent or Interactive request parameters
-     * @return a new PRT
+     * @return a token request
      */
     @NonNull
     MicrosoftStsTokenRequest createTokenRequest(@NonNull final T parameters) throws BaseException;


### PR DESCRIPTION
- Added Teams app's redirectURL that is registered in US Gov cloud. Related broker PR that is using this : https://github.com/AzureAD/ad-accounts-for-android/pull/2555
- Also, in one of the renewAccessToken methods (that is not currently being used when PRTV3 is enabled), we did not make changes required for NAA (skipping caching the tokens in NAA flow). Although this is not required now, just adding the changes to maintain consistency.