### PR TITLE
v2.0 for openID

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [PATCH] Use v2.0 url for OpenID Client (#2208)
 
 V.16.1.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OpenIdProviderConfigurationClient.java
@@ -53,7 +53,7 @@ public class OpenIdProviderConfigurationClient {
     private static final String TAG = OpenIdProviderConfigurationClient.class.getSimpleName();
     private static final String HTTPS_SCHEME = "https";
     private static final String WELL_KNOWN_CONFIG_HOST = "login.microsoftonline.com";
-    private static final String WELL_KNOWN_CONFIG_PATH = "/.well-known/openid-configuration";
+    private static final String WELL_KNOWN_CONFIG_PATH = "/v2.0/.well-known/openid-configuration";
     private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
     private static final Map<URI, OpenIdProviderConfiguration> sConfigCache = new HashMap<>();
     private static final HttpClient httpClient = UrlConnectionHttpClient.getDefaultInstance();


### PR DESCRIPTION
Today, we use openID Configuration for getting the CIAM Authorization request, as well as a small use case in `AzureActiveDirectoryAudience.java`. Our existing implementation for open id uses `/.well-known/openid-configuration`, but this seems to have been broken for CIAM tenants, as they no longer get the correct authorization url from this configuration. The correct configuration is now /v2.0/.well-known/openid-configuration, which returns the correct authorization request for CIAM.

As for the audience use case, open id is used when the authority url is not using a home tenant (common, organizations, or consumer), and not using a uuid tenant, in which case we try to check it in openid. This is a very small use case, it doesn't seem like anything would break by updating to v2.0 openID on this end.

Common consumer validation before i skipped the check https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1191815&view=results