### PR TITLE
Add AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Add AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp (#2294)
 - [MINOR] Update SignIn/Signup parameters classes for Native Auth(#2284)
 - [MINOR] Add IsQrPinAvailableCommand, controllers behavior and define constants for the isQrAvailable API (#2219)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#2245)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1532,8 +1532,6 @@ public final class AuthenticationConstants {
          * place, so that we only need to make updates in one location, and it's clearer what we need
          * to do when adding new APIs.
          */
-        @Getter
-        @Accessors(prefix = "m")
         @AllArgsConstructor
         public enum API {
             MSAL_HELLO(MSAL_HELLO_PATH, null, VERSION_3),
@@ -1568,15 +1566,27 @@ public final class AuthenticationConstants {
             /**
              * The content provider path that the API exists behind.
              */
-            private String mPath;
+            private final String mPath;
             /**
              * The broker-host-to-broker protocol version that the API requires.
              */
-            private String mBrokerVersion;
+            private final String mBrokerVersion;
             /**
              * The msal-to-broker version that the API requires.
              */
-            private String mMsalVersion;
+            private final String mMsalVersion;
+
+            public String getPath(){
+                return mPath;
+            }
+
+            public String getBrokerVersion(){
+                return mBrokerVersion;
+            }
+
+            public String getMsalVersion(){
+                return mMsalVersion;
+            }
         }
 
         /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerAddAccountStrategy.java
@@ -46,6 +46,7 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.
 
 /**
  * A strategy for communicating with the targeted broker via AccountManager's addAccount().
+ * This will only communicate to the owner of com.microsoft.workaccount account type.
  * <p>
  * NOTE: SuppressLint is added because this API requires MANAGE_ACCOUNTS for API<= 22.
  * AccountManagerUtil.canUseAccountManagerOperation() will validate that.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
@@ -37,7 +37,6 @@ import com.microsoft.identity.common.logging.Logger
 /**
  * An IPC strategy that utilizes AccountManager.addAccount().
  *
- * Designed to be used for communication to a specific broker app. (e.g. AuthApp, CP, LTW)
  * The receiving end of this class is Broker's AccountAuthenticatorForBrokerDiscovery.
  * Each broker apps would need to wire that class up to AccountManager manually,
  * with a unique account type.
@@ -107,9 +106,10 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
                 AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp?{
             if (!AccountManagerUtil.canUseAccountManagerOperation(
                     context,
-                    listOf(LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                    setOf(LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
                         CP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
-                        AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE))){
+                        AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE)
+                )){
                 return null
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker.ipc
+
+import android.accounts.AccountManager
+import android.accounts.AuthenticatorDescription
+import android.content.Context
+import android.os.Bundle
+import com.microsoft.identity.common.exception.BrokerCommunicationException
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.BrokerValidator
+import com.microsoft.identity.common.internal.broker.IBrokerValidator
+import com.microsoft.identity.common.internal.util.AccountManagerUtil
+import com.microsoft.identity.common.internal.util.ProcessUtil
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * An IPC strategy that utilizes AccountManager.addAccount().
+ *
+ * Designed to be used for communication to a specific broker app. (e.g. AuthApp, CP, LTW)
+ * The receiving end of this class is Broker's AccountAuthenticatorForBrokerDiscovery.
+ * Each broker apps would need to wire that class up to AccountManager manually,
+ * with a unique account type.
+ * (see getAccountTypeForEachPackage() and
+ * https://developer.android.com/training/sync-adapters/creating-authenticator)
+ *
+ * As of Jan 23, this class (and AccountAuthenticatorForBrokerDiscovery) only supports
+ * Broker Discovery and Passthrough mode.
+ *
+ * NOTE: This is not an official IPC Mechanism, therefore it is meant to be used as a backup only.
+ * (Apparently, it's more resilient than Content Provider and Bound Service under certain scenarios).
+ **/
+class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
+    internal constructor (private val accountTypeForEachPackage: Map<String, String>,
+                          private val sendRequestViaAccountManager: (accountType: String, bundle: Bundle) -> Bundle,
+                          private val getAccountManagerApps: () -> Array<AuthenticatorDescription>,
+                          private val brokerValidator: IBrokerValidator) : IIpcStrategy {
+    companion object {
+        val TAG = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp::class.simpleName
+
+        // Content of the bundle to be sent.
+        /** Key associated to Content Provider path of [BrokerOperationBundle.Operation] **/
+        const val CONTENT_PROVIDER_PATH_KEY = "CONTENT_PROVIDER_PATH"
+
+        /** Key associated to request bundle **/
+        const val REQUEST_BUNDLE_KEY = "REQUEST_BUNDLE"
+
+        // Account types associated to each broker apps.
+        /** Account type for Link To Windows (defined in Broker's res/xml/ltw_account_manager_passthrough_backup.xml) **/
+        internal const val LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE = "com.microsoft.ltwpassthroughbackup"
+
+        /** Account type for Company Portal (defined in Broker's res/xml/cp_account_manager_passthrough_backup.xml) **/
+        internal const val CP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE = "com.microsoft.cppassthroughbackup"
+
+        /** Account type for Authenticator (defined in Broker's res/xml/authapp_account_manager_passthrough_backup.xml) **/
+        internal const val AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE = "com.microsoft.authapppassthroughbackup"
+
+        /**
+         * Returns AccountManager account types associated to each Broker app packages.
+         **/
+        internal fun getAccountTypeForEachPackage(): Map<String, String>{
+            val result = mapOf(
+                BrokerData.debugMockLtw.packageName to LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                BrokerData.prodLTW.packageName to LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+
+                BrokerData.debugMockCp.packageName to CP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                BrokerData.prodCompanyPortal.packageName to CP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+
+                BrokerData.debugMockAuthApp.packageName to AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                BrokerData.prodMicrosoftAuthenticator.packageName to AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+            )
+
+            // This will throw an error if any PROD apps doesn't implement this mechanism.
+            // (To make sure we don't miss this if we have to add another broker app in the future).
+            BrokerData.prodBrokers.forEach {
+                assert(result.containsKey(it.packageName))
+            }
+
+            return result
+        }
+
+        /**
+         * Gets an instance of this class.
+         * This will return null if AccountManager cannot be used as an IPC mechanism.
+         * */
+        fun tryCreateInstance(context: Context):
+                AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp?{
+            if (!AccountManagerUtil.canUseAccountManagerOperation(
+                    context,
+                    listOf(LTW_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                        CP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                        AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE))){
+                return null
+            }
+
+            val accountManager = AccountManager.get(context)
+
+            return AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+                accountTypeForEachPackage = getAccountTypeForEachPackage(),
+                sendRequestViaAccountManager = { accountType, requestBundle ->
+                    accountManager.addAccount(
+                        accountType,
+                        null,
+                        null,
+                        requestBundle,
+                        null,
+                        null,
+                        ProcessUtil.getPreferredHandler()
+                    ).result
+                },
+                getAccountManagerApps = {
+                    accountManager.authenticatorTypes
+                },
+                brokerValidator = BrokerValidator(context))
+        }
+    }
+
+    @Throws(BrokerCommunicationException::class)
+    override fun communicateToBroker(bundle: BrokerOperationBundle): Bundle? {
+        val methodTag = "$TAG:communicateToBroker"
+        val targetPackageName = bundle.targetBrokerAppPackageName
+
+        val accountType = accountTypeForEachPackage.getOrElse(targetPackageName) {
+            throw BrokerCommunicationException(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                type,
+                "AccountManagerBackupIpcStrategy doesn't recognize $targetPackageName as a broker",
+                null
+            )
+        }
+
+        // check if the account type owner actually belongs to the corresponding broker app.
+        validateTargetApp(targetPackageName, accountType)
+
+        // Pack the request bundle.
+        // Changing this format is a breaking change
+        // as the receiving end might be on an older broker version (therefore doesn't recognize the change)
+        val requestBundle = Bundle().apply {
+            putParcelable(REQUEST_BUNDLE_KEY, bundle.bundle)
+            putString(CONTENT_PROVIDER_PATH_KEY, bundle.operation.contentApi.path)
+        }
+
+        return try {
+            val result = sendRequestViaAccountManager(accountType, requestBundle)
+            result
+        } catch (e: Throwable) {
+            Logger.error(methodTag, e.message, e)
+            // Technically... this might NOT be a connection error.
+            // AccountManager returns both connection error and legit failure
+            // (i.e. not supported, bad request) as AuthenticatorException...
+            // It also has no error code. The only difference would be in the error message.
+            throw BrokerCommunicationException(
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                type,
+                "AccountManager failed to respond - ${e.message}",
+                e
+            )
+        }
+    }
+
+    /**
+     * Check if the App currently associated to the given account type is
+     * actually a valid broker app.
+     **/
+    @Throws(BrokerCommunicationException::class)
+    private fun validateTargetApp(
+        targetPackageName: String,
+        accountType: String,
+    ) {
+        val targetAppInfo = try {
+            getAccountManagerApps().first {
+                it.packageName == targetPackageName && it.type == accountType
+            }
+        } catch (t: Throwable) {
+            throw BrokerCommunicationException(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                type,
+                "$targetPackageName doesn't support account manager backup ipc for Broker Discovery.",
+                null)
+        }
+
+        if (!brokerValidator.isValidBrokerPackage(targetAppInfo.packageName)) {
+            throw BrokerCommunicationException(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                type,
+                "${targetAppInfo.packageName} is not a valid broker app",
+                null
+            )
+        }
+    }
+
+    override fun getType(): IIpcStrategy.Type {
+        return IIpcStrategy.Type.ACCOUNT_MANAGER_ADD_ACCOUNT
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/BrokerOperationBundle.java
@@ -46,8 +46,6 @@ import lombok.experimental.Accessors;
 public class BrokerOperationBundle {
     private static final String TAG = BrokerOperationBundle.class.getSimpleName();
 
-    @Getter
-    @Accessors(prefix = "m")
     public enum Operation {
         MSAL_HELLO(API.MSAL_HELLO, BrokerAccountManagerOperation.HELLO),
         MSAL_GET_INTENT_FOR_INTERACTIVE_REQUEST(API.ACQUIRE_TOKEN_INTERACTIVE, BrokerAccountManagerOperation.GET_INTENT_FOR_INTERACTIVE_REQUEST),
@@ -80,6 +78,15 @@ public class BrokerOperationBundle {
       
         final API mContentApi;
         final String mAccountManagerOperation;
+
+        public API getContentApi(){
+            return mContentApi;
+        }
+
+        public String getAccountManagerOperation(){
+            return mAccountManagerOperation;
+        }
+
         Operation(API contentApi, String accountManagerOperation) {
             this.mContentApi = contentApi;
             this.mAccountManagerOperation = accountManagerOperation;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -203,7 +203,7 @@ public class BrokerMsalController extends BaseController {
         }
 
         if (AccountManagerUtil.canUseAccountManagerOperation(applicationContext,
-                Collections.singletonList(BROKER_ACCOUNT_TYPE)))
+                Collections.singleton(BROKER_ACCOUNT_TYPE)))
         {
             sb.append("AccountManagerStrategy.");
             strategies.add(new AccountManagerAddAccountStrategy(applicationContext));

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -41,6 +41,7 @@ import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationB
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SSO_TOKEN;
 import static com.microsoft.identity.common.internal.controllers.BrokerOperationExecutor.BrokerOperation;
 import static com.microsoft.identity.common.internal.util.StringUtil.isEmpty;
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
@@ -117,6 +118,7 @@ import com.microsoft.identity.common.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -200,7 +202,9 @@ public class BrokerMsalController extends BaseController {
             strategies.add(new BoundServiceStrategy<>(client));
         }
 
-        if (AccountManagerUtil.canUseAccountManagerOperation(applicationContext)) {
+        if (AccountManagerUtil.canUseAccountManagerOperation(applicationContext,
+                Collections.singletonList(BROKER_ACCOUNT_TYPE)))
+        {
             sb.append("AccountManagerStrategy.");
             strategies.add(new AccountManagerAddAccountStrategy(applicationContext));
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
@@ -35,6 +35,8 @@ import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.logging.Logger;
 
+import java.util.List;
+
 public final class AccountManagerUtil {
     private static final String TAG = AccountManagerUtil.class.getSimpleName();
 
@@ -46,7 +48,8 @@ public final class AccountManagerUtil {
     /**
      * To verify if the caller can use to AccountManager to use broker.
      */
-    public static boolean canUseAccountManagerOperation(final Context context) {
+    public static boolean canUseAccountManagerOperation(final Context context,
+                                                        final List<String> accountTypes) {
         final String methodTag = TAG + ":canUseAccountManagerOperation:";
 
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -63,9 +66,10 @@ public final class AccountManagerUtil {
             if (devicePolicyManager != null) {
                 final String[] accountTypesWithManagementDisabled = devicePolicyManager.getAccountTypesWithManagementDisabled();
                 if (accountTypesWithManagementDisabled != null) {
-                    for (final String accountType : accountTypesWithManagementDisabled) {
-                        if (BROKER_ACCOUNT_TYPE.equalsIgnoreCase(accountType)) {
-                            Logger.verbose(methodTag, "Broker account type is disabled by MDM.");
+                    for (final String disabledAccountType : accountTypesWithManagementDisabled) {
+                        if (accountTypes.contains(disabledAccountType)) {
+                            Logger.info(methodTag, "Account type " + disabledAccountType +
+                                    " is disabled by MDM.");
                             return false;
                         }
                     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AccountManagerUtil.java
@@ -23,8 +23,6 @@
 
 package com.microsoft.identity.common.internal.util;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
-
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -35,7 +33,7 @@ import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.logging.Logger;
 
-import java.util.List;
+import java.util.Set;
 
 public final class AccountManagerUtil {
     private static final String TAG = AccountManagerUtil.class.getSimpleName();
@@ -46,10 +44,13 @@ public final class AccountManagerUtil {
     }
 
     /**
-     * To verify if the caller can use to AccountManager to use broker.
+     * To verify if the caller can use to AccountManager to communicate to broker.
+     *
+     * @param context       an Android context.
+     * @param accountTypes  AccountManager account type to check (if they're being controlled by MDM).
      */
     public static boolean canUseAccountManagerOperation(final Context context,
-                                                        final List<String> accountTypes) {
+                                                        final Set<String> accountTypes) {
         final String methodTag = TAG + ":canUseAccountManagerOperation:";
 
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
@@ -1,0 +1,254 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker.ipc
+
+import android.accounts.AuthenticatorDescription
+import android.accounts.AuthenticatorException
+import android.os.Bundle
+import com.microsoft.identity.common.exception.BrokerCommunicationException
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.IBrokerValidator
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.Companion.AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.Companion.CONTENT_PROVIDER_PATH_KEY
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.Companion.getAccountTypeForEachPackage
+import com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest {
+
+    private val alwaysSuccessBrokerValidator = object: IBrokerValidator {
+        override fun isValidBrokerPackage(packageName: String): Boolean {
+            return true
+        }
+
+        override fun isSignedByKnownKeys(brokerData: BrokerData): Boolean {
+            return true
+        }
+    }
+
+    private val properlySetUpAccountManagerApps = {
+        Array(3) {
+            when (it) {
+                0 -> AuthenticatorDescription(
+                    "com.mock.testhaha",
+                    "com.testhaha.someApp",
+                    0, 0, 0, 0
+                )
+                // Targeted app (in this case, AuthApp)
+                // is registered as account type owner.
+                1 -> AuthenticatorDescription(
+                    AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    0, 0, 0, 0
+                )
+                // Also registered as broker account type.
+                2 -> AuthenticatorDescription(
+                    BROKER_ACCOUNT_TYPE,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    0, 0, 0, 0
+                )
+                3 -> AuthenticatorDescription(
+                    "com.contoso.conacct",
+                    "com.contoso.anotherapp",
+                    0, 0, 0, 0
+                )
+                else -> throw IndexOutOfBoundsException()
+            }
+        }
+    }
+
+    @Test
+    fun testSendingSuccessRequest(){
+        val strategy = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+            accountTypeForEachPackage = getAccountTypeForEachPackage(),
+            sendRequestViaAccountManager = { accountType, bundle ->
+                if (accountType == AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE &&
+                    bundle.getString(CONTENT_PROVIDER_PATH_KEY) ==
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL.contentApi.path){
+                    return@AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp Bundle().apply {
+                        putBoolean("Happy", true)
+                    }
+                }
+
+                throw IllegalStateException("Should not reach this line!")
+            },
+            getAccountManagerApps = properlySetUpAccountManagerApps,
+            brokerValidator = alwaysSuccessBrokerValidator
+        )
+
+        val result = strategy.communicateToBroker(
+                BrokerOperationBundle(
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    null
+                )
+            )
+
+        Assert.assertTrue(result!!.getBoolean("Happy"))
+    }
+
+    @Test
+    fun testGettingErrorFromAccountManager(){
+        val strategy = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+            accountTypeForEachPackage = getAccountTypeForEachPackage(),
+            sendRequestViaAccountManager = { accountType, bundle ->
+                throw AuthenticatorException("some error happened!")
+            },
+            getAccountManagerApps = properlySetUpAccountManagerApps,
+            brokerValidator = alwaysSuccessBrokerValidator
+        )
+
+        try {
+            strategy.communicateToBroker(
+                BrokerOperationBundle(
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    null
+                )
+            )
+        }catch (t: Throwable) {
+            Assert.assertEquals(
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                (t as BrokerCommunicationException).category)
+            Assert.assertTrue(t.cause is AuthenticatorException)
+        }
+    }
+
+    // Try sending request to an app that is not in the list.
+    @Test
+    fun testSendingRequestToNonBrokerApp(){
+        val strategy = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+            accountTypeForEachPackage = getAccountTypeForEachPackage(),
+            sendRequestViaAccountManager = { _, _ ->
+                throw IllegalStateException("Should not reach this layer!")
+            },
+            getAccountManagerApps = properlySetUpAccountManagerApps,
+            brokerValidator = alwaysSuccessBrokerValidator
+        )
+
+        try {
+            strategy.communicateToBroker(
+                BrokerOperationBundle(
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL,
+                    "com.microsoft.somerandomapp",
+                    null
+                )
+            )
+        } catch (t: Throwable) {
+            Assert.assertEquals(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE,
+                (t as BrokerCommunicationException).category)
+        }
+    }
+
+    // Targeted app is not properly registered to account manager.
+    @Test
+    fun testAppNotRegisteredInAccountManager(){
+        val strategy = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+            accountTypeForEachPackage = getAccountTypeForEachPackage(),
+            sendRequestViaAccountManager = { _, _ ->
+                throw IllegalStateException("Should not reach this layer!")
+            },
+            getAccountManagerApps = {
+                Array(2) {
+                    when (it) {
+                        0 -> AuthenticatorDescription(
+                            "com.mock.testhaha",
+                            "com.testhaha.someApp",
+                            0, 0, 0, 0
+                        )
+                        // Only registered as broker account type.
+                        // We expect AUTHAPP_BACKUP_IPC_ACCOUNT_MANAGER_ACCOUNT_TYPE to be here
+                        // But it's not.... so it would fail.
+                        1 -> AuthenticatorDescription(
+                            BROKER_ACCOUNT_TYPE,
+                            BrokerData.debugMicrosoftAuthenticator.packageName,
+                            0, 0, 0, 0
+                        )
+                        2 -> AuthenticatorDescription(
+                            "com.contoso.conacct",
+                            "com.contoso.anotherapp",
+                            0, 0, 0, 0
+                        )
+                        else -> throw IndexOutOfBoundsException()
+                    }
+                }
+            },
+            brokerValidator = alwaysSuccessBrokerValidator
+        )
+
+        try {
+            strategy.communicateToBroker(
+                BrokerOperationBundle(
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    null
+                )
+            )
+        } catch (t: Throwable) {
+            Assert.assertEquals(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                (t as BrokerCommunicationException).category)
+        }
+    }
+
+    // Request should fail if the targeted app is not a valid broker package.
+    @Test
+    fun testInvalidBrokerApp(){
+        val strategy = AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp(
+            accountTypeForEachPackage = getAccountTypeForEachPackage(),
+            sendRequestViaAccountManager = { _, _ ->
+                throw IllegalStateException("Should not reach this layer!")
+            },
+            getAccountManagerApps = properlySetUpAccountManagerApps,
+            brokerValidator = object: IBrokerValidator {
+                override fun isValidBrokerPackage(packageName: String): Boolean {
+                    // Not a valid broker package!
+                   return false
+                }
+
+                override fun isSignedByKnownKeys(brokerData: BrokerData): Boolean {
+                    return false
+                }
+            }
+        )
+
+        try {
+            strategy.communicateToBroker(
+                BrokerOperationBundle(
+                    BrokerOperationBundle.Operation.BROKER_DISCOVERY_METADATA_RETRIEVAL,
+                    BrokerData.debugMicrosoftAuthenticator.packageName,
+                    null
+                )
+            )
+        } catch (t: Throwable) {
+            Assert.assertEquals(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                (t as BrokerCommunicationException).category)
+        }
+    }
+}


### PR DESCRIPTION
First part of https://microsoft-my.sharepoint-df.com/:w:/p/rapong/EUJd76fanC9Hgpic0UbLjvUBsFRv6jKt_uTz888YNUj07w?e=cJHbNz

Implement an IPC strategy which utilizes AccountManager.

added tests, and also validated e2e (with my prototype)
- with broker discovery
- with passthrough scenario 
- with passthrough scenario via Legacy WPJ API (chained AccountManager requests)