### PR TITLE
Fix to generate new Asymmetric Key

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@ V.Next
 - [MINOR] Updating JSON version (#2221)
 - [PATCH] Passing span context to AuthorizationActivity (#2209)
 - [MINOR] Bumping Moshi versions; force setting Okio version (#2210)
-- [MINOR] Fix to generate new Asymmetric Key (#2222)
+- [PATCH] Fix to generate new Asymmetric Key (#2222)
 
 V.16.1.1
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ V.Next
 - [MINOR] Updating JSON version (#2221)
 - [PATCH] Passing span context to AuthorizationActivity (#2209)
 - [MINOR] Bumping Moshi versions; force setting Okio version (#2210)
+- [MINOR] Fix to generate new Asymmetric Key (#2222)
 
 V.16.1.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -153,9 +153,10 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
 
     @Override
     protected void performCleanupIfMintShrFails(@NonNull final Exception e) {
+        final String methodTag = TAG + ":performCleanupIfMintShrFails";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
                 && e.getCause() instanceof KeyPermanentlyInvalidatedException) {
-            Logger.warn(TAG, "Unable to access asymmetric key - clearing.");
+            Logger.warn(methodTag, "Unable to access asymmetric key - clearing.");
             clearAsymmetricKey();
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -983,6 +983,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             );
 
             signedJWT.sign(signer);
+            clearAsymmetricKey();
 
             return signedJWT.serialize();
         } catch (final NoSuchAlgorithmException e) {
@@ -1033,9 +1034,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     }
 
     private static boolean isNegativeInternalError(@NonNull final Throwable t) {
-        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
-                (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))
-        ) {
+        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))) {
             Logger.info(TAG, "Found internal Keystore code: -33 error.");
             return true;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -126,7 +126,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
      * Seeing this on android 13, we think it's being caused by the new Samsung patch release Build Number : G991BXXS9EWIA
      * <a href="https://doc.samsungmobile.com/sm-g991b/xeo/doc.html">...</a>
      */
-    public static final String NEGATIVE_THIRTY_THREE_INTERNAL_ERROR = "internal Keystore code: -33";
+    public static final String NEGATIVE_THIRTY_THREE_INTERNAL_ERROR_MSG = "internal Keystore code: -33";
 
     /**
      * Log message when private key material cannot be found.
@@ -1034,7 +1034,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     }
 
     private static boolean isNegativeInternalError(@NonNull final Throwable t) {
-        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))) {
+        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR_MSG))) {
             Logger.info(TAG, "Found internal Keystore code: -33 error.");
             return true;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -983,7 +983,6 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             );
 
             signedJWT.sign(signer);
-            clearAsymmetricKey();
 
             return signedJWT.serialize();
         } catch (final NoSuchAlgorithmException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -992,7 +992,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if ((e.getMessage()!=null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+            if ((e.getMessage() != null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                     (e.getCause() != null && e.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                     (e.getCause() != null && isNegativeInternalErrorInvalidKeyException(e.getCause()))
             ) {
@@ -1033,7 +1033,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     }
 
     private static boolean isNegativeInternalErrorInvalidKeyException(@NonNull final Throwable t) {
-        if ((t.getMessage()!=null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && isNegativeInternalErrorKeyStoreException(t.getCause()))
         ) {
@@ -1044,7 +1044,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     }
 
     private static boolean isNegativeInternalErrorKeyStoreException(@NonNull final Throwable t) {
-        if ((t.getMessage()!=null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))
         ) {
             Logger.info(TAG, "Found internal Keystore code: -33 error from KeyStoreException");
@@ -1055,6 +1055,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
 
     /**
      * Perform any cleanup such as clear asymmetric key if unable to mint SHR with existing keys.
+     *
      * @param e the exception that occurred while minting SHR
      */
     protected abstract void performCleanupIfMintShrFails(@NonNull final Exception e);

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -996,7 +996,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                     (e.getCause() != null && e.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                     (e.getCause() != null && isNegativeInternalErrorInvalidKeyException(e.getCause()))
             ) {
-                Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key", e);
+                Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key.", e);
                 Logger.info(methodTag, "Unable to access asymmetric key, clearing the key.");
                 clearAsymmetricKey();
                 Logger.info(methodTag, "Generating new PoP asymmetric key.");
@@ -1037,7 +1037,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                 (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && isNegativeInternalErrorKeyStoreException(t.getCause()))
         ) {
-            Logger.info(TAG, "Found internal Keystore code: -33 error from InvalidKeyException");
+            Logger.info(TAG, "Found internal Keystore code: -33 error from InvalidKeyException.");
             return true;
         }
         return false;
@@ -1047,7 +1047,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))
         ) {
-            Logger.info(TAG, "Found internal Keystore code: -33 error from KeyStoreException");
+            Logger.info(TAG, "Found internal Keystore code: -33 error from KeyStoreException.");
             return true;
         }
         return false;

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -986,6 +986,19 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
+            if (e.getMessage()!=null && e.getMessage().contains("internal Keystore code: -33")) {
+                Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key", e);
+                Logger.info(methodTag, "Unable to access asymmetric key, clearing the key.");
+                clearAsymmetricKey();
+                Logger.info(methodTag, "Generating new PoP asymmetric key.");
+                final String thumbprint = generateAsymmetricKey();
+                Logger.info(methodTag, "Generated new PoP asymmetric key.");
+                Logger.verbosePII(
+                        methodTag,
+                        "Generated new PoP asymmetric key with thumbprint: "
+                                + thumbprint
+                );
+            }
             exception = e;
             errCode = JWT_SIGNING_FAILURE;
         } catch (final UnrecoverableEntryException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -992,7 +992,10 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if (e.getMessage()!=null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) {
+            if ((e.getMessage()!=null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+                    (e.getCause() != null && e.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+                    (e.getCause() != null && isNegativeInternalErrorInvalidKeyException(e.getCause()))
+            ) {
                 Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key", e);
                 Logger.info(methodTag, "Unable to access asymmetric key, clearing the key.");
                 clearAsymmetricKey();
@@ -1027,6 +1030,27 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         );
 
         throw clientException;
+    }
+
+    private static boolean isNegativeInternalErrorInvalidKeyException(@NonNull final Throwable t) {
+        if ((t.getMessage()!=null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+                (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+                (t.getCause() != null && isNegativeInternalErrorKeyStoreException(t.getCause()))
+        ) {
+            Logger.info(TAG, "Found internal Keystore code: -33 error from InvalidKeyException");
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isNegativeInternalErrorKeyStoreException(@NonNull final Throwable t) {
+        if ((t.getMessage()!=null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
+                (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))
+        ) {
+            Logger.info(TAG, "Found internal Keystore code: -33 error from KeyStoreException");
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -123,6 +123,12 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     private static final int RSA_KEY_SIZE = 2048;
 
     /**
+     * Seeing this on android 13, we think it's being caused by the new Samsung patch release Build Number : G991BXXS9EWIA
+     * <a href="https://doc.samsungmobile.com/sm-g991b/xeo/doc.html">...</a>
+     */
+    public static final String NEGATIVE_THIRTY_THREE_INTERNAL_ERROR = "internal Keystore code: -33";
+
+    /**
      * Log message when private key material cannot be found.
      */
     private static final String PRIVATE_KEY_NOT_FOUND = "Not an instance of a PrivateKeyEntry";
@@ -986,7 +992,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if (e.getMessage()!=null && e.getMessage().contains("internal Keystore code: -33")) {
+            if (e.getMessage()!=null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) {
                 Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key", e);
                 Logger.info(methodTag, "Unable to access asymmetric key, clearing the key.");
                 clearAsymmetricKey();

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -992,9 +992,9 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if ((e.getMessage() != null && e.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
-                    (e.getCause() != null && e.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
-                    (e.getCause() != null && isNegativeInternalErrorInvalidKeyException(e.getCause()))
+            if((e != null && isNegativeInternalError(e)) ||
+                    (e.getCause() != null && isNegativeInternalError(e.getCause())) ||
+                    (e.getCause().getCause() != null && isNegativeInternalError(e.getCause().getCause()))
             ) {
                 Logger.error(methodTag, "Getting Invalid key blob, Invalid private RSA key.", e);
                 Logger.info(methodTag, "Unable to access asymmetric key, clearing the key.");
@@ -1032,22 +1032,11 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         throw clientException;
     }
 
-    private static boolean isNegativeInternalErrorInvalidKeyException(@NonNull final Throwable t) {
-        if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
-                (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
-                (t.getCause() != null && isNegativeInternalErrorKeyStoreException(t.getCause()))
-        ) {
-            Logger.info(TAG, "Found internal Keystore code: -33 error from InvalidKeyException.");
-            return true;
-        }
-        return false;
-    }
-
-    private static boolean isNegativeInternalErrorKeyStoreException(@NonNull final Throwable t) {
+    private static boolean isNegativeInternalError(@NonNull final Throwable t) {
         if ((t.getMessage() != null && t.getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR)) ||
                 (t.getCause() != null && t.getCause().getMessage().contains(NEGATIVE_THIRTY_THREE_INTERNAL_ERROR))
         ) {
-            Logger.info(TAG, "Found internal Keystore code: -33 error from KeyStoreException.");
+            Logger.info(TAG, "Found internal Keystore code: -33 error.");
             return true;
         }
         return false;

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -992,7 +992,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if((e != null && isNegativeInternalError(e)) ||
+            if ((e != null && isNegativeInternalError(e)) ||
                     (e.getCause() != null && isNegativeInternalError(e.getCause())) ||
                     (e.getCause().getCause() != null && isNegativeInternalError(e.getCause().getCause()))
             ) {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -993,7 +993,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             exception = e;
             errCode = KEYSTORE_NOT_INITIALIZED;
         } catch (final JOSEException e) {
-            if ((e != null && isNegativeInternalError(e)) ||
+            if ((isNegativeInternalError(e)) ||
                     (e.getCause() != null && isNegativeInternalError(e.getCause())) ||
                     (e.getCause().getCause() != null && isNegativeInternalError(e.getCause().getCause()))
             ) {


### PR DESCRIPTION
Fix for the ICM: https://portal.microsofticm.com/imp/v3/incidents/details/427505121/home?fullScreen=incident-description

WHAT?
The error Invalid private RSA is prevalent on Samsung S21 devices Android 13 asper the telemetry and as per the Microsoft Defender team.

MAM team faced the same issue and have opened a ticket on Samsung.
MAM fix: https://msazure.visualstudio.com/Intune/_git/xplat-Android-MDM/commit/221c0ff82504386e283c3e6164b2e142c6c9e436?refName=refs/heads/rygo/keystore

We are trying to emulate the same fix in the broker where we :
- Clear the current RSA key
- re-generate the RSA key

for the error com.nimbusds.jose.JOSEException: Invalid private RSA key: Keystore operation failed

WHY?
The recent Samsung updates for S21 seem to be corrupting the RSA key in the Keystore and we do not have a recovery path to generate a new one. I am scoping this change only to the cases where we see internal Keystore code: -33.

Testing?
Tested by forcefully clearing the current key, expiring the token and then making sure the token is returned using the newly generated key. 