### PR TITLE
Username checking in native auth requests

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
@@ -53,6 +53,7 @@ data class ResetPasswordStartRequest private constructor(
             headers: Map<String, String?>
         ): ResetPasswordStartRequest {
             // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(username, "username")
             ArgUtils.validateNonNullArg(clientId, "clientId")
             ArgUtils.validateNonNullArg(challengeType, "challengeType")
             ArgUtils.validateNonNullArg(requestUrl, "requestUrl")

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
@@ -53,6 +53,7 @@ data class SignInInitiateRequest private constructor(
             headers: Map<String, String?>
         ): SignInInitiateRequest {
             // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(username, "username")
             ArgUtils.validateNonNullArg(clientId, "clientId")
             ArgUtils.validateNonNullArg(challengeType, "challengeType")
             ArgUtils.validateNonNullArg(requestUrl, "requestUrl")

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
@@ -57,6 +57,7 @@ data class SignUpStartRequest private constructor(
             headers: Map<String, String?>
         ): SignUpStartRequest {
             // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(username, "username")
             ArgUtils.validateNonNullArg(clientId, "clientId")
             ArgUtils.validateNonNullArg(challengeType, "challengeType")
             ArgUtils.validateNonNullArg(requestUrl, "requestUrl")

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
@@ -96,8 +96,8 @@ class NativeAuthRequestHandlerTest {
         )
 
     // signup start tests
-    @Test
-    fun testSignUpStartWithEmptyUsernameShouldNotThrowException() {
+    @Test(expected = ClientException::class)
+    fun testSignUpStartWithEmptyUsernameShouldThrowException() {
         val commandParameters = SignUpStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
             .username(emptyString)
@@ -157,21 +157,6 @@ class NativeAuthRequestHandlerTest {
             commandParameters = commandParameters
         )
     }
-
-    @Test(expected = ClientException::class)
-    fun testSignUpStartWithEmptyUsernameShouldThrowException() {
-        val commandParameters = SignUpStartCommandParameters.builder()
-            .platformComponents(mock<PlatformComponents>())
-            .username(emptyString)
-            .clientId(clientId)
-            .correlationId(correlationId)
-            .build()
-
-        nativeAuthRequestProvider.createSignUpStartRequest(
-            commandParameters = commandParameters
-        )
-    }
-
 
     @Test
     fun testSignUpStartSuccess() {
@@ -367,8 +352,8 @@ class NativeAuthRequestHandlerTest {
     }
 
     // signin tests
-    @Test
-    fun testSignInInitiateWithEmptyUsernameShouldNotThrowException() {
+    @Test(expected = ClientException::class)
+    fun testSignInInitiateWithEmptyUsernameShouldThrowException() {
         val commandParameters = SignInStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
             .username(emptyString)
@@ -500,7 +485,7 @@ class NativeAuthRequestHandlerTest {
         )
     }
 
-    @Test
+    @Test(expected = ClientException::class)
     fun testSignInInitiateWithPasswordCommandParametersWithEmptyUsernameShouldNotThrowException() {
         val commandParameters = SignInStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
@@ -659,8 +644,8 @@ class NativeAuthRequestHandlerTest {
     }
 
     // sspr start tests
-    @Test
-    fun testResetPasswordStartWithEmptyUsernameShouldNotThrowException() {
+    @Test(expected = ClientException::class)
+    fun testResetPasswordStartWithEmptyUsernameShouldThrowException() {
         val commandParameters = ResetPasswordStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
             .username(emptyString)

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestHandlerTest.kt
@@ -158,6 +158,21 @@ class NativeAuthRequestHandlerTest {
         )
     }
 
+    @Test(expected = ClientException::class)
+    fun testSignUpStartWithEmptyUsernameShouldThrowException() {
+        val commandParameters = SignUpStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(emptyString)
+            .clientId(clientId)
+            .correlationId(correlationId)
+            .build()
+
+        nativeAuthRequestProvider.createSignUpStartRequest(
+            commandParameters = commandParameters
+        )
+    }
+
+
     @Test
     fun testSignUpStartSuccess() {
         val commandParameters = SignUpStartCommandParameters.builder()


### PR DESCRIPTION
Put back ArgUtils.validateNonNullArg(username, "username") in all initial native auth requests.

Company PRs:
msal: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2080
native sample app: https://github.com/Azure-Samples/ms-identity-ciam-native-auth-android-sample/pull/24