### PR TITLE
Changes to support safe deserialization of KeyPair in Linux

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Changes to support safe deserialization of KeyPair in Linux (#2319)
 
 V.17.1.0
 ---------

--- a/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/BrokerProtocolVersionUtil.java
@@ -126,7 +126,7 @@ public class BrokerProtocolVersionUtil {
      * @param requiredBrokerProtocol minimum required protocol version for the feature.
      * @return true if the provided protocol is larger or equal than required protocol, false otherwise.
      */
-    protected static final boolean isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
+    public static boolean isProvidedBrokerProtocolLargerOrEqualThanRequiredBrokerProtocol(
             @Nullable final String providedBrokerProtocol,
             @NonNull final String requiredBrokerProtocol) {
 


### PR DESCRIPTION
This is really simple; just makes a method public (changing from protected)

See related: https://github.com/AzureAD/ad-accounts-for-android/pull/2693