### PR TITLE
Allow OneAuth to bypass redirect uri check via build config

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -37,8 +37,8 @@ if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion !=
 }
 
 boolean newBrokerDiscoveryEnabledFlag = project.hasProperty("newBrokerDiscoveryEnabledFlag")
-
 boolean trustDebugBrokerFlag = project.hasProperty("trustDebugBrokerFlag")
+boolean bypassRedirectUriCheck = project.hasProperty("bypassRedirectUriCheck")
 
 android {
     compileSdk rootProject.ext.compileSdkVersion
@@ -59,6 +59,7 @@ android {
                 "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-rCN", "zh-rTW"
         buildConfigField("boolean", "newBrokerDiscoveryEnabledFlag", "$newBrokerDiscoveryEnabledFlag")
         buildConfigField("boolean", "trustDebugBrokerFlag", "$trustDebugBrokerFlag")
+        buildConfigField("boolean", "bypassRedirectUriCheck", "$bypassRedirectUriCheck")
     }
 
     buildTypes {

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -136,6 +136,12 @@ public class AndroidPlatformUtil implements IPlatformUtil {
     @Override
     public boolean isValidCallingApp(@NonNull String redirectUri, @NonNull String packageName) {
         final String methodTag = TAG + ":isValidCallingApp";
+
+        if (BuildConfig.bypassRedirectUriCheck) {
+            Logger.warn(methodTag, "Bypassing RedirectUri Check. This should not be enabled in PROD.");
+            return true;
+        }
+
         final String expectedBrokerRedirectUri = PackageHelper.getBrokerRedirectUri(mContext, packageName);
         boolean isValidBrokerRedirect = StringUtil.equalsIgnoreCase(redirectUri, expectedBrokerRedirectUri);
         if (packageName.equals(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
@@ -149,10 +155,7 @@ public class AndroidPlatformUtil implements IPlatformUtil {
                 isValidBrokerRedirect |= StringUtil.equalsIgnoreCase(redirectUri, AuthenticationConstants.Broker.BROKER_REDIRECT_URI);
             }
         }
-        if (isValidHubRedirectURIForNAATests(redirectUri)) {
-            // To handle the testing of NAA scenario, we have to allow list teams app redirectURIs. Do not do this in Release build
-            return true;
-        }
+
         if (!isValidBrokerRedirect) {
             com.microsoft.identity.common.logging.Logger.error(
                     methodTag,
@@ -208,14 +211,6 @@ public class AndroidPlatformUtil implements IPlatformUtil {
     @Override
     public String getPackageNameFromUid(int uid) {
         return mContext.getPackageManager().getNameForUid(uid);
-    }
-
-    private boolean isValidHubRedirectURIForNAATests(String redirectUri) {
-        // The only allow-listed hub app on ESTS is Teams app. We cannot use our test app's clientId/redirecrURI for testing NAA scenarios
-        // Below redirectURI is being used in our automation tests and also by OneAuth tests for NAA
-        return BuildConfig.DEBUG && (redirectUri.equals("msauth://com.microsoft.teams/VCpKgbYCXucoq1mZ4BZPsh5taNE=")
-                        || redirectUri.equals("msauth://com.microsoft.teams/fcg80qvoM1YMKJZibjBwQcDfOno=")
-                        || redirectUri.equals("https://login.microsoftonline.com/common/oauth2/nativeclient"));
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common
+
+import org.junit.Test
+
+/**
+ * Tests for making sure compile time flags aren't turned on in PROD build.
+ **/
+class BuildConfigTest {
+
+    @Test
+    fun failIfBypassRedirecUriCheckEnabled(){
+        assert(!BuildConfig.bypassRedirectUriCheck)
+    }
+
+    @Test
+    fun failIfTrustDebugBrokerFlagEnabled(){
+        assert(!BuildConfig.trustDebugBrokerFlag)
+    }
+
+    @Test
+    fun failIfNewBrokerDiscoveryEnabledFlagEnabled(){
+        assert(!BuildConfig.newBrokerDiscoveryEnabledFlag)
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
@@ -38,9 +38,4 @@ class BuildConfigTest {
     fun failIfTrustDebugBrokerFlagEnabled(){
         assert(!BuildConfig.trustDebugBrokerFlag)
     }
-
-    @Test
-    fun failIfNewBrokerDiscoveryEnabledFlagEnabled(){
-        assert(!BuildConfig.newBrokerDiscoveryEnabledFlag)
-    }
 }


### PR DESCRIPTION
If set, the Redirect URI validation in Android Broker will be bypassed.

This will allow MSALTestApp/OneAuthTestApp to impersonate as 1st party apps (i.e. Outlook, OneDrive, etc).