### PR TITLE
Change function name for mock api

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/BuildValues.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/BuildValues.java
@@ -50,7 +50,7 @@ public class BuildValues {
         return USE_MOCK_API_FOR_NATIVE_AUTH_AUTHORITY;
     }
 
-    public static void setUseRealAuthority(Boolean ura) {
-        USE_MOCK_API_FOR_NATIVE_AUTH_AUTHORITY = ura;
+    public static void setUseMockApiForNativeAuth(Boolean useMockApi) {
+        USE_MOCK_API_FOR_NATIVE_AUTH_AUTHORITY = useMockApi;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
@@ -20,6 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
+
 package com.microsoft.identity.common.java.nativeauth;
 
 import com.microsoft.identity.common.java.BuildConfig;

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
@@ -20,7 +20,6 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-
 package com.microsoft.identity.common.java.nativeauth;
 
 import com.microsoft.identity.common.java.BuildConfig;

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
@@ -20,7 +20,9 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.java;
+package com.microsoft.identity.common.java.nativeauth;
+
+import com.microsoft.identity.common.java.BuildConfig;
 
 import javax.annotation.Nonnull;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -23,8 +23,7 @@
 
 package com.microsoft.identity.common.java.nativeauth.providers
 
-import com.microsoft.identity.common.java.BuildConfig
-import com.microsoft.identity.common.java.BuildValues
+import com.microsoft.identity.common.java.nativeauth.BuildValues
 import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration


### PR DESCRIPTION
Use consistent function name in BuildValues for mock API usage.