### PR TITLE
Reduce the amount of setAccountVisibility() call.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Reduce the amount of setAccountVisibility() call. (#2355)
 - [PATCH] Move SHOULD_USE_ACCOUNT_MANAGER_UNTIL_EPOCH_MILLISECONDS_KEY to BaseActiveBrokerCache (#2340)
 - [PATCH] Add cache for ContentProviderStrategy.isSupportedByTargetedBroker() (#2338)
 - [PATCH] isSupportedByTargetedBroker should only be invoked in bg thread (#2339)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
@@ -103,40 +103,33 @@ public class AccountManagerBrokerAccount implements IBrokerAccount {
             accountManager.addAccountExplicitly(account, null, null);
         }
 
-        // On Android O and above, GET_ACCOUNTS permission is being replaced by accountVisibility.
-        // This change is to make the account visible to both Authenticator App and Company Portal.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            accountManager.setAccountVisibility(
-                    account,
-                    AZURE_AUTHENTICATOR_APP_PACKAGE_NAME,
-                    AccountManager.VISIBILITY_VISIBLE
-            );
-            accountManager.setAccountVisibility(
-                    account,
-                    COMPANY_PORTAL_APP_PACKAGE_NAME,
-                    AccountManager.VISIBILITY_VISIBLE
-            );
+        setVisibility(accountManager, account, AZURE_AUTHENTICATOR_APP_PACKAGE_NAME);
+        setVisibility(accountManager, account, COMPANY_PORTAL_APP_PACKAGE_NAME);
 
-            if (BrokerData.getShouldTrustDebugBrokers()){
+        if (BrokerData.getShouldTrustDebugBrokers()){
+            setVisibility(accountManager, account, BrokerData.getDebugMockCp().getPackageName());
+            setVisibility(accountManager, account, BrokerData.getDebugMockAuthApp().getPackageName());
+            setVisibility(accountManager, account, BrokerData.getDebugBrokerHost().getPackageName());
+        }
+
+        return adapt(account);
+    }
+
+    // On Android O and above, GET_ACCOUNTS permission is being replaced by accountVisibility.
+    // This change is to make the account visible to both Authenticator App and Company Portal.
+    private static void setVisibility(@NonNull final AccountManager accountManager,
+                                      @NonNull final Account account,
+                                      @NonNull final String packageName) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (accountManager.getAccountVisibility(account, packageName)
+                    != AccountManager.VISIBILITY_VISIBLE) {
                 accountManager.setAccountVisibility(
                         account,
-                        BrokerData.getDebugMockCp().getPackageName(),
-                        AccountManager.VISIBILITY_VISIBLE
-                );
-                accountManager.setAccountVisibility(
-                        account,
-                        BrokerData.getDebugMockAuthApp().getPackageName(),
-                        AccountManager.VISIBILITY_VISIBLE
-                );
-                accountManager.setAccountVisibility(
-                        account,
-                        BrokerData.getDebugBrokerHost().getPackageName(),
+                        packageName,
                         AccountManager.VISIBILITY_VISIBLE
                 );
             }
         }
-
-        return adapt(account);
     }
 
     @Nullable

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AccountManagerBrokerAccount.java
@@ -120,15 +120,13 @@ public class AccountManagerBrokerAccount implements IBrokerAccount {
     private static void setVisibility(@NonNull final AccountManager accountManager,
                                       @NonNull final Account account,
                                       @NonNull final String packageName) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (accountManager.getAccountVisibility(account, packageName)
-                    != AccountManager.VISIBILITY_VISIBLE) {
-                accountManager.setAccountVisibility(
-                        account,
-                        packageName,
-                        AccountManager.VISIBILITY_VISIBLE
-                );
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                accountManager.getAccountVisibility(account, packageName) != AccountManager.VISIBILITY_VISIBLE) {
+            accountManager.setAccountVisibility(
+                    account,
+                    packageName,
+                    AccountManager.VISIBILITY_VISIBLE
+            );
         }
     }
 


### PR DESCRIPTION
We've got a report from Samsung that the event emitted by this API leads to a battery drain (There's another app which listens to it, and trigger heavy background task)

While we don't know why this just happened starting Feb 2024 (this logic was added in 2019), we should probably do this anyway.

EDIT: Confirmed as a known issue by android OS - setAccountVisibility() will always broadcast even if the value hasn't changed.
(They were aware of it since mid last year. Was told they can pick up the fix , but it will take 6-12 month for the fix to propagate).