### PR TITLE
Return exception from first controller in SilentTokenCommand in case all controllers throw exceptions.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.17.3.0
 ---------
+- [PATCH] Return exception from first controller in SilentTokenCommand in case all controllers throw exceptions. (#2377)
 - [PATCH] Fix mAuthorizationStrategy is null in LocalMsalController (due to #2352) (#2370)
 - [MINOR] Move the getActiveBroker() invocation to background thread (#2352)
 - [PATCH] Return status code in errorResponse when server response is not in expected Json format. (#2321)

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -105,26 +105,28 @@ public class SilentTokenCommand extends TokenCommand {
                         span.setStatus(StatusCode.OK);
                         return result;
                     }
-                } catch (UiRequiredException | ClientException e) {
-                    if (e.getErrorCode().equals(OAuth2ErrorCode.INVALID_GRANT) // was invalid_grant
-                            && controllers.size() > ii + 1) { // isn't the last controller we can try
-                        exceptionFromFirstController = exceptionFromFirstController == null ? e : exceptionFromFirstController;
-                        continue;
-                    } else if ((e.getErrorCode().equals(ErrorStrings.NO_TOKENS_FOUND)
-                            || e.getErrorCode().equals(ErrorStrings.NO_ACCOUNT_FOUND))
-                            && controllers.size() > ii + 1) {
-                        exceptionFromFirstController = exceptionFromFirstController == null ? e : exceptionFromFirstController;
-                        //if no token or account for this silent call, we should continue to the next silent call.
-                        continue;
+                } catch (final UiRequiredException | ClientException e) {
+                    // if this isn't the last controller and
+                    // error code was invalid_grant or if no token or account for this silent call
+                    // continue with next controller.
+                    if (controllers.size() > ii + 1
+                            && (e.getErrorCode().equals(OAuth2ErrorCode.INVALID_GRANT)
+                            || e.getErrorCode().equals(ErrorStrings.NO_TOKENS_FOUND)
+                            || e.getErrorCode().equals(ErrorStrings.NO_ACCOUNT_FOUND))) {
+                        if (ii == 0) {
+                            exceptionFromFirstController = e;
+                        }
                     } else {
                         if (exceptionFromFirstController != null) {
+                            // throw exception from the first controller
                             throw exceptionFromFirstController;
                         } else {
                             throw e;
                         }
                     }
-                } catch (final Exception e) {
+                } catch (final Throwable e) {
                     if (exceptionFromFirstController != null) {
+                        // throw exception from the first controller
                         throw exceptionFromFirstController;
                     } else {
                         throw e;

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -123,6 +123,12 @@ public class SilentTokenCommand extends TokenCommand {
                             throw e;
                         }
                     }
+                } catch (final Exception e) {
+                    if (exceptionFromFirstController != null) {
+                        throw exceptionFromFirstController;
+                    } else {
+                        throw e;
+                    }
                 }
             }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -106,27 +106,19 @@ public class SilentTokenCommand extends TokenCommand {
                         return result;
                     }
                 } catch (final UiRequiredException | ClientException e) {
+                    if (ii == 0 ) {
+                        exceptionFromFirstController = e;
+                    }
                     // if this isn't the last controller and
                     // error code was invalid_grant or if no token or account for this silent call
                     // continue with next controller.
-                    if (controllers.size() > ii + 1
-                            && (e.getErrorCode().equals(OAuth2ErrorCode.INVALID_GRANT)
-                            || e.getErrorCode().equals(ErrorStrings.NO_TOKENS_FOUND)
-                            || e.getErrorCode().equals(ErrorStrings.NO_ACCOUNT_FOUND))) {
-                        if (ii == 0) {
-                            exceptionFromFirstController = e;
-                        }
-                    } else {
-                        if (exceptionFromFirstController != null) {
-                            // throw exception from the first controller
-                            throw exceptionFromFirstController;
-                        } else {
-                            throw e;
-                        }
+                    if (ii >= controllers.size() || !(OAuth2ErrorCode.INVALID_GRANT.equals(e.getErrorCode())
+                            || ErrorStrings.NO_TOKENS_FOUND.equals(e.getErrorCode())
+                            || ErrorStrings.NO_ACCOUNT_FOUND.equals(e.getErrorCode()))) {
+                        throw exceptionFromFirstController;
                     }
                 } catch (final Throwable e) {
                     if (exceptionFromFirstController != null) {
-                        // throw exception from the first controller
                         throw exceptionFromFirstController;
                     } else {
                         throw e;

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/SilentTokenCommand.java
@@ -34,9 +34,7 @@ import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
-import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
-import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 
 import java.util.List;
@@ -74,6 +72,7 @@ public class SilentTokenCommand extends TokenCommand {
         final List<BaseController> controllers = getControllerFactory().getAllControllers();
 
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            Exception exceptionFromFirstController = null;
             for (int ii = 0; ii < controllers.size(); ii++) {
                 final BaseController controller = controllers.get(ii);
 
@@ -109,14 +108,20 @@ public class SilentTokenCommand extends TokenCommand {
                 } catch (UiRequiredException | ClientException e) {
                     if (e.getErrorCode().equals(OAuth2ErrorCode.INVALID_GRANT) // was invalid_grant
                             && controllers.size() > ii + 1) { // isn't the last controller we can try
+                        exceptionFromFirstController = exceptionFromFirstController == null ? e : exceptionFromFirstController;
                         continue;
                     } else if ((e.getErrorCode().equals(ErrorStrings.NO_TOKENS_FOUND)
                             || e.getErrorCode().equals(ErrorStrings.NO_ACCOUNT_FOUND))
                             && controllers.size() > ii + 1) {
+                        exceptionFromFirstController = exceptionFromFirstController == null ? e : exceptionFromFirstController;
                         //if no token or account for this silent call, we should continue to the next silent call.
                         continue;
                     } else {
-                        throw e;
+                        if (exceptionFromFirstController != null) {
+                            throw exceptionFromFirstController;
+                        } else {
+                            throw e;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Returning exception from first controller in SilentTokenCommand in case all controllers throw exceptions.
This is to ensure that for cases where both Broker and Msal Local controller fail, we return the error from Broker Controller (which is the first controller), so that client tries to handle/recover from the error on broker side.

