### PR TITLE
Deprecate legacy telemetry code

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Deprecate legacy telemetry code (#2327)
 
 V.17.1.0
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryContext.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryContext.java
@@ -42,6 +42,7 @@ import lombok.NonNull;
  * TelemetryContext for Android.
  * Containing Android Metadata. It also persists data in SharedPreferences.
  */
+@Deprecated
 public class AndroidTelemetryContext extends AbstractTelemetryContext {
 
     private static final String TAG = AndroidTelemetryContext.class.getSimpleName();

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryPropertiesCache.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/AndroidTelemetryPropertiesCache.java
@@ -34,6 +34,7 @@ import lombok.NonNull;
  * Telemetry properties cache for Android.
  * Use Shared Preference as storage.
  * */
+@Deprecated
 public class AndroidTelemetryPropertiesCache extends TelemetryPropertiesCache {
 
     private static final String SHARED_PREFS_NAME = "com.microsoft.common.telemetry-properties";

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Telemetry.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/Telemetry.java
@@ -42,6 +42,7 @@ import lombok.NonNull;
  * This is now acting as an adapter for {@link com.microsoft.identity.common.java.telemetry.Telemetry}.
  **/
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+@Deprecated
 public class Telemetry extends com.microsoft.identity.common.java.telemetry.Telemetry {
     private final static String TAG = Telemetry.class.getSimpleName();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryEventStrings.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/TelemetryEventStrings.java
@@ -7,7 +7,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  * @see com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
  * */
-// TODO @Deprecated
+@Deprecated
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class TelemetryEventStrings extends com.microsoft.identity.common.java.telemetry.TelemetryEventStrings {
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/BrokerEndEvent.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/BrokerEndEvent.java
@@ -32,6 +32,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Value;
 
+@Deprecated
 public class BrokerEndEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public BrokerEndEvent() {
         super();

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/BrokerStartEvent.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/BrokerStartEvent.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class BrokerStartEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public BrokerStartEvent() {
         super();

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/UiEndEvent.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/UiEndEvent.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class UiEndEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public UiEndEvent() {
         super();

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/UiStartEvent.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/events/UiStartEvent.java
@@ -28,6 +28,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class UiStartEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public UiStartEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/AbstractTelemetryContext.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/AbstractTelemetryContext.java
@@ -34,6 +34,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
  * TelemetryContext is a dictionary of information about the state of the device.
  * It is attached to every outgoing telemetry calls.
  */
+@Deprecated
 public abstract class AbstractTelemetryContext extends Properties {
     private TelemetryPropertiesCache mTelemetryPropsCache;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/CliTelemInfo.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/CliTelemInfo.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+@Deprecated
 public class CliTelemInfo implements Serializable {
 
     private static final String TAG = CliTelemInfo.class.getSimpleName();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
@@ -29,6 +29,7 @@ import java.util.Map;
  * An interface describing a telemetry accessor i.e. anyone that has the ability to return a
  * telemetry object.
  */
+@Deprecated
 public interface ITelemetryAccessor {
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryCallback.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryCallback.java
@@ -27,6 +27,7 @@ package com.microsoft.identity.common.java.telemetry;
  * Temporary interface.
  * For injecting telemetry into common (until broker's telemetry is properly wired up).
  * */
+@Deprecated
 public interface ITelemetryCallback {
     void logEvent(final String operation, final Boolean isFailed, final String reason);
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/Properties.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/Properties.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * The base class for the event properties.
  */
+@Deprecated
 public class Properties {
     private ConcurrentHashMap<String, String> mProperties;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
@@ -55,6 +55,7 @@ import lombok.NonNull;
  * A singleton class for logging Telemetry.
  * Must be instantiated via {@link Telemetry.Builder} before use.
  */
+@Deprecated
 public class Telemetry {
     private final static String TAG = Telemetry.class.getSimpleName();
     private static volatile Telemetry sTelemetryInstance = null;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryConfiguration.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryConfiguration.java
@@ -26,6 +26,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
 
+@Deprecated
 public class TelemetryConfiguration implements Serializable {
 
     private static final long serialVersionUID = 4048693049821792485L;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryEventStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryEventStrings.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.telemetry;
 
+@Deprecated
 public class TelemetryEventStrings {
     private static final String EVENT_PREFIX = "Microsoft.MSAL.";
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryPropertiesCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/TelemetryPropertiesCache.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 /**
  * Tracks properties used in telemetry.
  */
+@Deprecated
 public class TelemetryPropertiesCache {
 
     // region Cached Properties

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/BrokerTelemetryAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/BrokerTelemetryAdapter.java
@@ -41,6 +41,7 @@ import lombok.NonNull;
  * and add combine it with the aggregated event. This means that the event sent by {@link TelemetryAggregationAdapter} only contains
  * the last error that was dispatched.
  */
+@Deprecated
 public class BrokerTelemetryAdapter extends TelemetryAggregationAdapter {
     public BrokerTelemetryAdapter(@NonNull IBrokerTelemetryObserver observer) {
         super(observer);

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/ITelemetryAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/ITelemetryAdapter.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.telemetry.adapter;
 
+@Deprecated
 public interface ITelemetryAdapter<T> {
     //Future extensibility void process(T observable, Rule rule);
     void process(T observable);

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/TelemetryAggregationAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/TelemetryAggregationAdapter.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class TelemetryAggregationAdapter implements ITelemetryAdapter<List<Map<String, String>>> {
     private ITelemetryAggregatedObserver mObserver;
     private static final String START = "start";

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/TelemetryDefaultAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/adapter/TelemetryDefaultAdapter.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.telemetry.observers.ITelemetryDefaultO
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public final class TelemetryDefaultAdapter implements ITelemetryAdapter<List<Map<String, String>>> {
     private ITelemetryDefaultObserver mObserver;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ApiEndEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ApiEndEvent.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 
 import lombok.NonNull;
 
+@Deprecated
 public class ApiEndEvent extends BaseEvent {
     public ApiEndEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ApiStartEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ApiStartEvent.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 
 import lombok.NonNull;
 
+@Deprecated
 public class ApiStartEvent extends BaseEvent {
     private static final String TAG = ApiStartEvent.class.getSimpleName();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/BaseEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/BaseEvent.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 
 import lombok.NonNull;
 
+@Deprecated
 public class BaseEvent extends Properties {
     public BaseEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/BrokerEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/BrokerEvent.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 /**
  * A generic broker event. This can be used to emit any kind of event in the broker. e.g. an event with the IPC strategy.
  */
+@Deprecated
 public class BrokerEvent extends BaseEvent {
     public BrokerEvent(final String eventName) {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CacheEndEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CacheEndEvent.java
@@ -32,6 +32,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Value;
 
+@Deprecated
 public class CacheEndEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public CacheEndEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CacheStartEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CacheStartEvent.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class CacheStartEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public CacheStartEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CertBasedAuthResultEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/CertBasedAuthResultEvent.java
@@ -30,6 +30,7 @@ import lombok.NonNull;
 /**
  * Event specifically for emitting certificate-based authentication (CBA) result information.
  */
+@Deprecated
 public class CertBasedAuthResultEvent extends BaseEvent {
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ContentProviderCallEvent.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 /**
  * Telemetry Event to capture details about a content provider call from broker
  */
+@Deprecated
 public class ContentProviderCallEvent extends BaseEvent {
     /**
      * Constructor for ContentProviderCallEvent

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/DeprecatedApiUsageEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/DeprecatedApiUsageEvent.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 
 import javax.annotation.Nonnull;
 
+@Deprecated
 public class DeprecatedApiUsageEvent extends BaseEvent {
 
     public DeprecatedApiUsageEvent() {

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ErrorEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/ErrorEvent.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 /**
  * An error event captures an Exception and extracts details from it.
  */
+@Deprecated
 public class ErrorEvent extends BaseEvent {
 
     public static final String ERROR_TAG_PREFIX = "tag_";

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/HttpEndEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/HttpEndEvent.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Event;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class HttpEndEvent extends BaseEvent {
     public HttpEndEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/HttpStartEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/HttpStartEvent.java
@@ -28,6 +28,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.EventType;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class HttpStartEvent extends BaseEvent {
     public HttpStartEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/PivProviderStatusEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/PivProviderStatusEvent.java
@@ -27,6 +27,7 @@ import com.microsoft.identity.common.java.telemetry.TelemetryEventStrings;
 /**
  * Event for emitting status information of when a PivProvider is present, added, or removed from the Security static list.
  */
+@Deprecated
 public class PivProviderStatusEvent extends BaseEvent {
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/UiShownEvent.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/events/UiShownEvent.java
@@ -29,6 +29,7 @@ import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings
 /** This event is used in telemetry to check if UI was visible to the end user.
  *  The value is set in case UI is visible, even if it is for a brief second.
 */
+@Deprecated
 public class UiShownEvent extends com.microsoft.identity.common.java.telemetry.events.BaseEvent {
     public UiShownEvent() {
         super();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/IBrokerTelemetryObserver.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/IBrokerTelemetryObserver.java
@@ -22,5 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.telemetry.observers;
 
+@Deprecated
 public interface IBrokerTelemetryObserver extends ITelemetryAggregatedObserver {
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryAggregatedObserver.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryAggregatedObserver.java
@@ -28,6 +28,7 @@ import java.util.Map;
  * Telemetry observer interface for MATS (Microsoft Authentication Telemetry Service) format.
  * The calling application need to implement the interface for further data processing.
  */
+@Deprecated
 public interface ITelemetryAggregatedObserver extends ITelemetryObserver<Map<String, String>> {
     @Override
     void onReceived(Map<String, String> telemetryData);

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryDefaultObserver.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryDefaultObserver.java
@@ -28,6 +28,7 @@ import java.util.Map;
 /**
  * The default telemetry observer interface which upload raw telemetry data.
  */
+@Deprecated
 public interface ITelemetryDefaultObserver extends ITelemetryObserver<List<Map<String, String>>> {
     @Override
     void onReceived(List<Map<String, String>> telemetryData);

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryObserver.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/observers/ITelemetryObserver.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.java.telemetry.observers;
 /**
  * The interface function for apps to override if they want to get the Telemetry.
  */
+@Deprecated
 public interface ITelemetryObserver<T> {
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/AbstractTelemetryRelayClient.java
@@ -33,6 +33,7 @@ import lombok.NonNull;
  *
  * @param <T>
  */
+@Deprecated
 public abstract class AbstractTelemetryRelayClient<T> implements ITelemetryObserver<T> {
 
     private static final String TAG = AbstractTelemetryRelayClient.class.getSimpleName();

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/ITelemetryEventFilter.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
  * An interface that describes an event filter for a telemetry relay client {@link AbstractTelemetryRelayClient}
  * @param <T> the event data
  */
+@Deprecated
 public interface ITelemetryEventFilter<T> {
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/TelemetryRelayException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/relay/TelemetryRelayException.java
@@ -37,6 +37,7 @@ import lombok.experimental.Accessors;
 @EqualsAndHashCode(callSuper = true)
 @Data()
 @Accessors(prefix = "m")
+@Deprecated
 public class TelemetryRelayException extends BaseException  {
     private static final long serialVersionUID = -1543623857511895210L;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/rules/TelemetryAggregationRules.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/rules/TelemetryAggregationRules.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 public class TelemetryAggregationRules {
     private static TelemetryAggregationRules sInstance;
     private Set<String> aggregatedPropertiesSet;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/rules/TelemetryPiiOiiRules.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/rules/TelemetryPiiOiiRules.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Device;
 import static com.microsoft.identity.common.java.telemetry.TelemetryEventStrings.Key;
 
+@Deprecated
 final public class TelemetryPiiOiiRules {
     private static TelemetryPiiOiiRules sInstance;
     private Set<String> piiPropertiesSet;


### PR DESCRIPTION
Marking all classes of old telemetry with Deprecated annotation (Since we have moved to using Open Telemetry). Changelog is marked as MINOR (rather than major) because per SemVer a deprecation isn't a breaking change and thus can be done via a MINOR release. 

When we completely remove this code in a future release then we will mark it as MAJOR.