### PR TITLE
Handle Receiver Callback Exception in CommandDispatcher interactive command

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Add exception registration in LocalBroadcaster (#2305)
 - [MINOR] Add IpcStrategyWithBackup (#2301)
 - [PATCH] Fix MSAL Issue 1864 (#2280)
 - [MINOR] Add AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp (#2294)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ---------
-- [PATCH] Add exception registration in LocalBroadcaster (#2305)
+- [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command (#2305)
 - [MINOR] Add IpcStrategyWithBackup (#2301)
 - [PATCH] Fix MSAL Issue 1864 (#2280)
 - [MINOR] Add AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp (#2294)

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -94,7 +94,7 @@ public class LocalMSALController extends BaseController {
     private IAuthorizationStrategy mAuthorizationStrategy = null;
 
     @SuppressWarnings({WarningType.rawtype_warning, WarningType.unchecked_warning})
-    ResultFuture<AuthorizationResult> mAuthorizationResultFuture = null;
+    private ResultFuture<AuthorizationResult> mAuthorizationResultFuture = null;
 
     @SuppressWarnings(WarningType.rawtype_warning)
     private AuthorizationRequest mAuthorizationRequest = null;

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -261,8 +261,6 @@ public class LocalMSALController extends BaseController {
                         .put(TelemetryEventStrings.Key.REQUEST_CODE, String.valueOf(requestCode))
         );
 
-
-
         try {
             mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
         } catch (Exception e){

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -55,6 +55,7 @@ import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.platform.DevicePoPUtils;
+import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -263,8 +264,7 @@ public class LocalMSALController extends BaseController {
 
 
         try {
-            throw new NullPointerException("Test");
-//            mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
+            mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
         } catch (Exception e){
             // If the future is somehow initialized and waiting, give the future an exception
             if (mAuthorizationFuture != null && !mAuthorizationFuture.isDone()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -28,62 +28,62 @@ import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.common.internal.broker.BrokerData;
+import com.microsoft.identity.common.internal.commands.RefreshOnCommand;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
+import com.microsoft.identity.common.java.WarningType;
+import com.microsoft.identity.common.java.authorities.Authority;
+import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
+import com.microsoft.identity.common.java.authscheme.IPoPAuthenticationSchemeParams;
+import com.microsoft.identity.common.java.cache.ICacheRecord;
+import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
+import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
+import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommandParameters;
+import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
+import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
+import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommandParameters;
 import com.microsoft.identity.common.java.configuration.LibraryConfiguration;
+import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.controllers.CommandDispatcher;
+import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.java.exception.ArgumentException;
 import com.microsoft.identity.common.java.exception.BrokerRequiredException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
-import com.microsoft.identity.common.java.cache.ICacheRecord;
-import com.microsoft.identity.common.internal.commands.RefreshOnCommand;
-import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
-import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommandParameters;
-import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
-import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.platform.DevicePoPUtils;
-import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
-import com.microsoft.identity.common.java.controllers.BaseController;
-import com.microsoft.identity.common.java.result.AcquireTokenResult;
-import com.microsoft.identity.common.java.result.GenerateShrResult;
-import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
-import com.microsoft.identity.common.internal.telemetry.Telemetry;
-import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
-import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
-import com.microsoft.identity.common.java.util.ThreadUtils;
-import com.microsoft.identity.common.java.WarningType;
-import com.microsoft.identity.common.java.authorities.Authority;
-import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
-import com.microsoft.identity.common.java.authscheme.IPoPAuthenticationSchemeParams;
-import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
-import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
-import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommandParameters;
-import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResponse;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationStatus;
 import com.microsoft.identity.common.java.providers.oauth2.IAuthorizationStrategy;
-import com.microsoft.identity.common.java.providers.oauth2.IResult;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.request.SdkType;
+import com.microsoft.identity.common.java.result.AcquireTokenResult;
+import com.microsoft.identity.common.java.result.GenerateShrResult;
+import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
-import com.microsoft.identity.common.java.util.ported.PropertyBag;
+import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.java.util.ResultUtil;
+import com.microsoft.identity.common.java.util.ThreadUtils;
+import com.microsoft.identity.common.java.util.ported.PropertyBag;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 import lombok.EqualsAndHashCode;
 
@@ -94,6 +94,9 @@ public class LocalMSALController extends BaseController {
 
     @SuppressWarnings(WarningType.rawtype_warning)
     private IAuthorizationStrategy mAuthorizationStrategy = null;
+
+    @SuppressWarnings({WarningType.rawtype_warning, WarningType.unchecked_warning})
+    ResultFuture<AuthorizationResult> mAuthorizationFuture = null;
 
     @SuppressWarnings(WarningType.rawtype_warning)
     private AuthorizationRequest mAuthorizationRequest = null;
@@ -230,12 +233,14 @@ public class LocalMSALController extends BaseController {
         mAuthorizationRequest = getAuthorizationRequest(strategy, parameters);
 
         // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to requestAuthorization method
-        @SuppressWarnings(WarningType.unchecked_warning) final Future<AuthorizationResult> future = strategy.requestAuthorization(
+        mAuthorizationFuture = strategy.requestAuthorization(
                 mAuthorizationRequest,
                 mAuthorizationStrategy
         );
 
-        return future.get();
+        AuthorizationResult result = mAuthorizationFuture.get();
+        mAuthorizationFuture = null;
+        return result;
     }
 
     @Override
@@ -255,7 +260,20 @@ public class LocalMSALController extends BaseController {
                         .put(TelemetryEventStrings.Key.REQUEST_CODE, String.valueOf(requestCode))
         );
 
-        mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
+
+
+        try {
+            throw new NullPointerException("Test");
+//            mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
+        } catch (Exception e){
+            // If the future is somehow initialized and waiting, give the future an exception
+            if (mAuthorizationFuture != null && !mAuthorizationFuture.isDone()) {
+                mAuthorizationFuture.setException(e);
+            } else {
+                // Best Effort
+                throw e;
+            }
+        }
 
         Telemetry.emit(
                 new ApiEndEvent()

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -56,11 +56,8 @@ import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.platform.DevicePoPUtils;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
-import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
-import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResponse;
-import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
@@ -97,7 +94,7 @@ public class LocalMSALController extends BaseController {
     private IAuthorizationStrategy mAuthorizationStrategy = null;
 
     @SuppressWarnings({WarningType.rawtype_warning, WarningType.unchecked_warning})
-    ResultFuture<AuthorizationResult> mAuthorizationFuture = null;
+    ResultFuture<AuthorizationResult> mAuthorizationResultFuture = null;
 
     @SuppressWarnings(WarningType.rawtype_warning)
     private AuthorizationRequest mAuthorizationRequest = null;
@@ -234,13 +231,13 @@ public class LocalMSALController extends BaseController {
         mAuthorizationRequest = getAuthorizationRequest(strategy, parameters);
 
         // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to requestAuthorization method
-        mAuthorizationFuture = strategy.requestAuthorization(
+        mAuthorizationResultFuture = strategy.requestAuthorization(
                 mAuthorizationRequest,
                 mAuthorizationStrategy
         );
 
-        AuthorizationResult result = mAuthorizationFuture.get();
-        mAuthorizationFuture = null;
+        AuthorizationResult result = mAuthorizationResultFuture.get();
+        mAuthorizationResultFuture = null;
         return result;
     }
 
@@ -265,8 +262,8 @@ public class LocalMSALController extends BaseController {
             mAuthorizationStrategy.completeAuthorization(requestCode, RawAuthorizationResult.fromPropertyBag(data));
         } catch (Exception e){
             // If the future is somehow initialized and waiting, give the future an exception
-            if (mAuthorizationFuture != null && !mAuthorizationFuture.isDone()) {
-                mAuthorizationFuture.setException(e);
+            if (mAuthorizationResultFuture != null && !mAuthorizationResultFuture.isDone()) {
+                mAuthorizationResultFuture.setException(e);
             } else {
                 // Best Effort
                 throw e;

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 
-import java.util.concurrent.Future;
+import com.microsoft.identity.common.java.util.ResultFuture;
 
 /**
  * Azure Active Directory Federation Services 2012 R2 OAuth Strategy
@@ -70,7 +70,7 @@ public class ActiveDirectoryFederationServices2012R2OAuth2Strategy extends OAuth
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy)
+    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy)
             throws ClientException {
         return super.requestAuthorization(request, IAuthorizationStrategy);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 
-import java.util.concurrent.Future;
+import com.microsoft.identity.common.java.util.ResultFuture;
 
 /**
  * Azure Active Directory Federation Services 2016 oAuth2 Strategy.
@@ -68,7 +68,7 @@ public class ActiveDirectoryFederationServices2016OAuth2Strategy extends OAuth2S
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy) throws ClientException {
+    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, IAuthorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 
-import java.util.concurrent.Future;
+import com.microsoft.identity.common.java.util.ResultFuture;
 
 /**
  * Azure Active Directory B2C OAuth Strategy.
@@ -68,7 +68,7 @@ public class AzureActiveDirectoryB2COAuth2Strategy extends OAuth2Strategy {
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy authorizationStrategy) throws ClientException {
+    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy authorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, authorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -33,20 +33,17 @@ import androidx.fragment.app.Fragment;
 
 import com.microsoft.identity.common.internal.providers.oauth2.AndroidAuthorizationStrategy;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivityFactory;
-import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
-import com.microsoft.identity.common.java.ui.BrowserDescriptor;
+import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URI;
-import java.util.List;
-import java.util.concurrent.Future;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
@@ -77,7 +74,7 @@ public abstract class BrowserAuthorizationStrategy<
     }
 
     @Override
-    public Future<AuthorizationResult> requestAuthorization(
+    public ResultFuture<AuthorizationResult> requestAuthorization(
             GenericAuthorizationRequest authorizationRequest,
             GenericOAuth2Strategy oAuth2Strategy)
             throws ClientException {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -43,9 +45,6 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URI;
-import java.util.concurrent.Future;
-
-import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
 /**
  * Serve as a class to do the OAuth2 auth code grant flow with Android embedded web view.
@@ -76,8 +75,8 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
      * The activity result is set in Authorization.setResult() and passed to the onActivityResult() of the calling activity.
      */
     @Override
-    public Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
-                                                            GenericOAuth2Strategy oAuth2Strategy) throws ClientException {
+    public ResultFuture<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
+                                                                  GenericOAuth2Strategy oAuth2Strategy) throws ClientException {
         final String methodTag = TAG + ":requestAuthorization";
         mAuthorizationResultFuture = new ResultFuture<>();
         mOAuth2Strategy = oAuth2Strategy;

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -758,7 +758,7 @@ public class CommandDispatcher {
                                 public void onReceive(@NonNull PropertyBag dataBag) {
                                     try {
                                         completeInteractive(dataBag);
-                                    } catch (Exception e) {
+                                    } catch (final Exception e) {
                                         receiverException[0] = ExceptionAdapter.baseExceptionFromException(e);
                                     }
                                 }
@@ -780,7 +780,7 @@ public class CommandDispatcher {
                             // If we received an exception during the receiver callback execution,
                             // we should set that as the command result
                             if (receiverException[0] != null) {
-                                commandResult = CommandResult.of(CommandResult.ResultStatus.ERROR, receiverException, correlationId);
+                                commandResult = CommandResult.of(CommandResult.ResultStatus.ERROR, receiverException[0], correlationId);
                             }
 
                             Logger.info(TAG + methodName,

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IAuthorizationStrategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IAuthorizationStrategy.java
@@ -26,7 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 
-import java.util.concurrent.Future;
+import com.microsoft.identity.common.java.util.ResultFuture;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -43,8 +43,8 @@ public interface IAuthorizationStrategy<
     /**
      * Perform the authorization request.
      */
-    Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
-                                                     GenericOAuth2Strategy oAuth2Strategy)
+    ResultFuture<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
+                                                           GenericOAuth2Strategy oAuth2Strategy)
             throws ClientException;
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -30,7 +30,6 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.commands.parameters.RopcTokenCommandParameters;
-import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.dto.IAccountRecord;
 import com.microsoft.identity.common.java.eststelemetry.EstsTelemetry;
 import com.microsoft.identity.common.java.exception.ClientException;
@@ -53,10 +52,11 @@ import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.Micro
 import com.microsoft.identity.common.java.telemetry.Telemetry;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.java.telemetry.events.UiShownEvent;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.java.util.ObjectMapper;
+import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.java.util.StringUtil;
-import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -67,7 +67,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.Future;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -139,15 +138,14 @@ public abstract class OAuth2Strategy
      * @param authorizationStrategy generic authorization strategy.
      * @return GenericAuthorizationResponse
      */
-    @NonNull
-    public Future<AuthorizationResult> requestAuthorization(
+    public ResultFuture<AuthorizationResult> requestAuthorization(
             final GenericAuthorizationRequest request,
             final GenericAuthorizationStrategy authorizationStrategy)
             throws ClientException {
         validateAuthorizationRequest(request);
 
         // Suppressing unchecked warnings due to casting an object in reference of current class to the child class GenericOAuth2Strategy while calling method requestAuthorization()
-        @SuppressWarnings(WarningType.unchecked_warning) final Future<AuthorizationResult> authorizationFuture =
+        @SuppressWarnings(WarningType.unchecked_warning) final ResultFuture<AuthorizationResult> authorizationFuture =
                 authorizationStrategy.requestAuthorization(request, this);
         Telemetry.emit(new UiShownEvent().putVisible(TelemetryEventStrings.Value.TRUE));
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -66,7 +66,7 @@ public enum LocalBroadcaster {
         final String methodName = ":registerExceptionDuringCallback";
 
         if (!mReceivers.containsKey(alias)){
-            // Reaching this should be impossible, log
+            // Reaching this should be impossible, log a warning instead of throwing another exception
             Logger.warn(TAG + methodName, "No alias found in the local broadcaster when trying to register exception for: " + alias);
         } else {
             Logger.error(TAG + methodName, "Registering Exception for Alias: " + alias, e);

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -42,7 +42,6 @@ public enum LocalBroadcaster {
     }
 
     final ConcurrentHashMap<String, IReceiverCallback> mReceivers = new ConcurrentHashMap<>();
-    final ConcurrentHashMap<String, Exception> mExceptions = new ConcurrentHashMap<>();
 
     public void registerCallback(@NonNull final String alias, @NonNull final IReceiverCallback callback){
         final String methodName = ":registerCallback";
@@ -56,48 +55,11 @@ public enum LocalBroadcaster {
         mReceivers.put(alias, callback);
     }
 
-    /**
-     * Register an exception for an exisiting receiver alias.
-     * This should only be called inside the {@link IReceiverCallback#onReceive} method.
-     * @param alias alias of the receiver to log the exception
-     * @param e the exception being logged
-     */
-    public void registerExceptionDuringCallback(@NonNull final String alias, @NonNull final Exception e){
-        final String methodName = ":registerExceptionDuringCallback";
-
-        if (!mReceivers.containsKey(alias)){
-            // Reaching this should be impossible, log a warning instead of throwing another exception
-            Logger.warn(TAG + methodName, "No alias found in the local broadcaster when trying to register exception for: " + alias);
-        } else {
-            Logger.error(TAG + methodName, "Registering Exception for Alias: " + alias, e);
-            mExceptions.put(alias, e);
-        }
-    }
-
-    /**
-     * Get the exception for receiver alias provided.
-     * @param alias alias of the receiver to fetch exception for
-     * @return the exception registered for the receiver, returns null if alias is not registered, or if no exception exists
-     */
-    public Exception getExceptionForAlias(@NonNull final String alias){
-        final String methodName = ":getExceptionForAlias";
-
-        if (mReceivers.containsKey(alias) && mExceptions.containsKey(alias)){
-            Logger.info(TAG + methodName, "Returning exception for alias: " + alias);
-            return mExceptions.get(alias);
-        }
-
-        // If there is no receiver for the given alias, or if there is no exception for that receiver,
-        // return null.
-        return null;
-    }
-
     public void unregisterCallback(@NonNull final String alias){
         final String methodName = ":unregisterCallback";
 
         Logger.info(TAG + methodName, "Removing alias: " + alias);
         mReceivers.remove(alias);
-        mExceptions.remove(alias);
     }
 
     public boolean hasReceivers(@NonNull final String alias) {
@@ -125,7 +87,6 @@ public enum LocalBroadcaster {
      */
     public void clearReceivers() {
         mReceivers.clear();
-        mExceptions.clear();
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ported/LocalBroadcaster.java
@@ -42,6 +42,7 @@ public enum LocalBroadcaster {
     }
 
     final ConcurrentHashMap<String, IReceiverCallback> mReceivers = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<String, Exception> mExceptions = new ConcurrentHashMap<>();
 
     public void registerCallback(@NonNull final String alias, @NonNull final IReceiverCallback callback){
         final String methodName = ":registerCallback";
@@ -55,11 +56,48 @@ public enum LocalBroadcaster {
         mReceivers.put(alias, callback);
     }
 
+    /**
+     * Register an exception for an exisiting receiver alias.
+     * This should only be called inside the {@link IReceiverCallback#onReceive} method.
+     * @param alias alias of the receiver to log the exception
+     * @param e the exception being logged
+     */
+    public void registerExceptionDuringCallback(@NonNull final String alias, @NonNull final Exception e){
+        final String methodName = ":registerExceptionDuringCallback";
+
+        if (!mReceivers.containsKey(alias)){
+            // Reaching this should be impossible, log
+            Logger.warn(TAG + methodName, "No alias found in the local broadcaster when trying to register exception for: " + alias);
+        } else {
+            Logger.error(TAG + methodName, "Registering Exception for Alias: " + alias, e);
+            mExceptions.put(alias, e);
+        }
+    }
+
+    /**
+     * Get the exception for receiver alias provided.
+     * @param alias alias of the receiver to fetch exception for
+     * @return the exception registered for the receiver, returns null if alias is not registered, or if no exception exists
+     */
+    public Exception getExceptionForAlias(@NonNull final String alias){
+        final String methodName = ":getExceptionForAlias";
+
+        if (mReceivers.containsKey(alias) && mExceptions.containsKey(alias)){
+            Logger.info(TAG + methodName, "Returning exception for alias: " + alias);
+            return mExceptions.get(alias);
+        }
+
+        // If there is no receiver for the given alias, or if there is no exception for that receiver,
+        // return null.
+        return null;
+    }
+
     public void unregisterCallback(@NonNull final String alias){
         final String methodName = ":unregisterCallback";
 
         Logger.info(TAG + methodName, "Removing alias: " + alias);
         mReceivers.remove(alias);
+        mExceptions.remove(alias);
     }
 
     public boolean hasReceivers(@NonNull final String alias) {
@@ -87,6 +125,7 @@ public enum LocalBroadcaster {
      */
     public void clearReceivers() {
         mReceivers.clear();
+        mExceptions.clear();
     }
 
     /**

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockStrategyWithMockedHttpResponse.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockStrategyWithMockedHttpResponse.java
@@ -30,8 +30,6 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.internal.testutils.mocks.MockSuccessAuthorizationResultMockedTests;
 
-import java.util.concurrent.Future;
-
 public class MockStrategyWithMockedHttpResponse extends ResourceOwnerPasswordCredentialsTestStrategy {
 
     /**
@@ -46,12 +44,12 @@ public class MockStrategyWithMockedHttpResponse extends ResourceOwnerPasswordCre
     /**
      * Template method for executing an OAuth2 authorization request.
      *
-     * @param request               microsoft sts authorization request.
+     * @param request                microsoft sts authorization request.
      * @param IAuthorizationStrategy authorization strategy.
      * @return GenericAuthorizationResponse
      */
     @Override
-    public Future<AuthorizationResult> requestAuthorization(
+    public ResultFuture<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultMockedTests authorizationResult = new MockSuccessAuthorizationResultMockedTests();

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockTestStrategy.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockTestStrategy.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.internal.testutils.strategies;
 
 import static com.microsoft.identity.common.java.net.HttpConstants.HeaderField.X_MS_CLITELEM;
 
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -43,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.Future;
 
 public class MockTestStrategy extends ResourceOwnerPasswordCredentialsTestStrategy {
 
@@ -59,12 +57,12 @@ public class MockTestStrategy extends ResourceOwnerPasswordCredentialsTestStrate
     /**
      * Template method for executing an OAuth2 authorization request.
      *
-     * @param request               microsoft sts authorization request.
+     * @param request                microsoft sts authorization request.
      * @param IAuthorizationStrategy authorization strategy.
      * @return GenericAuthorizationResponse
      */
     @Override
-    public Future<AuthorizationResult> requestAuthorization(
+    public ResultFuture<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultMockedTests authorizationResult = new MockSuccessAuthorizationResultMockedTests();

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/ResourceOwnerPasswordCredentialsTestStrategy.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/ResourceOwnerPasswordCredentialsTestStrategy.java
@@ -41,8 +41,6 @@ import com.microsoft.identity.internal.testutils.MicrosoftStsRopcTokenRequest;
 import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.mocks.MockSuccessAuthorizationResultNetworkTests;
 
-import java.util.concurrent.Future;
-
 public class ResourceOwnerPasswordCredentialsTestStrategy extends MicrosoftStsOAuth2Strategy {
 
     public static final String USERNAME_EMPTY_OR_NULL = "username_empty_or_null";
@@ -71,12 +69,12 @@ public class ResourceOwnerPasswordCredentialsTestStrategy extends MicrosoftStsOA
     /**
      * Template method for executing an OAuth2 authorization request.
      *
-     * @param request               microsoft sts authorization request.
+     * @param request                microsoft sts authorization request.
      * @param IAuthorizationStrategy authorization strategy.
      * @return GenericAuthorizationResponse
      */
     @Override
-    public Future<AuthorizationResult> requestAuthorization(
+    public ResultFuture<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultNetworkTests authorizationResult = new MockSuccessAuthorizationResultNetworkTests();


### PR DESCRIPTION
Related Bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2502607

Related PR https://github.com/AzureAD/ad-accounts-for-android/pull/2690

Teams is seeing a crash during `LocalMSALController.onFinishAuthorizationSession()`, where we occasionally get a `NullPointerException` on `mAuthorizationStrategy.completeAuthorization()`. It's unclear why this happens, but the root issue that such an exception should be routed as a BaseException and sent back as a command result. This PR handles this by routing the exception through the command result if it happens during the callback

Also add a check to see if the authorization future is initialized and waiting, provide an exception for it if we run into the NPE.

E2E testing
I tested this with MSALTestApp by throwing a NPE explicitly in complereAuthorization() and caught the exception, routing through to a command result.