### PR TITLE
Fixing generateSHR command controller logic

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.commands.parameters.GenerateShrCommandParameters;
 import com.microsoft.identity.common.java.controllers.BaseController;
+import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.result.GenerateShrResult;
 
 import java.util.List;
@@ -106,6 +107,15 @@ public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
                 } else {
                     throw new ClientException(errorCode, errorMessage);
                 }
+            } else {
+                Logger.verbose(
+                        methodTag,
+                        "Executing with controller: "
+                                + controller.getClass().getSimpleName()
+                                + ": Succeeded"
+                );
+
+                return result;
             }
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/commands/GenerateShrCommand.java
@@ -75,9 +75,8 @@ public class GenerateShrCommand extends BaseCommand<GenerateShrResult> {
         final GenerateShrCommandParameters parameters = (GenerateShrCommandParameters) getParameters();
 
         // Iterate over our controllers, to service the request either locally or via the broker...
-        // if the local (embedded) cache contains tokens for the supplied user, we will sign using
-        // the embedded PoP keys. If no local user-state exists, the broker will be delegated to
-        // where the same check is performed.
+        // If the broker cache contains tokens for the supplied user, we will sign using
+        // broker PoP keys. If not, check if local user-state exists.
         BaseController controller;
         for (int ii = 0; ii < getControllers().size(); ii++) {
             controller = getControllers().get(ii);


### PR DESCRIPTION
Issue : AT PoP generate SHR tests are failing in the daily pipeline

Cause : In this PR, we changed the order of the controller - https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2040. We are first adding BrokerMsalController if broker is installed. After this change, GenerateSHRCommand was first trying to generateSHR with BrokerMsalController and it would succeed. But the result is not returned. It would then try with LocalMsalController and fails because the account is added to broker. This is an existing bug which got surfaced with recent changes.

Fix : Return from GenerateSHRCommand with the result if a controller returns a successful response.