### PR TITLE
Ignore NativeAuth unit tests

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
@@ -85,6 +85,7 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
+@Ignore
 class ResetPasswordOAuth2StrategyTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
@@ -79,6 +79,7 @@ import java.util.UUID
  * These tests run on the mock API, see: https://native-ux-mock-api.azurewebsites.net/
  */
 
+
 @RunWith(
     PowerMockRunner::class
 )

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
@@ -50,6 +50,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -72,6 +73,7 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
+@Ignore
 class SignInOAuthStrategyTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
@@ -47,6 +47,7 @@ import com.microsoft.identity.common.nativeauth.MockApiResponseType
 import com.microsoft.identity.common.nativeauth.MockApiUtils.Companion.configureMockApi
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -69,6 +70,7 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
+@Ignore
 class SignUpOAuth2StrategyTest {
     private val username = "user@email.com"
     private val invalidUsername = "invalidUsername"

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
@@ -48,11 +48,13 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
+@Ignore
 class ResetPasswordScenarioTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
@@ -45,11 +45,13 @@ import com.microsoft.identity.common.nativeauth.MockApiResponseType
 import com.microsoft.identity.common.nativeauth.MockApiUtils.Companion.configureMockApi
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
+@Ignore
 class SignUpScenarioTest {
     private val username = "user@email.com"
     private val email = "user@email.com"

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -70,6 +70,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -87,6 +88,7 @@ import java.util.UUID
  * Tests for [NativeAuthMsalController].
  */
 @RunWith(RobolectricTestRunner::class)
+@Ignore
 class NativeAuthControllerTest {
     private val code = "12345"
     private val credentialToken = "sk490fj8a83n*@f-1"

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
@@ -52,10 +52,12 @@ import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAu
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.net.URL
 
+@Ignore
 class NativeAuthRequestHandlerTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()


### PR DESCRIPTION
Native Auth unit tests are marked as ignored because the mock API web service is not functioning.