### PR TITLE
Get rid of malformed javadoc syntax errors

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -231,10 +231,6 @@ android.libraryVariants.all { variant ->
 
         // We're excluding these generated files
         exclude '**/R.java'
-
-        // Javadoc doesn't support kotlin.
-        // TODO: Migrate to Dokka
-        exclude '**/*.kt'
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -227,7 +227,7 @@ android.libraryVariants.all { variant ->
         classpath += files(android.getBootClasspath())
 
         options.memberLevel = JavadocMemberLevel.PUBLIC
-        options.addStringOption('Xdoclint:none', '-quiet')
+        options.addBooleanOption('Xdoclint:none', true)
 
         // We're excluding these generated files
         exclude '**/R.java'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -231,6 +231,10 @@ android.libraryVariants.all { variant ->
 
         // We're excluding these generated files
         exclude '**/R.java'
+
+        // Javadoc doesn't support kotlin.
+        // TODO: Migrate to Dokka
+        exclude '**/*.kt'
     }
 }
 

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -74,7 +74,7 @@ task generateJavadoc(type: Javadoc) {
     classpath += project.sourceSets.main.compileClasspath
 
     options.memberLevel = JavadocMemberLevel.PUBLIC
-    options.addStringOption('Xdoclint:none', '-quiet')
+    options.addBooleanOption('Xdoclint:none', true)
 
     exclude '**/BuildConfig.Java'
     exclude '**/R.java'

--- a/common4j/src/main/com/microsoft/identity/common/java/BaseAccount.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/BaseAccount.java
@@ -46,7 +46,7 @@ public abstract class BaseAccount implements IAccountRecord {
     public abstract String getUniqueIdentifier();
 
     /**
-     * @return cache identifiers in List<String>
+     * @return cache identifiers.
      */
     public abstract List<String> getCacheIdentifiers();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAudience.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAudience.java
@@ -75,11 +75,6 @@ public abstract class AzureActiveDirectoryAudience {
      * <p>
      * Method which queries the {@link OpenIdProviderConfiguration}
      * to get tenant UUID for the authority with tenant alias.
-     *
-     * @return : tenant UUID
-     * @throws ServiceException
-     * @throws ClientException
-     * @throws URISyntaxException
      */
     //@WorkerThread
     public String getTenantUuidForAlias(@NonNull final String authority)

--- a/common4j/src/main/com/microsoft/identity/common/java/authscheme/PopAuthenticationSchemeInternal.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authscheme/PopAuthenticationSchemeInternal.java
@@ -118,7 +118,7 @@ public class PopAuthenticationSchemeInternal
 
     /**
      * This constructor intended to be used when this class is acting as a DTO between
-     * MSAL -> Broker. Because no {@link IClockSkewManager} is supplied, functions related to access
+     * MSAL to Broker. Because no {@link IClockSkewManager} is supplied, functions related to access
      * token signing cannot be used.
      *
      * @param popManager

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerApplicationMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerApplicationMetadata.java
@@ -29,7 +29,7 @@ import com.google.gson.annotations.SerializedName;
  * defined on {@link AbstractApplicationMetadata}.
  * <p>
  * Please note that two applications are "the same" if their client_id, environment, and app UID
- * (user) are the same. An app may not simultaneously be both FoCI & non-FoCI.
+ * (user) are the same. An app may not simultaneously be both FoCI and non-FoCI.
  */
 public class BrokerApplicationMetadata extends AbstractApplicationMetadata {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -170,7 +170,7 @@ public class BrokerOAuth2TokenCache
     }
 
     /**
-     * Broker-only API to persist WPJ's Accounts & their associated credentials.
+     * Broker-only API to persist WPJ's Accounts and their associated credentials.
      *
      * @param accountRecord     The {@link AccountRecord} to store.
      * @param idTokenRecord     The {@link IdTokenRecord} to store.
@@ -611,7 +611,7 @@ public class BrokerOAuth2TokenCache
     /**
      * The caller of this method should inspect the result carefully.
      * <p>
-     * If the result contains >1 element: tokens were found for the provided filter criteria and
+     * If the result contains {@literal >} 1 element: tokens were found for the provided filter criteria and
      * additionally, tokens were found for this Account relative to a guest tenant.
      * <p>
      * If the result contains exactly 1 element, you may receive 1 of a few different

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -1286,7 +1286,6 @@ public class BrokerOAuth2TokenCache
      * @param homeAccountId The homeAccountId of the Account targeted for deletion.
      * @param realm         The tenant id of the targeted Account (if applicable).
      * @return An {@link AccountDeletionRecord}, containing the deleted {@link AccountDeletionRecord}s.
-     * @see BrokerOAuth2TokenCache#removeAccountFromDevice(AccountRecord).
      */
     @Override
     public AccountDeletionRecord removeAccount(@Nullable final String environment,

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -1286,7 +1286,7 @@ public class BrokerOAuth2TokenCache
      * @param homeAccountId The homeAccountId of the Account targeted for deletion.
      * @param realm         The tenant id of the targeted Account (if applicable).
      * @return An {@link AccountDeletionRecord}, containing the deleted {@link AccountDeletionRecord}s.
-     * @see #removeAccountFromDevice(AccountRecord).
+     * @see BrokerOAuth2TokenCache#removeAccountFromDevice(AccountRecord).
      */
     @Override
     public AccountDeletionRecord removeAccount(@Nullable final String environment,

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -242,7 +242,7 @@ public class BrokerOAuth2TokenCache
     }
 
     /**
-     * Broker-only API to persist WPJ's Accounts & their associated credentials.
+     * Broker-only API to persist WPJ's Accounts and their associated credentials.
      *
      * @param accountRecord      The {@link AccountRecord} to store.
      * @param idTokenRecord      The {@link IdTokenRecord} to store.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/CacheKeyValueDelegate.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/CacheKeyValueDelegate.java
@@ -63,7 +63,7 @@ import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.Cac
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Uses Gson to serialize instances of <T> into {@link String}s.
+ * Uses Gson to serialize instances into {@link String}s.
  */
 public class CacheKeyValueDelegate implements ICacheKeyValueDelegate {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Account & Credential cache interface.
+ * Account and Credential cache interface.
  */
 public interface IAccountCredentialCache {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -291,8 +291,6 @@ public class MsalCppOAuth2TokenCache
 
     /**
      * Gets an immutable {@link List} of {@link AccountRecord} objects.
-     *
-     * @return {@link List<AccountRecord>}
      */
     public List<AccountRecord> getAllAccounts() {
         return Collections.unmodifiableList(

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalCppOAuth2TokenCache.java
@@ -124,9 +124,8 @@ public class MsalCppOAuth2TokenCache
     }
 
     /**
-     * @param accountRecord : AccountRecord associated with the input credentials, can be null.
-     * @param credentials   : list of Credential which can include AccessTokenRecord, IdTokenRecord and RefreshTokenRecord.
-     * @throws ClientException : If the supplied Account or Credential are null or schema invalid.
+     * @param credentials       list of Credential which can include AccessTokenRecord, IdTokenRecord and RefreshTokenRecord.
+     * @throws ClientException  If the supplied Account or Credential are null or schema invalid.
      */
     public synchronized void saveCredentials(@NonNull final Credential... credentials) throws ClientException {
         if (credentials.length == 0) {

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImpl.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImpl.java
@@ -40,13 +40,12 @@ import java.util.concurrent.TimeUnit;
  * A simple metadata store definition that uses INameValueStorage to persist, read,
  * update, and delete data. Please note that all CRUD actions return success, as the underlying
  * store's API does not surface a success indicator. If you need stronger guarantees that an
- * operation was successful, use {@link SharedPreferencesSimpleCacheImpl} which is less performance
+ * operation was successful, use SharedPreferencesSimpleCacheImpl which is less performance
  * oriented.
  * <p>
  * Data serializes as JSON.
  *
  * @param <T> The type of metadata that will be persisted.
- * @see SharedPreferencesSimpleCacheImpl
  */
 public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements ISimpleCache<T>, IListTypeToken {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
@@ -64,10 +64,10 @@ public class PKeyAuthChallengeFactory {
      *
      * @param redirectUri Location: urn:http-auth:CertAuth?
      *                    Nonce=[nonce value]
-     *                    &CertAuthorities=[distinguished names of CAs>
-     *                    &Version=1.0
-     *                    &SubmitUrl=[URL to submit response]
-     *                    &Context=[server state thatclient must convey back]
+     *                    {@literal &}CertAuthorities=[distinguished names of CAs>
+     *                    {@literal &}Version=1.0
+     *                    {@literal &}SubmitUrl=[URL to submit response]
+     *                    {@literal &}Context=[server state thatclient must convey back]
      * @return Return PKeyAuth challenge object
      */
     public PKeyAuthChallenge getPKeyAuthChallengeFromWebViewRedirect(@NonNull final String redirectUri) throws ClientException {
@@ -96,11 +96,6 @@ public class PKeyAuthChallengeFactory {
      *
      * This is retrieved from response from token endpoint
      * (read: it would be triggered in silent flow only).
-     *
-     * @param header
-     * @param authority
-     * @throws ClientException
-     * @throws UnsupportedEncodingException
      */
     public PKeyAuthChallenge getPKeyAuthChallengeFromTokenEndpointResponse(@NonNull final String header, @NonNull final String authority)
             throws ClientException, UnsupportedEncodingException {

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
@@ -62,10 +62,12 @@ public class PKeyAuthChallengeFactory {
      * This is retrieved from response from auth endpoint
      * (read: it would be triggered in interactive flow only).
      *
-     * @param redirectUri Location: urn:http-auth:CertAuth?Nonce=<noncevalue>
-     *                    &CertAuthorities=<distinguished names of CAs>&Version=1.0
-     *                    &SubmitUrl=<URL to submit response>&Context=<server state that
-     *                    client must convey back>
+     * @param redirectUri Location: urn:http-auth:CertAuth?
+     *                    Nonce=[nonce value]
+     *                    &CertAuthorities=[distinguished names of CAs>
+     *                    &Version=1.0
+     *                    &SubmitUrl=[URL to submit response]
+     *                    &Context=[server state thatclient must convey back]
      * @return Return PKeyAuth challenge object
      */
     public PKeyAuthChallenge getPKeyAuthChallengeFromWebViewRedirect(@NonNull final String redirectUri) throws ClientException {

--- a/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/challengehandlers/PKeyAuthChallengeFactory.java
@@ -64,7 +64,7 @@ public class PKeyAuthChallengeFactory {
      *
      * @param redirectUri Location: urn:http-auth:CertAuth?
      *                    Nonce=[nonce value]
-     *                    {@literal &}CertAuthorities=[distinguished names of CAs>
+     *                    {@literal &}CertAuthorities=[distinguished names of CAs]
      *                    {@literal &}Version=1.0
      *                    {@literal &}SubmitUrl=[URL to submit response]
      *                    {@literal &}Context=[server state thatclient must convey back]

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -939,9 +939,6 @@ public abstract class BaseController {
 
     /**
      * Helper method to get a cached account
-     *
-     * @param parameters
-     * @return
      */
     protected AccountRecord getCachedAccountRecord(
             @NonNull final SilentTokenCommandParameters parameters) throws ClientException {

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
@@ -213,8 +213,6 @@ public interface IDevicePopManager {
 
     /**
      * Async API to generate the req_cnf used for auth code redemptions.
-     *
-     * @return The req_cnf value.
      */
     void getRequestConfirmation(TaskCompletedCallbackWithError<String, ClientException> callback);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/SigningAlgorithm.java
@@ -27,7 +27,7 @@ import lombok.NonNull;
 /**
  * Signing algorithms supported by our underlying keystore. Not all algs available at all device
  * levels. Please note that Common supports a minimal subset of signing algorithms due to device/OEM
- * specific incompatibilities when attempting AndroidKeystore-based key generations >256 bits.
+ * specific incompatibilities when attempting AndroidKeystore-based key generations {@literal >} 256 bits.
  * RSA-PKCS1 is favored over RSA-PSS for broader compatibility.
  *
  * More info: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1453707

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccessTokenRecord.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccessTokenRecord.java
@@ -35,6 +35,7 @@ import static com.microsoft.identity.common.java.dto.AccessTokenRecord.Serialize
 import static com.microsoft.identity.common.java.dto.AccessTokenRecord.SerializedNames.TOKEN_TYPE;
 
 import com.google.gson.annotations.SerializedName;
+import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -48,7 +49,7 @@ public class AccessTokenRecord extends Credential {
 
     public static class SerializedNames extends Credential.SerializedNames {
         /**
-         * <strong>Deprecated<strong> string of access token type.  Prefer @link{#TOKEN_TYPE} instead.
+         * <strong>Deprecated</strong> string of access token type.  Prefer @link{#TOKEN_TYPE} instead.
          */
         @Deprecated
         public static final String ACCESS_TOKEN_TYPE = "access_token_type";

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
@@ -46,8 +46,6 @@ public abstract class AccountCredentialBase implements Cloneable {
 
     /**
      * Setter of additional fields.
-     *
-     * @param additionalFields Map<String, JsonElement>
      */
     public void setAdditionalFields(@NonNull final Map<String, JsonElement> additionalFields) {
         mAdditionalFields = Collections.synchronizedMap(additionalFields);

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/AccountCredentialBase.java
@@ -39,8 +39,6 @@ public abstract class AccountCredentialBase implements Cloneable {
 
     /**
      * Getter of additional fields.
-     *
-     * @return additional fields in Map<String, JsonElement>
      */
     public Map<String, JsonElement> getAdditionalFields() {
         return mAdditionalFields;

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/CredentialType.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/CredentialType.java
@@ -80,8 +80,6 @@ public enum CredentialType {
 
     /**
      * Get the credential type name set.
-     *
-     * @return Set<String>
      */
     public static Set<String> valueSet() {
         final Set<String> strTypes = new HashSet<>();

--- a/common4j/src/main/com/microsoft/identity/common/java/dto/IAccountRecord.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/dto/IAccountRecord.java
@@ -110,7 +110,7 @@ public interface IAccountRecord {
 
     /**
      * Gets the client_info as a base64 encoded String of JSON.
-     * Decoded JSON has the format of {"uid":"<UUID>", "utid":"<UUID>"}.
+     * Decoded JSON has the format of {"uid":"[UUID]", "utid":"[UUID]"}.
      *
      * @return The client_info to get.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -219,7 +219,7 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     /**
      * Set the telemetry on base exception.
      *
-     * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
+     * @param telemetry the telemetry data.
      */
     public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
         mTelemetry.addAll(telemetry);

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ServiceException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ServiceException.java
@@ -94,8 +94,7 @@ public class ServiceException extends BaseException {
     public static final String UNKNOWN_ERROR = "unknown_error";
 
     /**
-     * When service response contains 1000030 -> MsaGrantedRefreshTokenNotSupportedOnAadTenant
-     * <a href="https://msazure.visualstudio.com/One/_git/ESTS-Main?path=/src/Product/Microsoft.AzureAD.Common/Diagnostics/ErrrorCodes/StsErrorCode.xml&version=GBmaster&line=16896&lineEnd=16897&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents">...</a>
+     * When service response contains <a href="https://msazure.visualstudio.com/One/_git/ESTS-Main?path=/src/Product/Microsoft.AzureAD.Common/Diagnostics/ErrrorCodes/StsErrorCode.xml&version=GBmaster&line=16896&lineEnd=16897&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents">MsaGrantedRefreshTokenNotSupportedOnAadTenant</a>
      */
     public static final String MsaGrantedRefreshTokenNotSupportedOnAadTenantErrorCode = "1000030";
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -48,7 +48,7 @@ public enum CommonFlight implements IFlightConfig {
 
     /**
      * Flight to control the timeout duration for Acquire Token Silent Calls
-     * The default value is set to {@link ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS}
+     * The default value is set to ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS.
      */
     ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS("AcquireTokenSilentTimeoutMilliSeconds", ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS),
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/ResetPasswordSubmitCodeCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/ResetPasswordSubmitCodeCommandParameters.java
@@ -29,7 +29,7 @@ import lombok.experimental.SuperBuilder;
 
 /**
  * A set of Reset Password Submit Code command parameters for submitting the one-time password to the server for authentication.
- * extends from {@link BaseNativeAuthCommandParameters
+ * extends from {@link BaseNativeAuthCommandParameters}
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/ResetPasswordSubmitNewPasswordCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/ResetPasswordSubmitNewPasswordCommandParameters.java
@@ -30,7 +30,7 @@ import lombok.experimental.SuperBuilder;
 
 /**
  * A set of Reset Password Submit New Password command parameters for submitting the new password of the user.
- * extends from {@link BaseNativeAuthCommandParameters
+ * extends from {@link BaseNativeAuthCommandParameters}
  */
 @Getter
 @EqualsAndHashCode(callSuper = true)

--- a/common4j/src/main/com/microsoft/identity/common/java/net/SSLSocketFactoryWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/SSLSocketFactoryWrapper.java
@@ -45,7 +45,7 @@ import lombok.experimental.Accessors;
 
 /**
  * This class is a SSLSocketFactory wrapper that supports Higher TLS by default.
- * In Android, the default socket would return one that only supports up to TLSv1.1 if API<20
+ * In Android, the default socket would return one that only supports up to TLSv1.1 if API {@literal <} 20
  * reference: https://developer.android.com/reference/javax/net/ssl/SSLSocket
  */
 public class SSLSocketFactoryWrapper extends SSLSocketFactory {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
@@ -39,7 +39,7 @@ import lombok.AllArgsConstructor;
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopSpan.java
@@ -33,9 +33,9 @@ import lombok.AllArgsConstructor;
 
 /**
  * A custom noop implementation of {@link Span} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
@@ -26,9 +26,9 @@ import io.opentelemetry.api.trace.TraceFlags;
 
 /**
  * A custom noop implementation of {@link io.opentelemetry.api.trace.TraceFlags} to be used in MSAL
- * for scenarios where minSdkVersion of calling application < 24. The reason for this is because the
+ * for scenarios where minSdkVersion of calling application {@literal <} 24. The reason for this is because the
  * default no-op implementation uses "static interface methods" and these get left out of the APK
- * for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because the
+ * for applications whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the
  * consumers-rules are NOT honored when minification is disabled and R8 applies some default
  * proguard rules that leaves static interface methods out of the APK. This causes a
  * "NoSuchMethodError" when such methods are invoked.

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceFlags.java
@@ -32,7 +32,7 @@ import io.opentelemetry.api.trace.TraceFlags;
  * consumers-rules are NOT honored when minification is disabled and R8 applies some default
  * proguard rules that leaves static interface methods out of the APK. This causes a
  * "NoSuchMethodError" when such methods are invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceState.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceState.java
@@ -35,13 +35,13 @@ import lombok.Builder;
 
 /**
  * A custom noop implementation of {@link TraceState} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceStateBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/NoopTraceStateBuilder.java
@@ -27,13 +27,13 @@ import io.opentelemetry.api.trace.TraceStateBuilder;
 
 /**
  * A custom noop implementation of {@link TraceStateBuilder} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
@@ -29,13 +29,13 @@ import io.opentelemetry.context.Context;
  * Extension methods for {@link Context}.
  * <p>
  * This basically provides a custom, safe implementation of {@link Context#wrap(Runnable)}
- * to be used in MSAL for scenarios where minSdkVersion of calling application < 24. The reason for
+ * to be used in MSAL for scenarios where minSdkVersion of calling application {@literal <} 24. The reason for
  * this is because the default implementation uses "static interface methods" and these get left out
- * of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because
+ * of the APK for applications whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because
  * the consumers-rules are NOT honored when minification is disabled and R8 applies some default
  * proguard rules that leaves static interface methods out of the APK. This causes a
  * "NoSuchMethodError" when such methods are invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
@@ -28,7 +28,7 @@ import io.opentelemetry.context.Context;
 /**
  * Extension methods for {@link Context}.
  * <p>
- * This basically provides a custom, safe implementation of {@link Context#current()#wrap(Runnable)}
+ * This basically provides a custom, safe implementation of {@link Context#wrap(Runnable)}
  * to be used in MSAL for scenarios where minSdkVersion of calling application < 24. The reason for
  * this is because the default implementation uses "static interface methods" and these get left out
  * of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OtelContextExtension.java
@@ -47,7 +47,7 @@ public class OtelContextExtension {
 
     /**
      * Returns a Runnable that makes this the current context and then invokes the input Runnable.
-     * See {@link Context#current()#wrap(Runnable)}
+     * See {@link Context#wrap(Runnable)}
      *
      * @param runnable the runnable to wrap
      * @return the wrapped runnable

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -36,13 +36,13 @@ import lombok.NonNull;
  * Extension methods for {@link Span}.
  * <p>
  * This basically provides a custom, safe implementation of {@link Span#current()} to be used in
- * MSAL for scenarios where minSdkVersion of calling application < 24. The reason for this is
+ * MSAL for scenarios where minSdkVersion of calling application {@literal <} 24. The reason for this is
  * because the default no-op implementation uses "static interface methods" and these get left out
- * of the APK for applications whose MIN SDK is < 24 and minification through R8 is DISABLED because
+ * of the APK for applications whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because
  * the consumers-rules are NOT honored when minification is disabled and R8 applies some default
  * proguard rules that leaves static interface methods out of the APK. This causes a
  * "NoSuchMethodError" when such methods are invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenErrorResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenErrorResponse.java
@@ -52,7 +52,7 @@ public class MicrosoftTokenErrorResponse extends TokenErrorResponse {
     }
 
     /**
-     * @param errorCodes error codes of the Microsoft token error response in type List<Long>.
+     * @param errorCodes error codes of the Microsoft token error response.
      */
     public void setErrorCodes(final List<Long> errorCodes) {
         mErrorCodes = errorCodes;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenResponse.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftTokenResponse.java
@@ -91,7 +91,6 @@ public class MicrosoftTokenResponse extends TokenResponse {
      * Set the session key JWE associated with this result, or null if none.
      *
      * @param sessionKeyJwe the session key JWE associated with this result, or null if none.
-     * @return
      */
     public void setSessionKeyJwe(final String sessionKeyJwe) {
         mSessionKeyJwe = sessionKeyJwe;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryOAuth2Strategy.java
@@ -53,18 +53,6 @@ import static com.microsoft.identity.common.java.exception.ErrorStrings.AUTHORIT
 
 /**
  * The Azure Active Directory OAuth 2.0 Strategy.
- * <MicrosoftStsAccessToken,
- * MicrosoftStsAccount,
- * MicrosoftStsAuthorizationRequest,
- * MicrosoftStsAuthorizationRequest.Builder,
- * AuthorizationStrategy,
- * MicrosoftStsOAuth2Configuration,
- * MicrosoftStsAuthorizationResponse,
- * MicrosoftStsRefreshToken,
- * MicrosoftStsTokenRequest,
- * MicrosoftStsTokenResponse,
- * TokenResult,
- * AuthorizationResult>
  */
 // Suppressing rawtype warnings due to the generic types AuthorizationStrategy, AuthorizationResult and AuthorizationResultFactory
 @SuppressWarnings(WarningType.rawtype_warning)

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/IAcquireMicrosoftStsTokenStrategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/IAcquireMicrosoftStsTokenStrategy.java
@@ -33,8 +33,7 @@ import lombok.NonNull;
 
 /**
  * Acquire token strategy for Microsoft STS
- *  * @param <T> is expected to be either {@link InteractiveTokenCommandParameters}
- *  *           or {@link SilentTokenCommandParameters}
+ * T is expected to be either {@link InteractiveTokenCommandParameters} or {@link SilentTokenCommandParameters}
  */
 public interface IAcquireMicrosoftStsTokenStrategy<T extends TokenCommandParameters> {
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
@@ -219,7 +219,7 @@ public class IDToken {
     }
 
     /**
-     * @return Token claims in Map<String, String>.
+     * @return Token claims
      */
     public Map<String, ?> getTokenClaims() {
         return mTokenClaims == null ? Collections.<String, Object>emptyMap() : Collections.unmodifiableMap(mTokenClaims);

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -227,7 +227,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
     /**
      * Set the telemetry on local authentication result.
      *
-     * @param telemetry the {@link List<Map<String, String>>} containing telemetry data
+     * @param telemetry the telemetry data
      */
     public void setTelemetry(@NonNull final List<Map<String, String>> telemetry) {
         mTelemetry.addAll(telemetry);

--- a/common4j/src/main/com/microsoft/identity/common/java/storage/MultiTypeNameValueStorage.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/storage/MultiTypeNameValueStorage.java
@@ -37,7 +37,7 @@ import lombok.NonNull;
 /**
  * An implementation of {@link IMultiTypeNameValueStorage}.
  * <p>
- * The internal implementation here is backed by an implementation of a {@link INameValueStorage<String>}.
+ * The internal implementation here is backed by an implementation of a {@link INameValueStorage} with String.
  * Strings are dropped directly into the storage, whereas Long values are adapted into a String
  * using the {@link IGenericTypeStringAdapter#LongStringAdapter}.
  * <p>

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/ITelemetryAccessor.java
@@ -34,9 +34,6 @@ public interface ITelemetryAccessor {
 
     /**
      * Obtain telemetry data.
-     *
-     * @return a {@link List<Map<String, String>>} containing telemetry data. Generally this would
-     * be the data produced from {@link Telemetry} class.
      */
     List<Map<String, String>> getTelemetry();
 

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/Telemetry.java
@@ -220,7 +220,6 @@ public class Telemetry {
      * Emit the event into the telemetry raw data map.
      *
      * @param event BaseEvent object
-     * @return the event reference for future properties modification.
      */
     public static void emit(final BaseEvent event) {
         final Telemetry instance = getInstance();

--- a/common4j/src/main/com/microsoft/identity/common/java/util/CommonURIBuilder.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/CommonURIBuilder.java
@@ -36,7 +36,7 @@ import lombok.NonNull;
  * We want to make sure we never send duplicated parameters to the server.
  * This is done by
  * 1. disabling {@link cz.msebera.android.httpclient.client.utils.URIBuilder#addParameter(String, String)} and
- * {@link cz.msebera.android.httpclient.client.utils.URIBuilder#addParameters(List))}
+ * {@link cz.msebera.android.httpclient.client.utils.URIBuilder#addParameters(List)}
  * 2. adding {@link CommonURIBuilder#addParametersIfAbsent}
  */
 public class CommonURIBuilder extends cz.msebera.android.httpclient.client.utils.URIBuilder {

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -115,7 +115,7 @@ public interface IPlatformUtil {
      * We use KeyManagerFactory to construct an {@link javax.net.ssl.SSLContext} object
      * with a WPJ certificate - to authenticate into DRS (via TLS challenge).
      *
-     * @link https://developer.android.com/reference/javax/net/ssl/KeyManagerFactory
+     * @link <a href="https://developer.android.com/reference/javax/net/ssl/KeyManagerFactory">KeyManagerFactory</a>
      **/
     KeyManagerFactory getSslContextKeyManagerFactory() throws NoSuchAlgorithmException;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -115,7 +115,7 @@ public interface IPlatformUtil {
      * We use KeyManagerFactory to construct an {@link javax.net.ssl.SSLContext} object
      * with a WPJ certificate - to authenticate into DRS (via TLS challenge).
      *
-     * @link <a href="https://developer.android.com/reference/javax/net/ssl/KeyManagerFactory">KeyManagerFactory</a>
+     * See <a href="https://developer.android.com/reference/javax/net/ssl/KeyManagerFactory">KeyManagerFactory</a>
      **/
     KeyManagerFactory getSslContextKeyManagerFactory() throws NoSuchAlgorithmException;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class JsonUtil {
 
     /**
-     * Extract JSON Object into Map<String, String>.
+     * Extract JSON Object into a String Map
      *
      * @param jsonString String
      * @return Map

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ObjectMapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ObjectMapper.java
@@ -290,7 +290,7 @@ public final class ObjectMapper {
      * Method to serialize the object into a map.
      *
      * @param object Object
-     * @return Map<String, Object>
+     * @return a hash map.
      */
     public static Map<String, Object> serializeObjectHashMap(final Object object) {
         String json = ObjectMapper.serializeObjectToJsonString(object);

--- a/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
@@ -167,7 +167,7 @@ public class QueryParamsAdapter extends TypeAdapter<List<Map.Entry<String, Strin
     }
 
     /**
-     * Serializes a List<Map.Entry<String, String>>.
+     * Serializes a query string parameter map.
      *
      * @param extraQueryStringParameters an object to serialize.
      * @return a serialized string.
@@ -177,7 +177,7 @@ public class QueryParamsAdapter extends TypeAdapter<List<Map.Entry<String, Strin
     }
 
     /**
-     * Deerializes a string into a List<Map.Entry<String, String>>.
+     * Deserializes a string into a query string parameter map.
      *
      * @param jsonString a string to deserialize.
      * @return a deserialized object.

--- a/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 
 /**
- * Class to serialize and deserialize query parameters from List<Map.Entry<String, String>> to json String
+ * Class to serialize and deserialize query parameters from List to json String
  * and vice versa.
  *
  * NOTE: Even we no longer use Pair (Since it's android-only), we are keeping this the same

--- a/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/QueryParamsAdapter.java
@@ -202,7 +202,7 @@ public class QueryParamsAdapter extends TypeAdapter<List<Map.Entry<String, Strin
     /**
      * Create a Type for the List of query params.
      *
-     * @return a Type object representing the type of the query params in this case List<Map.Entry<String, String>>
+     * @return a Type object representing the type of the query params.
      */
     public static Type getListType() {
         return TypeToken.getParameterized(List.class, TypeToken.getParameterized(Map.Entry.class, String.class, String.class).getRawType()).getType();

--- a/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/StringUtil.java
@@ -135,8 +135,8 @@ public class StringUtil {
 
     /**
      * Helper method to get uid from home account id
-     * V2 home account format : <uid>.<utid>
-     * V1 : it's stored as <uid>
+     * V2 home account format : [uid].[utid]
+     * V1 : it's stored as [uid]
      *
      * @param homeAccountId
      * @return valid uid or null if it's not in either of the format.
@@ -190,7 +190,7 @@ public class StringUtil {
      *
      * @param items     String
      * @param delimiter String
-     * @return List<String>
+     * @return a List of string tokens.
      */
     public static List<String> getStringTokens(final String items, final String delimiter) {
         final StringTokenizer tokenizer = new StringTokenizer(items, delimiter);
@@ -210,7 +210,7 @@ public class StringUtil {
      *
      * @param input     String
      * @param delimiter char
-     * @return ArrayList<String>
+     * @return the splitted input in ArrayList
      */
     public static ArrayList<String> splitWithQuotes(String input, char delimiter) {
         final ArrayList<String> items = new ArrayList<>();

--- a/common4j/src/main/com/microsoft/identity/common/java/util/ThreadUtils.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/ThreadUtils.java
@@ -65,7 +65,7 @@ public class ThreadUtils {
      *
      * @param corePool      The smallest number of threads to keep alive in the pool.
      * @param maxPool       The maximum number of threads to allow in the thread pool, after which RejectedExecutionException will occur.
-     * @param queueSize     The number of items to keep in the queue.  If this is < 0, the queue is unbounded.
+     * @param queueSize     The number of items to keep in the queue.  If this is less than 0, the queue is unbounded.
      * @param keepAliveTime The amount of time to keep excess (greater than corePool size) threads alive before terminating them.
      * @param keepAliveUnit The time unit on that time.
      * @param poolName      The name of the thread pool in use.

--- a/common4j/src/main/io/opentelemetry/api/NoopOpenTelemetry.java
+++ b/common4j/src/main/io/opentelemetry/api/NoopOpenTelemetry.java
@@ -29,13 +29,13 @@ import io.opentelemetry.context.propagation.NoopContextPropagators;
 
 /**
  * A custom noop implementation of {@link OpenTelemetry} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/io/opentelemetry/api/metrics/NoopMeterProvider.java
+++ b/common4j/src/main/io/opentelemetry/api/metrics/NoopMeterProvider.java
@@ -24,13 +24,13 @@ package io.opentelemetry.api.metrics;
 
 /**
  * A custom noop implementation of {@link MeterProvider} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/io/opentelemetry/api/trace/NoopTracerProvider.java
+++ b/common4j/src/main/io/opentelemetry/api/trace/NoopTracerProvider.java
@@ -24,13 +24,13 @@ package io.opentelemetry.api.trace;
 
 /**
  * A custom noop implementation of {@link TracerProvider} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <}  24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static

--- a/common4j/src/main/io/opentelemetry/context/propagation/NoopContextPropagators.java
+++ b/common4j/src/main/io/opentelemetry/context/propagation/NoopContextPropagators.java
@@ -23,13 +23,13 @@ package io.opentelemetry.context.propagation;
 
 /**
  * A custom noop implementation of {@link ContextPropagators} to be used in MSAL for scenarios where
- * minSdkVersion of calling application < 24. The reason for this is because the default no-op
+ * minSdkVersion of calling application {@literal <} 24. The reason for this is because the default no-op
  * implementation uses "static interface methods" and these get left out of the APK for applications
- * whose MIN SDK is < 24 and minification through R8 is DISABLED because the consumers-rules are NOT
+ * whose MIN SDK is {@literal <} 24 and minification through R8 is DISABLED because the consumers-rules are NOT
  * honored when minification is disabled and R8 applies some default proguard rules that leaves
  * static interface methods out of the APK. This causes a "NoSuchMethodError" when such methods are
  * invoked.
- * This is not a problem for Broker Hosting applications as the MIN SDK for those is already >= 24.
+ * This is not a problem for Broker Hosting applications as the MIN SDK for those is already {@literal >}= 24.
  * The issue only arises for the some MSAL consumers falling into the above situation. Tracing is
  * disabled by default anyway for MSAL (and only turned on for Broker) and Open Telemetry uses its
  * own Noop implementations, however, here we are just providing our own that DON'T use static


### PR DESCRIPTION
This PR only fix errors due to malformed syntax. 
There are some other errors that needs to be addressed before we can get javadoc up and running again.
https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=2858395

Warnings are not addressed in this PR.