### PR TITLE
Added telemetry for cross cloud and MSA passthrough requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ---------
 - [PATCH] Return status code in errorResponse when server response is not in expected Json format. (#2321)
 - [PATCH] Reduce the amount of setAccountVisibility() call. (#2355)
+- [MINOR] Added telemetry for cross cloud and MSA passthrough requests (#2367)
 
 V.17.2.0
 ---------

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -192,6 +192,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
         }
 
         if (cloudOfThisAuthority != null && cloudOfAuthorityToCheck != null) {
+            // Depending upon the caller of this method, home_cloud_name may or may not be a PRT's home cloud.
             SpanExtension.current().setAttribute(AttributeName.home_cloud_name.name(), cloudOfAuthorityToCheck.getPreferredCacheHostName());
             SpanExtension.current().setAttribute(AttributeName.requested_cloud_name.name(), cloudOfThisAuthority.getPreferredCacheHostName());
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -26,6 +26,8 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectorySlice;
@@ -187,6 +189,11 @@ public class AzureActiveDirectoryAuthority extends Authority {
         // Can't verify, return false.
         if (cloudOfThisAuthority == null && cloudOfAuthorityToCheck == null) {
             return false;
+        }
+
+        if (cloudOfThisAuthority != null && cloudOfAuthorityToCheck != null) {
+            SpanExtension.current().setAttribute(AttributeName.home_cloud_name.name(), cloudOfAuthorityToCheck.getPreferredCacheHostName());
+            SpanExtension.current().setAttribute(AttributeName.requested_cloud_name.name(), cloudOfThisAuthority.getPreferredCacheHostName());
         }
 
         return Objects.equals(cloudOfThisAuthority, cloudOfAuthorityToCheck);

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -272,5 +272,15 @@ public enum AttributeName {
     /**
      * Indicates the package name of the app making the request to the broker.
      */
-    calling_package_name;
+    calling_package_name,
+
+    /**
+     * Indicates the requested cloud in the request made to broker.
+     */
+    requested_cloud_name,
+
+    /**
+     * Indicates the prt's home authority.
+     */
+    home_cloud_name;
 }


### PR DESCRIPTION
Capturing telemetry to get the number of cross cloud requests. 
Related broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/2759