### PR TITLE
Fix client Discovery

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+V.16.1.1
+----------
+- [PATCH] Fix client Discovery (#2213)
+
 V.16.1.0
 ----------
 - [MINOR] Handle crypto error gracefully (#2190)


### PR DESCRIPTION
1. In BrokerDiscoveryClient, only call setShouldUseAccountManagerForTheNextMilliseconds() when we cannot get an active broker from ipc mechanism.
2. In BrokerDiscoveryClientFactory, separate instances for clientSdk (MSAL) and brokerSdk (WPJ API, Broker API)