### PR TITLE
Return BrokerData from getFromContext if invoked from unit test

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -227,17 +227,20 @@ data class BrokerData(val packageName : String,
          * Returns a [BrokerData] object matching the owner of the [Context].
          **/
         @JvmStatic
-        fun getFromContext(context: Context): BrokerData {
+        fun getFromContext(context: Context): BrokerData? {
             val signingCertificateThumbprint = PackageHelper(context).getSha512SignatureForPackage(context.packageName)
 
-            // If it's in the list of known brokers, return the one in the list since it has a log-friendly "nickName"
+            if (BuildConfig.DEBUG &&
+                context.packageName == debugBrokerHost.packageName &&
+                signingCertificateThumbprint.isNullOrEmpty()) {
+                // If invoked by unit test, signingCertificateThumbprint would be null.
+                return debugBrokerHost
+            }
+
             return allBrokers.firstOrNull {
                 it.packageName == context.packageName &&
                         it.signingCertificateThumbprint == signingCertificateThumbprint
-            } ?: BrokerData(
-                context.packageName,
-                signingCertificateThumbprint
-            )
+            }
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -225,14 +225,17 @@ data class BrokerData(val packageName : String,
 
         /**
          * Returns a [BrokerData] object matching the owner of the [Context].
+         * 
+         * NOTE: This method does NOT perform any validation.
+         * If you want to make sure that the context owner is not a malicious app, use [BrokerValidator]
          **/
         @JvmStatic
         fun getFromContext(context: Context): BrokerData? {
             val signingCertificateThumbprint = PackageHelper(context).getSha512SignatureForPackage(context.packageName)
 
+            // If invoked by unit test, signingCertificateThumbprint would be null.
             if (context.packageName == debugBrokerHost.packageName &&
                 signingCertificateThumbprint.isNullOrEmpty()) {
-                // If invoked by unit test, signingCertificateThumbprint would be null.
                 return debugBrokerHost
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -227,12 +227,17 @@ data class BrokerData(val packageName : String,
          * Returns a [BrokerData] object matching the owner of the [Context].
          **/
         @JvmStatic
-        fun getFromContext(context: Context): BrokerData?{
+        fun getFromContext(context: Context): BrokerData {
             val signingCertificateThumbprint = PackageHelper(context).getSha512SignatureForPackage(context.packageName)
+
+            // If it's in the list of known brokers, return the one in the list since it has a log-friendly "nickName"
             return allBrokers.firstOrNull {
                 it.packageName == context.packageName &&
                         it.signingCertificateThumbprint == signingCertificateThumbprint
-            }
+            } ?: BrokerData(
+                context.packageName,
+                signingCertificateThumbprint
+            )
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -230,8 +230,7 @@ data class BrokerData(val packageName : String,
         fun getFromContext(context: Context): BrokerData? {
             val signingCertificateThumbprint = PackageHelper(context).getSha512SignatureForPackage(context.packageName)
 
-            if (BuildConfig.DEBUG &&
-                context.packageName == debugBrokerHost.packageName &&
+            if (context.packageName == debugBrokerHost.packageName &&
                 signingCertificateThumbprint.isNullOrEmpty()) {
                 // If invoked by unit test, signingCertificateThumbprint would be null.
                 return debugBrokerHost


### PR DESCRIPTION
Either we do this, or we have to shadow every tests that might touch this code path.

I was thinking that it's okay to add the logic here - given that this is to get the data for the calling broker process itself.  No validation is really done here.

(can't add BuildConfig.DEBUG because the test pipeline will always use the RELEASE build)