### PR TITLE
Move addition of passkey header from BaseController to WebView fragment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.Next
 - [PATCH] Passing span context to AuthorizationActivity (#2209)
 - [MINOR] Bumping Moshi versions; force setting Okio version (#2210)
 - [PATCH] Fix to generate new Asymmetric Key (#2222)
+- [MINOR] Move addition of passkey header from BaseController to WebView fragment (#2237)
 
 V.16.1.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient;
 import com.microsoft.identity.common.internal.ui.webview.OnPageLoadedCallback;
 import com.microsoft.identity.common.internal.ui.webview.WebViewUtil;
+import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.logging.Logger;
@@ -126,6 +127,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mAuthorizationRequestUrl = state.getString(REQUEST_URL);
         mRedirectUri = state.getString(REDIRECT_URI);
         mRequestHeaders = getRequestHeaders(state);
+        // In cases of WebView as an auth agent, we want to always add the passkey protocol header.
+        // (Not going to add passkey protocol header until full feature is ready.)
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            if (mRequestHeaders == null) {
+                mRequestHeaders = new HashMap<>();
+            }
+            mRequestHeaders.put(FidoConstants.PASSKEY_PROTOCOL_HEADER_NAME, FidoConstants.PASSKEY_PROTOCOL_HEADER_VALUE);
+        }
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -127,14 +127,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mAuthorizationRequestUrl = state.getString(REQUEST_URL);
         mRedirectUri = state.getString(REDIRECT_URI);
         mRequestHeaders = getRequestHeaders(state);
-        // In cases of WebView as an auth agent, we want to always add the passkey protocol header.
-        // (Not going to add passkey protocol header until full feature is ready.)
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            if (mRequestHeaders == null) {
-                mRequestHeaders = new HashMap<>();
-            }
-            mRequestHeaders.put(FidoConstants.PASSKEY_PROTOCOL_HEADER_NAME, FidoConstants.PASSKEY_PROTOCOL_HEADER_VALUE);
-        }
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
@@ -281,7 +273,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             // Suppressing unchecked warnings due to casting of serializable String to HashMap<String, String>
             @SuppressWarnings(WarningType.unchecked_warning)
             HashMap<String, String> requestHeaders = (HashMap<String, String>) state.getSerializable(REQUEST_HEADERS);
-
+            // In cases of WebView as an auth agent, we want to always add the passkey protocol header.
+            // (Not going to add passkey protocol header until full feature is ready.)
+            if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+                if (requestHeaders == null) {
+                    requestHeaders = new HashMap<>();
+                }
+                requestHeaders.put(FidoConstants.PASSKEY_PROTOCOL_HEADER_NAME, FidoConstants.PASSKEY_PROTOCOL_HEADER_VALUE);
+            }
             return requestHeaders;
         } catch (Exception e) {
             return null;

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -325,12 +325,6 @@ public abstract class BaseController {
             );
             completeRequestHeaders.put(PKEYAUTH_HEADER, PKEYAUTH_VERSION);
 
-            // Not going to add passkey protocol header until full feature is ready.
-            if (FidoConstants.IS_PASSKEY_SUPPORT_READY
-                    && interactiveTokenCommandParameters.getAuthorizationAgent() == AuthorizationAgent.WEBVIEW) {
-                completeRequestHeaders.put(FidoConstants.PASSKEY_PROTOCOL_HEADER_NAME, FidoConstants.PASSKEY_PROTOCOL_HEADER_VALUE);
-            }
-
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
             setBuilderProperties(builder, parameters, interactiveTokenCommandParameters, completeRequestHeaders);
 


### PR DESCRIPTION
### Summary
The initial work I did to add the passkey protocol header occurs in the BaseController and the PrtV3 authorization strategy classes. Adding the header in these two places covers the scenarios that MSAL/Broker needs.
However, in their non-brokered auth flow, OneAuth utilizes the `AuthorizationActivityFactory.getAuthorizationActivityIntent` directly, so they are not making use of any controllers in this case (though they do use BrokerMsalController for broker scenarios). (For context, `getAuthorizationActivityIntent` is called down the line by our strategies).  Thus, with the header logic the way it is, OneAuth is going to need to add the passkey header themselves to their `getAuthorizationActivityIntent` call.

They brought up the idea that if I were to move the addition of the passkey header to a class that's covered by `getAuthorizationActivityIntent`, then they would be able to get the logic automatically. 
If I move the passkey header logic to `WebViewAuthorizationFragment`, my understanding is that it would be inherited by both MSAL and broker (so I can also remove the logic from PrtV3 authorization strategy, iiuc) as well as OneAuth. And I also wouldn't have to check for authorization agent == WEBVIEW anymore. But this change would not be correlating to where we typically add headers (which is in BaseController and the PrtV3 auth strategy). 

~~I want to get some input from the team about this before commiting to making such a change.~~ Decided to make the change. 