### PR TITLE
Remove PasswordRequired and CodeRequired results from the SignInWithContinuationTokenCommandResult

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/util/CommandResultUtilTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/util/CommandResultUtilTest.kt
@@ -576,9 +576,7 @@ class CommandResultUtilTestSignInWithContinuationTokenCommandResult(private val 
         @JvmStatic
         @Parameters
         fun getSignInWithContinuationTokenCommandResults() = listOf(
-            signInCodeRequiredCommandResult,
             signInCompleteCommandResult,
-            signInPasswordRequiredCommandResult,
             redirectCommandResult,
             unknownErrorCommandResult
         )

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/SignInCommandResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/SignInCommandResult.kt
@@ -44,7 +44,7 @@ interface SignInCommandResult {
         SignInSubmitPasswordCommandResult
 
     data class PasswordRequired(val continuationToken: String) :
-        SignInStartCommandResult, SignInWithContinuationTokenCommandResult
+        SignInStartCommandResult
 
     data class CodeRequired(
         val continuationToken: String,
@@ -52,7 +52,7 @@ interface SignInCommandResult {
         val challengeChannel: String,
         val codeLength: Int
     ) :
-        SignInStartCommandResult, SignInWithContinuationTokenCommandResult, SignInResendCodeCommandResult
+        SignInStartCommandResult, SignInResendCodeCommandResult
 
     data class UserNotFound(val error: String, val errorDescription: String, val correlationId: String = DiagnosticContext.INSTANCE.threadCorrelationId, val errorCodes: List<Int>) :
         SignInStartCommandResult


### PR DESCRIPTION
The PasswordRequired  and CodeRequired results are never returned. Remove them from the possible returned results of the SignInWithContinuationTokenCommandResult 

Partner PR in msal repo: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2009