### PR TITLE
Correcting passkey telemetry attribute

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
@@ -61,8 +61,8 @@ class AuthFidoChallengeHandler (
             OTelUtility.createSpan(SpanName.Fido.name)
         }
         span.setAttribute(
-            AttributeName.fido_challenge.name,
-            fidoChallenge::class.simpleName.toString()
+            AttributeName.fido_challenge_handler.name,
+            TAG
         );
         // First verify submitUrl and context. Without these two, we can't respond back to the server.
         // If either one of these are missing or malformed, throw an exception and let the main WebViewClient handle it.

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -255,10 +255,6 @@ public enum AttributeName {
     broker_operation_name,
 
     /**
-     * Fido challenge type.
-     */
-    fido_challenge,
-    /**
      * Fido challenge handler type.
      */
     fido_challenge_handler


### PR DESCRIPTION
### Summary
Correcting the Otel attribute set in the passkey logic. I was originally setting the Fido challenge class type, but this is now not helpful info after the refactoring that has been completed. The challenge handler class type is now being set, and I removed the challenge entry from AttributeName.
