### PR TITLE
Add back Teams NPE fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 V.Next
 ---------
-- [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command ()
+- [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command (#2315)
 - [MINOR] Add flight to control silent token timeout (#2311)
 - [MINOR] Add IpcStrategyWithBackup (#2301)
 - [PATCH] Fix MSAL Issue 1864 (#2280)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command ()
 - [MINOR] Add flight to control silent token timeout (#2311)
 - [MINOR] Add IpcStrategyWithBackup (#2301)
 - [PATCH] Fix MSAL Issue 1864 (#2280)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -753,10 +753,16 @@ public class CommandDispatcher {
 
                             EstsTelemetry.getInstance().emitApiId(command.getPublicApiId());
 
+                            final BaseException[] receiverException = new BaseException[1];
+
                             final LocalBroadcaster.IReceiverCallback resultReceiver = new LocalBroadcaster.IReceiverCallback() {
                                 @Override
                                 public void onReceive(@NonNull PropertyBag dataBag) {
-                                    completeInteractive(dataBag);
+                                    try {
+                                        completeInteractive(dataBag);
+                                    } catch (final Exception e) {
+                                        receiverException[0] = ExceptionAdapter.baseExceptionFromException(e);
+                                    }
                                 }
                             };
 
@@ -772,6 +778,12 @@ public class CommandDispatcher {
                             sCommand = null;
 
                             LocalBroadcaster.INSTANCE.unregisterCallback(RETURN_AUTHORIZATION_REQUEST_RESULT);
+
+                            // If we received an exception during the receiver callback execution,
+                            // we should set that as the command result
+                            if (receiverException[0] != null) {
+                                commandResult = CommandResult.of(CommandResult.ResultStatus.ERROR, receiverException[0], correlationId);
+                            }
 
                             Logger.info(TAG + methodName,
                                     "Completed interactive request for correlation id : **" + correlationId +


### PR DESCRIPTION
Previously implemented a fix for common to address this bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2502607. Original common PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2305, which has now been reverted. During release process in february, realized that the original fix introduced a break in MSAL. Not totally clear where the break was, but realized that parts of the fix that were causing the break were unnecessary. This PR is to add back the parts of the fix that would address the teams bug, without introducing the breaking change in MSAL and Broker (we don't change the method signatures in `OAuth2Strategy.requestAuthorization()` or `IAuthorizationStrategy.requestAuthorization()`). Instead of changing signature, we use a type check.

Testing:
Tested manually, was able to recover after throwing NPE
Also ran common consumers pipeline check