### PR TITLE
Enable the new Broker Discovery by default in MSAL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Enable Broker Discovery by default in MSAL (#2445)
 - [PATCH] Add null check for CBA logging (#2443)
 - [MINOR] Add support for per tenant flighting in broker (#2433)
 - [MINOR] Fix AccountManager Strategy (#2427)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
@@ -42,7 +42,7 @@ class BrokerDiscoveryClientFactory {
         private val TAG = BrokerDiscoveryClientFactory::class.simpleName
 
         @Volatile
-        private var IS_NEW_DISCOVERY_ENABLED = false
+        private var IS_NEW_DISCOVERY_ENABLED = true
 
         @Volatile
         private var clientSdkInstance: IBrokerDiscoveryClient? = null


### PR DESCRIPTION
Now that we're enabling the feature on LTW to 100%, and oneauth has turned this on by default since January.
It should be safe to enable this for MSAL apps (mostly 3rd party)