### PR TITLE
Small fixes

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.kt
+++ b/common/src/main/java/com/microsoft/identity/common/exception/BrokerCommunicationException.kt
@@ -46,7 +46,8 @@ class BrokerCommunicationException(
         // The operation is not supported on the client (calling) side of IPC connection.
         OPERATION_NOT_SUPPORTED_ON_CLIENT_SIDE("ipc_operation_not_supported_on_client_side"),  // The operation is not supported on the server (target) side of IPC connection.
         OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE("ipc_operation_not_supported_on_server_side"),  // IPC connection failed due to an error.
-        CONNECTION_ERROR("ipc_connection_error");
+        CONNECTION_ERROR("ipc_connection_error"),
+        VALIDATION_ERROR("ipc_validation_error");
 
         override fun toString(): String {
             return categoryName

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
@@ -193,17 +193,17 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
             }
         } catch (t: Throwable) {
             throw BrokerCommunicationException(
-                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                BrokerCommunicationException.Category.VALIDATION_ERROR,
                 type,
-                "$targetPackageName doesn't support account manager backup ipc for Broker Discovery.",
+                "$targetPackageName doesn't support account manager backup ipc.",
                 null)
         }
 
         if (!brokerValidator.isValidBrokerPackage(targetAppInfo.packageName)) {
             throw BrokerCommunicationException(
-                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                BrokerCommunicationException.Category.VALIDATION_ERROR,
                 type,
-                "${targetAppInfo.packageName} is not a valid broker app",
+                "${targetAppInfo.packageName} is not a valid broker app.",
                 null
             )
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
@@ -193,7 +193,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
             }
         } catch (t: Throwable) {
             throw BrokerCommunicationException(
-                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
                 type,
                 "$targetPackageName doesn't support account manager backup ipc for Broker Discovery.",
                 null)
@@ -201,7 +201,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
 
         if (!brokerValidator.isValidBrokerPackage(targetAppInfo.packageName)) {
             throw BrokerCommunicationException(
-                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
                 type,
                 "${targetAppInfo.packageName} is not a valid broker app",
                 null

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/BrokerMsalController.java
@@ -40,7 +40,6 @@ import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationB
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SIGN_OUT_FROM_SHARED_DEVICE;
 import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.MSAL_SSO_TOKEN;
 import static com.microsoft.identity.common.internal.controllers.BrokerOperationExecutor.BrokerOperation;
-import static com.microsoft.identity.common.internal.util.StringUtil.isEmpty;
 import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_BROKER_INTERACTIVE_ACQUIRE_TOKEN_RESULT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
@@ -115,9 +114,9 @@ import com.microsoft.identity.common.java.util.ThreadUtils;
 import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.logging.Logger;
+import com.microsoft.identity.common.sharedwithoneauth.OneAuthSharedFunctions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -164,7 +163,7 @@ public class BrokerMsalController extends BaseController {
         this(applicationContext,
                 components,
                 activeBrokerPackageName,
-                getIpcStrategies(applicationContext, activeBrokerPackageName));
+                OneAuthSharedFunctions.getIpcStrategies(applicationContext, activeBrokerPackageName));
     }
 
     @VisibleForTesting
@@ -176,42 +175,6 @@ public class BrokerMsalController extends BaseController {
                 mComponents,
                 HELLO_CACHE_ENTRY_TIMEOUT
         );
-    }
-
-    /**
-     * Gets a list of communication strategies.
-     * Order of objects in the list will reflects the order of strategies that will be used.
-     */
-    @NonNull
-    static List<IIpcStrategy> getIpcStrategies(final Context applicationContext,
-                                               final String activeBrokerPackageName) {
-        final String methodTag = TAG + ":getIpcStrategies";
-        final List<IIpcStrategy> strategies = new ArrayList<>();
-        final StringBuilder sb = new StringBuilder(100);
-        sb.append("Broker Strategies added : ");
-
-        final ContentProviderStrategy contentProviderStrategy = new ContentProviderStrategy(applicationContext);
-        if (contentProviderStrategy.isSupportedByTargetedBroker(activeBrokerPackageName)) {
-            sb.append("ContentProviderStrategy, ");
-            strategies.add(contentProviderStrategy);
-        }
-
-        final MicrosoftAuthClient client = new MicrosoftAuthClient(applicationContext);
-        if (client.isBoundServiceSupported(activeBrokerPackageName)) {
-            sb.append("BoundServiceStrategy, ");
-            strategies.add(new BoundServiceStrategy<>(client));
-        }
-
-        if (AccountManagerUtil.canUseAccountManagerOperation(applicationContext,
-                Collections.singleton(BROKER_ACCOUNT_TYPE)))
-        {
-            sb.append("AccountManagerStrategy.");
-            strategies.add(new AccountManagerAddAccountStrategy(applicationContext));
-        }
-
-        Logger.info(methodTag, sb.toString());
-
-        return strategies;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/sharedwithoneauth/OneAuthSharedFunctions.kt
+++ b/common/src/main/java/com/microsoft/identity/common/sharedwithoneauth/OneAuthSharedFunctions.kt
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.sharedwithoneauth
+
+import android.content.Context
+import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient
+import com.microsoft.identity.common.internal.broker.ipc.AccountManagerAddAccountStrategy
+import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy
+import com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
+import com.microsoft.identity.common.internal.util.AccountManagerUtil
+import com.microsoft.identity.common.java.AuthenticationConstants
+import com.microsoft.identity.common.logging.Logger
+
+// Functions to be invoked by both OneAuth and MSAL Android
+// Making a change to any method signature is a breaking change.
+class OneAuthSharedFunctions {
+
+    companion object {
+        val TAG = OneAuthSharedFunctions::class.java
+
+        /**
+         * Constructs a list of [IIpcStrategy] to communicate from
+         * OneAuth/MSAL to Broker process.
+         *
+         * @param context [Context]
+         * @param activeBrokerPackageName name of the app hosting the broker process to communicate to.
+         **/
+        @JvmStatic
+        fun getIpcStrategies(
+            context: Context,
+            activeBrokerPackageName: String,
+        ): List<IIpcStrategy> {
+            val methodTag = "$TAG:getIpcStrategies"
+            val strategies: MutableList<IIpcStrategy> = ArrayList()
+
+            val sb = StringBuilder(100)
+            sb.append("Broker Strategies added : ")
+            val contentProviderStrategy = ContentProviderStrategy(context)
+            if (contentProviderStrategy.isSupportedByTargetedBroker(activeBrokerPackageName)) {
+                sb.append("ContentProviderStrategy, ")
+                strategies.add(contentProviderStrategy)
+            }
+
+            val client = MicrosoftAuthClient(context)
+            if (client.isBoundServiceSupported(activeBrokerPackageName)) {
+                sb.append("BoundServiceStrategy, ")
+                strategies.add(BoundServiceStrategy(client))
+            }
+
+            if (AccountManagerUtil.canUseAccountManagerOperation(
+                    context, setOf(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE)
+                )
+            ) {
+                sb.append("AccountManagerStrategy.")
+                strategies.add(AccountManagerAddAccountStrategy(context))
+            }
+
+            Logger.info(methodTag, sb.toString())
+            return strategies
+        }
+
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
@@ -211,7 +211,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest {
             )
         } catch (t: Throwable) {
             Assert.assertEquals(
-                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
                 (t as BrokerCommunicationException).category)
         }
     }
@@ -247,7 +247,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest {
             )
         } catch (t: Throwable) {
             Assert.assertEquals(
-                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                BrokerCommunicationException.Category.CONNECTION_ERROR,
                 (t as BrokerCommunicationException).category)
         }
     }

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest.kt
@@ -211,7 +211,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest {
             )
         } catch (t: Throwable) {
             Assert.assertEquals(
-                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                BrokerCommunicationException.Category.VALIDATION_ERROR,
                 (t as BrokerCommunicationException).category)
         }
     }
@@ -247,7 +247,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerAppTest {
             )
         } catch (t: Throwable) {
             Assert.assertEquals(
-                BrokerCommunicationException.Category.CONNECTION_ERROR,
+                BrokerCommunicationException.Category.VALIDATION_ERROR,
                 (t as BrokerCommunicationException).category)
         }
     }


### PR DESCRIPTION
1. Introduces ``OneAuthSharedFunctions``, and `package com.microsoft.identity.common.sharedwithoneauth` We'll start keeping interfaces that are also consumed by OneAuth here.

With a clear interface, the amount of "android msal team making an internal change and break oneauth" should gradually reduce in the long run.

(yes... I broke them again....)

(ps. I'm not moving all the shared code in this PR. That would introduce a major breaking change 🤣 )

2. Introduced a more specific error code in ``AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp``