### PR TITLE
Add Test App to Account Visibility List

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/AccountManagerBrokerDiscoveryUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/AccountManagerBrokerDiscoveryUtil.kt
@@ -74,8 +74,6 @@ class AccountManagerBrokerDiscoveryUtil(
             throw ClientException(ClientException.ACCOUNT_MANAGER_FAILED, t.message)
         }
 
-        Logger.info(methodTag, "${authenticators.size} Authenticators registered.")
-
         authenticators.forEach { authenticator ->
             if (authenticator.packageName == null || authenticator.type == null){
                 return@forEach
@@ -83,22 +81,20 @@ class AccountManagerBrokerDiscoveryUtil(
 
             val packageName = authenticator.packageName.trim()
             val accountType = authenticator.type.trim()
-            Logger.info(methodTag, "Authenticator: $packageName type: $accountType")
 
             if (AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE.equals(accountType, ignoreCase = true)) {
-                Logger.info(methodTag, "Verify: $packageName")
-
                 val brokerData = knownBrokerApps.filter {
                     it.packageName.equals(packageName, ignoreCase = true)
                 }.firstOrNull(isSignedByKnownKeys)
 
                 if (brokerData != null) {
+                    Logger.info(methodTag, "$brokerData is the active AccountManager broker.")
                     return brokerData
                 }
             }
         }
 
-        Logger.info(methodTag, "No valid broker is found")
+        Logger.info(methodTag, "No valid AccountManager broker is found")
         return null
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
@@ -116,6 +116,24 @@ public class AccountManagerBrokerAccount implements IBrokerAccount {
                     COMPANY_PORTAL_APP_PACKAGE_NAME,
                     AccountManager.VISIBILITY_VISIBLE
             );
+
+            if (BrokerData.getShouldTrustDebugBrokers()){
+                accountManager.setAccountVisibility(
+                        account,
+                        BrokerData.getDebugMockCp().getPackageName(),
+                        AccountManager.VISIBILITY_VISIBLE
+                );
+                accountManager.setAccountVisibility(
+                        account,
+                        BrokerData.getDebugMockAuthApp().getPackageName(),
+                        AccountManager.VISIBILITY_VISIBLE
+                );
+                accountManager.setAccountVisibility(
+                        account,
+                        BrokerData.getDebugBrokerHost().getPackageName(),
+                        AccountManager.VISIBILITY_VISIBLE
+                );
+            }
         }
 
         return adapt(account);

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
@@ -119,10 +119,10 @@ open class BrokerValidator: IBrokerValidator {
         return try {
             val signingCertificate = getSigningCertificateForApp(brokerData.packageName)
             validateSigningCertificate(brokerData.signingCertificateThumbprint, signingCertificate)
-            Logger.info(methodTag, "$brokerData is a valid broker app.")
+            Logger.verbose(methodTag, "$brokerData is a valid broker app.")
             true
         } catch (t: Throwable) {
-            Logger.info(methodTag, "$brokerData verification failed: " + t.message)
+            Logger.verbose(methodTag, "$brokerData verification failed: " + t.message)
             false
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -172,11 +172,11 @@ public class MicrosoftStsOAuth2Strategy
         // If the host has a hardcoded trust, we can just use the hostname.
         if (null != cloudEnv) {
             final String preferredCacheHostName = cloudEnv.getPreferredCacheHostName();
-            Logger.info(
+            Logger.verbose(
                     TAG + methodName,
                     "Using preferred cache host name..."
             );
-            Logger.infoPII(
+            Logger.verbose(
                     TAG + methodName,
                     "Preferred cache hostname: [" + preferredCacheHostName + "]"
             );


### PR DESCRIPTION
Make the account manager account visible to test apps.

This is required to repro https://github.com/AzureAD/ad-accounts-for-android/pull/2614

(Only account(s) will be visible to these apps - the apps still cannot access the data unless it's the Account Manager active broker)