### PR TITLE
Adding base64Url encoding method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ V.Next
 - [PATCH] Create consistent use of correlation ID throughout a user flow (#2283)
 - [MINOR] Added support for setting no log level (#2282)
 - [MINOR] Redirect to hub app in case of NAA flow (#2290)
+- [MINOR] Adding base64Url encoding method (#2303)
 
 v.17.0.1
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -88,7 +88,6 @@ class WebAuthnJsonUtil {
             val data: ByteArray = this.toByteArray(Charsets.UTF_8)
             val base64: String = Base64.encodeToString(data, (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
             return base64.replace("=", "")
-            //return base64.replace("=", "").replace("+", "-").replace("/", "_")
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.fido
 
+import android.util.Base64
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.java.constants.FidoConstants
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_ID_JSON_KEY
@@ -55,7 +56,7 @@ class WebAuthnJsonUtil {
                 }
             }
             val options = PublicKeyCredentialRequestOptions(
-                challenge,
+                challenge.base64UrlEncoded(),
                 relyingPartyIdentifier,
                 publicKeyCredentialDescriptorList,
                 userVerificationPolicy
@@ -77,6 +78,17 @@ class WebAuthnJsonUtil {
                 authResponseJsonObject = authResponseJsonObject.put(WEBAUTHN_RESPONSE_ID_JSON_KEY, fullResponseJsonObject.get(WEBAUTHN_RESPONSE_ID_JSON_KEY))
             }
             return authResponseJsonObject.toString()
+        }
+
+        /**
+         * Returns a base64URL encoding of the string.
+         * @return String
+         */
+        fun String.base64UrlEncoded(): String {
+            val data: ByteArray = this.toByteArray(Charsets.UTF_8)
+            val base64: String = Base64.encodeToString(data, (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
+            return base64.replace("=", "")
+            //return base64.replace("=", "").replace("+", "-").replace("/", "_")
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -86,8 +86,7 @@ class WebAuthnJsonUtil {
          */
         fun String.base64UrlEncoded(): String {
             val data: ByteArray = this.toByteArray(Charsets.UTF_8)
-            val base64: String = Base64.encodeToString(data, (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
-            return base64.replace("=", "")
+            return Base64.encodeToString(data, (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
         }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtilTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtilTest.kt
@@ -22,12 +22,18 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.fido
 
+import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil.Companion.base64UrlEncoded
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 
+@RunWith(RobolectricTestRunner::class)
 class WebAuthnJsonUtilTest {
-    val challengeStr = "T1xCsnxM2DNL2KdK5CLa6fMhD7OBqho6syzInk_n-Uo"
+    // Demo challenge from https://jwt.io/
+    val challengeStr = "O.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
     val relyingPartyIdentifier = "login.microsoft.com"
     val userVerificationPolicy = "required"
     val version = "1.0"
@@ -40,8 +46,8 @@ class WebAuthnJsonUtilTest {
     val allowCredentials2 = "id2"
 
     //Moshi's built in adapter alphabetizes  the fields.
-    val expectedJsonAllFieldsFilled = """{"allowCredentials":[{"id":"$allowCredentials1","type":"public-key"},{"id":"$allowCredentials2","type":"public-key"}],"challenge":"$challengeStr","rpId":"$relyingPartyIdentifier","userVerification":"$userVerificationPolicy"}"""
-    val expectedJsonOnlyRequiredFields = """{"allowCredentials":[],"challenge":"$challengeStr","rpId":"$relyingPartyIdentifier","userVerification":"$userVerificationPolicy"}"""
+    val expectedJsonAllFieldsFilled = """{"allowCredentials":[{"id":"$allowCredentials1","type":"public-key"},{"id":"$allowCredentials2","type":"public-key"}],"challenge":"${challengeStr.base64UrlEncoded()}","rpId":"$relyingPartyIdentifier","userVerification":"$userVerificationPolicy"}"""
+    val expectedJsonOnlyRequiredFields = """{"allowCredentials":[],"challenge":"${challengeStr.base64UrlEncoded()}","rpId":"$relyingPartyIdentifier","userVerification":"$userVerificationPolicy"}"""
 
     //Test AuthenticationResponse values and Json strings.
     //Demo values from Google's Credential Manager docs, or made up.
@@ -66,6 +72,12 @@ class WebAuthnJsonUtilTest {
     val demoAuthenticationResponseJsonOnlyRequiredFields = """{"clientExtensionResults":{},"id":"KEDetxZcUfinhVi6Za5nZQ","rawId":"KEDetxZcUfinhVi6Za5nZQ","response":{"attestationObject":null,"authenticatorData":"$authenticatorData","clientDataJSON":"$clientDataJSON","id":"$idAssertionResponse","signature":"$signature","userHandle":"$userHandle"},"type":"public-key"}"""
     val demoAuthenticationResponseJsonMissingSignature = """{"clientExtensionResults":{},"id":"KEDetxZcUfinhVi6Za5nZQ","rawId":"KEDetxZcUfinhVi6Za5nZQ","response":{"attestationObject":null,"authenticatorData":"$authenticatorData","clientDataJSON":"$clientDataJSON","id":"$idAssertionResponse","userHandle":"$userHandle"},"type":"public-key"}"""
     val demoAuthenticationResponseJsonMissingIdInAuthenticatorAssertionResponse = """{"clientExtensionResults":{},"id":"$idAssertionResponse","rawId":"KEDetxZcUfinhVi6Za5nZQ","response":{"attestationObject":null,"authenticatorData":"$authenticatorData","clientDataJSON":"$clientDataJSON","signature":"$signature","userHandle":"$userHandle"},"type":"public-key"}"""
+
+    // Demo JWT from https://jwt.io/
+    val demoJWT = "O.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    val expectedEncodedJWT = "Ty5leUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl4TWpNME5UWTNPRGt3SWl3aWJtRnRaU0k2SWtwdmFHNGdSRzlsSWl3aWFXRjBJam94TlRFMk1qTTVNREl5ZlEuU2ZsS3h3UkpTTWVLS0YyUVQ0ZndwTWVKZjM2UE9rNnlKVl9hZFFzc3c1Yw"
+    val randomString = "qwerty12345.QWERTYSomethingElseHere"
+    val expectedEncodedRandomString = "cXdlcnR5MTIzNDUuUVdFUlRZU29tZXRoaW5nRWxzZUhlcmU"
 
 
     @Test
@@ -118,5 +130,20 @@ class WebAuthnJsonUtilTest {
         val result = WebAuthnJsonUtil.extractAuthenticatorAssertionResponseJson(demoAuthenticationResponseJsonMissingIdInAuthenticatorAssertionResponse)
         // Should include id.
         JSONAssert.assertEquals(expectedAuthenticationAssertionResponseOnlyRequiredFields, result, JSONCompareMode.LENIENT)
+    }
+
+    @Test
+    fun testBase64UrlEncoded_JWTFromServer() {
+        assertEquals(expectedEncodedJWT, demoJWT.base64UrlEncoded())
+    }
+
+    @Test
+    fun testBase64UrlEncoded_EmptyString() {
+        assertEquals("", "".base64UrlEncoded())
+    }
+
+    @Test
+    fun testBase64UrlEncoded_RandomString() {
+        assertEquals(expectedEncodedRandomString, randomString.base64UrlEncoded())
     }
 }


### PR DESCRIPTION
### Summary
The challenge field of the `PublicKeyCredentialRequestOptionsJSON` class is meant to have a value that is base64Url encoded (see https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptionsjson). This PR adds a method to encode a String to be base64Url encoded, adds unit tests, and updates associated existing unit tests.

