### PR TITLE
Clean up native auth common logging

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
@@ -24,8 +24,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.AcquireTokenNoFixedScopesCommandParameters
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.result.AcquireTokenResult
 
 /**
@@ -47,19 +45,8 @@ class AcquireTokenNoFixedScopesCommand(
     }
 
     override fun execute(): AcquireTokenResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.acquireTokenSilent(
             parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.AcquireTokenNoFixedScopesCommandParameters
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.result.AcquireTokenResult
 
 /**
@@ -45,8 +47,19 @@ class AcquireTokenNoFixedScopesCommand(
     }
 
     override fun execute(): AcquireTokenResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.acquireTokenSilent(
             parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/AcquireTokenNoFixedScopesCommand.kt
@@ -59,6 +59,7 @@ class AcquireTokenNoFixedScopesCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordResendCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the self service password reset flow.
@@ -49,8 +51,19 @@ class ResetPasswordResendCodeCommand(
      * It calls the resetPasswordResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordResendCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.resetPasswordResendCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
@@ -63,6 +63,7 @@ class ResetPasswordResendCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordResendCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordResendCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the self service password reset flow.
@@ -51,19 +49,8 @@ class ResetPasswordResendCodeCommand(
      * It calls the resetPasswordResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordResendCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.resetPasswordResendCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordStartCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to trigger user self service password reset start flow.
@@ -49,8 +51,19 @@ class ResetPasswordStartCommand(
      * It calls the resetPasswordStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordStartCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.resetPasswordStart(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordStartCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to trigger user self service password reset start flow.
@@ -51,19 +49,8 @@ class ResetPasswordStartCommand(
      * It calls the resetPasswordStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordStartCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.resetPasswordStart(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordStartCommand.kt
@@ -63,6 +63,7 @@ class ResetPasswordStartCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
@@ -63,6 +63,7 @@ class ResetPasswordSubmitCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordSubmitCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the self service password reset flow.
@@ -49,8 +51,19 @@ class ResetPasswordSubmitCodeCommand(
      * It calls the resetPasswordSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordSubmitCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.resetPasswordSubmitCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordSubmitCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the self service password reset flow.
@@ -51,19 +49,8 @@ class ResetPasswordSubmitCodeCommand(
      * It calls the resetPasswordSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordSubmitCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.resetPasswordSubmitCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitNewPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordSubmitNewPasswordCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's new password to the server in the self service password reset flow
@@ -54,19 +52,8 @@ class ResetPasswordSubmitNewPasswordCommand(
      * It calls the resetPasswordSubmitNewPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordSubmitNewPasswordCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.resetPasswordSubmitNewPassword(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
@@ -66,6 +66,7 @@ class ResetPasswordSubmitNewPasswordCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/ResetPasswordSubmitNewPasswordCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitNewPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordSubmitNewPasswordCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's new password to the server in the self service password reset flow
@@ -52,8 +54,19 @@ class ResetPasswordSubmitNewPasswordCommand(
      * It calls the resetPasswordSubmitNewPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): ResetPasswordSubmitNewPasswordCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.resetPasswordSubmitNewPassword(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInResendCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the sign in flow.
@@ -50,8 +52,19 @@ class SignInResendCodeCommand(
      * It calls the signInResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInResendCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signInResendCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
@@ -64,6 +64,7 @@ class SignInResendCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInResendCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInResendCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the sign in flow.
@@ -52,19 +50,8 @@ class SignInResendCodeCommand(
      * It calls the signInResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInResendCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signInResendCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInStartCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to trigger user sign in start flow.
@@ -49,8 +51,18 @@ class SignInStartCommand(
      * It calls the signInStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInStartCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
         val result = controller.signInStart(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
@@ -62,6 +62,7 @@ class SignInStartCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInStartCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInStartCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to trigger user sign in start flow.
@@ -51,18 +49,8 @@ class SignInStartCommand(
      * It calls the signInStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInStartCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
         val result = controller.signInStart(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInSubmitCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the sign in flow.
@@ -51,19 +49,8 @@ class SignInSubmitCodeCommand(
      * It calls the signInSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInSubmitCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signInSubmitCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInSubmitCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the sign in flow.
@@ -49,8 +51,19 @@ class SignInSubmitCodeCommand(
      * It calls the signInSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInSubmitCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signInSubmitCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitCodeCommand.kt
@@ -63,6 +63,7 @@ class SignInSubmitCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
@@ -63,6 +63,7 @@ class SignInSubmitPasswordCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInSubmitPasswordCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's password to the server in the sign in flow
@@ -49,8 +51,19 @@ class SignInSubmitPasswordCommand(
      * It calls the signInSubmitPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInSubmitPasswordCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signInSubmitPassword(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInSubmitPasswordCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInSubmitPasswordCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's password to the server in the sign in flow
@@ -51,19 +49,8 @@ class SignInSubmitPasswordCommand(
      * It calls the signInSubmitPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInSubmitPasswordCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signInSubmitPassword(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
@@ -63,6 +63,7 @@ class SignInWithContinuationTokenCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInWithContinuationTokenCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to use continuation token generated from sign in/self-service-password-reset flow to get the user authenticated.
@@ -51,19 +49,8 @@ class SignInWithContinuationTokenCommand(
      * It calls the signInWithContinuationToken method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInWithContinuationTokenCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signInWithContinuationToken(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignInWithContinuationTokenCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInWithContinuationTokenCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to use continuation token generated from sign in/self-service-password-reset flow to get the user authenticated.
@@ -49,8 +51,19 @@ class SignInWithContinuationTokenCommand(
      * It calls the signInWithContinuationToken method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignInWithContinuationTokenCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signInWithContinuationToken(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpResendCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the sign up flow. The resend
@@ -53,19 +51,8 @@ class SignUpResendCodeCommand(
      * It calls the signUpResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpResendCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signUpResendCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
@@ -65,6 +65,7 @@ class SignUpResendCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpResendCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpResendCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to resend otp code request in the sign up flow. The resend
@@ -51,8 +53,19 @@ class SignUpResendCodeCommand(
      * It calls the signUpResendCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpResendCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signUpResendCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
@@ -24,8 +24,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpStartCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpStartCommandParameters
 
 /**
@@ -51,19 +49,8 @@ class SignUpStartCommand(
      * It calls the signUpStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpStartCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signUpStart(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
@@ -63,6 +63,7 @@ class SignUpStartCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpStartCommand.kt
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpStartCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpStartCommandParameters
 
 /**
@@ -49,8 +51,19 @@ class SignUpStartCommand(
      * It calls the signUpStart method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpStartCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signUpStart(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
@@ -63,6 +63,7 @@ class SignUpSubmitCodeCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitCodeCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the self service password reset flow.
@@ -51,19 +49,8 @@ class SignUpSubmitCodeCommand(
      * It calls the signUpSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitCodeCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signUpSubmitCode(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitCodeCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitCodeCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's otp code to the server in the self service password reset flow.
@@ -49,8 +51,19 @@ class SignUpSubmitCodeCommand(
      * It calls the signUpSubmitCode method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitCodeCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signUpSubmitCode(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitPasswordCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's password to the server in the self service password reset flow.
@@ -51,19 +49,8 @@ class SignUpSubmitPasswordCommand(
      * It calls the signUpSubmitPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitPasswordCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signUpSubmitPassword(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
@@ -63,6 +63,7 @@ class SignUpSubmitPasswordCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitPasswordCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitPasswordCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's password to the server in the self service password reset flow.
@@ -49,8 +51,19 @@ class SignUpSubmitPasswordCommand(
      * It calls the signUpSubmitPassword method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitPasswordCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signUpSubmitPassword(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
@@ -63,6 +63,7 @@ class SignUpSubmitUserAttributesCommand(
 
         Logger.info(
             TAG,
+            parameters.getCorrelationId(),
             "Returning result: $result"
         )
         return result

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitUserAttributesCommandResult
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's attributes to the server in the sign up flow.
@@ -49,8 +51,19 @@ class SignUpSubmitUserAttributesCommand(
      * It calls the signUpSubmitUserAttributes method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitUserAttributesCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
         val result = controller.signUpSubmitUserAttributes(
             parameters = parameters
+        )
+
+        Logger.info(
+            TAG,
+            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/SignUpSubmitUserAttributesCommand.kt
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.nativeauth.internal.commands
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignUpSubmitUserAttributesCommandResult
-import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.logging.Logger
 
 /**
  * Command class to call controllers to submit the user's attributes to the server in the sign up flow.
@@ -51,19 +49,8 @@ class SignUpSubmitUserAttributesCommand(
      * It calls the signUpSubmitUserAttributes method of the native auth MSAL controller with the given parameters.
      */
     override fun execute(): SignUpSubmitUserAttributesCommandResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            methodName = "${TAG}.execute"
-        )
-
         val result = controller.signUpSubmitUserAttributes(
             parameters = parameters
-        )
-
-        Logger.info(
-            TAG,
-            "Returning result: $result"
         )
         return result
     }

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/BaseNativeAuthController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/BaseNativeAuthController.kt
@@ -33,7 +33,6 @@ import com.microsoft.identity.common.java.commands.parameters.SilentTokenCommand
 import com.microsoft.identity.common.java.controllers.BaseController
 import com.microsoft.identity.common.java.dto.AccountRecord
 import com.microsoft.identity.common.java.exception.ClientException
-import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenResponse
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResponse
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -515,7 +515,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signUpStart",
                 e
             )

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -515,7 +515,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signUpStart",
                 e
             )

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -1507,6 +1507,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpStartUsingPasswordRequest"
+        )
         return oAuth2Strategy.performSignUpStart(
             commandParameters = parameters
         )
@@ -1517,6 +1522,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performSignUpChallengeCall"
+        )
         return oAuth2Strategy.performSignUpChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -1527,12 +1537,22 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitCodeCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitCode"
+        )
         return oAuth2Strategy.performSignUpSubmitCode(commandParameters = parameters)
     }
     private fun performSignUpSubmitPassword(
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitPasswordCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitPassword"
+        )
         return oAuth2Strategy.performSignUpSubmitPassword(commandParameters = parameters)
     }
 
@@ -1541,6 +1561,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitUserAttributesCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitUserAttributes"
+        )
         return oAuth2Strategy.performSignUpSubmitUserAttributes(commandParameters = parameters)
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -126,7 +126,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInStart(parameters: SignInStartCommandParameters): SignInStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signInStart"
         )
 
@@ -142,7 +142,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             {
                 Logger.verbose(
                     TAG,
-                    parameters.getCorrelationId(),
+                    parameters.correlationId,
                     "Parameters has password"
                 )
                 val mergedScopes = addDefaultScopes(parameters.scopes)
@@ -165,7 +165,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             {
                 Logger.verbose(
                     TAG,
-                    parameters.getCorrelationId(),
+                    parameters.correlationId,
                     "Parameters doesn't have password"
                 )
                 return processSignInInitiateApiResult(
@@ -175,7 +175,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signInStart",
                 e
             )
@@ -190,7 +190,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInWithContinuationToken(parameters: SignInWithContinuationTokenCommandParameters): SignInWithContinuationTokenCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signInWithContinuationToken"
         )
 
@@ -253,7 +253,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInSubmitCode(parameters: SignInSubmitCodeCommandParameters): SignInSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signInSubmitCode"
         )
 
@@ -325,7 +325,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInResendCode(parameters: SignInResendCodeCommandParameters): SignInResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signInResendCode"
         )
 
@@ -394,7 +394,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInSubmitPassword(parameters: SignInSubmitPasswordCommandParameters): SignInSubmitPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signInSubmitPassword"
         )
 
@@ -405,7 +405,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             val parametersWithScopes =
                 CommandUtil.createSignInSubmitPasswordCommandParametersWithScopes(
                     parameters,
-                    parameters.getCorrelationId(),
+                    parameters.correlationId,
                     mergedScopes
                 )
 
@@ -438,7 +438,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpStart(parameters: SignUpStartCommandParameters): SignUpStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signUpStart"
         )
         try {
@@ -529,7 +529,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitCode(parameters: SignUpSubmitCodeCommandParameters): SignUpSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signUpSubmitCode"
         )
 
@@ -544,7 +544,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signUpSubmitCode",
                 e
             )
@@ -558,7 +558,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpResendCode(parameters: SignUpResendCodeCommandParameters): SignUpResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signUpResendCode"
         )
 
@@ -573,7 +573,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signUpResendCode",
                 e
             )
@@ -587,7 +587,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitUserAttributes(parameters: SignUpSubmitUserAttributesCommandParameters): SignUpSubmitUserAttributesCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signUpSubmitUserAttributes"
         )
 
@@ -602,7 +602,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signUpSubmitUserAttributes",
                 e
             )
@@ -616,7 +616,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitPassword(parameters: SignUpSubmitPasswordCommandParameters): SignUpSubmitPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.signUpSubmitPassword"
         )
 
@@ -630,7 +630,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in signUpSubmitPassword",
                 e
             )
@@ -656,7 +656,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): AcquireTokenResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.acquireTokenSilent"
         )
 
@@ -670,7 +670,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         val silentTokenCommandParameters =
             CommandUtil.convertAcquireTokenNoFixedScopesCommandParameters(
                 parameters,
-                parameters.getCorrelationId()
+                parameters.correlationId
             )
 
         // We want to retrieve all tokens from the cache, regardless of their scopes. Since in the
@@ -713,7 +713,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         ) {
             Logger.info(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "RefreshOn is active. This will extend your token usage in the rare case servers are not available."
             )
         }
@@ -728,7 +728,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             } else {
                 Logger.warn(
                     TAG,
-                    parameters.getCorrelationId(),
+                    parameters.correlationId,
                     "Access token is expired. Removing from cache..."
                 )
 
@@ -775,7 +775,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } else if (fullCacheRecord.accessToken.isExpired) {
             Logger.warn(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Access token is expired. Removing from cache..."
             )
 
@@ -789,7 +789,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } else {
             Logger.verbose(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Returning silent result"
             )
             setAcquireTokenResult(acquireTokenSilentResult, silentTokenCommandParameters, cacheRecords)
@@ -827,7 +827,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordStart(parameters: ResetPasswordStartCommandParameters): ResetPasswordStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.resetPasswordStart"
         )
 
@@ -862,7 +862,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 is ResetPasswordStartApiResult.UnsupportedChallengeType, is ResetPasswordStartApiResult.UnknownError -> {
                     Logger.warn(
                         TAG,
-                        parameters.getCorrelationId(),
+                        parameters.correlationId,
                         "Unexpected result: $resetPasswordStartApiResult"
                     )
                     resetPasswordStartApiResult as ApiErrorResult
@@ -876,7 +876,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in resetPasswordStart",
                 e
             )
@@ -890,7 +890,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordSubmitCode(parameters: ResetPasswordSubmitCodeCommandParameters): ResetPasswordSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.resetPasswordSubmitCode"
         )
 
@@ -938,7 +938,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in resetPasswordSubmitCode",
                 e
             )
@@ -952,7 +952,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordResendCode(parameters: ResetPasswordResendCodeCommandParameters): ResetPasswordResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.resetPasswordResendCode"
         )
 
@@ -999,7 +999,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in resetPasswordResendCode",
                 e
             )
@@ -1014,7 +1014,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordSubmitNewPassword(parameters: ResetPasswordSubmitNewPasswordCommandParameters): ResetPasswordSubmitNewPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.resetPasswordSubmitNewPassword"
         )
 
@@ -1062,7 +1062,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.getCorrelationId(),
+                parameters.correlationId,
                 "Exception thrown in resetPasswordSubmitNewPassword",
                 e
             )
@@ -1192,7 +1192,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performContinuationTokenTokenRequest"
         )
         return oAuth2Strategy.performContinuationTokenTokenRequest(
@@ -1206,7 +1206,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performOOBTokenRequest"
         )
         return oAuth2Strategy.performOOBTokenRequest(
@@ -1221,7 +1221,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performPasswordTokenCall"
         )
         return oAuth2Strategy.performPasswordTokenRequest(
@@ -1235,7 +1235,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInInitiateApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performSignInInitiateCall"
         )
         return oAuth2Strategy.performSignInInitiate(
@@ -1265,7 +1265,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordStartApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performResetPasswordStartCall"
         )
         return oAuth2Strategy.performResetPasswordStart(
@@ -1295,7 +1295,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordContinueApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performResetPasswordContinueCall"
         )
         return oAuth2Strategy.performResetPasswordContinue(
@@ -1309,7 +1309,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordSubmitApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.getCorrelationId(),
+            correlationId = parameters.correlationId,
             methodName = "${TAG}.performResetPasswordSubmitCall"
         )
         return oAuth2Strategy.performResetPasswordSubmit(
@@ -1340,7 +1340,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInCommandResult.Complete {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parametersWithScopes.getCorrelationId(),
+            correlationId = parametersWithScopes.correlationId,
             methodName = "${TAG}.saveAndReturnTokens"
         )
         val records: List<ICacheRecord> = saveTokens(
@@ -1480,7 +1480,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ) {
         Logger.verbose(
             TAG,
-            parameters.getCorrelationId(),
+            parameters.correlationId,
             "Renewing access token..."
         )
 
@@ -1507,6 +1507,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.correlationId,
+            methodName = "${TAG}.performSignUpStartUsingPasswordRequest"
+        )
         return oAuth2Strategy.performSignUpStart(
             commandParameters = parameters
         )
@@ -1517,6 +1522,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performSignUpChallengeCall"
+        )
         return oAuth2Strategy.performSignUpChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -1527,12 +1537,22 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitCodeCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.correlationId,
+            methodName = "${TAG}.performSignUpSubmitCode"
+        )
         return oAuth2Strategy.performSignUpSubmitCode(commandParameters = parameters)
     }
     private fun performSignUpSubmitPassword(
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitPasswordCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.correlationId,
+            methodName = "${TAG}.performSignUpSubmitPassword"
+        )
         return oAuth2Strategy.performSignUpSubmitPassword(commandParameters = parameters)
     }
 
@@ -1541,6 +1561,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitUserAttributesCommandParameters
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.correlationId,
+            methodName = "${TAG}.performSignUpSubmitUserAttributes"
+        )
         return oAuth2Strategy.performSignUpSubmitUserAttributes(commandParameters = parameters)
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -126,7 +126,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInStart(parameters: SignInStartCommandParameters): SignInStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signInStart"
         )
 
@@ -142,7 +142,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             {
                 Logger.verbose(
                     TAG,
-                    parameters.correlationId,
+                    parameters.getCorrelationId(),
                     "Parameters has password"
                 )
                 val mergedScopes = addDefaultScopes(parameters.scopes)
@@ -165,7 +165,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             {
                 Logger.verbose(
                     TAG,
-                    parameters.correlationId,
+                    parameters.getCorrelationId(),
                     "Parameters doesn't have password"
                 )
                 return processSignInInitiateApiResult(
@@ -175,7 +175,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signInStart",
                 e
             )
@@ -190,7 +190,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInWithContinuationToken(parameters: SignInWithContinuationTokenCommandParameters): SignInWithContinuationTokenCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signInWithContinuationToken"
         )
 
@@ -253,7 +253,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInSubmitCode(parameters: SignInSubmitCodeCommandParameters): SignInSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signInSubmitCode"
         )
 
@@ -325,7 +325,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInResendCode(parameters: SignInResendCodeCommandParameters): SignInResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signInResendCode"
         )
 
@@ -394,7 +394,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signInSubmitPassword(parameters: SignInSubmitPasswordCommandParameters): SignInSubmitPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signInSubmitPassword"
         )
 
@@ -405,7 +405,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             val parametersWithScopes =
                 CommandUtil.createSignInSubmitPasswordCommandParametersWithScopes(
                     parameters,
-                    parameters.correlationId,
+                    parameters.getCorrelationId(),
                     mergedScopes
                 )
 
@@ -438,7 +438,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpStart(parameters: SignUpStartCommandParameters): SignUpStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signUpStart"
         )
         try {
@@ -529,7 +529,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitCode(parameters: SignUpSubmitCodeCommandParameters): SignUpSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signUpSubmitCode"
         )
 
@@ -544,7 +544,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signUpSubmitCode",
                 e
             )
@@ -558,7 +558,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpResendCode(parameters: SignUpResendCodeCommandParameters): SignUpResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signUpResendCode"
         )
 
@@ -573,7 +573,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signUpResendCode",
                 e
             )
@@ -587,7 +587,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitUserAttributes(parameters: SignUpSubmitUserAttributesCommandParameters): SignUpSubmitUserAttributesCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signUpSubmitUserAttributes"
         )
 
@@ -602,7 +602,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signUpSubmitUserAttributes",
                 e
             )
@@ -616,7 +616,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun signUpSubmitPassword(parameters: SignUpSubmitPasswordCommandParameters): SignUpSubmitPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.signUpSubmitPassword"
         )
 
@@ -630,7 +630,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in signUpSubmitPassword",
                 e
             )
@@ -656,7 +656,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): AcquireTokenResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.acquireTokenSilent"
         )
 
@@ -670,7 +670,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         val silentTokenCommandParameters =
             CommandUtil.convertAcquireTokenNoFixedScopesCommandParameters(
                 parameters,
-                parameters.correlationId
+                parameters.getCorrelationId()
             )
 
         // We want to retrieve all tokens from the cache, regardless of their scopes. Since in the
@@ -713,7 +713,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         ) {
             Logger.info(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "RefreshOn is active. This will extend your token usage in the rare case servers are not available."
             )
         }
@@ -728,7 +728,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             } else {
                 Logger.warn(
                     TAG,
-                    parameters.correlationId,
+                    parameters.getCorrelationId(),
                     "Access token is expired. Removing from cache..."
                 )
 
@@ -775,7 +775,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } else if (fullCacheRecord.accessToken.isExpired) {
             Logger.warn(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Access token is expired. Removing from cache..."
             )
 
@@ -789,7 +789,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } else {
             Logger.verbose(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Returning silent result"
             )
             setAcquireTokenResult(acquireTokenSilentResult, silentTokenCommandParameters, cacheRecords)
@@ -827,7 +827,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordStart(parameters: ResetPasswordStartCommandParameters): ResetPasswordStartCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.resetPasswordStart"
         )
 
@@ -862,7 +862,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 is ResetPasswordStartApiResult.UnsupportedChallengeType, is ResetPasswordStartApiResult.UnknownError -> {
                     Logger.warn(
                         TAG,
-                        parameters.correlationId,
+                        parameters.getCorrelationId(),
                         "Unexpected result: $resetPasswordStartApiResult"
                     )
                     resetPasswordStartApiResult as ApiErrorResult
@@ -876,7 +876,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in resetPasswordStart",
                 e
             )
@@ -890,7 +890,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordSubmitCode(parameters: ResetPasswordSubmitCodeCommandParameters): ResetPasswordSubmitCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.resetPasswordSubmitCode"
         )
 
@@ -938,7 +938,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in resetPasswordSubmitCode",
                 e
             )
@@ -952,7 +952,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordResendCode(parameters: ResetPasswordResendCodeCommandParameters): ResetPasswordResendCodeCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.resetPasswordResendCode"
         )
 
@@ -999,7 +999,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in resetPasswordResendCode",
                 e
             )
@@ -1014,7 +1014,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     fun resetPasswordSubmitNewPassword(parameters: ResetPasswordSubmitNewPasswordCommandParameters): ResetPasswordSubmitNewPasswordCommandResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.resetPasswordSubmitNewPassword"
         )
 
@@ -1062,7 +1062,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         } catch (e: Exception) {
             Logger.error(
                 TAG,
-                parameters.correlationId,
+                parameters.getCorrelationId(),
                 "Exception thrown in resetPasswordSubmitNewPassword",
                 e
             )
@@ -1192,7 +1192,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performContinuationTokenTokenRequest"
         )
         return oAuth2Strategy.performContinuationTokenTokenRequest(
@@ -1206,7 +1206,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performOOBTokenRequest"
         )
         return oAuth2Strategy.performOOBTokenRequest(
@@ -1221,7 +1221,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInTokenApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performPasswordTokenCall"
         )
         return oAuth2Strategy.performPasswordTokenRequest(
@@ -1235,7 +1235,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInInitiateApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performSignInInitiateCall"
         )
         return oAuth2Strategy.performSignInInitiate(
@@ -1265,7 +1265,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordStartApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performResetPasswordStartCall"
         )
         return oAuth2Strategy.performResetPasswordStart(
@@ -1295,7 +1295,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordContinueApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performResetPasswordContinueCall"
         )
         return oAuth2Strategy.performResetPasswordContinue(
@@ -1309,7 +1309,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): ResetPasswordSubmitApiResult {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parameters.correlationId,
+            correlationId = parameters.getCorrelationId(),
             methodName = "${TAG}.performResetPasswordSubmitCall"
         )
         return oAuth2Strategy.performResetPasswordSubmit(
@@ -1340,7 +1340,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ): SignInCommandResult.Complete {
         LogSession.logMethodCall(
             tag = TAG,
-            correlationId = parametersWithScopes.correlationId,
+            correlationId = parametersWithScopes.getCorrelationId(),
             methodName = "${TAG}.saveAndReturnTokens"
         )
         val records: List<ICacheRecord> = saveTokens(
@@ -1480,7 +1480,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
     ) {
         Logger.verbose(
             TAG,
-            parameters.correlationId,
+            parameters.getCorrelationId(),
             "Renewing access token..."
         )
 
@@ -1507,11 +1507,6 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performSignUpStartUsingPasswordRequest"
-        )
         return oAuth2Strategy.performSignUpStart(
             commandParameters = parameters
         )
@@ -1522,11 +1517,6 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.performSignUpChallengeCall"
-        )
         return oAuth2Strategy.performSignUpChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -1537,22 +1527,12 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitCodeCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performSignUpSubmitCode"
-        )
         return oAuth2Strategy.performSignUpSubmitCode(commandParameters = parameters)
     }
     private fun performSignUpSubmitPassword(
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitPasswordCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performSignUpSubmitPassword"
-        )
         return oAuth2Strategy.performSignUpSubmitPassword(commandParameters = parameters)
     }
 
@@ -1561,11 +1541,6 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parameters: SignUpSubmitUserAttributesCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performSignUpSubmitUserAttributes"
-        )
         return oAuth2Strategy.performSignUpSubmitUserAttributes(commandParameters = parameters)
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/authorities/NativeAuthCIAMAuthority.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/authorities/NativeAuthCIAMAuthority.kt
@@ -104,8 +104,9 @@ class NativeAuthCIAMAuthority (
             correlationId = null,
             "${TAG}.getChallengeTypesWithDefault"
         )
-        Logger.info(TAG, "Challenge Types passed = $challengeTypes")
-        return (challengeTypes ?: emptyList()).plus(listOf(NativeAuthConstants.GrantType.REDIRECT)).distinct().joinToString(" ")
+        val challengeTypesWithDefault = (challengeTypes ?: emptyList()).plus(listOf(NativeAuthConstants.GrantType.REDIRECT)).distinct().joinToString(" ")
+        Logger.info(TAG, "Challenge Types used = $challengeTypesWithDefault")
+        return challengeTypesWithDefault
     }
 
     @Throws(ClientException::class)

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -24,9 +24,7 @@
 package com.microsoft.identity.common.java.nativeauth.providers
 
 import com.microsoft.identity.common.java.nativeauth.BuildValues
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
-import com.microsoft.identity.common.java.nativeauth.authorities.NativeAuthCIAMAuthority
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Configuration
 import com.microsoft.identity.common.java.util.UrlUtil
 import java.net.MalformedURLException
@@ -81,11 +79,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignUpStartEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignUpStartEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGNUP_START_ENDPOINT_SUFFIX
@@ -98,11 +91,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignUpChallengeEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignUpChallengeEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGNUP_CHALLENGE_ENDPOINT_SUFFIX
@@ -115,11 +103,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignUpContinueEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignUpContinueEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGNUP_CONTINUE_ENDPOINT_SUFFIX
@@ -132,11 +115,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the reset password start endpoint
      */
     fun getResetPasswordStartEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getResetPasswordStartEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = RESET_PASSWORD_START_ENDPOINT_SUFFIX
@@ -149,11 +127,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the reset password challenge endpoint
      */
     fun getResetPasswordChallengeEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getResetPasswordChallengeEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = RESET_PASSWORD_CHALLENGE_ENDPOINT_SUFFIX
@@ -166,11 +139,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the reset password continue endpoint
      */
     fun getResetPasswordContinueEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getResetPasswordContinueEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = RESET_PASSWORD_CONTINUE_ENDPOINT_SUFFIX
@@ -183,11 +151,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the reset password submit endpoint
      */
     fun getResetPasswordSubmitEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getResetPasswordSubmitEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = RESET_PASSWORD_SUBMIT_ENDPOINT_SUFFIX
@@ -200,11 +163,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the reset password poll completion endpoint
      */
     fun getResetPasswordPollCompletionEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getResetPasswordPollCompletionEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = RESET_PASSWORD_COMPLETE_ENDPOINT_SUFFIX
@@ -217,11 +175,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignInInitiateEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignInInitiateEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGN_IN_INITIATE_ENDPOINT_SUFFIX
@@ -234,11 +187,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignInChallengeEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignInChallengeEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGN_IN_CHALLENGE_ENDPOINT_SUFFIX
@@ -251,11 +199,6 @@ class NativeAuthOAuth2Configuration(
      * @return URL the endpoint
      */
     fun getSignInTokenEndpoint(): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getSignInTokenEndpoint"
-        )
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGN_IN_TOKEN_ENDPOINT_SUFFIX
@@ -263,11 +206,6 @@ class NativeAuthOAuth2Configuration(
     }
 
     private fun getEndpointUrlFromRootAndTenantAndSuffix(root: URL, endpointSuffix: String): URL {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            "${TAG}.getEndpointUrlFromRootAndTenantAndSuffix"
-        )
         return try {
             if (BuildValues.getDC().isNotEmpty()) {
                 UrlUtil.appendPathAndQueryToURL(root, endpointSuffix, "dc=${BuildValues.getDC()}")

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
@@ -33,7 +33,6 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpS
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy
 import com.microsoft.identity.common.java.nativeauth.providers.interactors.ResetPasswordInteractor
@@ -92,11 +91,6 @@ class NativeAuthOAuth2Strategy(
     fun performSignUpStart(
         commandParameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            "${TAG}.performSignUpStart"
-        )
         return signUpInteractor.performSignUpStart(commandParameters)
     }
 
@@ -108,11 +102,6 @@ class NativeAuthOAuth2Strategy(
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            "${TAG}.performSignUpChallenge"
-        )
         return signUpInteractor.performSignUpChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -126,11 +115,6 @@ class NativeAuthOAuth2Strategy(
     fun performSignUpSubmitCode(
         commandParameters: SignUpSubmitCodeCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            "${TAG}.performSignUpSubmitCode"
-        )
         return signUpInteractor.performSignUpSubmitCode(
             commandParameters = commandParameters
         )
@@ -143,11 +127,6 @@ class NativeAuthOAuth2Strategy(
     fun performSignUpSubmitPassword(
         commandParameters: SignUpSubmitPasswordCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            "${TAG}.performSignUpSubmitPassword"
-        )
         return signUpInteractor.performSignUpSubmitPassword(
             commandParameters = commandParameters
         )
@@ -160,11 +139,6 @@ class NativeAuthOAuth2Strategy(
     fun performSignUpSubmitUserAttributes(
         commandParameters: SignUpSubmitUserAttributesCommandParameters
     ): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            "${TAG}.performSignUpSubmitUserAttributes"
-        )
         return signUpInteractor.performSignUpSubmitUserAttributes(
             commandParameters = commandParameters
         )
@@ -176,11 +150,6 @@ class NativeAuthOAuth2Strategy(
     fun performSignInInitiate(
         parameters: SignInStartCommandParameters
     ): SignInInitiateApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performSignInInitiate"
-        )
         return signInInteractor.performSignInInitiate(parameters)
     }
 
@@ -191,11 +160,6 @@ class NativeAuthOAuth2Strategy(
         continuationToken: String,
         correlationId: String
     ): SignInChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            "${TAG}.performSignInChallenge"
-        )
         return signInInteractor.performSignInChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -209,11 +173,6 @@ class NativeAuthOAuth2Strategy(
     fun performContinuationTokenTokenRequest(
         parameters: SignInWithContinuationTokenCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performContinuationTokenRequest"
-        )
         return signInInteractor.performContinuationTokenTokenRequest(
             parameters = parameters
         )
@@ -225,11 +184,6 @@ class NativeAuthOAuth2Strategy(
     fun performOOBTokenRequest(
         parameters: SignInSubmitCodeCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performOOBTokenRequest"
-        )
         return signInInteractor.performOOBTokenRequest(
             parameters = parameters
         )
@@ -241,11 +195,6 @@ class NativeAuthOAuth2Strategy(
     fun performPasswordTokenRequest(
         parameters: SignInSubmitPasswordCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performPasswordTokenRequest"
-        )
         return signInInteractor.performPasswordTokenRequest(
             parameters = parameters
         )
@@ -259,11 +208,6 @@ class NativeAuthOAuth2Strategy(
     fun performResetPasswordStart(
         parameters: ResetPasswordStartCommandParameters
     ): ResetPasswordStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performResetPasswordStart"
-        )
         return resetPasswordInteractor.performResetPasswordStart(
             parameters = parameters
         )
@@ -278,11 +222,6 @@ class NativeAuthOAuth2Strategy(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            "${TAG}.performResetPasswordChallenge"
-        )
         return resetPasswordInteractor.performResetPasswordChallenge(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -297,11 +236,6 @@ class NativeAuthOAuth2Strategy(
     fun performResetPasswordContinue(
         parameters: ResetPasswordSubmitCodeCommandParameters
     ): ResetPasswordContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performResetPasswordContinue"
-        )
         return resetPasswordInteractor.performResetPasswordContinue(
             parameters = parameters
         )
@@ -315,11 +249,6 @@ class NativeAuthOAuth2Strategy(
     fun performResetPasswordSubmit(
         parameters: ResetPasswordSubmitNewPasswordCommandParameters
     ): ResetPasswordSubmitApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.getCorrelationId(),
-            "${TAG}.performResetPasswordSubmit"
-        )
         return resetPasswordInteractor.performResetPasswordSubmit(
             commandParameters = parameters
         )
@@ -334,11 +263,6 @@ class NativeAuthOAuth2Strategy(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordPollCompletionApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            "${TAG}.performResetPasswordPollCompletion"
-        )
         return resetPasswordInteractor.performResetPasswordPollCompletion(
             continuationToken = continuationToken,
             correlationId = correlationId

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2StrategyFactory.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2StrategyFactory.kt
@@ -23,7 +23,6 @@
 
 package com.microsoft.identity.common.java.nativeauth.providers
 
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
 import com.microsoft.identity.common.java.nativeauth.providers.interactors.ResetPasswordInteractor
 import com.microsoft.identity.common.java.nativeauth.providers.interactors.SignInInteractor

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -35,9 +35,7 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpS
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
 import com.microsoft.identity.common.java.logging.DiagnosticContext
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
-import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.net.HttpConstants
 import com.microsoft.identity.common.java.nativeauth.providers.requests.resetpassword.ResetPasswordChallengeRequest
 import com.microsoft.identity.common.java.nativeauth.providers.requests.resetpassword.ResetPasswordContinueRequest
@@ -80,12 +78,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createSignInInitiateRequest(
         commandParameters: SignInStartCommandParameters
     ): SignInInitiateRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createSignInInitiateRequest"
-        )
-
         return SignInInitiateRequest.create(
             username = commandParameters.username,
             clientId = config.clientId,
@@ -105,12 +97,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
         continuationToken: String,
         correlationId: String
     ): SignInChallengeRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.createSignInChallengeRequest"
-        )
-
         return SignInChallengeRequest.create(
             clientId = config.clientId,
             continuationToken = continuationToken,
@@ -129,12 +115,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createOOBTokenRequest(
         commandParameters: SignInSubmitCodeCommandParameters
     ): SignInTokenRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createOOBTokenRequest"
-        )
-
         return SignInTokenRequest.createOOBTokenRequest(
             oob = commandParameters.code,
             scopes = commandParameters.scopes,
@@ -153,12 +133,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createContinuationTokenTokenRequest(
         commandParameters: SignInWithContinuationTokenCommandParameters
     ): SignInTokenRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createContinuationTokenRequest"
-        )
-
         return SignInTokenRequest.createContinuationTokenRequest(
             continuationToken = commandParameters.continuationToken,
             scopes = commandParameters.scopes,
@@ -177,12 +151,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createPasswordTokenRequest(
         commandParameters: SignInSubmitPasswordCommandParameters
     ): SignInTokenRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createPasswordTokenRequest"
-        )
-
         return SignInTokenRequest.createPasswordTokenRequest(
             password = commandParameters.password,
             scopes = commandParameters.scopes,
@@ -199,12 +167,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createResetPasswordStartRequest(
         commandParameters: ResetPasswordStartCommandParameters
     ): ResetPasswordStartRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createResetPasswordStartRequest"
-        )
-
         return ResetPasswordStartRequest.create(
             clientId = config.clientId,
             username = commandParameters.username,
@@ -220,12 +182,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
         continuationToken: String,
         correlationId: String
     ): ResetPasswordChallengeRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.createResetPasswordChallengeRequest"
-        )
-
         return ResetPasswordChallengeRequest.create(
             clientId = config.clientId,
             continuationToken = continuationToken,
@@ -240,12 +196,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createResetPasswordContinueRequest(
         commandParameters: ResetPasswordSubmitCodeCommandParameters
     ): ResetPasswordContinueRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createResetPasswordContinueRequest"
-        )
-
         return ResetPasswordContinueRequest.create(
             clientId = config.clientId,
             continuationToken = commandParameters.continuationToken,
@@ -260,12 +210,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createSignUpStartRequest(
         commandParameters: SignUpStartCommandParameters
     ): SignUpStartRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createSignUpStartRequest"
-        )
-
         return SignUpStartRequest.create(
             username = commandParameters.username,
             password = commandParameters.password,
@@ -282,12 +226,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createResetPasswordSubmitRequest(
         commandParameters: ResetPasswordSubmitNewPasswordCommandParameters
     ): ResetPasswordSubmitRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createResetPasswordSubmitRequest"
-        )
-
         return ResetPasswordSubmitRequest.create(
             clientId = config.clientId,
             continuationToken = commandParameters.continuationToken,
@@ -303,12 +241,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
         continuationToken: String,
         correlationId: String
     ): ResetPasswordPollCompletionRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.createResetPasswordPollCompletionRequest"
-        )
-
         return ResetPasswordPollCompletionRequest.create(
             clientId = config.clientId,
             continuationToken = continuationToken,
@@ -322,12 +254,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createSignUpSubmitCodeRequest(
         commandParameters: SignUpSubmitCodeCommandParameters
     ): SignUpContinueRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createSignUpSubmitCodeRequest"
-        )
-
         return SignUpContinueRequest.create(
             oob = commandParameters.code,
             clientId = config.clientId,
@@ -341,12 +267,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createSignUpSubmitPasswordRequest(
         commandParameters: SignUpSubmitPasswordCommandParameters
     ): SignUpContinueRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createSignUpSubmitPasswordRequest"
-        )
-
         return SignUpContinueRequest.create(
             password = commandParameters.password,
             clientId = config.clientId,
@@ -360,12 +280,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     internal fun createSignUpSubmitUserAttributesRequest(
         commandParameters: SignUpSubmitUserAttributesCommandParameters
     ): SignUpContinueRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.createSignUpSubmitUserAttributesRequest"
-        )
-
         return SignUpContinueRequest.create(
             attributes = commandParameters.userAttributes,
             clientId = config.clientId,
@@ -382,12 +296,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeRequest {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.createSignUpChallengeRequest"
-        )
-
         return SignUpChallengeRequest.create(
             continuationToken = continuationToken,
             clientId = config.clientId,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -386,16 +386,10 @@ class NativeAuthResponseHandler {
                 MicrosoftStsTokenResponse::class.java
             )
 
-            Logger.info(TAG, String.format("MicrosoftStsTokenResponse authority:%s " +
-                    "cloud_instance_host_name:%s" +
-                    " isMsaAccount:%s tenantId %s" +
-                    " cloudInstanceHostName %s",
-                {apiResponse.authority},
-                {apiResponse.refreshTokenExpiresIn},
-                {apiResponse.isMsaAccount},
-                {apiResponse.tenantId},
-                {apiResponse.cloudInstanceHostName})
-            )
+            Logger.info(TAG, "MicrosoftStsTokenResponse authority:${apiResponse.authority} " +
+                    "cloud_instance_host_name:${apiResponse.refreshTokenExpiresIn}" +
+                    " isMsaAccount:${apiResponse.isMsaAccount} tenantId ${apiResponse.tenantId}" +
+                    " cloudInstanceHostName ${apiResponse.cloudInstanceHostName}")
 
             return SignInTokenApiResult.Success(
                 tokenResponse = apiResponse,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -385,7 +385,18 @@ class NativeAuthResponseHandler {
                 response.body,
                 MicrosoftStsTokenResponse::class.java
             )
-            // TODO add safe logging
+
+            Logger.info(TAG, String.format("MicrosoftStsTokenResponse authority:%s " +
+                    "cloud_instance_host_name:%s" +
+                    " isMsaAccount:%s tenantId %s" +
+                    " cloudInstanceHostName %s",
+                {apiResponse.authority},
+                {apiResponse.refreshTokenExpiresIn},
+                {apiResponse.isMsaAccount},
+                {apiResponse.tenantId},
+                {apiResponse.cloudInstanceHostName})
+            )
+
             return SignInTokenApiResult.Success(
                 tokenResponse = apiResponse,
                 correlationId = correlationId

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -386,10 +386,13 @@ class NativeAuthResponseHandler {
                 MicrosoftStsTokenResponse::class.java
             )
 
-            Logger.info(TAG, "MicrosoftStsTokenResponse authority:${apiResponse.authority} " +
-                    "cloud_instance_host_name:${apiResponse.refreshTokenExpiresIn}" +
-                    " isMsaAccount:${apiResponse.isMsaAccount} tenantId ${apiResponse.tenantId}" +
-                    " cloudInstanceHostName ${apiResponse.cloudInstanceHostName}")
+            Logger.info(TAG, "MicrosoftStsTokenResponse authority:${apiResponse.authority}, " +
+                    "expiresIn:${apiResponse.expiresIn}, " +
+                    "extExpiresIn:${apiResponse.extExpiresIn}, " +
+                    "responseReceivedTime:${apiResponse.responseReceivedTime}, " +
+                    "scope:${apiResponse.scope}, " +
+                    "tokenType:${apiResponse.tokenType}"
+            )
 
             return SignInTokenApiResult.Success(
                 tokenResponse = apiResponse,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.interactors
 
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitNewPasswordCommandParameters
@@ -61,7 +63,16 @@ class ResetPasswordInteractor(
     fun performResetPasswordStart(
         parameters: ResetPasswordStartCommandParameters
     ): ResetPasswordStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performResetPasswordStart(parameters: ResetPasswordStartCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createResetPasswordStartRequest(commandParameters = parameters)
+
+        Logger.info("${TAG}.performResetPasswordStart", "performResetPasswordStart: request = $request")
+
         return performResetPasswordStart(
             requestCorrelationId = parameters.getCorrelationId(),
             request = request
@@ -72,6 +83,12 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordStartRequest
     ): ResetPasswordStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performResetPasswordStart"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -94,10 +111,19 @@ class ResetPasswordInteractor(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performResetPasswordChallenge(continuationToken: String, correlationId: String)"
+        )
+
         val request = nativeAuthRequestProvider.createResetPasswordChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
         )
+
+        Logger.info("${TAG}.performResetPasswordChallenge", "performResetPasswordChallenge: request = $request")
+
         return performResetPasswordChallenge(
             requestCorrelationId = correlationId,
             request = request
@@ -108,6 +134,12 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordChallengeRequest
     ): ResetPasswordChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performResetPasswordChallenge"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -129,9 +161,17 @@ class ResetPasswordInteractor(
     fun performResetPasswordContinue(
         parameters: ResetPasswordSubmitCodeCommandParameters
     ): ResetPasswordContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performResetPasswordContinue(parameters: ResetPasswordSubmitCodeCommandParameters)"
+        )
         val request = nativeAuthRequestProvider.createResetPasswordContinueRequest(
             commandParameters = parameters
         )
+
+        Logger.info("${TAG}.performResetPasswordContinue", "performResetPasswordContinue: request = $request")
+
         return performResetPasswordContinue(
             requestCorrelationId = parameters.getCorrelationId(),
             request = request
@@ -142,6 +182,11 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordContinueRequest
     ): ResetPasswordContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performResetPasswordContinue"
+        )
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -163,9 +208,17 @@ class ResetPasswordInteractor(
     fun performResetPasswordSubmit(
         commandParameters: ResetPasswordSubmitNewPasswordCommandParameters
     ): ResetPasswordSubmitApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = commandParameters.getCorrelationId(),
+            methodName = "${TAG}.performResetPasswordSubmit(commandParameters: ResetPasswordSubmitNewPasswordCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createResetPasswordSubmitRequest(
             commandParameters = commandParameters
         )
+
+        Logger.info("${TAG}.performResetPasswordSubmit", "performResetPasswordSubmit: request = $request")
 
         try {
             return performResetPasswordSubmit(
@@ -182,6 +235,12 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordSubmitRequest
     ): ResetPasswordSubmitApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performResetPasswordSubmit"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -204,10 +263,19 @@ class ResetPasswordInteractor(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordPollCompletionApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performResetPasswordPollCompletion(continuationToken: String, correlationId: String)"
+        )
+
         val request = nativeAuthRequestProvider.createResetPasswordPollCompletionRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
         )
+
+        Logger.info("${TAG}.performResetPasswordPollCompletion", "performResetPasswordPollCompletion: request = $request")
+
         return performResetPasswordPollCompletion(
             requestCorrelationId = correlationId,
             request = request
@@ -218,6 +286,12 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordPollCompletionRequest
     ): ResetPasswordPollCompletionApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performResetPasswordPollCompletion"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
@@ -71,7 +71,11 @@ class ResetPasswordInteractor(
 
         val request = nativeAuthRequestProvider.createResetPasswordStartRequest(commandParameters = parameters)
 
-        Logger.info("${TAG}.performResetPasswordStart", "performResetPasswordStart: request = $request")
+        Logger.verbose(
+            "${TAG}.performResetPasswordStart",
+            parameters.getCorrelationId(),
+            "performResetPasswordStart: request = $request"
+        )
 
         return performResetPasswordStart(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -102,7 +106,16 @@ class ResetPasswordInteractor(
             requestCorrelationId = requestCorrelationId,
             response = httpResponse
         )
-        return apiResponse.toResult()
+        val result = apiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToResetPasswordStartApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -122,7 +135,11 @@ class ResetPasswordInteractor(
             correlationId = correlationId
         )
 
-        Logger.info("${TAG}.performResetPasswordChallenge", "performResetPasswordChallenge: request = $request")
+        Logger.verbose(
+            "${TAG}.performResetPasswordChallenge",
+            correlationId,
+            "performResetPasswordChallenge: request = $request"
+        )
 
         return performResetPasswordChallenge(
             requestCorrelationId = correlationId,
@@ -153,7 +170,16 @@ class ResetPasswordInteractor(
             response = httpResponse,
             requestCorrelationId = requestCorrelationId
         )
-        return apiResponse.toResult()
+        val result = apiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToResetPasswordChallengeApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -170,7 +196,11 @@ class ResetPasswordInteractor(
             commandParameters = parameters
         )
 
-        Logger.info("${TAG}.performResetPasswordContinue", "performResetPasswordContinue: request = $request")
+        Logger.verbose(
+            "${TAG}.performResetPasswordContinue",
+            parameters.getCorrelationId(),
+            "performResetPasswordContinue: request = $request"
+        )
 
         return performResetPasswordContinue(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -200,7 +230,16 @@ class ResetPasswordInteractor(
             requestCorrelationId = requestCorrelationId,
             response = httpResponse
         )
-        return apiResponse.toResult()
+        val result = apiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToResetPasswordContinueApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -218,7 +257,11 @@ class ResetPasswordInteractor(
             commandParameters = commandParameters
         )
 
-        Logger.info("${TAG}.performResetPasswordSubmit", "performResetPasswordSubmit: request = $request")
+        Logger.verbose(
+            "${TAG}.performResetPasswordSubmit",
+            commandParameters.getCorrelationId(),
+            "performResetPasswordSubmit: request = $request"
+        )
 
         try {
             return performResetPasswordSubmit(
@@ -254,7 +297,16 @@ class ResetPasswordInteractor(
             response = httpResponse,
             requestCorrelationId = requestCorrelationId
         )
-        return apiResponse.toResult()
+        val result = apiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToResetPasswordSubmitApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -274,7 +326,11 @@ class ResetPasswordInteractor(
             correlationId = correlationId
         )
 
-        Logger.info("${TAG}.performResetPasswordPollCompletion", "performResetPasswordPollCompletion: request = $request")
+        Logger.verbose(
+            "${TAG}.performResetPasswordPollCompletion",
+            correlationId,
+            "performResetPasswordPollCompletion: request = $request"
+        )
 
         return performResetPasswordPollCompletion(
             requestCorrelationId = correlationId,
@@ -305,7 +361,16 @@ class ResetPasswordInteractor(
             requestCorrelationId = requestCorrelationId,
             response = httpResponse
         )
-        return apiResponse.toResult()
+        val result = apiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToResetPasswordSubmitApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/ResetPasswordInteractor.kt
@@ -25,7 +25,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.interactors
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordSubmitNewPasswordCommandParameters
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
 import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthRequestProvider
 import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthResponseHandler
@@ -62,12 +61,6 @@ class ResetPasswordInteractor(
     fun performResetPasswordStart(
         parameters: ResetPasswordStartCommandParameters
     ): ResetPasswordStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performResetPasswordStart(parameters: ResetPasswordStartCommandParameters)"
-        )
-
         val request = nativeAuthRequestProvider.createResetPasswordStartRequest(commandParameters = parameters)
         return performResetPasswordStart(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -79,12 +72,6 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordStartRequest
     ): ResetPasswordStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performResetPasswordStart"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -107,12 +94,6 @@ class ResetPasswordInteractor(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.performResetPasswordChallenge(continuationToken: String)"
-        )
-
         val request = nativeAuthRequestProvider.createResetPasswordChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -127,12 +108,6 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordChallengeRequest
     ): ResetPasswordChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performResetPasswordChallenge"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -154,12 +129,6 @@ class ResetPasswordInteractor(
     fun performResetPasswordContinue(
         parameters: ResetPasswordSubmitCodeCommandParameters
     ): ResetPasswordContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performResetPasswordContinue(parameters: ResetPasswordSubmitCodeCommandParameters)"
-        )
-
         val request = nativeAuthRequestProvider.createResetPasswordContinueRequest(
             commandParameters = parameters
         )
@@ -173,12 +142,6 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordContinueRequest
     ): ResetPasswordContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performResetPasswordContinue"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -200,12 +163,6 @@ class ResetPasswordInteractor(
     fun performResetPasswordSubmit(
         commandParameters: ResetPasswordSubmitNewPasswordCommandParameters
     ): ResetPasswordSubmitApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.correlationId,
-            methodName = "${TAG}.performResetPasswordSubmit(commandParameters: ResetPasswordSubmitNewPasswordCommandParameters)"
-        )
-
         val request = nativeAuthRequestProvider.createResetPasswordSubmitRequest(
             commandParameters = commandParameters
         )
@@ -225,12 +182,6 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordSubmitRequest
     ): ResetPasswordSubmitApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performResetPasswordSubmit"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -253,12 +204,6 @@ class ResetPasswordInteractor(
         continuationToken: String,
         correlationId: String
     ): ResetPasswordPollCompletionApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.performResetPasswordPollCompletion(continuationToken: String)"
-        )
-
         val request = nativeAuthRequestProvider.createResetPasswordPollCompletionRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -273,12 +218,6 @@ class ResetPasswordInteractor(
         requestCorrelationId: String,
         request: ResetPasswordPollCompletionRequest
     ): ResetPasswordPollCompletionApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performResetPasswordPollCompletion"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
@@ -25,7 +25,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.interactors
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
 import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthRequestProvider
@@ -59,11 +58,6 @@ class SignInInteractor(
     fun performSignInInitiate(
         parameters: SignInStartCommandParameters
     ): SignInInitiateApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performSignInInitiate(parameters: SignInStartCommandParameters)"
-        )
         val request = nativeAuthRequestProvider.createSignInInitiateRequest(
             commandParameters = parameters
         )
@@ -77,11 +71,6 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInInitiateRequest
     ): SignInInitiateApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performSignInInitiate"
-        )
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -104,11 +93,6 @@ class SignInInteractor(
         continuationToken: String,
         correlationId: String
     ): SignInChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.performSignInChallenge(continuationToken: String)"
-        )
         val request = nativeAuthRequestProvider.createSignInChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -123,11 +107,6 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInChallengeRequest
     ): SignInChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performSignInChallenge"
-        )
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -149,11 +128,6 @@ class SignInInteractor(
     fun performOOBTokenRequest(
         parameters: SignInSubmitCodeCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performOOBTokenRequest"
-        )
         val request = nativeAuthRequestProvider.createOOBTokenRequest(
             commandParameters = parameters
         )
@@ -166,11 +140,6 @@ class SignInInteractor(
     fun performContinuationTokenTokenRequest(
         parameters: SignInWithContinuationTokenCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performContinuationTokenTokenRequest"
-        )
         val request = nativeAuthRequestProvider.createContinuationTokenTokenRequest(
             commandParameters = parameters
         )
@@ -183,11 +152,6 @@ class SignInInteractor(
     fun performPasswordTokenRequest(
         parameters: SignInSubmitPasswordCommandParameters
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = parameters.correlationId,
-            methodName = "${TAG}.performPasswordTokenRequest"
-        )
         val request = nativeAuthRequestProvider.createPasswordTokenRequest(
             commandParameters = parameters
         )
@@ -205,11 +169,6 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInTokenRequest
     ): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performGetToken"
-        )
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.interactors
 
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters
@@ -37,6 +39,7 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInTokenApiResult
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.java.util.StringUtil
+import sun.jvm.hotspot.code.CompressedStream.L
 
 /**
  * Acts as a binding layer between the request providers and response handlers for a given request.
@@ -58,9 +61,18 @@ class SignInInteractor(
     fun performSignInInitiate(
         parameters: SignInStartCommandParameters
     ): SignInInitiateApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performSignInInitiate(parameters: SignInStartCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createSignInInitiateRequest(
             commandParameters = parameters
         )
+
+        Logger.info("${TAG}.performSignInInitiate", "performSignInInitiate: request = $request")
+
         return performSignInInitiate(
             requestCorrelationId = parameters.getCorrelationId(),
             request = request
@@ -71,6 +83,12 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInInitiateRequest
     ): SignInInitiateApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performSignInInitiate"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -93,10 +111,19 @@ class SignInInteractor(
         continuationToken: String,
         correlationId: String
     ): SignInChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performSignInChallenge(continuationToken: String, correlationId: String)"
+        )
+
         val request = nativeAuthRequestProvider.createSignInChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
         )
+
+        Logger.info("${TAG}.performSignInChallenge", "performSignInChallenge: request = $request")
+
         return performSignInChallenge(
             requestCorrelationId = correlationId,
             request = request
@@ -107,6 +134,12 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInChallengeRequest
     ): SignInChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performSignInChallenge"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -128,9 +161,18 @@ class SignInInteractor(
     fun performOOBTokenRequest(
         parameters: SignInSubmitCodeCommandParameters
     ): SignInTokenApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performOOBTokenRequest(parameters: SignInSubmitCodeCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createOOBTokenRequest(
             commandParameters = parameters
         )
+
+        Logger.info("${TAG}.performOOBTokenRequest", "performOOBTokenRequest: request = $request")
+
         return performGetToken(
             requestCorrelationId = parameters.getCorrelationId(),
             request = request
@@ -140,9 +182,18 @@ class SignInInteractor(
     fun performContinuationTokenTokenRequest(
         parameters: SignInWithContinuationTokenCommandParameters
     ): SignInTokenApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performContinuationTokenTokenRequest(parameters: SignInWithContinuationTokenCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createContinuationTokenTokenRequest(
             commandParameters = parameters
         )
+
+        Logger.info("${TAG}.performContinuationTokenTokenRequest", "performContinuationTokenTokenRequest: request = $request")
+
         return performGetToken(
             requestCorrelationId = parameters.getCorrelationId(),
             request = request
@@ -152,9 +203,18 @@ class SignInInteractor(
     fun performPasswordTokenRequest(
         parameters: SignInSubmitPasswordCommandParameters
     ): SignInTokenApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.performPasswordTokenRequest(parameters: SignInSubmitPasswordCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createPasswordTokenRequest(
             commandParameters = parameters
         )
+
+        Logger.info("${TAG}.performPasswordTokenRequest", "performPasswordTokenRequest: request = $request")
+
         try {
             return performGetToken(
                 requestCorrelationId = parameters.getCorrelationId(),
@@ -169,6 +229,12 @@ class SignInInteractor(
         requestCorrelationId: String,
         request: SignInTokenRequest
     ): SignInTokenApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performGetToken"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
@@ -39,7 +39,6 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInTokenApiResult
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.java.util.StringUtil
-import sun.jvm.hotspot.code.CompressedStream.L
 
 /**
  * Acts as a binding layer between the request providers and response handlers for a given request.

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignInInteractor.kt
@@ -71,7 +71,11 @@ class SignInInteractor(
             commandParameters = parameters
         )
 
-        Logger.info("${TAG}.performSignInInitiate", "performSignInInitiate: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignInInitiate",
+            parameters.getCorrelationId(),
+            "performSignInInitiate: request = $request"
+        )
 
         return performSignInInitiate(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -102,7 +106,16 @@ class SignInInteractor(
             requestCorrelationId = requestCorrelationId,
             response = response
         )
-        return rawApiResponse.toResult()
+        val result = rawApiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToSignInInitiateApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -122,7 +135,11 @@ class SignInInteractor(
             correlationId = correlationId
         )
 
-        Logger.info("${TAG}.performSignInChallenge", "performSignInChallenge: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignInChallenge",
+            correlationId,
+            "performSignInChallenge: request = $request"
+        )
 
         return performSignInChallenge(
             requestCorrelationId = correlationId,
@@ -149,11 +166,20 @@ class SignInInteractor(
             headers,
             encodedRequest.toByteArray(charset(ObjectMapper.ENCODING_SCHEME))
         )
-        val result = nativeAuthResponseHandler.getSignInChallengeResultFromHttpResponse(
+        val rawApiResponse = nativeAuthResponseHandler.getSignInChallengeResultFromHttpResponse(
             requestCorrelationId = requestCorrelationId,
             response = response
         )
-        return result.toResult()
+        val result = rawApiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToSignInChallengeApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -171,7 +197,11 @@ class SignInInteractor(
             commandParameters = parameters
         )
 
-        Logger.info("${TAG}.performOOBTokenRequest", "performOOBTokenRequest: request = $request")
+        Logger.verbose(
+            "${TAG}.performOOBTokenRequest",
+            parameters.getCorrelationId(),
+            "performOOBTokenRequest: request = $request"
+        )
 
         return performGetToken(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -192,7 +222,11 @@ class SignInInteractor(
             commandParameters = parameters
         )
 
-        Logger.info("${TAG}.performContinuationTokenTokenRequest", "performContinuationTokenTokenRequest: request = $request")
+        Logger.verbose(
+            "${TAG}.performContinuationTokenTokenRequest",
+            parameters.getCorrelationId(),
+            "performContinuationTokenTokenRequest: request = $request"
+        )
 
         return performGetToken(
             requestCorrelationId = parameters.getCorrelationId(),
@@ -213,7 +247,11 @@ class SignInInteractor(
             commandParameters = parameters
         )
 
-        Logger.info("${TAG}.performPasswordTokenRequest", "performPasswordTokenRequest: request = $request")
+        Logger.verbose(
+            "${TAG}.performPasswordTokenRequest",
+            parameters.getCorrelationId(),
+            "performPasswordTokenRequest: request = $request"
+        )
 
         try {
             return performGetToken(

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
@@ -25,7 +25,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.interactors
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
 import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthRequestProvider
 import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthResponseHandler
@@ -60,18 +59,12 @@ class SignUpInteractor(
     fun performSignUpStart(
         commandParameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = commandParameters.getCorrelationId(),
-            methodName = "${TAG}.performSignUpStart"
-        )
-
         val request = nativeAuthRequestProvider.createSignUpStartRequest(
             commandParameters = commandParameters
         )
         try {
             return performSignUpStart(
-                requestCorrelationId = commandParameters.getCorrelationId(),
+                requestCorrelationId = commandParameters.correlationId,
                 request = request
             )
         } finally {
@@ -83,12 +76,6 @@ class SignUpInteractor(
         requestCorrelationId: String,
         request: SignUpStartRequest
     ): SignUpStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performSignUpStart"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -111,12 +98,6 @@ class SignUpInteractor(
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = correlationId,
-            methodName = "${TAG}.performSignUpChallenge"
-        )
-
         val request = nativeAuthRequestProvider.createSignUpChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
@@ -131,12 +112,6 @@ class SignUpInteractor(
         requestCorrelationId: String,
         request: SignUpChallengeRequest
     ): SignUpChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.performSignUpChallenge"
-        )
-
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.interactors
 
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpStartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
@@ -36,7 +38,7 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpStartApiResult
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.java.util.StringUtil
-import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters as SignUpSubmitPasswordCommandParameters1
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 
 /**
  * Acts as a binding layer between the request providers and response handlers for a given request.
@@ -59,12 +61,21 @@ class SignUpInteractor(
     fun performSignUpStart(
         commandParameters: SignUpStartCommandParameters
     ): SignUpStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = commandParameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpStart(commandParameters: SignUpStartCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createSignUpStartRequest(
             commandParameters = commandParameters
         )
+
+        Logger.info("${TAG}.performSignUpStart", "performSignUpStart: request = $request")
+
         try {
             return performSignUpStart(
-                requestCorrelationId = commandParameters.correlationId,
+                requestCorrelationId = commandParameters.getCorrelationId(),
                 request = request
             )
         } finally {
@@ -76,6 +87,12 @@ class SignUpInteractor(
         requestCorrelationId: String,
         request: SignUpStartRequest
     ): SignUpStartApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performSignUpStart"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -98,10 +115,19 @@ class SignUpInteractor(
         continuationToken: String,
         correlationId: String
     ): SignUpChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.performSignUpChallenge(continuationToken: String, correlationId: String)"
+        )
+
         val request = nativeAuthRequestProvider.createSignUpChallengeRequest(
             continuationToken = continuationToken,
             correlationId = correlationId
         )
+
+        Logger.info("${TAG}.performSignUpChallenge", "performSignUpChallenge: request = $request")
+
         return performSignUpChallenge(
             requestCorrelationId = correlationId,
             request = request
@@ -112,6 +138,12 @@ class SignUpInteractor(
         requestCorrelationId: String,
         request: SignUpChallengeRequest
     ): SignUpChallengeApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performSignUpChallenge"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl
@@ -131,9 +163,17 @@ class SignUpInteractor(
 
     //region /signup/continue
     fun performSignUpSubmitCode(commandParameters: SignUpSubmitCodeCommandParameters): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = commandParameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitCode(commandParameters: SignUpSubmitCodeCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createSignUpSubmitCodeRequest(
             commandParameters = commandParameters
         )
+
+        Logger.info("${TAG}.performSignUpSubmitCode", "performSignUpSubmitCode: request = $request")
 
         return performSignUpContinue(
             requestCorrelationId = commandParameters.getCorrelationId(),
@@ -141,10 +181,18 @@ class SignUpInteractor(
         )
     }
 
-    fun performSignUpSubmitPassword(commandParameters: SignUpSubmitPasswordCommandParameters1): SignUpContinueApiResult {
+    fun performSignUpSubmitPassword(commandParameters: SignUpSubmitPasswordCommandParameters): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = commandParameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitPassword(commandParameters: SignUpSubmitPasswordCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createSignUpSubmitPasswordRequest(
             commandParameters = commandParameters
         )
+
+        Logger.info("${TAG}.performSignUpSubmitPassword", "performSignUpSubmitPassword: request = $request")
 
         try {
             return performSignUpContinue(
@@ -157,9 +205,17 @@ class SignUpInteractor(
     }
 
     fun performSignUpSubmitUserAttributes(commandParameters: SignUpSubmitUserAttributesCommandParameters): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = commandParameters.getCorrelationId(),
+            methodName = "${TAG}.performSignUpSubmitUserAttributes(commandParameters: SignUpSubmitUserAttributesCommandParameters)"
+        )
+
         val request = nativeAuthRequestProvider.createSignUpSubmitUserAttributesRequest(
             commandParameters = commandParameters
         )
+
+        Logger.info("${TAG}.performSignUpSubmitUserAttributes", "performSignUpSubmitUserAttributes: request = $request")
 
         return performSignUpContinue(
             requestCorrelationId = commandParameters.getCorrelationId(),
@@ -171,6 +227,12 @@ class SignUpInteractor(
         requestCorrelationId: String,
         request: SignUpContinueRequest
     ): SignUpContinueApiResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = requestCorrelationId,
+            methodName = "${TAG}.performSignUpContinue"
+        )
+
         val encodedRequest: String = ObjectMapper.serializeObjectToFormUrlEncoded(request.parameters)
         val headers = request.headers
         val requestUrl = request.requestUrl

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/interactors/SignUpInteractor.kt
@@ -71,7 +71,11 @@ class SignUpInteractor(
             commandParameters = commandParameters
         )
 
-        Logger.info("${TAG}.performSignUpStart", "performSignUpStart: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignUpStart",
+            commandParameters.getCorrelationId(),
+            "performSignUpStart: request = $request"
+        )
 
         try {
             return performSignUpStart(
@@ -106,7 +110,16 @@ class SignUpInteractor(
             response = response,
             requestCorrelationId = requestCorrelationId
         )
-        return rawApiResponse.toResult()
+        val result = rawApiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToSignUpStartApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -126,7 +139,11 @@ class SignUpInteractor(
             correlationId = correlationId
         )
 
-        Logger.info("${TAG}.performSignUpChallenge", "performSignUpChallenge: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignUpChallenge",
+            correlationId,
+            "performSignUpChallenge: request = $request"
+        )
 
         return performSignUpChallenge(
             requestCorrelationId = correlationId,
@@ -157,7 +174,16 @@ class SignUpInteractor(
             response = response,
             requestCorrelationId = requestCorrelationId
         )
-        return rawApiResponse.toResult()
+        val result = rawApiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToSignUpChallengeApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 
@@ -173,7 +199,11 @@ class SignUpInteractor(
             commandParameters = commandParameters
         )
 
-        Logger.info("${TAG}.performSignUpSubmitCode", "performSignUpSubmitCode: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignUpSubmitCode",
+            commandParameters.getCorrelationId(),
+            "performSignUpSubmitCode: request = $request"
+        )
 
         return performSignUpContinue(
             requestCorrelationId = commandParameters.getCorrelationId(),
@@ -192,7 +222,11 @@ class SignUpInteractor(
             commandParameters = commandParameters
         )
 
-        Logger.info("${TAG}.performSignUpSubmitPassword", "performSignUpSubmitPassword: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignUpSubmitPassword",
+            commandParameters.getCorrelationId(),
+            "performSignUpSubmitPassword: request = $request"
+        )
 
         try {
             return performSignUpContinue(
@@ -215,7 +249,11 @@ class SignUpInteractor(
             commandParameters = commandParameters
         )
 
-        Logger.info("${TAG}.performSignUpSubmitUserAttributes", "performSignUpSubmitUserAttributes: request = $request")
+        Logger.verbose(
+            "${TAG}.performSignUpSubmitUserAttributes",
+            commandParameters.getCorrelationId(),
+            "performSignUpSubmitUserAttributes: request = $request"
+        )
 
         return performSignUpContinue(
             requestCorrelationId = commandParameters.getCorrelationId(),
@@ -246,7 +284,16 @@ class SignUpInteractor(
             response = response,
             requestCorrelationId = requestCorrelationId
         )
-        return rawApiResponse.toResult()
+        val result = rawApiResponse.toResult()
+
+        Logger.verbose(
+            "${TAG}.rawResponseToSignUpContinueApiResult",
+            requestCorrelationId,
+            "rawApiResponse = $result " +
+                    "result = $result"
+        )
+
+        return result
     }
     //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordChallengeApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.resetp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.isExpiredToken
 import com.microsoft.identity.common.java.nativeauth.util.isOOB

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordChallengeApiResponse.kt
@@ -60,12 +60,6 @@ class ResetPasswordChallengeApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordChallengeApiResult
      */
     fun toResult(): ResetPasswordChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordContinueApiResponse.kt
@@ -57,11 +57,6 @@ class ResetPasswordContinueApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordContinueApiResult
      */
     fun toResult(): ResetPasswordContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult" )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordContinueApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.resetp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.isExpiredToken
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordPollCompletionApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordPollCompletionApiResponse.kt
@@ -64,12 +64,6 @@ class ResetPasswordPollCompletionApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordPollCompletionApiResult
      */
     fun toResult(): ResetPasswordPollCompletionApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordPollCompletionApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordPollCompletionApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.resetp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.isExpiredToken
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordStartApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordStartApiResponse.kt
@@ -54,12 +54,6 @@ class ResetPasswordStartApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordStartApiResult
      */
     fun toResult(): ResetPasswordStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordStartApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordStartApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.resetp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
 import com.microsoft.identity.common.java.nativeauth.util.isUnsupportedChallengeType

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordSubmitApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordSubmitApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.resetp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.*
 import java.net.HttpURLConnection

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordSubmitApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/resetpassword/ResetPasswordSubmitApiResponse.kt
@@ -57,12 +57,6 @@ class ResetPasswordSubmitApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordSubmitApiResult
      */
     fun toResult(): ResetPasswordSubmitApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signin
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isOOB

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
@@ -62,12 +62,6 @@ class SignInChallengeApiResponse(
     * @see com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInChallengeApiResult
     */
     fun toResult(): SignInChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInInitiateApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInInitiateApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signin
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInInitiateApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInInitiateApiResponse.kt
@@ -55,12 +55,6 @@ class SignInInitiateApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInInitiateApiResult
      */
     fun toResult(): SignInInitiateApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -60,12 +60,6 @@ class SignInTokenApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInTokenApiResult
      */
     fun toErrorResult(): SignInTokenApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         if (error.isInvalidRequest()) {
             return when {
                 errorCodes.isNullOrEmpty() -> {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signin
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidAuthenticationType
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidCredentials

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpChallengeApiResponse.kt
@@ -61,12 +61,6 @@ class SignUpChallengeApiResponse(
      * @see com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpChallengeApiResult
      */
     fun toResult(): SignUpChallengeApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpChallengeApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signup
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isExpiredToken

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpContinueApiResponse.kt
@@ -68,12 +68,6 @@ class SignUpContinueApiResponse(
     }
 
     fun toResult(): SignUpContinueApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpContinueApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signup
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.UserAttributeApiResult

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpStartApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpStartApiResponse.kt
@@ -65,12 +65,6 @@ class SignUpStartApiResponse(
     }
 
     fun toResult(): SignUpStartApiResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.toResult"
-        )
-
         return when (statusCode) {
 
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpStartApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signup/SignUpStartApiResponse.kt
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.signup
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isAttributeValidationFailed


### PR DESCRIPTION
### Goal:
- Review our log statements and reduce to only those that are relevant and useful. Especially the logMethodCall should be much reduced. Not every method call is relevant to know about when debugging.
- Double check that the existing logs use string interpolation correctly to avoid leaking sensitive information in the logs.

### Changes summary:
- Every log item has correlation argument. (make sure use getCorrelationId() )
- The [NativeAuthMsalController.kt](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2374/files#diff-304daa7418210ef9cd11ee385364a4a6f74256dc627f404e53422ec50f75b282) layer acts as the main log layer. Instead, remove logSessions under OAuth2Configuration, OAuth2Strategy, RequestProvider since the users care more about the outcome of the request than the construction and sending of the request. Apply the rule "only logger unknown error" to NativeAuthMsalController.
- [Log challengeTypesWithDefault rather than passed challengeTypes](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2374/commits/be777c5813c6c15518b358a718b863562d92f5b3)
- Complete // TODO add safe logging using string interpolation with curly brackets and check the rest according to MSAL practice under MicrosoftStsTokenResponse.
- Add request and result Logger.verbose in interactors.

### TODO

- Test PII
- infoWithObject(final String tag, final String correlationID, final String message, final ILoggable object) like warnWithObject
- every log has correlationID


### Company PR:
https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2071

