### PR TITLE
[Hotfix] [Sep] [16.0.2] handle crypto error gracefully (#2190)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.16.0.2
+----------
+- [PATCH] Handle crypto error gracefully
+
 V.16.0.1
 ----------
 - [PATCH] Add LTW as prod broker app (#2179)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.16.0.2
 ----------
-- [PATCH] Handle crypto error gracefully
+- [PATCH] Handle crypto error gracefully (#2199)
 
 V.16.0.1
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,7 +31,7 @@ codeCoverageReport {
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def common4jVersion = "13.0.1"
+def common4jVersion = "13.0.2"
 if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion != '') {
     common4jVersion = project.distCommon4jVersion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -33,6 +33,7 @@ import static com.microsoft.identity.common.java.exception.ClientException.INVAL
 import static com.microsoft.identity.common.java.exception.ClientException.NO_SUCH_ALGORITHM;
 import static com.microsoft.identity.common.java.exception.ClientException.NO_SUCH_PADDING;
 import static com.microsoft.identity.common.java.exception.ClientException.UNEXPECTED_HMAC_LENGTH;
+import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_CRYPTO_ERROR;
 
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
 import com.microsoft.identity.common.java.crypto.key.KeyUtil;
@@ -116,11 +117,16 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         Logger.verbose(TAG + methodName, "Starting encryption");
 
         final String errCode;
-        final Exception exception;
-        try {
-            // load key for encryption if not loaded
-            final AbstractSecretKeyLoader keyLoader = getKeyLoaderForEncryption();
+        final Throwable exception;
 
+        // load key for encryption if not loaded
+        final AbstractSecretKeyLoader keyLoader = getKeyLoaderForEncryption();
+        if (keyLoader == null) {
+            // Developer error. Throw.
+            throw new IllegalStateException("KeyLoader list must not be null.");
+        }
+
+        try {
             final SecretKey encryptionKey = keyLoader.getKey();
             final SecretKey encryptionHMACKey = KeyUtil.getHMacKey(encryptionKey);
             final byte[] keyIdentifier = keyLoader.getKeyTypeIdentifier().getBytes(ENCODING_UTF8);
@@ -175,6 +181,9 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         } catch (final InvalidAlgorithmParameterException e) {
             errCode = INVALID_ALG_PARAMETER;
             exception = e;
+        } catch (final Throwable e) {
+            errCode = UNKNOWN_CRYPTO_ERROR;
+            exception = e;
         }
 
         throw new ClientException(errCode, exception.getMessage(), exception);
@@ -211,7 +220,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
                 final byte[] result = decryptWithSecretKey(dataBytes, keyLoader);
                 Logger.verbose(TAG + methodName, "Finished decryption with key:" + keyLoader.getAlias());
                 return result;
-            } catch (final ClientException e) {
+            } catch (final Throwable e) {
                 Logger.warn(TAG + methodName, "Failed to decrypt with key:" + keyLoader.getAlias() +
                         " thumbprint : " + KeyUtil.getKeyThumbPrint(keyLoader));
                 exceptionToThrowIfAllFails.addSuppressedException(e);

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/key/KeyUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/key/KeyUtil.java
@@ -77,7 +77,7 @@ public class KeyUtil {
         final String methodName = ":getKeyThumbPrint";
         try {
             return getKeyThumbPrint(keyLoader.getKey());
-        } catch (final ClientException e) {
+        } catch (final Throwable e) {
             Logger.warn(TAG + methodName, "failed to load key:" + e.getMessage());
             return UNKNOWN_THUMBPRINT;
         }
@@ -94,7 +94,7 @@ public class KeyUtil {
         final String methodName = ":getKeyThumbPrint";
         try {
             return getKeyThumbPrintFromHmacKey(getHMacKey(key));
-        } catch (NoSuchAlgorithmException e) {
+        } catch (Throwable e) {
             Logger.warn(TAG + methodName, "failed to calculate thumbprint:" + e.getMessage());
             return UNKNOWN_THUMBPRINT;
         }
@@ -116,7 +116,7 @@ public class KeyUtil {
             thumbprintMac.init(hmacKey);
             byte[] thumbPrintFinal = thumbprintMac.doFinal(thumbprintBytes);
             return StringUtil.encodeUrlSafeString(thumbPrintFinal);
-        } catch (final NoSuchAlgorithmException | InvalidKeyException e) {
+        } catch (final Throwable e) {
             Logger.warn(TAG + methodName, "failed to calculate thumbprint:" + e.getMessage());
             return UNKNOWN_THUMBPRINT;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -82,9 +82,9 @@ public class BaseException extends Exception implements IErrorInformation, ITele
      */
     @Getter
     @Accessors(prefix = "m")
-    private final List<Exception> mSuppressedException = new ArrayList<>();
+    private final List<Throwable> mSuppressedException = new ArrayList<>();
 
-    public void addSuppressedException(@NonNull final Exception e) {
+    public void addSuppressedException(@NonNull final Throwable e) {
         mSuppressedException.add(e);
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -188,6 +188,11 @@ public class ClientException extends BaseException {
     public static final String UNKNOWN_ERROR = "unknown_error";
 
     /**
+     * An unknown error that happens in the crypto layer.
+     */
+    public static final String UNKNOWN_CRYPTO_ERROR = "unknown_crypto_error";
+
+    /**
      * Temporary non-exposed error code to indicate that ADFS authority validation fails. ADFS as authority is not supported
      * for preview.
      */

--- a/common4j/versioning/version.properties
+++ b/common4j/versioning/version.properties
@@ -1,4 +1,4 @@
 #Wed May 12 20:08:39 UTC 2021
-versionName=13.0.1
+versionName=13.0.2
 versionCode=1
 latestPatchVersion=227

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=16.0.1
+versionName=16.0.2
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
We've discovered that Android KeyStore could throw an unexpected error due to a bug in their stack.

This is to make sure the error is handled gracefully without crashing the app.

related
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2197
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2198