### PR TITLE
Logs ClientCertChallenge

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -134,7 +134,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
                     .append(", ");
         }
 
-        logLine.append("\ngetPrincipals: ");
+        logLine.append("\nPrincipals: ");
         for (Principal p : request.getPrincipals()){
             logLine.append(p.getName())
                     .append(", ");

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -37,8 +37,10 @@ import androidx.annotation.RequiresApi;
 import com.microsoft.identity.common.java.opentelemetry.ICertBasedAuthTelemetryHelper;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 
 /**
  * Handles a received ClientCertRequest by prompting the user to choose from certificates
@@ -72,6 +74,9 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     @Override
     public Void processChallenge(ClientCertRequest request) {
         final String methodTag = TAG + ":processChallenge";
+
+        Logger.info(methodTag, printRequestDetails(request));
+
         KeyChain.choosePrivateKeyAlias(mActivity, new KeyChainAliasCallback() {
                     @Override
                     public void alias(String alias) {
@@ -115,6 +120,33 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
                 request.getPort(),
                 null);
         return null;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private String printRequestDetails(ClientCertRequest request) {
+
+        final StringBuilder logLine = new StringBuilder();
+        logLine.append("Processing challenge\n");
+
+        logLine.append("Key Type: ");
+        for (String s : request.getKeyTypes()){
+            logLine.append(s)
+                    .append(", ");
+        }
+
+        logLine.append("getPrincipals: ");
+        for (Principal p : request.getPrincipals()){
+            logLine.append(p.getName())
+                    .append(", ");
+        }
+
+        logLine.append("Host: ")
+                .append(request.getHost());
+
+        logLine.append("Port: ")
+                .append(request.getPort());
+
+        return logLine.toString();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -126,7 +126,7 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     private String printRequestDetails(ClientCertRequest request) {
 
         final StringBuilder logLine = new StringBuilder();
-        logLine.append("Processing challenge");
+        logLine.append("Processing CBA challenge");
 
         logLine.append("\nKey Type: ");
         for (String s : request.getKeyTypes()){

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -126,24 +126,24 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     private String printRequestDetails(ClientCertRequest request) {
 
         final StringBuilder logLine = new StringBuilder();
-        logLine.append("Processing challenge\n");
+        logLine.append("Processing challenge");
 
-        logLine.append("Key Type: ");
+        logLine.append("\nKey Type: ");
         for (String s : request.getKeyTypes()){
             logLine.append(s)
                     .append(", ");
         }
 
-        logLine.append("getPrincipals: ");
+        logLine.append("\ngetPrincipals: ");
         for (Principal p : request.getPrincipals()){
             logLine.append(p.getName())
                     .append(", ");
         }
 
-        logLine.append("Host: ")
+        logLine.append("\nHost: ")
                 .append(request.getHost());
 
-        logLine.append("Port: ")
+        logLine.append("\nPort: ")
                 .append(request.getPort());
 
         return logLine.toString();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/OnDeviceCertBasedAuthChallengeHandler.java
@@ -125,12 +125,11 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
     @RequiresApi(api = Build.VERSION_CODES.M)
     private String printRequestDetails(ClientCertRequest request) {
 
-        final StringBuilder logLine = new StringBuilder();
-        logLine.append("Processing CBA challenge");
+        final StringBuilder logLine = new StringBuilder(256);
+        logLine.append("Processing CBA challenge. \nKey Type: ");
 
-        logLine.append("\nKey Type: ");
-        for (String s : request.getKeyTypes()){
-            logLine.append(s)
+        for (String k : request.getKeyTypes()){
+            logLine.append(k)
                     .append(", ");
         }
 
@@ -141,9 +140,8 @@ public class OnDeviceCertBasedAuthChallengeHandler extends AbstractCertBasedAuth
         }
 
         logLine.append("\nHost: ")
-                .append(request.getHost());
-
-        logLine.append("\nPort: ")
+                .append(request.getHost())
+                .append("\nPort: ")
                 .append(request.getPort());
 
         return logLine.toString();


### PR DESCRIPTION
Needed for CBA investigation.

-----

Context: 

got an IcM where the customer is getting CBA prompt sporadically. https://portal.microsofticm.com/imp/v3/incidents/incident/505319757/summary

Either there's an OS bug, or the server is sporadically sending malformed challenge.

From [Android Documentation](https://developer.android.com/reference/android/security/KeyChain#choosePrivateKeyAlias(android.app.Activity,%20android.security.KeyChainAliasCallback,%20java.lang.String[],%20java.security.Principal[],%20android.net.Uri,%20java.lang.String))

`
keyTypes and issuers may be used to narrow down suggested choices to the user. If either keyTypes or issuers is specified and non-empty, and there are no matching certificates in the KeyChain, then the certificate selection prompt would be suppressed entirely
`