### PR TITLE
Use unauthorized client instead of invalid client

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
@@ -95,8 +95,8 @@ class ResetPasswordOAuth2StrategyTest {
     private val OOB_CODE = "123456"
     private val CONTINUATION_TOKEN = "1234"
     private val INVALID_GRANT_ERROR = "invalid_grant"
-    private val INVALID_CLIENT_ERROR = "invalid_client"
     private val UNSUPPORTED_CHALLENGE_TYPE_ERROR = "unsupported_challenge_type"
+    private val UNAUTHORIZED_CLIENT_ERROR = "unauthorized_client"
     private val EXPIRED_TOKEN_ERROR = "expired_token"
     private val PASSWORD_TOO_LONG_ERROR = "password_too_long"
     private val PASSWORD_TOO_SHORT_ERROR = "password_too_short"
@@ -177,7 +177,7 @@ class ResetPasswordOAuth2StrategyTest {
         configureMockApi(
             endpointType = MockApiEndpoint.SSPRStart,
             correlationId = correlationId,
-            responseType = MockApiResponseType.INVALID_CLIENT
+            responseType = MockApiResponseType.UNAUTHORIZED_CLIENT
         )
 
         val mockResetPasswordStartCommandParameters = mockk<ResetPasswordStartCommandParameters>()
@@ -188,7 +188,7 @@ class ResetPasswordOAuth2StrategyTest {
             mockResetPasswordStartCommandParameters
         )
         assertTrue(ssprStartResult is ResetPasswordStartApiResult.UnknownError)
-        assertEquals((ssprStartResult as ResetPasswordStartApiResult.UnknownError).error, INVALID_CLIENT_ERROR)
+        assertEquals((ssprStartResult as ResetPasswordStartApiResult.UnknownError).error, UNAUTHORIZED_CLIENT_ERROR)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
@@ -223,7 +223,7 @@ class SignUpOAuth2StrategyTest {
         configureMockApi(
             endpointType = MockApiEndpoint.SignUpStart,
             correlationId = correlationId,
-            responseType = MockApiResponseType.INVALID_CLIENT
+            responseType = MockApiResponseType.UNAUTHORIZED_CLIENT
         )
 
         val signUpStartCommandParameters = SignUpStartCommandParameters.builder()


### PR DESCRIPTION
The mock API responses from all endpoints have been update to return unauthorized_client error response instead of invalid_client.  Investigate and update any tests that are expecting invalid_client responses and replace this with unauthorized_client.