### PR TITLE
Support certificate with password

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
@@ -48,9 +48,15 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
     private final static String KEYSTORE_PROVIDER = "SunMSCAPI";
     private final static String CERTIFICATE_ALIAS = "LabVaultAccessCert";
     private final String mLabCredential;
+    private final String mLabCertPassword;
 
     public LabApiAuthenticationClient(@NonNull final String labSecret) {
+        this(labSecret, null);
+    }
+
+    public LabApiAuthenticationClient(@NonNull final String labSecret, final String labCertPassword) {
         mLabCredential = labSecret;
+        mLabCertPassword = labCertPassword;
     }
 
     @Override
@@ -66,7 +72,8 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
         if (mLabCredential != null && mLabCredential.trim().length() > 0) {
             if(mLabCredential.endsWith(".pfx")) {
                 try (final InputStream inputStream = new FileInputStream(mLabCredential)) {
-                    authenticationResult = confidentialAuthClient.acquireToken(inputStream, "", tokenParameters);
+                    final String certPass = mLabCertPassword == null ? "" : mLabCertPassword;
+                    authenticationResult = confidentialAuthClient.acquireToken(inputStream, certPass, tokenParameters);
                 } catch (final IOException e) {
                     throw new LabApiException(LabError.FAILED_TO_LOAD_CERTIFICATE);
                 }

--- a/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClientTest.java
+++ b/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClientTest.java
@@ -75,4 +75,22 @@ public class LabApiAuthenticationClientTest {
         }
     }
 
+    @Test
+    public void canGetTokenForLabApiUsingCertificateWithPassword() {
+        final LabApiAuthenticationClient labApiAuthenticationClient =
+                new LabApiAuthenticationClient("", "pass");
+
+        try {
+            final String accessToken = labApiAuthenticationClient.getAccessToken();
+            Assert.assertNotNull(accessToken);
+            Assert.assertNotEquals("", accessToken);
+            Assert.assertEquals(
+                    LabAuthenticationConstants.LAB_API_TOKEN_AUDIENCE,
+                    ((List<String>) jwtParser.parseJWT(accessToken).get(LabAuthenticationConstants.AUDIENCE_CLAIM)).get(0)
+            );
+        } catch (final LabApiException e) {
+            throw new AssertionError(e);
+        }
+    }
+
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ V.Next
 - [MINOR] Updating YubiKit and CredMan versions (#2417)
 - [PATCH] Adding check for OS version for passkeys (#2419)
 - [MINOR] Platform Specific Extra Query Parameters (#2426)
-- [MINOR] Support certificate with password(#2405)
+- [MINOR] Support certificate with password (#2405)
 
 Version 17.4.0
 ---------

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ V.Next
 - [MINOR] Updating YubiKit and CredMan versions (#2417)
 - [PATCH] Adding check for OS version for passkeys (#2419)
 - [MINOR] Platform Specific Extra Query Parameters (#2426)
-- [MINOR] Support certificate with password (#2405)
+- [MINOR] Support certificate with password(#2405)
 
 Version 17.4.0
 ---------

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ V.Next
 - [MINOR] Updating YubiKit and CredMan versions (#2417)
 - [PATCH] Adding check for OS version for passkeys (#2419)
 - [MINOR] Platform Specific Extra Query Parameters (#2426)
+- [MINOR] Support certificate with password (#2405)
 
 Version 17.4.0
 ---------


### PR DESCRIPTION
This change allows supplying an optional password with the certificate PFX file. We use this in our upstream pipelines that consume the common test utilities.