### PR TITLE
Redirect to hub app in case of NAA flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ V.Next
 - [MINOR] Implement updates of the native auth web API (#2261)
 - [MINOR] Update ResetPasswordPollCompletion related command, results, and responses to support signing in a user after a successful password reset. (#2281)
 - [MINOR] Added support for setting no log level (#2282)
+- [MINOR] Redirect to hub app in case of NAA flow (#2290)
 
 V.17.0.0
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -126,6 +126,7 @@ public abstract class BrowserAuthorizationStrategy<
     // Suppressing unchecked warnings during casting to HashMap<String,String> due to no generic type with mAuthorizationRequest
     @SuppressWarnings(WarningType.unchecked_warning)
     private Intent buildAuthorizationActivityStartIntent(Intent authIntent, URI requestUrl) {
+         // RedirectURI used to get the auth code in nested app auth is that of a hub app (brkRedirectURI)   
         final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         final Intent intent = AuthorizationActivityFactory.getAuthorizationActivityIntent(
                 getApplicationContext(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -126,11 +126,12 @@ public abstract class BrowserAuthorizationStrategy<
     // Suppressing unchecked warnings during casting to HashMap<String,String> due to no generic type with mAuthorizationRequest
     @SuppressWarnings(WarningType.unchecked_warning)
     private Intent buildAuthorizationActivityStartIntent(Intent authIntent, URI requestUrl) {
+        final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         final Intent intent = AuthorizationActivityFactory.getAuthorizationActivityIntent(
                 getApplicationContext(),
                 authIntent,
                 requestUrl.toString(),
-                mAuthorizationRequest.getRedirectUri(),
+                redirectUri,
                 mAuthorizationRequest.getRequestHeaders(),
                 AuthorizationAgent.BROWSER,
                 true,

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -93,6 +93,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
     // Suppressing unchecked warnings during casting to HashMap<String,String> due to no generic type with mAuthorizationRequest
     @SuppressWarnings(WarningType.unchecked_warning)
     private Intent buildAuthorizationActivityStartIntent(URI requestUrl) {
+        // RedirectURI used to get the auth code in nested app auth is that of a hub app (brkRedirectURI)       
         final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         return AuthorizationActivityFactory.getAuthorizationActivityIntent(
                     getApplicationContext(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -93,11 +93,12 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
     // Suppressing unchecked warnings during casting to HashMap<String,String> due to no generic type with mAuthorizationRequest
     @SuppressWarnings(WarningType.unchecked_warning)
     private Intent buildAuthorizationActivityStartIntent(URI requestUrl) {
+        final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         return AuthorizationActivityFactory.getAuthorizationActivityIntent(
                     getApplicationContext(),
                     null,
                     requestUrl.toString(),
-                    mAuthorizationRequest.getRedirectUri(),
+                    redirectUri,
                     mAuthorizationRequest.getRequestHeaders(),
                     AuthorizationAgent.WEBVIEW,
                     mAuthorizationRequest.isWebViewZoomEnabled(),


### PR DESCRIPTION
**Issue** : Found a bug while ACW team was testing NAA flow. In case of an interrupt flow, the redirectURI of calling apps would be passed to eSTS as the redirectURI. In NAA flow, redirectURI parameter is child app's redirectURI (which could just be a single page app's redirectURI). eSTS always returns the auth code back to hub app's redirectURI.  We would not be able to read/extract the auth code received because the redirectURI eSTS sends code to and the redirectURI we have passed to WebviewAuthorizationStrategy are different. 

**Fix** : Whenever it is a nested app flow (brkRedirectURI!=null), I am passing hub app's redirectURI to authorization strategy to pass the comparison that is made at this line https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/4900edb7f9db5952474586f83efd37b90995cde8/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java#L182