### PR TITLE
update nimbus

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Update nimbus-jose-jwt 9.37.3 (#2326)
 
 V.17.1.0
 ---------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -376,7 +376,7 @@ tasks.withType(GenerateMavenPom).all {
     destination = layout.buildDirectory.file("poms/${project.name}-${project.version}.pom").get().asFile
 }
 
-def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "14"
+def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "15"
 String configToCheck = project.hasProperty("dependenciesSizeCheckConfig") ? project.dependenciesSizeCheckConfig : "distReleaseRuntimeClasspath"
 tasks.register("dependenciesSizeCheck") {
     doLast() {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -39,7 +39,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.9"
+    nimbusVersion = "9.37.3"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
Why?
A vulnerability was found in old versions of nimbus.
 see: https://nvd.nist.gov/vuln/detail/CVE-2023-52428