### PR TITLE
Move the getActiveBroker() invocation to background thread

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Move the getActiveBroker() invocation to background thread (#2352)
 - [PATCH] Move SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY to BaseActiveBrokerCache (#2340)
 - [PATCH] Add cache for ContentProviderStrategy.isSupportedByTargetedBroker() (#2338)
 - [PATCH] isSupportedByTargetedBroker should only be invoked in bg thread (#2339)

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -740,7 +740,7 @@ public class CommandDispatcherTest {
 
         public ExceptionCommand(@NonNull final CommandParameters parameters,
                                 @NonNull final CommandCallback callback) {
-            super(parameters, getTestController(), callback, "test_id");
+            super(parameters, getTestController().asControllerFactory(), callback, "test_id");
         }
 
         @Override
@@ -759,7 +759,7 @@ public class CommandDispatcherTest {
 
         public CommandThrowingIErrorInformationException(@NonNull final CommandParameters parameters,
                                                          @NonNull final CommandCallback callback, String errorCode) {
-            super(parameters, getTestController(), callback, "test_id");
+            super(parameters, getTestController().asControllerFactory(), callback, "test_id");
             mErrorCode = errorCode;
         }
 
@@ -780,7 +780,7 @@ public class CommandDispatcherTest {
 
         public TestCommand(@NonNull final CommandParameters parameters,
                            @NonNull final CommandCallback callback, int value) {
-            super(parameters, getTestController(), callback, "test_id");
+            super(parameters, getTestController().asControllerFactory(), callback, "test_id");
             this.value = value;
         }
 
@@ -865,7 +865,7 @@ public class CommandDispatcherTest {
                                                         acquireTokenSilentCallCount,
                                                         controllerLatch,
                                                         shouldRefresh,
-                                                        throwRenewAccessTokenError),
+                                                        throwRenewAccessTokenError).asControllerFactory(),
                     callback,
                     "");
             this.tryLatch = tryLatch;
@@ -880,7 +880,7 @@ public class CommandDispatcherTest {
             executeMethodEntranceVerifierLatch.countDown();
             try {
                 tryLatch.await();
-                result = getDefaultController().acquireTokenSilent((SilentTokenCommandParameters) getParameters());
+                result = getControllerFactory().getDefaultController().acquireTokenSilent((SilentTokenCommandParameters) getParameters());
             } catch (InterruptedException e) {
                 e.printStackTrace();
                 throw new RuntimeException(e);
@@ -911,7 +911,7 @@ public class CommandDispatcherTest {
     public static class LongRunningTestCommand extends BaseCommand {
         public LongRunningTestCommand(@NonNull final CommandParameters parameters,
                            @NonNull final CommandCallback callback) {
-            super(parameters, getTestController(), callback, "test_id");
+            super(parameters, getTestController().asControllerFactory(), callback, "test_id");
         }
 
         @Override
@@ -942,7 +942,7 @@ public class CommandDispatcherTest {
                 controllerLatch.countDown();
                 acquireTokenSilentCallCount.getAndIncrement();
                 if(shouldRefresh){
-                    final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this, "LocalMSALControllerMockPubId");
+                    final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), "LocalMSALControllerMockPubId");
                     CommandDispatcher.submitAndForgetReturningFuture(refreshOnCommand);
                 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
@@ -60,10 +61,10 @@ public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
      * @param publicApiId The public API ID of this command.
      */
     public GenerateShrCommand(@NonNull final GenerateShrCommandParameters parameters,
-                              @NonNull final List<BaseController> controllers,
+                              @NonNull final IControllerFactory controllerFactory,
                               @NonNull final CommandCallback<GenerateShrResult, BaseException> callback,
                               @NonNull final String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
@@ -73,13 +74,15 @@ public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
         GenerateShrResult result = null;
         final GenerateShrCommandParameters parameters = (GenerateShrCommandParameters) getParameters();
 
+        final List<BaseController> controllers = getControllerFactory().getAllControllers();
+
         // Iterate over our controllers, to service the request either locally or via the broker...
         // if the local (embedded) cache contains tokens for the supplied user, we will sign using
         // the embedded PoP keys. If no local user-state exists, the broker will be delegated to
         // where the same check is performed.
         BaseController controller;
-        for (int ii = 0; ii < getControllers().size(); ii++) {
-            controller = getControllers().get(ii);
+        for (int ii = 0; ii < controllers.size(); ii++) {
+            controller = controllers.get(ii);
 
             com.microsoft.identity.common.internal.logging.Logger.verbose(
                     methodTag,
@@ -97,7 +100,7 @@ public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
                 // broker flow, errors will be returned as properties of the result, instead
                 // of as thrown Exceptions
                 if (NO_ACCOUNT_FOUND.equalsIgnoreCase(errorCode)) {
-                    if (getControllers().size() > ii + 1) {
+                    if (controllers.size() > ii + 1) {
                         // Try our next controller
                         continue;
                     } else {

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GetCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GetCurrentAccountCommand.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
+import com.microsoft.identity.common.java.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,29 +46,23 @@ import lombok.EqualsAndHashCode;
 public class GetCurrentAccountCommand extends BaseCommand<List<ICacheRecord>> {
     private static final String TAG = GetCurrentAccountCommand.class.getSimpleName();
 
-    public GetCurrentAccountCommand(@NonNull CommandParameters parameters,
-                                    @NonNull BaseController controller,
-                                    @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                    @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public GetCurrentAccountCommand(@NonNull CommandParameters parameters,
-                                    @NonNull List<BaseController> controllers,
-                                    @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                    @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+    public GetCurrentAccountCommand(@NonNull final CommandParameters parameters,
+                                    @NonNull final IControllerFactory controllerFactory,
+                                    @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                                    @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
     public List<ICacheRecord> execute() throws Exception {
         final String methodTag = TAG + ":execute";
 
-        List<ICacheRecord> result = new ArrayList<>();
+        final List<ICacheRecord> result = new ArrayList<>();
+        final List<BaseController> controllers = getControllerFactory().getAllControllers();
 
-        for (int ii = 0; ii < getControllers().size(); ii++) {
-            final BaseController controller = getControllers().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+        for (int ii = 0; ii < controllers.size(); ii++) {
+            final BaseController controller = controllers.get(ii);
+            Logger.verbose(
                     methodTag,
                     "Executing with controller: "
                             + controller.getClass().getSimpleName()

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GetDeviceModeCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GetDeviceModeCommand.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 
 import java.util.List;
 
@@ -42,22 +43,15 @@ import lombok.EqualsAndHashCode;
 public class GetDeviceModeCommand extends BaseCommand<Boolean> {
 
     public GetDeviceModeCommand(@NonNull CommandParameters parameters,
-                                @NonNull BaseController controller,
+                                @NonNull IControllerFactory controllerFactory,
                                 @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
                                 @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public GetDeviceModeCommand(@NonNull CommandParameters parameters,
-                                @NonNull List<BaseController> controllers,
-                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
     public Boolean execute() throws Exception {
-        return getDefaultController().getDeviceMode(getParameters());
+        return getControllerFactory().getDefaultController().getDeviceMode(getParameters());
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GetPreferredAuthMethodFromAuthenticator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GetPreferredAuthMethodFromAuthenticator.kt
@@ -25,7 +25,7 @@ package com.microsoft.identity.common.internal.commands
 import com.microsoft.identity.common.java.commands.BaseCommand
 import com.microsoft.identity.common.java.commands.CommandCallback
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters
-import com.microsoft.identity.common.java.controllers.BaseController
+import com.microsoft.identity.common.java.controllers.IControllerFactory
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod
 import lombok.EqualsAndHashCode
 
@@ -36,13 +36,13 @@ import lombok.EqualsAndHashCode
 @EqualsAndHashCode(callSuper = true)
 class GetPreferredAuthMethodFromAuthenticator(
     parameters: CommandParameters,
-    controller: BaseController,
+    controllerFactory: IControllerFactory,
     callback: CommandCallback<*, *>,
     publicApiId: String
-) : BaseCommand<PreferredAuthMethod?>(parameters, controller, callback, publicApiId) {
+) : BaseCommand<PreferredAuthMethod?>(parameters, controllerFactory, callback, publicApiId) {
 
     override fun execute(): PreferredAuthMethod {
-        return defaultController.preferredAuthMethod
+        return controllerFactory.getDefaultController().preferredAuthMethod
     }
 
     override fun isEligibleForEstsTelemetry(): Boolean {

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/LoadAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/LoadAccountCommand.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
+import com.microsoft.identity.common.java.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,29 +46,23 @@ import lombok.EqualsAndHashCode;
 public class LoadAccountCommand extends BaseCommand<List<ICacheRecord>> {
     private static final String TAG = LoadAccountCommand.class.getSimpleName();
 
-    public LoadAccountCommand(@NonNull CommandParameters parameters,
-                              @NonNull BaseController controller,
-                              @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                              @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public LoadAccountCommand(@NonNull CommandParameters parameters,
-                              @NonNull List<BaseController> controllers,
-                              @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                              @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+    public LoadAccountCommand(@NonNull final CommandParameters parameters,
+                              @NonNull final IControllerFactory controllerFactory,
+                              @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                              @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
     public List<ICacheRecord> execute() throws Exception {
         final String methodTag = TAG + ":execute";
 
-        List<ICacheRecord> result = new ArrayList<>();
+        final List<ICacheRecord> result = new ArrayList<>();
+        final List<BaseController> controllers = getControllerFactory().getAllControllers();
 
-        for (int ii = 0; ii < getControllers().size(); ii++) {
-            final BaseController controller = getControllers().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+        for (int ii = 0; ii < controllers.size(); ii++) {
+            final BaseController controller = controllers.get(ii);
+            Logger.verbose(
                     methodTag,
                     "Executing with controller: "
                             + controller.getClass().getSimpleName()

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/RefreshOnCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/RefreshOnCommand.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.result.VoidResult;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommandParameters;
@@ -42,15 +43,17 @@ public class RefreshOnCommand extends BaseCommand<VoidResult>{
 
     private static final String TAG = RefreshOnCommand.class.getSimpleName();
 
-    public RefreshOnCommand(@NonNull CommandParameters parameters, @NonNull BaseController controller, @NonNull String publicApiId) {
-        super(parameters, controller, new RefreshOnCallback(), publicApiId);
+    public RefreshOnCommand(@NonNull final CommandParameters parameters,
+                            @NonNull final IControllerFactory controllerFactory,
+                            @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, new RefreshOnCallback(), publicApiId);
     }
 
     @Override
     public VoidResult execute() throws IOException, ClientException, ServiceException {
         final String methodTag = TAG + ":execute";
 
-        final BaseController controller = getDefaultController();
+        final BaseController controller = getControllerFactory().getDefaultController();
         Logger.verbose(
                 methodTag,
                 "Executing with controller: "

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/RemoveAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/RemoveAccountCommand.java
@@ -29,6 +29,8 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
+import com.microsoft.identity.common.java.logging.Logger;
 
 import java.util.List;
 
@@ -42,29 +44,23 @@ import lombok.EqualsAndHashCode;
 public class RemoveAccountCommand extends BaseCommand<Boolean> {
     private static final String TAG = RemoveAccountCommand.class.getSimpleName();
 
-    public RemoveAccountCommand(@NonNull RemoveAccountCommandParameters parameters,
-                                @NonNull BaseController controller,
-                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public RemoveAccountCommand(@NonNull RemoveAccountCommandParameters parameters,
-                                @NonNull List<BaseController> controllers,
-                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+    public RemoveAccountCommand(@NonNull final RemoveAccountCommandParameters parameters,
+                                @NonNull final IControllerFactory controllerFactory,
+                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                                @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
     public Boolean execute() throws Exception {
         final String methodTag = TAG + ":execute";
 
-        boolean result = false;
+        final List<BaseController> controllers = getControllerFactory().getAllControllers();
 
-        for (int ii = 0; ii < getControllers().size(); ii++) {
-            final BaseController controller = getControllers().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+        boolean result = false;
+        for (int ii = 0; ii < controllers.size(); ii++) {
+            final BaseController controller = controllers.get(ii);
+            Logger.verbose(
                     methodTag,
                     "Executing with controller: "
                             + controller.getClass().getSimpleName()

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/RemoveCurrentAccountCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/RemoveCurrentAccountCommand.java
@@ -29,6 +29,8 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.RemoveAccountCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
+import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;
 
@@ -44,25 +46,18 @@ public class RemoveCurrentAccountCommand extends BaseCommand<Boolean> {
     private static final String TAG = RemoveCurrentAccountCommand.class.getSimpleName();
 
     public RemoveCurrentAccountCommand(@NonNull RemoveAccountCommandParameters parameters,
-                                       @NonNull BaseController controller,
+                                       @NonNull IControllerFactory controllerFactory,
                                        @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
                                        @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public RemoveCurrentAccountCommand(@NonNull RemoveAccountCommandParameters parameters,
-                                       @NonNull List<BaseController> controllers,
-                                       @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                       @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
     public Boolean execute() throws Exception {
         final String methodTag = TAG + ":execute";
 
-        for (final BaseController controller : getControllers()) {
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
+        for (final BaseController controller : getControllerFactory().getAllControllers()) {
+            Logger.verbose(
                     methodTag,
                     "Executing with controller: "
                             + controller.getClass().getSimpleName()

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -354,7 +354,7 @@ public class LocalMSALController extends BaseController {
                 && fullCacheRecord.getAccessToken().shouldRefresh()) {
             if (!fullCacheRecord.getAccessToken().isExpired()) {
                 setAcquireTokenResult(acquireTokenSilentResult, parametersWithScopes, cacheRecords);
-                final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this, PublicApiId.MSAL_REFRESH_ON);
+                final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), PublicApiId.MSAL_REFRESH_ON);
                 CommandDispatcher.submitAndForget(refreshOnCommand);
             } else {
                 Logger.warn(

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/BaseNativeAuthCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/BaseNativeAuthCommand.kt
@@ -22,12 +22,12 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.nativeauth.internal.commands
 
-import com.microsoft.identity.common.nativeauth.internal.controllers.BaseNativeAuthController
 import com.microsoft.identity.common.java.commands.BaseCommand
 import com.microsoft.identity.common.java.commands.CommandCallback
-import com.microsoft.identity.common.java.nativeauth.commands.parameters.BaseNativeAuthCommandParameters
 import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.BaseNativeAuthCommandParameters
+import com.microsoft.identity.common.nativeauth.internal.controllers.BaseNativeAuthController
 import lombok.EqualsAndHashCode
 
 /**
@@ -40,7 +40,7 @@ abstract class BaseNativeAuthCommand<T>(
     publicApiId: String
 ) : BaseCommand<T>(
     parameters,
-    controller,
+    controller.asControllerFactory(),
     object : CommandCallback<T, BaseException> {
         override fun onCancel() {
             onError(ClientException("onCancel not supported in native authentication flows"))

--- a/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/commands/GenerateShrCommandTest.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.util.ClockSkewManager;
 import com.microsoft.identity.common.java.util.UrlUtil;
 import com.microsoft.identity.common.java.util.ported.InMemoryStorage;
@@ -41,7 +42,10 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import lombok.NonNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class GenerateShrCommandTest {
@@ -50,6 +54,21 @@ public class GenerateShrCommandTest {
         @Override public void onCancel() {  }
         @Override public void onError(Object error) {  }
         @Override public void onTaskCompleted(Object o) {  }
+    };
+
+    private static final IControllerFactory emptyControllerFactory = new IControllerFactory() {
+
+        @NonNull
+        @Override
+        public List<BaseController> getAllControllers() {
+            return Collections.<BaseController>emptyList();
+        }
+
+        @NonNull
+        @Override
+        public BaseController getDefaultController() {
+            throw new IllegalStateException("Thins shouldn't be invoked in this flow.");
+        }
     };
 
     public static final GenerateShrCommandParameters PARAMS_ONE = GenerateShrCommandParameters.builder()
@@ -67,7 +86,7 @@ public class GenerateShrCommandTest {
             .parameters(PARAMS_ONE)
             .callback(EMPTY_CALLBACK)
             .publicApiId("ID")
-            .controllers(Collections.<BaseController>emptyList())
+            .controllerFactory(emptyControllerFactory)
             .build();
     public static final GenerateShrCommandParameters PARAMS_ONE_CLONE = GenerateShrCommandParameters.builder()
             .platformComponents(AndroidPlatformComponentsFactory.createFromContext(ApplicationProvider.getApplicationContext()))
@@ -84,7 +103,7 @@ public class GenerateShrCommandTest {
             .parameters(PARAMS_ONE_CLONE)
             .callback(EMPTY_CALLBACK)
             .publicApiId("ID")
-            .controllers(Collections.<BaseController>emptyList())
+            .controllerFactory(emptyControllerFactory)
             .build();
     public static final GenerateShrCommandParameters PARAMS_TWO = GenerateShrCommandParameters.builder()
             .platformComponents(AndroidPlatformComponentsFactory.createFromContext(ApplicationProvider.getApplicationContext()))
@@ -101,7 +120,7 @@ public class GenerateShrCommandTest {
             .parameters(PARAMS_TWO)
             .callback(EMPTY_CALLBACK)
             .publicApiId("ID")
-            .controllers(Collections.<BaseController>emptyList())
+            .controllerFactory(emptyControllerFactory)
             .build();
 
     @Test
@@ -111,7 +130,7 @@ public class GenerateShrCommandTest {
                 .parameters(paramsOne)
                 .callback(EMPTY_CALLBACK)
                 .publicApiId("ID")
-                .controllers(Collections.<BaseController>emptyList())
+                .controllerFactory(emptyControllerFactory)
                 .build();
 
         GenerateShrCommandParameters paramsTwo = GenerateShrCommandParameters.builder()
@@ -129,7 +148,7 @@ public class GenerateShrCommandTest {
                 .parameters(paramsTwo)
                 .callback(EMPTY_CALLBACK)
                 .publicApiId("ID")
-                .controllers(Collections.<BaseController>emptyList())
+                .controllerFactory(emptyControllerFactory)
                 .build();
         Map<BaseCommand, Boolean> map = new HashMap<>();
         map.put(commandOne, true);

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/BaseCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/BaseCommand.java
@@ -27,6 +27,7 @@ import lombok.NonNull;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,37 +55,24 @@ public abstract class BaseCommand<T> implements ICommand<T> {
     private final CommandCallback callback;
 
     @NonNull
-    private final List<BaseController> controllers;
-
-    @NonNull
     @EqualsAndHashCode.Exclude
     private final String publicApiId;
 
-    public BaseCommand(@NonNull final CommandParameters parameters,
-                       @NonNull final BaseController controller,
-                       @NonNull final CommandCallback callback,
-                       @NonNull final String publicApiId) {
-        this.parameters = parameters;
-        this.callback = callback;
-        controllers = Collections.unmodifiableList(Arrays.asList(controller));
-        this.publicApiId = publicApiId;
-    }
+    @NonNull
+    @EqualsAndHashCode.Exclude
+    private final IControllerFactory controllerFactory;
 
     public BaseCommand(@NonNull final CommandParameters parameters,
-                       @NonNull final List<BaseController> controllers,
+                       @NonNull final IControllerFactory controllerFactory,
                        @NonNull final CommandCallback callback,
                        @NonNull final String publicApiId) {
         this.parameters = parameters;
-        this.controllers = Collections.unmodifiableList(new ArrayList<BaseController>(controllers));
         this.callback = callback;
+        this.controllerFactory = controllerFactory;
         this.publicApiId = publicApiId;
     }
 
     public abstract T execute() throws Exception;
-
-    public BaseController getDefaultController() {
-        return controllers.get(0);
-    }
 
     @Override
     public boolean isEligibleForCaching() {

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowAuthResultCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowAuthResultCommand.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
@@ -50,11 +51,11 @@ public class DeviceCodeFlowAuthResultCommand extends BaseCommand<AuthorizationRe
 
     public static final String DEVICE_ID_CLAIM = "deviceid";
 
-    public DeviceCodeFlowAuthResultCommand(@NonNull DeviceCodeFlowCommandParameters parameters,
-                                 @NonNull BaseController controller,
-                                 @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                 @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
+    public DeviceCodeFlowAuthResultCommand(@NonNull final DeviceCodeFlowCommandParameters parameters,
+                                 @NonNull final IControllerFactory controllerFactory,
+                                 @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                                 @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
@@ -73,7 +74,7 @@ public class DeviceCodeFlowAuthResultCommand extends BaseCommand<AuthorizationRe
 
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Get the controller used to execute the command
-            final BaseController controller = getDefaultController();
+            final BaseController controller = getControllerFactory().getDefaultController();
 
             span.setAttribute(AttributeName.controller_name.name(), controller.getClass().getSimpleName());
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowCommand.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -55,11 +56,11 @@ import lombok.NonNull;
 public class DeviceCodeFlowCommand extends TokenCommand {
     private static final String TAG = DeviceCodeFlowCommand.class.getSimpleName();
 
-    public DeviceCodeFlowCommand(@NonNull DeviceCodeFlowCommandParameters parameters,
-                                 @NonNull BaseController controller,
-                                 @SuppressWarnings(WarningType.rawtype_warning) @NonNull DeviceCodeFlowCommandCallback callback,
-                                 @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
+    public DeviceCodeFlowCommand(@NonNull final DeviceCodeFlowCommandParameters parameters,
+                                 @NonNull final IControllerFactory controllerFactory,
+                                 @SuppressWarnings(WarningType.rawtype_warning) @NonNull final DeviceCodeFlowCommandCallback callback,
+                                 @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class DeviceCodeFlowCommand extends TokenCommand {
 
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Get the controller used to execute the command
-            final BaseController controller = getDefaultController();
+            final BaseController controller = getControllerFactory().getDefaultController();
 
             span.setAttribute(AttributeName.controller_name.name(), controller.getClass().getSimpleName());
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowTokenResultCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/DeviceCodeFlowTokenResultCommand.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -51,12 +52,12 @@ public class DeviceCodeFlowTokenResultCommand extends TokenCommand{
 
     private final AuthorizationResult mAuthorizationResult;
 
-    public DeviceCodeFlowTokenResultCommand(@NonNull DeviceCodeFlowCommandParameters parameters,
-                                @NonNull AuthorizationResult authorizationResult,
-                                @NonNull BaseController controller,
-                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
+    public DeviceCodeFlowTokenResultCommand(@NonNull final DeviceCodeFlowCommandParameters parameters,
+                                @NonNull final AuthorizationResult authorizationResult,
+                                @NonNull final IControllerFactory controllerFactory,
+                                @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                                @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
 
         mAuthorizationResult = authorizationResult;
     }
@@ -77,7 +78,7 @@ public class DeviceCodeFlowTokenResultCommand extends TokenCommand{
 
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Get the controller used to execute the command
-            final BaseController controller = getDefaultController();
+            final BaseController controller = getControllerFactory().getDefaultController();
 
             // Fetch the parameters
             final DeviceCodeFlowCommandParameters commandParameters = (DeviceCodeFlowCommandParameters) getParameters();

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
@@ -48,17 +49,10 @@ public class InteractiveTokenCommand extends TokenCommand {
     private static final String TAG = InteractiveTokenCommand.class.getSimpleName();
 
     public InteractiveTokenCommand(@NonNull final InteractiveTokenCommandParameters parameters,
-                                   @NonNull final BaseController controller,
+                                   @NonNull final IControllerFactory controllerFactory,
                                    @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
                                    @NonNull final String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public InteractiveTokenCommand(@NonNull InteractiveTokenCommandParameters parameters,
-                                   @NonNull List<BaseController> controllers,
-                                   @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                                   @NonNull final String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
@@ -77,7 +71,7 @@ public class InteractiveTokenCommand extends TokenCommand {
                         "Executing interactive token command..."
                 );
 
-                final BaseController controller = getDefaultController();
+                final BaseController controller = getControllerFactory().getDefaultController();
 
                 span.setAttribute(AttributeName.controller_name.name(), controller.getClass().getSimpleName());
 
@@ -111,7 +105,7 @@ public class InteractiveTokenCommand extends TokenCommand {
     public void onFinishAuthorizationSession(int requestCode,
                                              int resultCode,
                                              @NonNull final PropertyBag data) {
-        getDefaultController().onFinishAuthorizationSession(requestCode, resultCode, data);
+        getControllerFactory().getDefaultController().onFinishAuthorizationSession(requestCode, resultCode, data);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/RopcTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/RopcTokenCommand.java
@@ -26,6 +26,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.RopcTokenCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 
@@ -42,17 +43,10 @@ public class RopcTokenCommand extends TokenCommand {
     private static final String TAG = RopcTokenCommand.class.getSimpleName();
 
     public RopcTokenCommand(@NonNull final RopcTokenCommandParameters parameters,
-                            @NonNull final BaseController controller,
+                            @NonNull final IControllerFactory controllerFactory,
                             @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
                             @NonNull final String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public RopcTokenCommand(@NonNull final RopcTokenCommandParameters parameters,
-                            @NonNull final List<BaseController> controllers,
-                            @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
-                            @NonNull final String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override
@@ -64,7 +58,7 @@ public class RopcTokenCommand extends TokenCommand {
                     "Executing ROPC token command..."
             );
 
-            return getDefaultController()
+            return getControllerFactory().getDefaultController()
                     .acquireTokenWithPassword(
                             (RopcTokenCommandParameters) getParameters()
                     );

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/TokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/TokenCommand.java
@@ -27,6 +27,7 @@ import lombok.NonNull;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.commands.parameters.TokenCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.controllers.IControllerFactory;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 
@@ -37,18 +38,11 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public abstract class TokenCommand extends BaseCommand<AcquireTokenResult> {
 
-    public TokenCommand(@NonNull TokenCommandParameters parameters,
-                        @NonNull BaseController controller,
-                        @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                        @NonNull String publicApiId) {
-        super(parameters, controller, callback, publicApiId);
-    }
-
-    public TokenCommand(@NonNull TokenCommandParameters parameters,
-                        @NonNull List<BaseController> controllers,
-                        @SuppressWarnings(WarningType.rawtype_warning) @NonNull CommandCallback callback,
-                        @NonNull String publicApiId) {
-        super(parameters, controllers, callback, publicApiId);
+    public TokenCommand(@NonNull final TokenCommandParameters parameters,
+                        @NonNull final IControllerFactory controllerFactory,
+                        @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
+                        @NonNull final String publicApiId) {
+        super(parameters, controllerFactory, callback, publicApiId);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -1166,4 +1166,26 @@ public abstract class BaseController {
             );
         }
     }
+
+    /**
+     * Returns this controller as a controller factory.
+     **/
+    public IControllerFactory asControllerFactory(){
+        final BaseController thisController = this;
+        return new IControllerFactory() {
+            @NonNull
+            @Override
+            public BaseController getDefaultController() {
+                return thisController;
+            }
+
+            @NonNull
+            @Override
+            public List<BaseController> getAllControllers() {
+                final List<BaseController> list = new ArrayList<>();
+                list.add(thisController);
+                return list;
+            }
+        };
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/IControllerFactory.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/IControllerFactory.kt
@@ -1,0 +1,54 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.controllers
+
+interface IControllerFactory {
+
+    /**
+     * Returns the appropriate MSAL Controller depending on Authority, App and Device state
+     *
+     * 1) The client indicates it wants to use broker
+     * 2) If not AAD Authority use local controller
+     * 3) If the the authority is AAD and the Audience is instance of AnyPersonalAccount
+     * Use the local controller
+     * 4) If broker is not installed use local controller
+     * 5) Otherwise return broker controller
+     */
+    fun getDefaultController(): BaseController
+
+    /**
+     * Returns one or more controllers to address a given request.
+     *
+     * The order of the response matters.  The local controller should be returned first in order to
+     * ensure that any local refresh tokens are preferred over the use of the broker
+     *
+     * Only return the broker controller when the following are true:
+     *
+     * 1) The client indicates it wants to use broker
+     * 2) The authority is AAD
+     * 3) The audience is not AnyPersonalAccount
+     * 4) The broker is installed
+     * 5) The broker redirect URI for the client is registered
+     */
+    fun getAllControllers(): List<BaseController>
+}


### PR DESCRIPTION
## Why?
Once the BrokerDiscoveryClientFactory.IS_NEW_DISCOVERY_ENABLED is set to true, 
the getActiveBroker() operation could be long running (due to the first time broker discovery operation).

In order to avoid ANR issue (in MSAL), I'm moving the operation to the background thread.

This is done by making all the commands retrieve MSAL Controllers in its execute() block, which is executed by CommandDispatcher. 

## Changes
- Create IControllerFactory interface, make MSALControllerFactory inherits from it.
- Make all commands take IControllerFactory instead of controller objects.