### PR TITLE
Revert "update nimbus"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@ V.Next
 - [MINOR] Changes to support safe deserialization of KeyPair in Linux (#2319)
 - [MINOR] Request camera permission on the WebViewAuthorizationFragment (#2258)
 - [MINOR] Deprecate legacy telemetry code (#2327)
-- [PATCH] Update nimbus-jose-jwt 9.37.3 (#2326)
 - [MINOR] Gracefully handles unexpected error in encryption layer (#2318)
 
 V.17.1.1

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -368,7 +368,7 @@ tasks.withType(GenerateMavenPom).all {
     destination = layout.buildDirectory.file("poms/${project.name}-${project.version}.pom").get().asFile
 }
 
-def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "15"
+def dependenciesSizeInMb = project.hasProperty("dependenciesSizeMb") ? project.dependenciesSizeMb : "14"
 String configToCheck = project.hasProperty("dependenciesSizeCheckConfig") ? project.dependenciesSizeCheckConfig : "distReleaseRuntimeClasspath"
 tasks.register("dependenciesSizeCheck") {
     doLast() {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -39,7 +39,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.37.3"
+    nimbusVersion = "9.9"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
This reverts #2326

Why?
This change is breaking CP and blocking the release.
CP cannot update the library right now, because they need to do an IP scan before updating a lib. That would usually take a couple weeks to get the results back.
And because the severity part of this vulnerability is unclear, we will move this change to April release, giving more time to CP folks do their investigation. 