### PR TITLE
Gracefully handles unexpected error in encryption layer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Gracefully handles unexpected error in encryption layer (#2318)
 - [PATCH] Handle Receiver Callback Exception in CommandDispatcher interactive command (#2315)
 - [MINOR] Add flight to control silent token timeout (#2311)
 - [MINOR] Add IpcStrategyWithBackup (#2301)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidAuthSdkStorageEncryptionManager.java
@@ -99,7 +99,8 @@ public class AndroidAuthSdkStorageEncryptionManager extends StorageEncryptionMan
             return Collections.<AbstractSecretKeyLoader>singletonList(mKeyStoreKeyLoader);
         }
 
-        Logger.warn(methodTag, "Cannot find a matching key to decrypt the given blob");
+        Logger.warn(methodTag,
+                "Cannot find a matching key to decrypt the given blob. Key Identifier = " + keyIdentifier);
         return Collections.emptyList();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -176,7 +176,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
             final String storedValue = mSharedPreferences.getString(key, null);
             if (StringUtil.isNullOrEmpty(storedValue)) {
                 Logger.info(methodTag, "Data associated to the given key is null or empty", null);
-                remove(key);
                 return null;
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -137,44 +137,59 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     public final void putString(
             final String key,
             final String value) {
+        final String methodTag = TAG + ":putString";
+
         synchronized (cacheLock) {
             if (value != null) {
                 fileCache.put(key, value);
             } else {
                 fileCache.remove(key);
             }
+
             final SharedPreferences.Editor editor = mSharedPreferences.edit();
 
             if (null == mEncryptionManager || StringUtil.isNullOrEmpty(value)) {
-                editor.putString(key, value);
-            } else {
-                final String encryptedValue = encrypt(value);
-                editor.putString(key, encryptedValue);
+                editor.putString(key, value).apply();
+                return;
             }
 
-            editor.apply();
+            // If the encryption failed, we won't be storing anything.
+            try {
+                editor.putString(key, mEncryptionManager.encrypt(value)).apply();
+            } catch (final ClientException e){
+                Logger.error(methodTag, "Failed to store encrypted value", null);
+            }
         }
     }
 
     @Override
     @Nullable
     public final String getString(final String key) {
+        final String methodTag = TAG + ":getString";
+
         synchronized (cacheLock) {
             String memCache = fileCache.get(key);
             if (memCache != null) {
                 return memCache;
             }
-            String restoredValue = mSharedPreferences.getString(key, null);
 
-            if (null != mEncryptionManager && !StringUtil.isNullOrEmpty(restoredValue)) {
-                restoredValue = decrypt(restoredValue);
-
-                if (StringUtil.isNullOrEmpty(restoredValue)) {
-                    logWarningAndRemoveKey(key);
-                }
+            final String storedValue = mSharedPreferences.getString(key, null);
+            if (StringUtil.isNullOrEmpty(storedValue)) {
+                Logger.info(methodTag, "Data associated to the given key is null or empty", null);
+                remove(key);
+                return null;
             }
 
-            return restoredValue;
+            if (mEncryptionManager == null){
+                return storedValue;
+            }
+
+            try {
+                return mEncryptionManager.decrypt(storedValue);
+            } catch (final ClientException e){
+                Logger.error(methodTag, "Failed to decrypt value", null);
+                return null;
+            }
         }
     }
 
@@ -194,17 +209,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         return 0;
     }
 
-    private void logWarningAndRemoveKey(String key) {
-        final String methodTag = TAG + ":logWarningAndRemoveKey";
-        Logger.warn(
-                methodTag,
-                "Failed to decrypt value! "
-                        + "This usually signals an issue with KeyStore or the provided SecretKeys."
-        );
-
-        remove(key);
-    }
-
     @Override
     public final Map<String, String> getAll() {
         // We're not synchronizing this access, since we're not modifying it here.
@@ -212,10 +216,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         @SuppressWarnings(WarningType.unchecked_warning) final Map<String, String> entries = (Map<String, String>) mSharedPreferences.getAll();
 
         if (null != mEncryptionManager) {
-            final Iterator<Map.Entry<String, String>> iterator = entries.entrySet().iterator();
-
-            while (iterator.hasNext()) {
-                final Map.Entry<String, String> entry = iterator.next();
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
                 //This is slightly wasteful, but we have no better key iterator and decryption
                 //is probably more painful than the additional file read when we miss in the cache.
                 String decryptedValue = getString(entry.getKey());
@@ -315,66 +316,4 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
                         + "]"
         );
     }
-
-    @Nullable
-    private String encrypt(@NonNull final String clearText) {
-        return encryptDecryptInternal(clearText, true);
-    }
-
-    @Nullable
-    private String decrypt(@NonNull final String encryptedBlob) {
-        return encryptDecryptInternal(encryptedBlob, false);
-    }
-
-    @Nullable
-    private String encryptDecryptInternal(
-            @NonNull final String inputText,
-            final boolean encrypt) {
-        final String methodTag = TAG + ":encryptDecryptInternal";
-
-        String result;
-        try {
-            result = encrypt
-                    ? mEncryptionManager.encrypt(inputText)
-                    : mEncryptionManager.decrypt(inputText);
-        } catch (ClientException e ) {
-            Logger.error(
-                    methodTag,
-                    "Failed to " + (encrypt ? "encrypt" : "decrypt") + " value",
-                    encrypt
-                            ? null // If we failed to encrypt, don't log the error as it may contain a token
-                            : e // If we failed to decrypt, we couldn't see that secret value so log the error
-            );
-
-            // TODO determine if an Exception should be thrown here...
-            result = null;
-        } catch (final ProviderException e) {
-            if ((Build.VERSION.SDK_INT == Build.VERSION_CODES.Q || Build.VERSION.SDK_INT == Build.VERSION_CODES.R)) {
-                // Catch the exception only on Android OS 10 & 11 as we are seeing some unknown crypto errors on these versions
-                Logger.error(
-                        methodTag,
-                        "Keystore error - Failed to " + (encrypt ? "encrypt" : "decrypt") + " value",
-                        encrypt
-                                ? null // If we failed to encrypt, don't log the error as it may contain a token
-                                : e // If we failed to decrypt, we couldn't see that secret value so log the error
-                );
-            }
-            result = null;
-        }
-
-        return result;
-    }
-
-    /**
-     * This method performs a commit() to ensure that all outstanding apply() calls are completed.
-     * This should be called after any putX() call where we need to ensure that apply() is not delayed or missed.
-     * @return true if the commit is successful.
-     */
-    public boolean flushSharedPreference(){
-        synchronized (cacheLock) {
-            final SharedPreferences.Editor editor = mSharedPreferences.edit();
-            return editor.commit();
-        }
-    }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -53,6 +53,7 @@ import javax.crypto.SecretKey;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
 
+import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_CRYPTO_ERROR;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.LOCALE_CHANGE_LOCK;
 import static com.microsoft.identity.common.java.util.ported.DateUtilities.isLocaleCalendarNonGregorian;
 import static com.microsoft.identity.common.java.exception.ClientException.ANDROID_KEYSTORE_UNAVAILABLE;
@@ -107,7 +108,7 @@ public class AndroidKeyStoreUtil {
         final String methodTag = TAG + ":generateKeyPair";
 
         synchronized (isLocaleCalendarNonGregorian(Locale.getDefault()) ? LOCALE_CHANGE_LOCK : new Object()) {
-            final Exception exception;
+            final Throwable exception;
             final String errCode;
 
             // Due to the following bug in lower API versions of keystore, locale workarounds may
@@ -150,6 +151,10 @@ public class AndroidKeyStoreUtil {
                 exception = e;
             } catch (final NoSuchProviderException e) {
                 errCode = NO_SUCH_PROVIDER;
+                exception = e;
+            } catch (final Throwable e) {
+                // For catching any unknown crypto error that might be thrown by the keystore layer.
+                errCode = UNKNOWN_CRYPTO_ERROR;
                 exception = e;
             } finally {
                 // Reset to our default locale after generating keys
@@ -197,7 +202,7 @@ public class AndroidKeyStoreUtil {
             throws ClientException {
         final String methodTag = TAG + ":readKeyPair";
 
-        final Exception exception;
+        final Throwable exception;
         final String errCode;
         try {
             final KeyStore keyStore = getKeyStore();
@@ -248,6 +253,10 @@ public class AndroidKeyStoreUtil {
         } catch (final UnrecoverableKeyException e) {
             errCode = INVALID_KEY_MISSING;
             exception = e;
+        } catch (final Throwable e) {
+            // For catching any unknown crypto error that might be thrown by the keystore layer.
+            errCode = UNKNOWN_CRYPTO_ERROR;
+            exception = e;
         }
 
         final ClientException clientException = new ClientException(
@@ -285,7 +294,7 @@ public class AndroidKeyStoreUtil {
             throws ClientException {
         final String methodTag = TAG + ":deleteKeyFromKeyStore";
 
-        final Exception exception;
+        final Throwable exception;
         final String errCode;
         try {
             final KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE_TYPE);
@@ -303,6 +312,10 @@ public class AndroidKeyStoreUtil {
             exception = e;
         } catch (final IOException e) {
             errCode = IO_ERROR;
+            exception = e;
+        } catch (final Throwable e) {
+            // For catching any unknown crypto error that might be thrown by the keystore layer.
+            errCode = UNKNOWN_CRYPTO_ERROR;
             exception = e;
         }
 
@@ -335,7 +348,7 @@ public class AndroidKeyStoreUtil {
             throws ClientException {
         final String methodTag = TAG + ":wrap";
 
-        final Exception exception;
+        final Throwable exception;
         final String errCode;
         try {
             Logger.verbose(methodTag, "Wrap secret key with a KeyPair.");
@@ -353,6 +366,10 @@ public class AndroidKeyStoreUtil {
             exception = e;
         } catch (final IllegalBlockSizeException e) {
             errCode = INVALID_BLOCK_SIZE;
+            exception = e;
+        } catch (final Throwable e) {
+            // For catching any unknown crypto error that might be thrown by the keystore layer.
+            errCode = UNKNOWN_CRYPTO_ERROR;
             exception = e;
         }
 
@@ -385,7 +402,7 @@ public class AndroidKeyStoreUtil {
                                    @NonNull final KeyPair keyPairForUnwrapping,
                                    @NonNull final String wrapAlgorithm) throws ClientException {
         final String methodTag = TAG + ":unwrap";
-        final Exception exception;
+        final Throwable exception;
         final String errCode;
         try {
             final Cipher wrapCipher = Cipher.getInstance(wrapAlgorithm);
@@ -411,6 +428,10 @@ public class AndroidKeyStoreUtil {
             exception = e;
         } catch (final InvalidKeyException e) {
             errCode = INVALID_KEY;
+            exception = e;
+        } catch (final Throwable e) {
+            // For catching any unknown crypto error that might be thrown by the keystore layer.
+            errCode = UNKNOWN_CRYPTO_ERROR;
             exception = e;
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -351,6 +351,10 @@ public class ExceptionAdapter {
 
     @NonNull
     public static ClientException clientExceptionFromException(@NonNull final Throwable exception) {
+        if (exception instanceof ClientException){
+            return (ClientException) exception;
+        }
+
         Throwable e = exception;
         if (exception instanceof ExecutionException) {
             e = exception.getCause();

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -35,6 +35,7 @@ import static com.microsoft.identity.common.java.exception.ClientException.NO_SU
 import static com.microsoft.identity.common.java.exception.ClientException.UNEXPECTED_HMAC_LENGTH;
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_CRYPTO_ERROR;
 
+import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
 import com.microsoft.identity.common.java.crypto.key.AbstractSecretKeyLoader;
 import com.microsoft.identity.common.java.crypto.key.KeyUtil;
 import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
@@ -47,6 +48,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.crypto.BadPaddingException;
@@ -121,7 +123,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         final AbstractSecretKeyLoader keyLoader = getKeyLoaderForEncryption();
         if (keyLoader == null) {
             // Developer error. Throw.
-            throw new IllegalStateException("KeyLoader list must not be null.");
+            throw new IllegalStateException("Cannot find a matching Keyloader.");
         }
 
         try {
@@ -179,6 +181,8 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         } catch (final InvalidAlgorithmParameterException e) {
             errCode = INVALID_ALG_PARAMETER;
             exception = e;
+        } catch (final ClientException e) {
+            throw e;
         } catch (final Throwable e) {
             errCode = UNKNOWN_CRYPTO_ERROR;
             exception = e;
@@ -189,44 +193,43 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
 
     @Override
     public byte[] decrypt(final byte[] cipherText) throws ClientException {
-        final String methodName = ":decrypt";
+        final String methodTag = TAG + ":decrypt";
 
         final byte[] dataBytes;
         try {
             dataBytes = stripEncodeVersionFromCipherText(cipherText);
         } catch (final ClientException e){
-            Logger.verbose(TAG + methodName,
+            Logger.verbose(methodTag,
                     "Failed to strip encode version from cipherText, string might not be encrypted. Exception: ", e.getMessage());
             return cipherText;
         }
 
         final List<AbstractSecretKeyLoader> keysForDecryption = getKeyLoaderForDecryption(cipherText);
         if (keysForDecryption.size() == 0) {
-            throw new IllegalStateException("KeyLoader list must not be null or empty.");
+            // Developer error. Throw.
+            throw new IllegalStateException("Cannot find a matching Keyloader.");
         }
 
-        final ClientException exceptionToThrowIfAllFails = new ClientException(ErrorStrings.DECRYPTION_FAILED,
-                "Tried all decryption keys and decryption still fails.");
-
+        final List<Throwable> suppressedException = new ArrayList<>();
         for (final AbstractSecretKeyLoader keyLoader : keysForDecryption) {
-            if (keyLoader == null){
-                throw new IllegalStateException("KeyLoader must not be null.");
-            }
-            
             try {
                 return decryptWithSecretKey(dataBytes, keyLoader);
             } catch (final Throwable e) {
-                Logger.warn(TAG + methodName, "Failed to decrypt with key:" + keyLoader.getAlias() +
+                Logger.warn(methodTag, "Failed to decrypt with key:" + keyLoader.getAlias() +
                         " thumbprint : " + KeyUtil.getKeyThumbPrint(keyLoader));
-                exceptionToThrowIfAllFails.addSuppressedException(e);
+                suppressedException.add(e);
             }
         }
 
-        Logger.warn(
-                TAG + methodName,
-                exceptionToThrowIfAllFails.getMessage());
-
-        throw exceptionToThrowIfAllFails;
+        // How should we throw an error?
+        if (suppressedException.size() == 1){
+            throw ExceptionAdapter.clientExceptionFromException(suppressedException.get(0));
+        } else {
+            final ClientException exceptionToThrowIfAllFails = new ClientException(ErrorStrings.DECRYPTION_FAILED,
+                    "Tried all decryption keys and decryption still fails.");
+            exceptionToThrowIfAllFails.getSuppressedException().addAll(suppressedException);
+            throw exceptionToThrowIfAllFails;
+        }
     }
 
     @Override
@@ -270,7 +273,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
                                         @NonNull final AbstractSecretKeyLoader keyLoader)
             throws ClientException {
         final String errCode;
-        final Exception exception;
+        final Throwable exception;
         try {
             final SecretKey secretKey = keyLoader.getKey();
             final SecretKey hmacKey = KeyUtil.getHMacKey(secretKey);
@@ -333,38 +336,14 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
         } catch (final IllegalArgumentException e) {
             errCode = DATA_MALFORMED;
             exception = e;
+        } catch (final ClientException e) {
+            throw e;
+        } catch (final Throwable e) {
+            errCode = UNKNOWN_CRYPTO_ERROR;
+            exception = e;
         }
 
         throw new ClientException(errCode, exception.getMessage(), exception);
-    }
-
-    /**
-     * Returns true if the given cipherText was encrypted by the owner of the identifier.
-     *
-     * @param cipherText    the cipherText to be verified against.
-     * @param keyIdentifier identifier to verify.
-     */
-    protected static boolean isEncryptedByThisKeyIdentifier(
-            final byte[] cipherText,
-            @NonNull final String keyIdentifier) {
-        final String methodName = ":isEncryptedByThisKeyIdentifier";
-
-        final byte[] bytes;
-        try {
-            bytes = stripEncodeVersionFromCipherText(cipherText);
-
-            final String keyVersion = new String(
-                    bytes,
-                    0,
-                    keyIdentifier.length(),
-                    ENCODING_UTF8
-            );
-
-            return keyIdentifier.equalsIgnoreCase(keyVersion);
-        } catch (final Exception e) {
-            Logger.verbose(TAG + methodName, e.getMessage());
-            return false;
-        }
     }
 
     /**
@@ -379,6 +358,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
             return new String(
                     stripEncodeVersionFromCipherText(cipherText),
                     0,
+                    // This method assumes that all key identifiers has the same length.
                     PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.length(),
                     ENCODING_UTF8
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/StorageEncryptionManager.java
@@ -87,6 +87,14 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
     private static final String ENCODE_VERSION = "E1";
 
     /**
+     * Length of key identifiers that are appended before the encrypted data.
+     * See: PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER,
+     *      AndroidWrappedKeyLoader.WRAPPED_KEY_KEY_IDENTIFIER,
+     *      KeyringKeyLoader.KEY_IDENTIFIER
+     */
+    public static final int KEY_IDENTIFIER_LENGTH = 4;
+
+    /**
      * IV generator.
      */
     private final IVGenerator mGenerator;
@@ -358,8 +366,7 @@ public abstract class StorageEncryptionManager implements IKeyAccessor {
             return new String(
                     stripEncodeVersionFromCipherText(cipherText),
                     0,
-                    // This method assumes that all key identifiers has the same length.
-                    PredefinedKeyLoader.USER_PROVIDED_KEY_IDENTIFIER.length(),
+                    KEY_IDENTIFIER_LENGTH,
                     ENCODING_UTF8
             );
         } catch (final Exception e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
@@ -137,13 +137,16 @@ public class EncryptedNameValueStorage<T> implements INameValueStorage<T> {
             return;
         }
 
-        // If the encryption failed, we won't be storing anything.
+        // If the encryption fails, write null to the storage.
+        // This might not be the right behavior, but it's possible that PROD relies on this.
+        String encryptedValue = null;
         try {
-            final String encryptedValue = mEncryptionManager.encrypt(adaptedValue);
-            mRawNameValueStorage.put(name, encryptedValue);
+            encryptedValue = mEncryptionManager.encrypt(adaptedValue);
         } catch (final ClientException e) {
             Logger.error(methodTag, "Failed to store encrypted value", null);
         }
+
+        mRawNameValueStorage.put(name, encryptedValue);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/EncryptedNameValueStorage.java
@@ -88,21 +88,22 @@ public class EncryptedNameValueStorage<T> implements INameValueStorage<T> {
     @Nullable
     @Override
     public T get(@NonNull final String name) {
+        final String methodTag = TAG + ":get";
+
         final String encryptedString = mRawNameValueStorage.get(name);
-
         if (StringUtil.isNullOrEmpty(encryptedString)) {
+            Logger.info(methodTag, "Data associated to the given key is null or empty", null);
+            remove(name);
             return null;
         }
 
-        final String decryptedString = decrypt(encryptedString);
-
-        if (StringUtil.isNullOrEmpty(decryptedString)) {
-            // This is what the Android Broker's SharedPreferencesFileManager does right now
-            logWarningAndRemoveKey(name);
+        try {
+            final String decryptedString = mEncryptionManager.decrypt(encryptedString);
+            return mStringAdapter.adapt(decryptedString);
+        } catch (final ClientException e){
+            Logger.error(methodTag, "Failed to read encrypted value", null);
             return null;
         }
-
-        return mStringAdapter.adapt(decryptedString);
     }
 
     @Override
@@ -123,20 +124,26 @@ public class EncryptedNameValueStorage<T> implements INameValueStorage<T> {
 
     @Override
     public void put(@NonNull final String name, @Nullable final T value) {
+        final String methodTag = TAG + ":put";
+
         if (value == null) {
             mRawNameValueStorage.put(name, null);
             return;
         }
 
         final String adaptedValue = mStringAdapter.adapt(value);
-
         if (StringUtil.isNullOrEmpty(adaptedValue)) {
             mRawNameValueStorage.put(name, adaptedValue);
             return;
         }
 
-        final String encryptedValue = encrypt(adaptedValue);
-        mRawNameValueStorage.put(name, encryptedValue);
+        // If the encryption failed, we won't be storing anything.
+        try {
+            final String encryptedValue = mEncryptionManager.encrypt(adaptedValue);
+            mRawNameValueStorage.put(name, encryptedValue);
+        } catch (final ClientException e) {
+            Logger.error(methodTag, "Failed to store encrypted value", null);
+        }
     }
 
     @Override
@@ -163,47 +170,5 @@ public class EncryptedNameValueStorage<T> implements INameValueStorage<T> {
             }
         }
         return newMap.entrySet().iterator();
-    }
-
-    @Nullable
-    private String encrypt(@NonNull final String clearText) {
-        return encryptDecryptInternal(clearText, true);
-    }
-
-    @Nullable
-    private String decrypt(@NonNull final String encryptedBlob) {
-        return encryptDecryptInternal(encryptedBlob, false);
-    }
-
-    @Nullable
-    private String encryptDecryptInternal(
-            @NonNull final String inputText,
-            final boolean encrypt) {
-        final String methodName = "encryptDecryptInternal";
-
-        try {
-            return encrypt
-                    ? mEncryptionManager.encrypt(inputText)
-                    : mEncryptionManager.decrypt(inputText);
-        } catch (final ClientException e) {
-            Logger.error(
-                    TAG + ":" + methodName,
-                    "Failed to " + (encrypt ? "encrypt" : "decrypt") + " value",
-                    encrypt
-                            ? null // If we failed to encrypt, don't log the error as it may contain a token
-                            : e // If we failed to decrypt, we couldn't see that secret value so log the error
-            );
-            return null;
-        }
-    }
-
-    private void logWarningAndRemoveKey(@NonNull final String key) {
-        Logger.warn(
-                TAG,
-                "Failed to decrypt value! "
-                        + "This usually signals an issue with KeyStore or the provided SecretKeys."
-        );
-
-        remove(key);
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/crypto/StorageEncryptionManagerTest.java
@@ -123,9 +123,7 @@ public class StorageEncryptionManagerTest {
             manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
             Assert.fail("decrypt() should throw an exception but it succeeds.");
         } catch (ClientException e){
-            Assert.assertEquals(e.getErrorCode(), ErrorStrings.DECRYPTION_FAILED);
-            Assert.assertEquals(((ClientException)e.getSuppressedException().get(0)).getErrorCode(),
-                    MockAES256KeyLoaderWithGetKeyError.FAIL_TO_LOAD_KEY_ERROR);
+            Assert.assertEquals(e.getErrorCode(), MockAES256KeyLoaderWithGetKeyError.FAIL_TO_LOAD_KEY_ERROR);
         }
     }
 
@@ -179,8 +177,7 @@ public class StorageEncryptionManagerTest {
             manager.decrypt(TEXT_ENCRYPTED_BY_PREDEFINED_KEY);
             Assert.fail("decrypt() should throw an exception but it succeeds.");
         } catch (final ClientException e){
-            Assert.assertEquals(e.getErrorCode(), ErrorStrings.DECRYPTION_FAILED);
-            Assert.assertEquals(((ClientException)e.getSuppressedException().get(0)).getErrorCode(), HMAC_MISMATCH);
+            Assert.assertEquals(HMAC_MISMATCH, e.getErrorCode());
         }
     }
 
@@ -188,52 +185,6 @@ public class StorageEncryptionManagerTest {
     public void testDecryptUnencryptedText() throws ClientException {
         final StorageEncryptionManager manager = new MockStorageEncryptionManager(PREDEFINED_KEY_IV, new MockAES256KeyLoader(PREDEFINED_KEY, PREDEFINED_KEY_IDENTIFIER));
         Assert.assertArrayEquals(TEXT_TO_BE_ENCRYPTED_WITH_PREDEFINED_KEY, manager.decrypt(TEXT_TO_BE_ENCRYPTED_WITH_PREDEFINED_KEY));
-    }
-
-    @Test
-    public void testIsEncryptedByThisKeyIdentifier_True() throws ClientException {
-       Assert.assertTrue(
-               StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                       TEXT_ENCRYPTED_BY_PREDEFINED_KEY,
-                       PREDEFINED_KEY_IDENTIFIER));
-
-    }
-
-    @Test
-    public void testIsEncryptedByThisKeyIdentifier_False() throws ClientException {
-        Assert.assertFalse(
-                StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                        TEXT_ENCRYPTED_BY_PREDEFINED_KEY,
-                        ANDROID_WRAPPED_KEY_IDENTIFIER));
-    }
-
-    @Test
-    public void testIsEncryptedByThisKeyIdentifier_StringNotEncrypted() throws ClientException {
-        Assert.assertFalse(
-                StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                        TEXT_TO_BE_ENCRYPTED_WITH_PREDEFINED_KEY,
-                        PREDEFINED_KEY_IDENTIFIER));
-    }
-
-    @Test
-    public void testIsEncryptedByThisKeyIdentifier_StringNotProperlyEncrypted() {
-        Assert.assertFalse(
-                StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                        "cE1".getBytes(ENCODING_UTF8),
-                        PREDEFINED_KEY_IDENTIFIER));
-
-        Assert.assertFalse(
-                StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                        "c".getBytes(ENCODING_UTF8),
-                        PREDEFINED_KEY_IDENTIFIER));
-    }
-
-    @Test
-    public void testIsEncryptedByThisKeyIdentifier_EncodeVersionNotSupported() {
-        Assert.assertFalse(
-                StorageEncryptionManager.isEncryptedByThisKeyIdentifier(
-                        EXPECTED_ENCRYPTED_TEXT_1_WITH_MALFORMED_ENCODE_VERSION,
-                        PREDEFINED_KEY_IDENTIFIER));
     }
 
     @Test
@@ -245,8 +196,7 @@ public class StorageEncryptionManagerTest {
             manager.decrypt(truncatedByteArray);
             Assert.fail("decrypt() should throw an exception but it succeeds.");
         } catch (final ClientException e){
-            Assert.assertEquals(e.getErrorCode(), ErrorStrings.DECRYPTION_FAILED);
-            Assert.assertEquals(((ClientException)e.getSuppressedException().get(0)).getErrorCode(), HMAC_MISMATCH);
+            Assert.assertEquals(HMAC_MISMATCH, e.getErrorCode());
         }
 
         try {
@@ -254,8 +204,7 @@ public class StorageEncryptionManagerTest {
             manager.decrypt(new String(TEXT_ENCRYPTED_BY_PREDEFINED_KEY, ENCODING_UTF8).substring(0, 25).getBytes(ENCODING_UTF8));
             Assert.fail("decrypt() should throw an exception but it succeeds.");
         } catch (final ClientException e){
-            Assert.assertEquals(e.getErrorCode(), ErrorStrings.DECRYPTION_FAILED);
-            Assert.assertEquals(((ClientException)e.getSuppressedException().get(0)).getErrorCode(), DATA_MALFORMED);
+            Assert.assertEquals(DATA_MALFORMED, e.getErrorCode());
         }
     }
 }


### PR DESCRIPTION
## Why?

We're getting unexpected error from KeyStore error from 14k Office app users. (~0.02%).
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2835735

The stack trace implies that this is a OS-level issue.  Somehow keystore is not working properly if it's invoked when the app is being booted up.

We've filed a fix to Google, but it hasn't been picked up yet.

On our side, we should be handle these errors gracefully, not crashing the hosting apps.

## Changes
1. Capture all unexpected throwable as ClientException with UNKNOWN_CRYPTO_ERROR. 
ClientException is not a RuntimeException and will be handled by the caller.

2. Catch the unexpected exception in AndroidKeyStoreUtil, as seen in the stack trace.

3. In decrypt(), only wraps error when there is more than one exception. (multiple key is used to decrypt, which is not the case for ADAL/MSAL/OneAuth)

I also removed isEncryptedByThisKeyIdentifier() because it's redundant with getKeyIdentifierFromCipherText(). 
This method is being consumed by broker, therefore it's a breaking change. 
Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2710