### PR TITLE
Add support for DC and flight SDK request parameters

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/TokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/TokenCommandParameters.java
@@ -67,6 +67,9 @@ public class TokenCommandParameters extends CommandParameters {
     @Expose()
     private final boolean forceRefresh;
 
+    @Expose()
+    private final String dc;
+
     private final String loginHint;
 
     private final List<Map.Entry<String, String>> extraOptions;

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -291,6 +291,14 @@ public abstract class BaseController {
 
         if (builder instanceof MicrosoftStsAuthorizationRequest.Builder) {
             ((MicrosoftStsAuthorizationRequest.Builder) builder).setApplicationIdentifier(parameters.getApplicationIdentifier());
+
+            if (parameters.getDc() != null) {
+                ((MicrosoftStsAuthorizationRequest.Builder) builder).setDc(parameters.getDc());
+            }
+
+            if (parameters.getFlightInformation() != null && !parameters.getFlightInformation().isEmpty()) {
+                ((MicrosoftStsAuthorizationRequest.Builder) builder).setFlightParameters(parameters.getFlightInformation());
+            }
         }
 
         final Set<String> scopes = parameters.getScopes();

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -92,6 +92,10 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
     @Accessors(prefix = "m")
     private transient final String mPkceCodeVerifier;
 
+    @Getter
+    @Accessors(prefix = "m")
+    private final String mDc;
+
     /**
      * The version of the calling library.
      */
@@ -154,6 +158,8 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
         mPkceCodeChallenge = challenge.getCodeChallenge();
         mPkceCodeVerifier = challenge.getCodeVerifier();
 
+        mDc = builder.mDc;
+
         mMultipleCloudAware = builder.mMultipleCloudAware;
         mLibraryVersion = builder.mLibraryVersion;
         mLibraryName = builder.mLibraryName;
@@ -183,6 +189,7 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
         private UUID mCorrelationId;
         private String mLoginHint;
         private PkceChallenge mPkceChallenge;
+        private String mDc;
         private PreferredAuthMethod mPreferredAuthMethod;
 
         public Builder() {
@@ -229,6 +236,11 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
          */
         public B setPkceChallenge(@NonNull final PkceChallenge pkceChallenge) {
             mPkceChallenge = pkceChallenge;
+            return self();
+        }
+
+        public B setDc(String dc) {
+            mDc = dc;
             return self();
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -120,6 +120,8 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     protected transient AzureActiveDirectorySlice mSlice;
 
     @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+    @Getter
+    @Accessors(prefix = "m")
     protected transient Map<String, String> mFlightParameters;
 
     // TODO private transient InstanceDiscoveryMetadata mInstanceDiscoveryMetadata;
@@ -256,6 +258,12 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         final CommonURIBuilder builder = new CommonURIBuilder(super.getAuthorizationRequestAsHttpRequest());
         builder.addParametersIfAbsent(mFlightParameters);
 
+        // DC passed as request command parameter
+        if (!StringUtil.isNullOrEmpty(getDc())) {
+            builder.addParameterIfAbsent(AzureActiveDirectorySlice.DC_PARAMETER, getDc());
+        }
+
+        // Slice passed as configuration parameter
         if (mSlice != null) {
             if (!StringUtil.isNullOrEmpty(mSlice.getSlice())) {
                 builder.addParameterIfAbsent(AzureActiveDirectorySlice.SLICE_PARAMETER, mSlice.getSlice());

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsOAuth2Strategy.java
@@ -376,6 +376,12 @@ public class MicrosoftStsOAuth2Strategy
             setTokenEndpoint(getCloudSpecificTokenEndpoint(response));
         }
 
+        // If DC or flight parameters are supplied by the developer, the token endpoint URL should
+        // be updated to contain these query parameters.
+        if (request.getDc() != null || (request.getFlightParameters() != null && !request.getFlightParameters().isEmpty())) {
+            updateTokenEndpoint(request.getDc(), request.getFlightParameters());
+        }
+
         final MicrosoftStsTokenRequest tokenRequest = new MicrosoftStsTokenRequest();
         tokenRequest.setCodeVerifier(request.getPkceCodeVerifier());
         tokenRequest.setCode(response.getCode());

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -52,10 +52,10 @@ import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.Micro
 import com.microsoft.identity.common.java.telemetry.Telemetry;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.java.telemetry.events.UiShownEvent;
-import com.microsoft.identity.common.java.util.CommonURIBuilder;
 import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.CommonURIBuilder;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -70,6 +70,7 @@ import java.util.concurrent.Future;
 
 import javax.net.ssl.HttpsURLConnection;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.CLIENT_REQUEST_ID;
@@ -286,6 +287,27 @@ public abstract class OAuth2Strategy
                 } catch (final URISyntaxException e) {
                     throw new ClientException(ClientException.MALFORMED_URL, e.getMessage(), e);
                 }
+            }
+        }
+    }
+
+    protected final void updateTokenEndpoint(@Nullable String dc, @Nullable Map<String, String> flightParameters) throws ClientException {
+        if (dc != null || (flightParameters != null && !flightParameters.isEmpty())) {
+            try {
+                final CommonURIBuilder commonUriBuilder = new CommonURIBuilder(mTokenEndpoint);
+                if (!StringUtil.isNullOrEmpty(dc)) {
+                    commonUriBuilder.setParameter(AzureActiveDirectorySlice.DC_PARAMETER, dc);
+                }
+
+                if (flightParameters != null && !flightParameters.isEmpty()) {
+                    for (Map.Entry<String, String> entry : flightParameters.entrySet()) {
+                        commonUriBuilder.setParameter(entry.getKey(), entry.getValue());
+                    }
+                }
+
+                mTokenEndpoint = commonUriBuilder.build().toString();
+            } catch (final URISyntaxException e) {
+                throw new ClientException(ClientException.MALFORMED_URL, e.getMessage(), e);
             }
         }
     }


### PR DESCRIPTION
Add support for DC and flight SDK request parameters, and attach to /authorize and /token requests

Corresponding MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2035