### PR TITLE
Revert "Enable the new Broker Discovery by default in MSAL (#2445)"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 V.Next
 ---------
-- [MINOR] Enable Broker Discovery by default in MSAL (#2445)
 - [PATCH] Add null check for CBA logging (#2443)
 - [MINOR] Add support for per tenant flighting in broker (#2433)
 - [MINOR] Fix AccountManager Strategy (#2427)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClientFactory.kt
@@ -42,7 +42,7 @@ class BrokerDiscoveryClientFactory {
         private val TAG = BrokerDiscoveryClientFactory::class.simpleName
 
         @Volatile
-        private var IS_NEW_DISCOVERY_ENABLED = true
+        private var IS_NEW_DISCOVERY_ENABLED = false
 
         @Volatile
         private var clientSdkInstance: IBrokerDiscoveryClient? = null


### PR DESCRIPTION
This reverts commit dce2d55eae0124413e00ae25222438da98bf9873.