### PR TITLE
Adding check for OS version for passkeys

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ---------
 - [MINOR] Update logic for matching requested claims for AT (#2401)
 - [MINOR] Updating YubiKit and CredMan versions (#2417)
+- [PATCH] Adding check for OS version for passkeys (#2419)
 
 Version 17.4.0
 ---------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.Next
 ---------
 - [MINOR] Update logic for matching requested claims for AT (#2401)
+- [MINOR] Updating YubiKit and CredMan versions (#2417)
 
 Version 17.4.0
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.fido
 
+import android.os.Build
 import android.webkit.WebView
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -69,6 +70,18 @@ class AuthFidoChallengeHandler (
         // If either one of these are missing or malformed, throw an exception and let the main WebViewClient handle it.
         val submitUrl = fidoChallenge.submitUrl.getOrThrow()
         val context = fidoChallenge.context.getOrThrow()
+        // Check the OS version as well. As of the time this is written, passkeys are only supported on devices that run Android 9 (API 28) or higher.
+        // https://developer.android.com/identity/sign-in/credential-manager
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            respondToChallengeWithError(
+                submitUrl = submitUrl,
+                context = context,
+                span = span,
+                errorMessage = "Device is running on an Android version less than 9 (API 28), which is the minimum level for passkeys.",
+                methodTag = methodTag
+            )
+            return null
+        }
         val authChallenge: String
         val relyingPartyIdentifier: String
         val userVerificationPolicy: String

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandlerTest.kt
@@ -33,8 +33,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk=[28])
 class AuthFidoChallengeHandlerTest {
     //Challenge parameters
     val challengeStr = "T1xCsnxM2DNL2KdK5CLa6fMhD7OBqho6syzInk_n-Uo"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -66,8 +66,8 @@ ext {
     tokenShare = "1.6.5"
     intuneAppSdkVersion = "8.6.3"
     javaAssistVersion = "3.27.0-GA"
-    yubikitAndroidVersion = "2.3.0"
-    yubikitPivVersion = "2.3.0"
+    yubikitAndroidVersion = "2.5.0"
+    yubikitPivVersion = "2.5.0"
     powerliftAndroidVersion="1.0.3"
     kotlinXCoroutinesVersion = "1.6.4"
     mockkVersion = "1.11.0"
@@ -79,7 +79,7 @@ ext {
     jetpackDataStoreVersion = "1.0.0"
     blockstoreVersion="16.2.0"
     lifecycleKtxVersion="2.5.1"
-    AndroidCredentialsVersion="1.2.0"
+    AndroidCredentialsVersion="1.2.2"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"


### PR DESCRIPTION
### Summary
According to the Credential Manager documentation, passkeys are only available for devices running on Android 9 (API 28) and above. I'm adding a check before most of the logic in AuthFidoChallengeHandler so that we can swiftly end the logic and return a message to the server.
