### PR TITLE
Fix mAuthorizationStrategy is null in LocalMsalController

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [PATCH] Fix mAuthorizationStrategy is null in LocalMsalController (due to #2352) (#2370)
 - [MINOR] Move the getActiveBroker() invocation to background thread (#2352)
 - [PATCH] Return status code in errorResponse when server response is not in expected Json format. (#2321)
 - [PATCH] Reduce the amount of setAccountVisibility() call. (#2355)

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/InteractiveTokenCommand.java
@@ -48,6 +48,8 @@ import lombok.NonNull;
 public class InteractiveTokenCommand extends TokenCommand {
     private static final String TAG = InteractiveTokenCommand.class.getSimpleName();
 
+    private  BaseController mController;
+
     public InteractiveTokenCommand(@NonNull final InteractiveTokenCommandParameters parameters,
                                    @NonNull final IControllerFactory controllerFactory,
                                    @SuppressWarnings(WarningType.rawtype_warning) @NonNull final CommandCallback callback,
@@ -71,11 +73,11 @@ public class InteractiveTokenCommand extends TokenCommand {
                         "Executing interactive token command..."
                 );
 
-                final BaseController controller = getControllerFactory().getDefaultController();
+                mController = getControllerFactory().getDefaultController();
 
-                span.setAttribute(AttributeName.controller_name.name(), controller.getClass().getSimpleName());
+                span.setAttribute(AttributeName.controller_name.name(), mController.getClass().getSimpleName());
 
-                final AcquireTokenResult result = controller.acquireToken((InteractiveTokenCommandParameters) getParameters());
+                final AcquireTokenResult result = mController.acquireToken((InteractiveTokenCommandParameters) getParameters());
 
                 if (result == null) {
                     span.setStatus(StatusCode.ERROR, "empty result");
@@ -105,7 +107,7 @@ public class InteractiveTokenCommand extends TokenCommand {
     public void onFinishAuthorizationSession(int requestCode,
                                              int resultCode,
                                              @NonNull final PropertyBag data) {
-        getControllerFactory().getDefaultController().onFinishAuthorizationSession(requestCode, resultCode, data);
+        mController.onFinishAuthorizationSession(requestCode, resultCode, data);
     }
 
     @Override


### PR DESCRIPTION
onFinishAuthorizationSession depends on an internal state of the controller, which is set as part of acquireToken()

therefore, we should be using the same controller object throughout the flow (not generating the new one from the factory).