### PR TITLE
Add flight to control silent token timeout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Add flight to control silent token timeout (#2311)
 - [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command (#2305)
 - [MINOR] Add IpcStrategyWithBackup (#2301)
 - [PATCH] Fix MSAL Issue 1864 (#2280)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -28,7 +28,6 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBr
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.RESULT_CODE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
-import static com.microsoft.identity.common.java.commands.SilentTokenCommand.ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_DCF_COMMAND_EXECUTION_END;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_DCF_COMMAND_EXECUTION_START;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.ACQUIRE_TOKEN_DCF_EXECUTOR_START;
@@ -58,6 +57,8 @@ import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.UserCancelException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightManager;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.logging.RequestContext;
@@ -251,7 +252,8 @@ public class CommandDispatcher {
             if (BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT){
                 commandResult = submitSilentReturningFuture(command).get();
             } else {
-                commandResult = submitSilentReturningFuture(command).get(ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
+                final int silentTokenTimeOutMs = CommonFlightManager.getIntValue(CommonFlight.ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS);
+                commandResult = submitSilentReturningFuture(command).get(silentTokenTimeOutMs, TimeUnit.MILLISECONDS);
             }
         } catch (final InterruptedException | ExecutionException | TimeoutException e) {
             throw ExceptionAdapter.baseExceptionFromException(e);

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.identity.common.java.flighting;
 
+import static com.microsoft.identity.common.java.commands.SilentTokenCommand.ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS;
+
 import lombok.NonNull;
 
 /**
@@ -42,7 +44,13 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to control whether to expose the CCS (CachedCredService) request sequence in TokenResponse.
      * This flight is default-on 
      */
-    EXPOSE_CCS_REQUEST_SEQUENCE_IN_TOKENRESPONSE("ExposeCcsRequestSequenceInTokenResponse", true);
+    EXPOSE_CCS_REQUEST_SEQUENCE_IN_TOKENRESPONSE("ExposeCcsRequestSequenceInTokenResponse", true),
+
+    /**
+     * Flight to control the timeout duration for Acquire Token Silent Calls
+     * The default value is set to {@link ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS}
+     */
+    ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS("AcquireTokenSilentTimeoutMilliSeconds", ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlightManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlightManager.java
@@ -50,4 +50,18 @@ public class CommonFlightManager {
 
         return mFlightProvider.isFlightEnabled(flightConfig);
     }
+
+    /**
+     * Gets the value of an integer flight.
+     *
+     * @param flightConfig {@link IFlightConfig} to check
+     * @return the flight value if set otherwise returns the defaultValue
+     */
+    public static int getIntValue(@NonNull IFlightConfig flightConfig) {
+        if (mFlightProvider == null) {
+            return (int) flightConfig.getDefaultValue();
+        }
+
+        return mFlightProvider.getIntValue(flightConfig);
+    }
 }


### PR DESCRIPTION
Adding a flight to control the timeout duration for Silent Token Calls.