### PR TITLE
Bump dependency size due to the ~500kb new NativeAuth code in common4j

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -365,7 +365,7 @@ tasks.withType(GenerateMavenPom).all {
     destination = layout.buildDirectory.file("poms/${project.name}-${project.version}.pom").get().asFile
 }
 
-def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "11"
+def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "11.5"
 String configToCheck = project.hasProperty("dependenciesSizeCheckConfig") ? project.dependenciesSizeCheckConfig : "distReleaseRuntimeClasspath"
 tasks.register("dependenciesSizeCheck") {
     doLast() {


### PR DESCRIPTION
This is mainly being done to accommodate Native Auth Code being merged to MSAL, which is about 400 KB of code being added to common4j's total size.

Similar PR in broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2636#pullrequestreview-1770772943

Native PR where size increased: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2233