### PR TITLE
Platform Specific Extra Query Parameters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ---------
 - [MINOR] Update logic for matching requested claims for AT (#2401)
 - [MINOR] Updating YubiKit and CredMan versions (#2417)
+- [MINOR] Platform Specific Extra Query Parameters (#2426)
 
 Version 17.4.0
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -219,7 +219,7 @@ public class AndroidPlatformUtil implements IPlatformUtil {
     }
 
     @Override
-    public List<Map.Entry<String, String>> setPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList) {
+    public List<Map.Entry<String, String>> updateWithAndGetPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList) {
         List<Map.Entry<String, String>> queryParams = originalList != null ?  new ArrayList<>(originalList) : new ArrayList<>();
 
         // Passkey feature support is only for Android at the moment.

--- a/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtilTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.platform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.java.constants.FidoConstants;
+import com.microsoft.identity.common.java.util.IPlatformUtil;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidPlatformUtilTest {
+
+    private final IPlatformUtil mPlatformUtil = new AndroidPlatformUtil(ApplicationProvider.getApplicationContext(), new Activity());
+    private final Map.Entry<String, String> webauthnEntry = new AbstractMap.SimpleEntry<>(FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD, FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE);
+
+    @Test
+    public void testSetPlatformSpecificExtraQueryParameters_list() {
+        final List <Map.Entry<String, String>> list = new ArrayList<>();
+        list.add(new AbstractMap.SimpleEntry<>("foo", "1"));
+
+        assertTrue(mPlatformUtil.setPlatformSpecificExtraQueryParameters(list).contains(webauthnEntry));
+    }
+
+    @Test
+    public void testSetPlatformSpecificExtraQueryParameters_emptyList() {
+        assertTrue(mPlatformUtil.setPlatformSpecificExtraQueryParameters(null).contains(webauthnEntry));
+    }
+
+    @Test
+    public void testSetPlatformSpecificExtraQueryParameters_alreadyHasParameter() {
+        final List <Map.Entry<String, String>> list = new ArrayList<>();
+        list.add(new AbstractMap.SimpleEntry<>("foo", "1"));
+        list.add(webauthnEntry);
+        final List <Map.Entry<String, String>> result = mPlatformUtil.setPlatformSpecificExtraQueryParameters(list);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains(webauthnEntry));
+        assertTrue(result.contains(new AbstractMap.SimpleEntry<>("foo", "1")));
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtilTest.java
@@ -53,12 +53,12 @@ public class AndroidPlatformUtilTest {
         final List <Map.Entry<String, String>> list = new ArrayList<>();
         list.add(new AbstractMap.SimpleEntry<>("foo", "1"));
 
-        assertTrue(mPlatformUtil.setPlatformSpecificExtraQueryParameters(list).contains(webauthnEntry));
+        assertTrue(mPlatformUtil.updateWithAndGetPlatformSpecificExtraQueryParameters(list).contains(webauthnEntry));
     }
 
     @Test
     public void testSetPlatformSpecificExtraQueryParameters_emptyList() {
-        assertTrue(mPlatformUtil.setPlatformSpecificExtraQueryParameters(null).contains(webauthnEntry));
+        assertTrue(mPlatformUtil.updateWithAndGetPlatformSpecificExtraQueryParameters(null).contains(webauthnEntry));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class AndroidPlatformUtilTest {
         final List <Map.Entry<String, String>> list = new ArrayList<>();
         list.add(new AbstractMap.SimpleEntry<>("foo", "1"));
         list.add(webauthnEntry);
-        final List <Map.Entry<String, String>> result = mPlatformUtil.setPlatformSpecificExtraQueryParameters(list);
+        final List <Map.Entry<String, String>> result = mPlatformUtil.updateWithAndGetPlatformSpecificExtraQueryParameters(list);
         assertNotNull(result);
         assertEquals(2, result.size());
         assertTrue(result.contains(webauthnEntry));

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.ui.BrowserDescriptor;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -127,4 +128,12 @@ public interface IPlatformUtil {
      */
     @Nullable
     String getPackageNameFromUid(final int uid);
+
+    /**
+     * We might want to add (or remove) extra query parameters which are specific to each platform.
+     * @param originalList existing list of extra query parameters to
+     * @return a list of extra query parameters, or null.
+     */
+    @Nullable
+    List<Map.Entry<String, String>> setPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList);
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/IPlatformUtil.java
@@ -135,5 +135,5 @@ public interface IPlatformUtil {
      * @return a list of extra query parameters, or null.
      */
     @Nullable
-    List<Map.Entry<String, String>> setPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList);
+    List<Map.Entry<String, String>> updateWithAndGetPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList);
 }

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
@@ -191,7 +191,7 @@ public class MockPlatformComponentsFactory {
 
         @Nullable
         @Override
-        public List<Map.Entry<String, String>> setPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList) {
+        public List<Map.Entry<String, String>> updateWithAndGetPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList) {
             return originalList;
         }
     };

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/components/MockPlatformComponentsFactory.java
@@ -39,9 +39,9 @@ import com.microsoft.identity.common.java.util.IBroadcaster;
 import com.microsoft.identity.common.java.util.IClockSkewManager;
 import com.microsoft.identity.common.java.util.IPlatformUtil;
 
-import java.security.cert.Certificate;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -187,6 +187,12 @@ public class MockPlatformComponentsFactory {
         @Override
         public String getPackageNameFromUid(int uid) {
             return null;
+        }
+
+        @Nullable
+        @Override
+        public List<Map.Entry<String, String>> setPlatformSpecificExtraQueryParameters(@Nullable List<Map.Entry<String, String>> originalList) {
+            return originalList;
         }
     };
 }


### PR DESCRIPTION
### Summary
Adding a method to IPlatformUtil `setPlatformSpecificExtraQueryParameters`. This method takes in an existing list of parameters or null and returns a list of parameters which has been edited based on the platform, or null (if the existing list was null).
An example of a query string parameter which benefits from this method is the passkey parameter, which only needs to be sent for Android broker and not Linux broker.

This is going to make the consumer checks fail at the broker stage, but I'll run them all once to make sure that the other libraries don't run into issues.