### PR TITLE
Add parameter to show if request is ATv2

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -193,6 +193,12 @@ stages:
         clean: true
         submodules: recursive
         persistCredentials: True
+      - task: AzureKeyVault@2
+        displayName: 'Get Key vault LabVaultAppSecret'
+        inputs:
+          azureSubscription: 'AuthSdkResourceManager'
+          KeyVaultName: 'MSIDLABS'
+          SecretsFilter: 'LabVaultAppSecret'
       - task: CmdLine@1
         displayName: Set MVN Access Token in Environment
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -227,7 +227,7 @@ stages:
             eval $(dbus-launch --sh-syntax)
             sudo apt install gnome-keyring
             /usr/bin/gnome-keyring-daemon --start --components=secrets
-            ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
+            ./gradlew LinuxBroker:linuxBrokerUnitTestCoverageReport -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PlabSecret=$(LabVaultAppSecret) -PcodeCoverageEnabled=true -Psystemd_mode_enabled=false
       - task: PublishTestResults@2
         condition: succeededOrFailed()
         inputs:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Add field in BrokerInteractiveTokenCommandParameters for ATv2. (#2363)
 - [PATCH] Return status code in errorResponse when server response is not in expected Json format. (#2321)
 - [PATCH] Reduce the amount of setAccountVisibility() call. (#2355)
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -77,7 +77,7 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     @Expose
     private final String homeTenantId;
 
-    // Parameter representing if this broker request is an ATv2 (Account Transfer) request
+    // Parameter representing if this broker request is an ATv2 request
     private final boolean isATv2Request;
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/BrokerInteractiveTokenCommandParameters.java
@@ -77,6 +77,9 @@ public class BrokerInteractiveTokenCommandParameters extends InteractiveTokenCom
     @Expose
     private final String homeTenantId;
 
+    // Parameter representing if this broker request is an ATv2 (Account Transfer) request
+    private final boolean isATv2Request;
+
     @Override
     public void validate() throws ArgumentException {
         super.validate();

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -188,7 +188,7 @@ public class ClientException extends BaseException {
     public static final String DUPLICATE_QUERY_PARAMETER = "duplicate_query_parameter";
 
     /**
-     * An Account Transfer V2 request do not contain an Slk.
+     * An Account Transfer V2 request did not contain an Slk.
      */
     public static final String MISSING_SLK = "missing_slk";
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -188,6 +188,11 @@ public class ClientException extends BaseException {
     public static final String DUPLICATE_QUERY_PARAMETER = "duplicate_query_parameter";
 
     /**
+     * An Account Transfer V2 request do not contain an Slk.
+     */
+    public static final String MISSING_SLK = "missing_slk";
+
+    /**
      * Extra query parameters set by the client app is already sent by the sdk.
      */
     public static final String UNKNOWN_ERROR = "unknown_error";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
@@ -457,6 +457,9 @@ public final class ErrorStrings {
                     "Please make sure to use your organizational account. " +
                     "If that doesn’t help, please return the device to your administrator.";
 
+    public static final String MISSING_SLK_ERROR_MESSAGE =
+            "During an Account Transfer V2 request, an slk transfer token was not passed in with the request.";
+
     /**
      * Home tenant of the BRT acccount doesn't match with WPJ account's UPN.
      */


### PR DESCRIPTION
Tiny PR to add a field in BrokerInteractiveTokenCommandParameters to denote ATv2 request.

Also add error string for SLK.

Had to skip cnsumers because of a failing msal test for DCF

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1282759&view=results