### PR TITLE
Set should trust debug broker flag from pipeline

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,6 +38,8 @@ if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion !=
 
 boolean newBrokerDiscoveryEnabledFlag = project.hasProperty("newBrokerDiscoveryEnabledFlag")
 
+boolean trustDebugBrokerFlag = project.hasProperty("trustDebugBrokerFlag")
+
 android {
     compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
@@ -56,6 +58,7 @@ android {
                 "kk", "ko", "lt", "lv", "ms", "nb", "nl", "pl", "pt-rBR", "pt-rPT", "ro",
                 "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-rCN", "zh-rTW"
         buildConfigField("boolean", "newBrokerDiscoveryEnabledFlag", "$newBrokerDiscoveryEnabledFlag")
+        buildConfigField("boolean", "trustDebugBrokerFlag", "$trustDebugBrokerFlag")
     }
 
     buildTypes {

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -65,7 +65,7 @@ data class BrokerData(val packageName : String,
          * Determines if the debug brokers should be trusted or not.
          * This should only be set to true only during testing.
          */
-        private var sShouldTrustDebugBrokers = BuildConfig.DEBUG
+        private var sShouldTrustDebugBrokers = BuildConfig.DEBUG || BuildConfig.trustDebugBrokerFlag
 
         @JvmStatic
         fun setShouldTrustDebugBrokers(value: Boolean) {


### PR DESCRIPTION
Works with https://github.com/AzureAD/android-complete/pull/270, see details there.