### PR TITLE
Update signing certificate list. adding Debug CP into the debug broker list.

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1026,7 +1026,7 @@ public final class AuthenticationConstants {
         public static final String MOCK_AUTH_APP_PACKAGE_NAME = "com.microsoft.mockauthapp";
 
         /**
-         * Signing certificate hash of MockAuthApp (signed with debug broker keystore key).
+         * Signing certificate thumbprint of MockAuthApp (signed with debug broker keystore key).
          * Generated with SHA-512.
          */
         public static final String MOCK_AUTH_APP_SIGNATURE_SHA512 = "QhjKSYYD31K7+C4q4Mpd08crE0LN/3GgnKVVuej4JWckUTc0Wp/i//LWLQnANaWiAjdESJJrjavu0cE6hkQihQ==";
@@ -1037,7 +1037,7 @@ public final class AuthenticationConstants {
         public static final String MOCK_CP_PACKAGE_NAME = "com.microsoft.mockcp";
 
         /**
-         * Signing certificate hash of MockCP (signed with debug broker keystore key).
+         * Signing certificate thumbprint of MockCP (signed with debug broker keystore key).
          * Generated with SHA-512.
          */
         public static final String MOCK_CP_SIGNATURE_SHA512 = "EZ2RCcsmf869Ec41PgHHnFdI0MgmVsADFFy8AtcfEKsjD1YAPtKxCMZVdT+y+K1IWRnPk4Lf2PUAcL5N49OqAA==";
@@ -1048,7 +1048,7 @@ public final class AuthenticationConstants {
         public static final String MOCK_LTW_PACKAGE_NAME = "com.microsoft.mockltw";
 
         /**
-         * Signing certificate hash of MockLTW (signed with debug broker keystore key).
+         * Signing certificate thumbprint of MockLTW (signed with debug broker keystore key).
          * Generated with SHA-512.
          */
         public static final String MOCK_LTW_SIGNATURE_SHA512 = "felxzv/rpqa69dOADXVVKnawk5x8snBW2k/kDxzQLVkbcdzAvrGm8gcBRItzUGIQTupHCTWksN6WBGbn+b0KIA==";
@@ -1069,7 +1069,7 @@ public final class AuthenticationConstants {
         public static final String COMPANY_PORTAL_APP_PACKAGE_NAME = "com.microsoft.windowsintune.companyportal";
 
         /**
-         * Signing certificate hash of the PROD-signed Intune Company portal app.
+         * Signing certificate thumbprint of the PROD-signed Intune Company portal app.
          * Generated with SHA-1.
          *
          * Deprecated. Used in legacy tests only.
@@ -1078,31 +1078,31 @@ public final class AuthenticationConstants {
         public static final String COMPANY_PORTAL_APP_RELEASE_SIGNATURE = "1L4Z9FJCgn5c0VLhyAxC5O9LdlE=";
 
         /**
-         * Signing certificate hash of the DEBUG-signed Intune Company portal app.
+         * Signing certificate thumbprint of the DEBUG-signed Intune Company portal app.
          * Generated with SHA-512.
          */
         public static final String COMPANY_PORTAL_APP_DEBUG_SIGNATURE_SHA512 = "oIuNoUwMsxC10VneTQXnt/GXN+Pjqd6mpOKEMF/cH3i06K93TZMBWq+fHN/zt4zUe/W6zGj6YLymd1/tGuypNQ==";
 
         /**
-         * Signing certificate hash of the PROD-signed Intune Company portal app.
+         * Signing certificate thumbprint of the PROD-signed Intune Company portal app.
          * Generated with SHA-512.
          */
         public static final String COMPANY_PORTAL_APP_RELEASE_SIGNATURE_SHA512 = "jPpMoaNvcxSLMX4yG4C3Gf86rtTqh33SqpuRKg4WOP+MnnpA52zZgvKLW76U4Cqqf68iaBk9W7k/jhciiSAtgQ==";
 
         /**
-         * Signing certificate hash of the PROD-signed Microsoft Authenticator app.
+         * Signing certificate thumbprint of the PROD-signed Microsoft Authenticator app.
          * Generated with SHA-512.
          */
         public static final String AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE_SHA512 = "Gu8CuaYmSV5CHWd6dz3tGPXIE+YTalCVIXi5lEBXpvUgsMKoHbU9Rqou3WNRNU1tsz8pvEADTCCJ5f02fbw9qw==";
 
         /**
-         * Signing certificate hash of the DEBUG-signed Microsoft Authenticator app.
+         * Signing certificate thumbprint of the DEBUG-signed Microsoft Authenticator app.
          * Generated with SHA-512.
          */
         public static final String AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE_SHA512 = "pdAtoxfsEwbpQsIaua5Uobl5AQEjqt40aPXI7UY1lIW0NTmg0G4jHQ5T5mujSjjU06q4mEHs5hb6z/Mr0PNlmQ==";
 
         /**
-         * Signing certificate hash of the Broker Host app.
+         * Signing certificate thumbprint of the Broker Host app.
          * Generated with SHA-512.
          */
         public static final String BROKER_HOST_APP_SIGNATURE_SHA512 = "xxAk8S05zu0Nkce+X2J6IKJ2e7YE4F9ZorZj0YnYUQ2vw8vLc8VGGOqJdTnVySbbcy9VY8UDbOfeOETSErYllw==";
@@ -1113,13 +1113,13 @@ public final class AuthenticationConstants {
         public static final String LTW_APP_PACKAGE_NAME = "com.microsoft.appmanager";
 
         /**
-         * Signing certificate hash of the PROD-signed Link To Windows app.
+         * Signing certificate thumbprint of the PROD-signed Link To Windows app.
          * Generated with SHA-512.
          */
         public static final String LTW_APP_SHA512_RELEASE_SIGNATURE = "WhUdh04ZkQLmNb//lKmohyqDdPMWXHcI0O3AvoLMtgF/smnED4r+Vguvgj6d4QG77Jl3avUKt6LeqF2TJPZVzg==";
 
         /**
-         * Signing certificate hash of the DEBUG-signed Link To Windows app.
+         * Signing certificate thumbprint of the DEBUG-signed Link To Windows app.
          * Generated with SHA-512.
          */
         public static final String LTW_APP_SHA512_DEBUG_SIGNATURE = "x28mHDILP8IZRH6EfjD4zC1bcpgk8euKS91klxoddu8+e34xEgy3Q9XTa3ySY7C7EXX4o/EJpDV8MqmEfIf7LA==";
@@ -1135,7 +1135,7 @@ public final class AuthenticationConstants {
         public static final String IPPHONE_APP_PACKAGE_NAME = "com.microsoft.skype.teams.ipphone";
 
         /**
-         * Signing certificate hash of the PROD-signed Teams IP Phones (Sakurai devices).
+         * Signing certificate thumbprint of the PROD-signed Teams IP Phones (Sakurai devices).
          *
          * Teams IP Phones (Sakurai devices) is supported by Intune, but does not have a back button nor browser.
          * The only supported detection of this phone is the application install state.
@@ -1144,7 +1144,7 @@ public final class AuthenticationConstants {
         public static final String IPPHONE_APP_SIGNATURE = "fcg80qvoM1YMKJZibjBwQcDfOno=";
 
         /**
-         * Signing certificate hash of the DEBUG-signed Teams IP Phones (Sakurai devices)
+         * Signing certificate thumbprint of the DEBUG-signed Teams IP Phones (Sakurai devices)
          * to unblock any teams local debug development.
          */
         public static final String IPPHONE_APP_DEBUG_SIGNATURE = "VCpKgbYCXucoq1mZ4BZPsh5taNE=";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1026,7 +1026,8 @@ public final class AuthenticationConstants {
         public static final String MOCK_AUTH_APP_PACKAGE_NAME = "com.microsoft.mockauthapp";
 
         /**
-         * Mock AuthApp SHA512 signature hash.
+         * Signing certificate hash of MockAuthApp (signed with debug broker keystore key).
+         * Generated with SHA-512.
          */
         public static final String MOCK_AUTH_APP_SIGNATURE_SHA512 = "QhjKSYYD31K7+C4q4Mpd08crE0LN/3GgnKVVuej4JWckUTc0Wp/i//LWLQnANaWiAjdESJJrjavu0cE6hkQihQ==";
 
@@ -1036,7 +1037,8 @@ public final class AuthenticationConstants {
         public static final String MOCK_CP_PACKAGE_NAME = "com.microsoft.mockcp";
 
         /**
-         * Mock CP SHA512 signature hash.
+         * Signing certificate hash of MockCP (signed with debug broker keystore key).
+         * Generated with SHA-512.
          */
         public static final String MOCK_CP_SIGNATURE_SHA512 = "EZ2RCcsmf869Ec41PgHHnFdI0MgmVsADFFy8AtcfEKsjD1YAPtKxCMZVdT+y+K1IWRnPk4Lf2PUAcL5N49OqAA==";
 
@@ -1046,7 +1048,8 @@ public final class AuthenticationConstants {
         public static final String MOCK_LTW_PACKAGE_NAME = "com.microsoft.mockltw";
 
         /**
-         * Mock LTW SHA512 signature hash.
+         * Signing certificate hash of MockLTW (signed with debug broker keystore key).
+         * Generated with SHA-512.
          */
         public static final String MOCK_LTW_SIGNATURE_SHA512 = "felxzv/rpqa69dOADXVVKnawk5x8snBW2k/kDxzQLVkbcdzAvrGm8gcBRItzUGIQTupHCTWksN6WBGbn+b0KIA==";
 
@@ -1066,50 +1069,41 @@ public final class AuthenticationConstants {
         public static final String COMPANY_PORTAL_APP_PACKAGE_NAME = "com.microsoft.windowsintune.companyportal";
 
         /**
-         * Signature info for Intune Company portal app that installs authenticator
-         * component. Generated with SHA-1.
+         * Signing certificate hash of the PROD-signed Intune Company portal app.
+         * Generated with SHA-1.
+         *
+         * Deprecated. Used in legacy tests only.
          */
+        @Deprecated
         public static final String COMPANY_PORTAL_APP_RELEASE_SIGNATURE = "1L4Z9FJCgn5c0VLhyAxC5O9LdlE=";
 
         /**
-         * Signature info for Intune Company portal app that installs authenticator
-         * component. Generated with SHA-512.
+         * Signing certificate hash of the DEBUG-signed Intune Company portal app.
+         * Generated with SHA-512.
+         */
+        public static final String COMPANY_PORTAL_APP_DEBUG_SIGNATURE_SHA512 = "oIuNoUwMsxC10VneTQXnt/GXN+Pjqd6mpOKEMF/cH3i06K93TZMBWq+fHN/zt4zUe/W6zGj6YLymd1/tGuypNQ==";
+
+        /**
+         * Signing certificate hash of the PROD-signed Intune Company portal app.
+         * Generated with SHA-512.
          */
         public static final String COMPANY_PORTAL_APP_RELEASE_SIGNATURE_SHA512 = "jPpMoaNvcxSLMX4yG4C3Gf86rtTqh33SqpuRKg4WOP+MnnpA52zZgvKLW76U4Cqqf68iaBk9W7k/jhciiSAtgQ==";
 
         /**
-         * Signature info for Azure authenticator release app that installs authenticator
-         * component. Generated with SHA-1.
-         */
-        public static final String AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE = "ho040S3ffZkmxqtQrSwpTVOn9r0=";
-
-        /**
-         * Signature info for Azure authenticator release app that installs authenticator
-         * component. Generated with SHA-512.
+         * Signing certificate hash of the PROD-signed Microsoft Authenticator app.
+         * Generated with SHA-512.
          */
         public static final String AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE_SHA512 = "Gu8CuaYmSV5CHWd6dz3tGPXIE+YTalCVIXi5lEBXpvUgsMKoHbU9Rqou3WNRNU1tsz8pvEADTCCJ5f02fbw9qw==";
 
         /**
-         * Signature info for Azure authenticator debug app that installs authenticator
-         * component. Generated with SHA-1.
-         */
-        public static final String AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE = "N1jdcbbnKDr0LaFZlqdhXgm2luE=";
-
-        /**
-         * Signature info for Azure authenticator debug app that installs authenticator
-         * component. Generated with SHA-512.
+         * Signing certificate hash of the DEBUG-signed Microsoft Authenticator app.
+         * Generated with SHA-512.
          */
         public static final String AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE_SHA512 = "pdAtoxfsEwbpQsIaua5Uobl5AQEjqt40aPXI7UY1lIW0NTmg0G4jHQ5T5mujSjjU06q4mEHs5hb6z/Mr0PNlmQ==";
 
         /**
-         * Signature info for Broker Host app that installs authenticator
-         * component.Generated with SHA-1.
-         */
-        public static final String BROKER_HOST_APP_SIGNATURE = "1wIqXSqBj7w+h11ZifsnqwgyKrY=";
-
-        /**
-         * Signature info for Broker Host app that installs authenticator
-         * component.Generated with SHA-512.
+         * Signing certificate hash of the Broker Host app.
+         * Generated with SHA-512.
          */
         public static final String BROKER_HOST_APP_SIGNATURE_SHA512 = "xxAk8S05zu0Nkce+X2J6IKJ2e7YE4F9ZorZj0YnYUQ2vw8vLc8VGGOqJdTnVySbbcy9VY8UDbOfeOETSErYllw==";
 
@@ -1119,12 +1113,14 @@ public final class AuthenticationConstants {
         public static final String LTW_APP_PACKAGE_NAME = "com.microsoft.appmanager";
 
         /**
-         * SHA512 signature hash of the Link To Windows app, signed by the production keystore key.
+         * Signing certificate hash of the PROD-signed Link To Windows app.
+         * Generated with SHA-512.
          */
         public static final String LTW_APP_SHA512_RELEASE_SIGNATURE = "WhUdh04ZkQLmNb//lKmohyqDdPMWXHcI0O3AvoLMtgF/smnED4r+Vguvgj6d4QG77Jl3avUKt6LeqF2TJPZVzg==";
 
         /**
-         * SHA512 signature hash of the Link To Windows app, signed by a debug keystore key.
+         * Signing certificate hash of the DEBUG-signed Link To Windows app.
+         * Generated with SHA-512.
          */
         public static final String LTW_APP_SHA512_DEBUG_SIGNATURE = "x28mHDILP8IZRH6EfjD4zC1bcpgk8euKS91klxoddu8+e34xEgy3Q9XTa3ySY7C7EXX4o/EJpDV8MqmEfIf7LA==";
 
@@ -1139,6 +1135,8 @@ public final class AuthenticationConstants {
         public static final String IPPHONE_APP_PACKAGE_NAME = "com.microsoft.skype.teams.ipphone";
 
         /**
+         * Signing certificate hash of the PROD-signed Teams IP Phones (Sakurai devices).
+         *
          * Teams IP Phones (Sakurai devices) is supported by Intune, but does not have a back button nor browser.
          * The only supported detection of this phone is the application install state.
          * App signature of Teams Phone app to detect it for the MDM Device CA redirect.
@@ -1146,7 +1144,8 @@ public final class AuthenticationConstants {
         public static final String IPPHONE_APP_SIGNATURE = "fcg80qvoM1YMKJZibjBwQcDfOno=";
 
         /**
-         * Teams IP Phones (Sakurai devices) debug signature to unblock any teams local debug development .
+         * Signing certificate hash of the DEBUG-signed Teams IP Phones (Sakurai devices)
+         * to unblock any teams local debug development.
          */
         public static final String IPPHONE_APP_DEBUG_SIGNATURE = "VCpKgbYCXucoq1mZ4BZPsh5taNE=";
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -94,6 +94,12 @@ data class BrokerData(val packageName : String,
         )
 
         @JvmStatic
+        val debugCompanyPortal = BrokerData(
+            AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME,
+            AuthenticationConstants.Broker.COMPANY_PORTAL_APP_DEBUG_SIGNATURE_SHA512
+        )
+
+        @JvmStatic
         val prodCompanyPortal = BrokerData(
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE_SHA512
@@ -153,6 +159,7 @@ data class BrokerData(val packageName : String,
                 init {
                     add(debugMicrosoftAuthenticator)
                     add(debugLTW)
+                    add(debugCompanyPortal)
                     add(debugBrokerHost)
                     add(debugMockCp)
                     add(debugMockAuthApp)

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/PackageUtils.java
@@ -165,7 +165,7 @@ public final class PackageUtils {
             }
         }
 
-        throw new ClientException(BROKER_VERIFICATION_FAILED_ERROR, BROKER_APP_VERIFICATION_FAILED + "SignatureHashes: " + hashListStringBuilder.toString());
+        throw new ClientException(BROKER_VERIFICATION_FAILED_ERROR, BROKER_APP_VERIFICATION_FAILED + " SignatureHashes: " + hashListStringBuilder.toString());
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/BrokerDataTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/BrokerDataTest.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.broker
 
 import com.microsoft.identity.common.BuildConfig
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.debugBrokerHost
+import com.microsoft.identity.common.internal.broker.BrokerData.Companion.debugCompanyPortal
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.debugLTW
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.debugMicrosoftAuthenticator
 import com.microsoft.identity.common.internal.broker.BrokerData.Companion.debugMockAuthApp
@@ -55,14 +56,15 @@ class BrokerDataTest {
     fun testGetValidBrokersInDebugMode() {
         setShouldTrustDebugBrokers(true)
         val brokerData: Set<BrokerData> = BrokerData.getKnownBrokerApps()
-        Assert.assertEquals(9, brokerData.size.toLong())
+        Assert.assertEquals(10, brokerData.size.toLong())
         Assert.assertTrue(brokerData.contains(debugBrokerHost))
-        Assert.assertTrue(brokerData.contains(prodCompanyPortal))
         Assert.assertTrue(brokerData.contains(debugMicrosoftAuthenticator))
         Assert.assertTrue(brokerData.contains(prodMicrosoftAuthenticator))
         Assert.assertTrue(brokerData.contains(prodLTW))
         Assert.assertTrue(brokerData.contains(debugLTW))
         Assert.assertTrue(brokerData.contains(debugMockLtw))
+        Assert.assertTrue(brokerData.contains(prodCompanyPortal))
+        Assert.assertTrue(brokerData.contains(debugCompanyPortal))
         Assert.assertTrue(brokerData.contains(debugMockCp))
         Assert.assertTrue(brokerData.contains(debugMockAuthApp))
     }


### PR DESCRIPTION
Get rid of (deprecated) SHA1 values.

adding Debug CP into the debug broker list.

This is a breaking change as it removes sha1 used in https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1935