### PR TITLE
Revert changes made to method signature for futures

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2012R2OAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 
-import com.microsoft.identity.common.java.util.ResultFuture;
+import java.util.concurrent.Future;
 
 /**
  * Azure Active Directory Federation Services 2012 R2 OAuth Strategy
@@ -70,7 +70,7 @@ public class ActiveDirectoryFederationServices2012R2OAuth2Strategy extends OAuth
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy)
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy)
             throws ClientException {
         return super.requestAuthorization(request, IAuthorizationStrategy);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/activedirectoryfederationservices/ActiveDirectoryFederationServices2016OAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 
-import com.microsoft.identity.common.java.util.ResultFuture;
+import java.util.concurrent.Future;
 
 /**
  * Azure Active Directory Federation Services 2016 oAuth2 Strategy.
@@ -68,7 +68,7 @@ public class ActiveDirectoryFederationServices2016OAuth2Strategy extends OAuth2S
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy) throws ClientException {
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy IAuthorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, IAuthorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/microsoft/azureactivedirectoryb2c/AzureActiveDirectoryB2COAuth2Strategy.java
@@ -43,7 +43,7 @@ import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 
-import com.microsoft.identity.common.java.util.ResultFuture;
+import java.util.concurrent.Future;
 
 /**
  * Azure Active Directory B2C OAuth Strategy.
@@ -68,7 +68,7 @@ public class AzureActiveDirectoryB2COAuth2Strategy extends OAuth2Strategy {
     // Suppressing unchecked warnings due to casting of AuthorizationRequest to GenericAuthorizationRequest and AuthorizationStrategy to GenericAuthorizationStrategy in the arguments of call to super class' method requestAuthorization
     @SuppressWarnings(WarningType.unchecked_warning)
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy authorizationStrategy) throws ClientException {
+    public Future<AuthorizationResult> requestAuthorization(AuthorizationRequest request, IAuthorizationStrategy authorizationStrategy) throws ClientException {
         return super.requestAuthorization(request, authorizationStrategy);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URI;
+import java.util.concurrent.Future;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
@@ -74,7 +75,7 @@ public abstract class BrowserAuthorizationStrategy<
     }
 
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(
+    public Future<AuthorizationResult> requestAuthorization(
             GenericAuthorizationRequest authorizationRequest,
             GenericOAuth2Strategy oAuth2Strategy)
             throws ClientException {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -45,6 +45,7 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.URI;
+import java.util.concurrent.Future;
 
 /**
  * Serve as a class to do the OAuth2 auth code grant flow with Android embedded web view.
@@ -75,8 +76,8 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
      * The activity result is set in Authorization.setResult() and passed to the onActivityResult() of the calling activity.
      */
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
-                                                                  GenericOAuth2Strategy oAuth2Strategy) throws ClientException {
+    public Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
+                                                            GenericOAuth2Strategy oAuth2Strategy) throws ClientException {
         final String methodTag = TAG + ":requestAuthorization";
         mAuthorizationResultFuture = new ResultFuture<>();
         mOAuth2Strategy = oAuth2Strategy;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IAuthorizationStrategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IAuthorizationStrategy.java
@@ -26,7 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 
-import com.microsoft.identity.common.java.util.ResultFuture;
+import java.util.concurrent.Future;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -43,8 +43,8 @@ public interface IAuthorizationStrategy<
     /**
      * Perform the authorization request.
      */
-    ResultFuture<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
-                                                           GenericOAuth2Strategy oAuth2Strategy)
+    Future<AuthorizationResult> requestAuthorization(GenericAuthorizationRequest authorizationRequest,
+                                                     GenericOAuth2Strategy oAuth2Strategy)
             throws ClientException;
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.Future;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -138,14 +139,14 @@ public abstract class OAuth2Strategy
      * @param authorizationStrategy generic authorization strategy.
      * @return GenericAuthorizationResponse
      */
-    public ResultFuture<AuthorizationResult> requestAuthorization(
+    public Future<AuthorizationResult> requestAuthorization(
             final GenericAuthorizationRequest request,
             final GenericAuthorizationStrategy authorizationStrategy)
             throws ClientException {
         validateAuthorizationRequest(request);
 
         // Suppressing unchecked warnings due to casting an object in reference of current class to the child class GenericOAuth2Strategy while calling method requestAuthorization()
-        @SuppressWarnings(WarningType.unchecked_warning) final ResultFuture<AuthorizationResult> authorizationFuture =
+        @SuppressWarnings(WarningType.unchecked_warning) final Future<AuthorizationResult> authorizationFuture =
                 authorizationStrategy.requestAuthorization(request, this);
         Telemetry.emit(new UiShownEvent().putVisible(TelemetryEventStrings.Value.TRUE));
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockStrategyWithMockedHttpResponse.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockStrategyWithMockedHttpResponse.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.internal.testutils.mocks.MockSuccessAuthorizationResultMockedTests;
 
+import java.util.concurrent.Future;
+
 public class MockStrategyWithMockedHttpResponse extends ResourceOwnerPasswordCredentialsTestStrategy {
 
     /**
@@ -49,7 +51,7 @@ public class MockStrategyWithMockedHttpResponse extends ResourceOwnerPasswordCre
      * @return GenericAuthorizationResponse
      */
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(
+    public Future<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultMockedTests authorizationResult = new MockSuccessAuthorizationResultMockedTests();

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockTestStrategy.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/MockTestStrategy.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.Future;
 
 public class MockTestStrategy extends ResourceOwnerPasswordCredentialsTestStrategy {
 
@@ -62,7 +63,7 @@ public class MockTestStrategy extends ResourceOwnerPasswordCredentialsTestStrate
      * @return GenericAuthorizationResponse
      */
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(
+    public Future<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultMockedTests authorizationResult = new MockSuccessAuthorizationResultMockedTests();

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/ResourceOwnerPasswordCredentialsTestStrategy.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/strategies/ResourceOwnerPasswordCredentialsTestStrategy.java
@@ -41,6 +41,8 @@ import com.microsoft.identity.internal.testutils.MicrosoftStsRopcTokenRequest;
 import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.mocks.MockSuccessAuthorizationResultNetworkTests;
 
+import java.util.concurrent.Future;
+
 public class ResourceOwnerPasswordCredentialsTestStrategy extends MicrosoftStsOAuth2Strategy {
 
     public static final String USERNAME_EMPTY_OR_NULL = "username_empty_or_null";
@@ -74,7 +76,7 @@ public class ResourceOwnerPasswordCredentialsTestStrategy extends MicrosoftStsOA
      * @return GenericAuthorizationResponse
      */
     @Override
-    public ResultFuture<AuthorizationResult> requestAuthorization(
+    public Future<AuthorizationResult> requestAuthorization(
             final MicrosoftStsAuthorizationRequest request,
             final IAuthorizationStrategy IAuthorizationStrategy) {
         final MockSuccessAuthorizationResultNetworkTests authorizationResult = new MockSuccessAuthorizationResultNetworkTests();


### PR DESCRIPTION
Revert changes made to method signature to return back a ResultFuture instead of a Future. It seems to have introduced a breaking change in MSAL, instead of debugging this during release time, I rolled back part of the solution for the original google crash. The fix still does the same thing, just by using a type casting rather than explicit return type being set to ResultFuture. As mentioned in the original PR, this scenario should theoretically be impossible anyway, as if we fail out of authorization because the strategy is null, then the future would not be initialized, but keeping the result future check there for additional security.

Original PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2305