### PR TITLE
Updating Labs App ID URL

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
@@ -40,7 +40,7 @@ import lombok.NonNull;
  * A an authentication client that can acquire access tokens for the Microsoft Identity Lab Api.
  */
 public class LabApiAuthenticationClient implements IAccessTokenSupplier {
-    private final static String SCOPE = "https://msidlab.com/.default";
+    private final static String SCOPE = "https://request.msidlab.com/.default";
     private final static String TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
     private final static String AUTHORITY = "https://login.microsoftonline.com/" + TENANT_ID;
     private final static String CLIENT_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabAuthenticationConstants.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabAuthenticationConstants.java
@@ -26,7 +26,7 @@ public class LabAuthenticationConstants {
 
     public static final String AUDIENCE_CLAIM = "aud";
     public static final String KEY_VAULT_TOKEN_AUDIENCE = "https://vault.azure.net";
-    public static final String LAB_API_TOKEN_AUDIENCE = "https://msidlab.com";
+    public static final String LAB_API_TOKEN_AUDIENCE = "https://request.msidlab.com";
     public static final String UPN_CLAIM = "upn";
 
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabAuthenticationHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabAuthenticationHelper.java
@@ -30,7 +30,7 @@ import com.microsoft.identity.internal.testutils.BuildConfig;
 
 class LabAuthenticationHelper extends ConfidentialClientHelper {
     private final static String LAB_APP_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
-    private final static String SCOPE = "https://msidlab.com/.default";
+    private final static String SCOPE = "https://default.msidlab.com/.default";
     private String mLabAppSecret = BuildConfig.LAB_CLIENT_SECRET;
     private static LabAuthenticationHelper sLabAuthHelper;
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabAuthenticationHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabAuthenticationHelper.java
@@ -30,7 +30,7 @@ import com.microsoft.identity.internal.testutils.BuildConfig;
 
 class LabAuthenticationHelper extends ConfidentialClientHelper {
     private final static String LAB_APP_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
-    private final static String SCOPE = "https://default.msidlab.com/.default";
+    private final static String SCOPE = "https://request.msidlab.com/.default";
     private String mLabAppSecret = BuildConfig.LAB_CLIENT_SECRET;
     private static LabAuthenticationHelper sLabAuthHelper;
 


### PR DESCRIPTION
### Summary
The labs team is making updates, so we need to change the app ID URL to their suggested workaround (which is looking to be a permanent fix). 