### PR TITLE
Add timeout to backup IPC mechanism

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 V.Next
 ---------
 
+V.17.1.1
+---------
+- [PATCH] Add timeout to backup IPC mechanism (#2323)
+
 V.17.1.0
 ---------
 - [MINOR] Add flight to control silent token timeout (#2311)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp.kt
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.internal.broker.IBrokerValidator
 import com.microsoft.identity.common.internal.util.AccountManagerUtil
 import com.microsoft.identity.common.internal.util.ProcessUtil
 import com.microsoft.identity.common.logging.Logger
+import java.util.concurrent.TimeUnit
 
 /**
  * An IPC strategy that utilizes AccountManager.addAccount().
@@ -126,7 +127,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
                         null,
                         null,
                         ProcessUtil.getPreferredHandler()
-                    ).result
+                    ).getResult(5, TimeUnit.SECONDS)
                 },
                 getAccountManagerApps = {
                     accountManager.authenticatorTypes
@@ -164,7 +165,13 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
             val result = sendRequestViaAccountManager(accountType, requestBundle)
             result
         } catch (e: Throwable) {
-            Logger.error(methodTag, e.message, e)
+            val errorMessage =
+                if (e.message.isNullOrEmpty())
+                    "${e.javaClass.simpleName} is thrown"
+                else
+                    e.message
+
+            Logger.error(methodTag, errorMessage, e)
             // Technically... this might NOT be a connection error.
             // AccountManager returns both connection error and legit failure
             // (i.e. not supported, bad request) as AuthenticatorException...
@@ -172,7 +179,7 @@ class AccountManagerBackupIpcStrategyTargetingSpecificBrokerApp
             throw BrokerCommunicationException(
                 BrokerCommunicationException.Category.CONNECTION_ERROR,
                 type,
-                "AccountManager failed to respond - ${e.message}",
+                "AccountManager failed to respond - $errorMessage",
                 e
             )
         }

--- a/versioning/version.properties
+++ b/versioning/version.properties
@@ -1,4 +1,4 @@
 #Tue Apr 06 22:55:08 UTC 2021
-versionName=17.1.0
+versionName=17.1.1
 versionCode=1
 latestPatchVersion=234


### PR DESCRIPTION
There's an edge case where the backup IPC mechnaism might deadlock. 

- I ran into this when I forced disabling the ContentProvider IPC.
- It doesn't happen in mock broker apps ... so it might have something to do with the way CP/AuthApp sets up :auth process

This fix will guarantee we're not stuck in the deadlock.

We'll still investigating for the root cause, but it might take a while.