### PR TITLE
Remove publishing to IDDP feed

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -346,14 +346,6 @@ afterEvaluate {
                     password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
                 }
             }
-            maven {
-                name "vsts-maven-android"
-                url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
-                credentials {
-                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-                }
-            }
         }
     }
 }

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -142,14 +142,6 @@ publishing {
                 password project.ext.vstsPassword
             }
         }
-        maven {
-            name "vsts-maven-android"
-            url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
-            credentials {
-                username project.vstsUsername
-                password project.vstsPassword
-            }
-        }
     }
 }
 


### PR DESCRIPTION
### What
Removing publishing common4j and common to IDDP feed, 

### Why
Currently we are publishing to two separate internal feeds (AndroidADAL and IDDP), 
We don't need to publish to IDDP feed as I don't see anyone consuming common4j and common from there.
