### PR TITLE
Fix crash during onCreate()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@ V.16.1.0
 ----------
 - [MINOR] Handle crypto error gracefully (#2190)
 - [MINOR] Stop logging thread name (#2185)
-- [MINOR] Adding Moshi, and WebAuthnJsonUtil(#2189)
+- [MINOR] Adding Moshi, and WebAuthnJsonUtil (#2189)
 
 V.16.0.1
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ V.Next
 - [MINOR] Handle crypto error gracefully (#2190)
 - [MINOR] Stop logging thread name (#2185)
 - [MINOR] Adding Moshi, and WebAuthnJsonUtil(#2189)
+- [MINOR] Fix crash during onCreate() (#2202)
 
 V.16.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -62,7 +62,10 @@ public final class BrokerActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState == null) {
-            mBrokerInteractiveRequestIntent = getIntent().getExtras().getParcelable(BROKER_INTENT);
+            Bundle extras = getIntent().getExtras();
+            if(extras != null) {
+                mBrokerInteractiveRequestIntent = extras.getParcelable(BROKER_INTENT);
+            }
         } else {
             mBrokerInteractiveRequestIntent = savedInstanceState.getParcelable(BROKER_INTENT);
             mBrokerIntentStarted = savedInstanceState.getBoolean(BROKER_INTENT_STARTED);

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerActivity.java
@@ -60,11 +60,14 @@ public final class BrokerActivity extends Activity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        final String methodTag = TAG + ":onCreate";
 
         if (savedInstanceState == null) {
             Bundle extras = getIntent().getExtras();
             if(extras != null) {
                 mBrokerInteractiveRequestIntent = extras.getParcelable(BROKER_INTENT);
+            } else {
+                Logger.warn(methodTag, "Extras is null.");
             }
         } else {
             mBrokerInteractiveRequestIntent = savedInstanceState.getParcelable(BROKER_INTENT);

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
@@ -82,10 +82,13 @@ public final class InstallCertActivityLauncher extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        final String methodTag = TAG + ":onCreate";
         if (savedInstanceState == null) {
             Bundle extras = getIntent().getExtras();
             if(extras != null) {
                 mInstallCertificateIntent = extras.getParcelable(INSTALL_CERT_INTENT);
+            } else {
+                Logger.warn(methodTag, "Extras is null.");
             }
         } else {
             // If the activity is being re-initialized after previously being shut down

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
@@ -83,7 +83,10 @@ public final class InstallCertActivityLauncher extends AppCompatActivity {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (savedInstanceState == null) {
-            mInstallCertificateIntent = getIntent().getExtras().getParcelable(INSTALL_CERT_INTENT);
+            Bundle extras = getIntent().getExtras();
+            if(extras != null) {
+                mInstallCertificateIntent = extras.getParcelable(INSTALL_CERT_INTENT);
+            }
         } else {
             // If the activity is being re-initialized after previously being shut down
             // then this Bundle contains the data it most recently supplied.


### PR DESCRIPTION
AB#2690156

LTW reported following crashes and this PR addresses the first 2 crashes:

Stack Trace
1.
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Parcelable android.os.Bundle.getParcelable(java.lang.String)' on a null object reference
at com.microsoft.identity.common.internal.broker.InstallCertActivityLauncher.onCreate(InstallCertActivityLauncher.java:16)

2.
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Parcelable android.os.Bundle.getParcelable(java.lang.String)' on a null object reference
at com.microsoft.identity.common.internal.broker.BrokerActivity.onCreate(BrokerActivity.java:16)

3.
Caused by: java.lang.IllegalStateException: Unexpected fragment type at com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskAuthorizationActivity.onCreate(CurrentTaskAuthorizationActivity.java:142)

See this bug for additional details: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2690156