### PR TITLE
Fix Adfs no resource id issue in automation (CherryPick)

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -23,8 +23,10 @@
 package com.microsoft.identity.client.ui.automation.interaction.microsoftsts;
 
 import androidx.annotation.NonNull;
+import androidx.test.uiautomator.UiObject2;
 
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 /**
@@ -36,14 +38,15 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
 
     @Override
     public void handleEmailField(@NonNull final String username) {
-        UiAutomatorUtils.handleInput("userNameInput", username);
+        final UiObject2 usernameObject = UiAutomatorUtils.obtainAllEditTextObjects(CommonUtils.FIND_UI_ELEMENT_TIMEOUT).get(0);
+        usernameObject.setText(username);
     }
 
     @Override
     public void handlePasswordField(@NonNull final String password) {
-        Logger.i(TAG, "Handle Adfs Login Password UI..");
-        UiAutomatorUtils.handleInput("passwordInput", password);
-        UiAutomatorUtils.handleButtonClick("submitButton");
+        final UiObject2 passwordObject = UiAutomatorUtils.obtainAllEditTextObjects(CommonUtils.FIND_UI_ELEMENT_TIMEOUT).get(1);
+        passwordObject.setText(password);
+        UiAutomatorUtils.handleButtonClickForObjectWithExactText("Sign in");
     }
 
     /**

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
@@ -97,7 +97,7 @@ public class AdbShellUtils {
         final String result = executeShellCommand(installCmdBuilder.toString());
         final String result2 = executeShellCommand("ls /data/local/tmp");
         Assert.assertNotNull(result);
-        Assert.assertEquals(result2, "Success", result.trim());
+        Assert.assertEquals("Files in /data/local/tmp: \n" + result2, "Success", result.trim());
     }
 
     /**

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -28,14 +28,18 @@ import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiScrollable;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
+
+import java.util.List;
 
 /**
  * This class contains utility methods for leveraging UI Automator to interact with UI elements.
@@ -361,7 +365,7 @@ public class UiAutomatorUtils {
     }
 
     /**
-     * Clicks the button element associated to the supplied text.
+     * Clicks the button element that contains the supplied text.
      *
      * @param text the text on the button to click
      */
@@ -376,7 +380,22 @@ public class UiAutomatorUtils {
     }
 
     /**
-     * Clicks the button element associated to the supplied text.
+     * Clicks the button element with exactly the supplied text.
+     *
+     * @param text the text on the button to click
+     */
+    public static void handleButtonClickForObjectWithExactText(@NonNull final String text) {
+        final UiObject button = obtainUiObjectWithExactText(text);
+
+        try {
+            button.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Clicks the button element that contains the supplied text.
      * Do not throw an exception if the button is not found.
      *
      * @param text the text on the button to click
@@ -482,6 +501,25 @@ public class UiAutomatorUtils {
         Logger.i(TAG, "Obtain an instance of the UiObject for the class name:" + clazz + " and index value:" + index);
         return obtainUiObjectWithUiSelector(new UiSelector().className(clazz).index(index),
                 FIND_UI_ELEMENT_TIMEOUT);
+    }
+
+    public static UiObject obtainUiObjectWithClassname(@NonNull final String classname) {
+        Logger.i(TAG, "Obtain an instance of the UiObject for the class name:" + classname);
+        return obtainUiObjectWithUiSelector(new UiSelector().className(classname),
+                FIND_UI_ELEMENT_TIMEOUT);
+    }
+
+    public static List<UiObject2> obtainAllEditTextObjects(final long existsTimeout) {
+        Logger.i(TAG, "Obtain all edit Text Objects in the view.");
+        final UiDevice device =
+                UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        // Wait for one edit text object to become visible
+        final UiObject firstEditText = device.findObject(new UiSelector().className("android.widget.EditText"));
+        firstEditText.waitForExists(existsTimeout);
+
+        // Return all edit texts currently visible
+        return device.findObjects(By.clazz("android.widget.EditText"));
     }
 
     public static UiObject obtainUiObjectWithUiSelector(@NonNull final UiSelector selector, final long existsTimeout) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -503,12 +503,6 @@ public class UiAutomatorUtils {
                 FIND_UI_ELEMENT_TIMEOUT);
     }
 
-    public static UiObject obtainUiObjectWithClassname(@NonNull final String classname) {
-        Logger.i(TAG, "Obtain an instance of the UiObject for the class name:" + classname);
-        return obtainUiObjectWithUiSelector(new UiSelector().className(classname),
-                FIND_UI_ELEMENT_TIMEOUT);
-    }
-
     public static List<UiObject2> obtainAllEditTextObjects(final long existsTimeout) {
         Logger.i(TAG, "Obtain all edit Text Objects in the view.");
         final UiDevice device =


### PR DESCRIPTION
We're no longer seeing any resource ids in adfs sign in flows, adding this to still automate adfs sign in without requiring resource ids. With this fix, there won't be as many failing automated tests.