### PR TITLE
Fix crash on MsaBrokerController initialization when queryContentProviders fails.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Fix crash on MsaBrokerController initialization when queryContentProviders fails. (#2328)
 - [MINOR] Gracefully handles unexpected error in encryption layer (#2318)
 
 V.17.1.0

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/ipc/ContentProviderStrategy.java
@@ -154,8 +154,13 @@ public class ContentProviderStrategy extends AbstractIpcStrategyWithServiceValid
         final String methodTag = TAG + ":isSupportedByTargetedBroker";
         final String contentProviderAuthority = getContentProviderAuthority(targetedBrokerPackageName);
 
-        final List<ProviderInfo> providers = mContext.getPackageManager()
-                .queryContentProviders(null, 0, 0);
+        final List<ProviderInfo> providers;
+        try {
+            providers = mContext.getPackageManager().queryContentProviders(null, 0, 0);
+        } catch (final Throwable t) {
+            Logger.error(methodTag, "Failed to query content providers.", t);
+            return false;
+        }
 
         if (providers == null) {
             Logger.error(methodTag, "Content Provider not found.", null);


### PR DESCRIPTION
Why?

we got this ICM https://portal.microsofticm.com/imp/v3/incidents/incident/475092277/summary 
where in some cases Defender app crashes because `queryContentProviders` throws an unexpected error.

What change?

Wrap queryContentProviders with try catch. 



