### PR TITLE
Update mock url for native auth and re-enable tests

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
@@ -41,21 +41,21 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpa
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordStartApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordSubmitApiResult
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters
+import com.microsoft.identity.common.nativeauth.ApiConstants
 import com.microsoft.identity.common.nativeauth.MockApiEndpoint
 import com.microsoft.identity.common.nativeauth.MockApiResponseType
 import com.microsoft.identity.common.nativeauth.MockApiUtils.Companion.configureMockApi
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signInChallengeRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signInInitiateRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signInTokenRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signUpChallengeRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signUpContinueRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.signUpStartRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.ssprChallengeRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.ssprContinueRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.ssprStartRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.ssprSubmitRequestUrl
-import com.microsoft.identity.common.nativeauth.utils.ApiConstants.Companion.ssprPollCompletionRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signInChallengeRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signInInitiateRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signInTokenRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signUpChallengeRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signUpContinueRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.signUpStartRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.ssprChallengeRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.ssprContinueRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.ssprStartRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.ssprSubmitRequestUrl
+import com.microsoft.identity.common.nativeauth.ApiConstants.Companion.ssprPollCompletionRequestUrl
 
 import io.mockk.every
 import io.mockk.mockk
@@ -76,7 +76,7 @@ import java.util.UUID
 /**
  * These are integration tests using real API responses instead of mocked API responses. This class
  * covers all sign up endpoints.
- * These tests run on the mock API, see: https://native-ux-mock-api.azurewebsites.net/
+ * These tests run on the mock API, see: https://native-auth-mock-api-private-preview.azurewebsites.net/
  */
 
 
@@ -86,7 +86,6 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
-@Ignore
 class ResetPasswordOAuth2StrategyTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
@@ -65,7 +65,7 @@ import java.util.UUID
 /**
  * These are integration tests using real API responses instead of mocked API responses. This class
  * covers all sign up endpoints.
- * These tests run on the mock API, see: https://native-ux-mock-api.azurewebsites.net/
+ * These tests run on the mock API, see: https://native-auth-mock-api-private-preview.azurewebsites.net/
  */
 @RunWith(
     RobolectricTestRunner::class
@@ -73,7 +73,6 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
-@Ignore
 class SignInOAuthStrategyTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
@@ -61,7 +61,7 @@ import java.util.UUID
 /**
  * These are integration tests using real API responses instead of mocked API responses. This class
  * covers all sign up endpoints.
- * These tests run on the mock API, see: https://native-ux-mock-api.azurewebsites.net/
+ * These tests run on the mock API, see: https://native-auth-mock-api-private-preview.azurewebsites.net/
  */
 
 @RunWith(
@@ -70,7 +70,6 @@ import java.util.UUID
 @PowerMockIgnore("javax.net.ssl.*")
 @PrepareForTest(DiagnosticContext::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
-@Ignore
 class SignUpOAuth2StrategyTest {
     private val username = "user@email.com"
     private val invalidUsername = "invalidUsername"

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
@@ -54,7 +54,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@Ignore
 class ResetPasswordScenarioTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
@@ -51,7 +51,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
-@Ignore
 class SignUpScenarioTest {
     private val username = "user@email.com"
     private val email = "user@email.com"

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -88,7 +88,6 @@ import java.util.UUID
  * Tests for [NativeAuthMsalController].
  */
 @RunWith(RobolectricTestRunner::class)
-@Ignore
 class NativeAuthControllerTest {
     private val code = "12345"
     private val credentialToken = "sk490fj8a83n*@f-1"

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/util/ApiConstants.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/util/ApiConstants.kt
@@ -29,17 +29,17 @@ import java.net.URL
  */
 interface ApiConstants {
     companion object {
-        val signUpStartRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/start")
-        val signUpChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/challenge")
-        val signUpContinueRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/continue")
-        val signInInitiateRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/initiate")
-        val signInChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/challenge")
-        val signInTokenRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/token")
-        val ssprStartRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/start")
-        val ssprChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/challenge")
-        val ssprContinueRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/continue")
-        val ssprSubmitRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/submit")
-        val ssprPollCompletionRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/poll_completion")
+        val signUpStartRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/signup/v1.0/start")
+        val signUpChallengeRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/signup/v1.0/challenge")
+        val signUpContinueRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/signup/v1.0/continue")
+        val signInInitiateRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/oauth2/v2.0/initiate")
+        val signInChallengeRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/oauth2/v2.0/challenge")
+        val signInTokenRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/oauth2/v2.0/token")
+        val ssprStartRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/resetpassword/v1.0/start")
+        val ssprChallengeRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/resetpassword/v1.0/challenge")
+        val ssprContinueRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/resetpassword/v1.0/continue")
+        val ssprSubmitRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/resetpassword/v1.0/submit")
+        val ssprPollCompletionRequestUrl = URL("https://native-auth-mock-api-private-preview.azurewebsites.net/1234/resetpassword/v1.0/poll_completion")
         val tokenEndpoint = URL("https://contoso.com/1234/token")
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -50,8 +50,8 @@ class NativeAuthOAuth2Configuration(
 
     companion object {
         //Base url for the mock API to make Native Auth calls. See the swagger at
-        // https://native-ux-mock-api.azurewebsites.net/doc#/ for all possible urls
-        private const val MOCK_API_URL_WITH_NATIVE_AUTH_TENANT = "https://native-ux-mock-api.azurewebsites.net/lumonconvergedps.onmicrosoft.com"
+        // https://native-auth-mock-api-private-preview.azurewebsites.net/doc#/ for all possible urls
+        private const val MOCK_API_URL_WITH_NATIVE_AUTH_TENANT = "https://native-auth-mock-api-private-preview.azurewebsites.net/lumonconvergedps.onmicrosoft.com"
 
         private const val SIGNUP_START_ENDPOINT_SUFFIX = "/signup/v1.0/start"
         private const val SIGNUP_CHALLENGE_ENDPOINT_SUFFIX = "/signup/v1.0/challenge"

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
@@ -52,12 +52,10 @@ import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAu
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.net.URL
 
-@Ignore
 class NativeAuthRequestHandlerTest {
     private val username = "user@email.com"
     private val password = "verySafePassword".toCharArray()

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -49,6 +49,7 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpContinueApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpStartApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpStartApiResult
+import com.microsoft.identity.common.nativeauth.ApiConstants
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
@@ -62,7 +63,7 @@ import java.net.URL
 
 class NativeAuthResponseHandlerTest {
     private val clientId = "1234"
-    private val requestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/start")
+    private val requestUrl =  ApiConstants.signUpStartRequestUrl
     private val challengeType = "oob password redirect"
     private val oobChallengeType = "oob"
     private val passwordChallengeType = "password"

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/ApiConstants.kt
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/ApiConstants.kt
@@ -30,17 +30,19 @@ import java.net.URL
  */
 interface ApiConstants {
     companion object {
-        val signUpStartRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/start")
-        val signUpChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/challenge")
-        val signUpContinueRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/signup/v1.0/continue")
-        val signInInitiateRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/initiate")
-        val signInChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/challenge")
-        val signInTokenRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/oauth2/v2.0/token")
-        val ssprStartRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/start")
-        val ssprChallengeRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/challenge")
-        val ssprContinueRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/continue")
-        val ssprSubmitRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/submit")
-        val ssprPollCompletionRequestUrl = URL("https://native-ux-mock-api.azurewebsites.net/1234/resetpassword/v1.0/poll_completion")
+        const val BASEPATH = "https://native-auth-mock-api-private-preview.azurewebsites.net/"
+        private const val BASE_REQUEST_PATH = BASEPATH + "1234/"
+        val signUpStartRequestUrl = URL(BASE_REQUEST_PATH + "signup/v1.0/start")
+        val signUpChallengeRequestUrl = URL(BASE_REQUEST_PATH + "signup/v1.0/challenge")
+        val signUpContinueRequestUrl = URL(BASE_REQUEST_PATH + "signup/v1.0/continue")
+        val signInInitiateRequestUrl = URL(BASE_REQUEST_PATH + "oauth2/v2.0/initiate")
+        val signInChallengeRequestUrl = URL(BASE_REQUEST_PATH + "oauth2/v2.0/challenge")
+        val signInTokenRequestUrl = URL(BASE_REQUEST_PATH + "oauth2/v2.0/token")
+        val ssprStartRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/start")
+        val ssprChallengeRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/challenge")
+        val ssprContinueRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/continue")
+        val ssprSubmitRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/submit")
+        val ssprPollCompletionRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/poll_completion")
         val tokenEndpoint = URL("https://contoso.com/1234/token")
     }
 }

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/MockApi.kt
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/MockApi.kt
@@ -45,14 +45,12 @@ class MockApi private constructor(
 ) {
     companion object {
 
-        // Base url for the config endpoint. The config endpoint for the mock API provides the
+        // The config endpoint for the mock API provides the
         // ability to clients to add a response to the queue, see existing responses and
         // delete all responses in the queue
-        private const val CONFIG_BASE_URL = "https://native-ux-mock-api.azurewebsites.net/config"
-
         // This endpoint allows a client to add a response to the response queue. When the client
         // makes a request with the matching correlation-id, the mock API will return that response
-        private const val MOCK_ADD_RESPONSE_URL = "$CONFIG_BASE_URL/response"
+        private const val MOCK_ADD_RESPONSE_URL = "${ApiConstants.BASEPATH}/config/response"
 
         private val headers = TreeMap<String, String?>().also {
             it[HttpConstants.HeaderField.CONTENT_TYPE] = "application/json"


### PR DESCRIPTION
This PR includes following changes:
1. Update Native Auth mock API url
2. Re-enable tests for Native Auth that called mock API
3. Deleted a duplicate copy of ApiConstants.kt file
4. Move a test file into correct folder.