### PR TITLE
Classifying more UNKNOWN_ERRORs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 V.Next
 ---------
 - [MINOR] Add null cursor BrokerCommunicationException error category (#2459)
+- [MINOR] Classifying more UNKNOWN_ERRORs (#2460)
 
 Version 17.6.1
 ---------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/InstallCertActivityLauncher.java
@@ -168,7 +168,7 @@ public final class InstallCertActivityLauncher extends AppCompatActivity {
                     } else {
                         final String errorMessage = StringUtil.isNullOrEmpty(exceptionMessage) ?
                                 CERT_INSTALLATION_FAILED_WITH_EMPTY_RESPONSE : exceptionMessage;
-                        callback.onError(new ClientException(ClientException.UNKNOWN_ERROR, errorMessage));
+                        callback.onError(new ClientException(ClientException.INSTALL_CERT_ERROR, errorMessage));
                     }
                     LocalBroadcaster.INSTANCE.unregisterCallback(INSTALL_CERT_BROADCAST_ALIAS);
                 });

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AndroidAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AndroidAuthorizationStrategy.java
@@ -82,7 +82,7 @@ public abstract class AndroidAuthorizationStrategy<
 
             final FragmentManager fragmentManager = fragment.getFragmentManager();
             if (fragmentManager == null) {
-                throw new ClientException(ClientException.UNKNOWN_ERROR, "Fragment Manager is null");
+                throw new ClientException(ClientException.NULL_OBJECT, "Fragment Manager is null");
             }
 
             fragmentManager.beginTransaction()
@@ -94,7 +94,7 @@ public abstract class AndroidAuthorizationStrategy<
 
         final Activity activity = mReferencedActivity.get();
         if (activity == null) {
-            throw new ClientException(ClientException.UNKNOWN_ERROR, "Referenced activity is null");
+            throw new ClientException(ClientException.NULL_OBJECT, "Referenced activity is null");
         }
         activity.startActivity(intent);
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -52,6 +52,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import org.json.JSONException;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -340,7 +341,8 @@ public class ExceptionAdapter {
 
     public static BaseException baseExceptionFromException(final Throwable exception) {
         Throwable e = exception;
-        if (exception instanceof ExecutionException) {
+        if (exception instanceof ExecutionException
+                && exception.getCause() != null) {
             e = exception.getCause();
         }
         if (e instanceof BaseException) {
@@ -357,7 +359,8 @@ public class ExceptionAdapter {
         }
 
         Throwable e = exception;
-        if (exception instanceof ExecutionException) {
+        if (exception instanceof ExecutionException
+                && exception.getCause() != null) {
             e = exception.getCause();
         }
 
@@ -393,7 +396,23 @@ public class ExceptionAdapter {
         if (e instanceof TimeoutException) {
             return new ClientException(
                     ClientException.TIMED_OUT,
-                    "A blocking operation has timed out",
+                    "A blocking operation has timed out: " + e.getMessage(),
+                    e
+            );
+        }
+
+        if (e instanceof NullPointerException) {
+            return new ClientException(
+                    ClientException.NULL_POINTER,
+                    e.getMessage()
+            );
+        }
+
+
+        if (e instanceof OutOfMemoryError) {
+            return new ClientException(
+                    ClientException.OUT_OF_MEMORY,
+                    e.getMessage(),
                     e
             );
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -52,7 +52,6 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import org.json.JSONException;
 
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -93,7 +92,7 @@ public class ExceptionAdapter {
                     methodTag,
                     "AuthorizationErrorResponse is not set"
             );
-            return new ClientException(ClientException.UNKNOWN_ERROR, "Authorization failed with unknown error. Authorization Status: " +authorizationResult.getAuthorizationStatus());
+            return new ClientException(ClientException.AUTHORIZATION_RESULT_ERROR, "Authorization failed with unknown error. Authorization Status: " +authorizationResult.getAuthorizationStatus());
         }
 
         //THERE ARE CURRENTLY NO USAGES of INVALID_REQUEST
@@ -403,7 +402,7 @@ public class ExceptionAdapter {
 
         if (e instanceof NullPointerException) {
             return new ClientException(
-                    ClientException.NULL_POINTER,
+                    ClientException.NULL_POINTER_ERROR,
                     e.getMessage()
             );
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -92,7 +92,7 @@ public class ExceptionAdapter {
                     methodTag,
                     "AuthorizationErrorResponse is not set"
             );
-            return new ClientException(ClientException.AUTHORIZATION_RESULT_ERROR, "Authorization failed with unknown error. Authorization Status: " +authorizationResult.getAuthorizationStatus());
+            return new ClientException(ClientException.AUTHORIZATION_RESULT_NULL_ERROR_RESPONSE, "Authorization error response is null. Authorization Status: " +authorizationResult.getAuthorizationStatus());
         }
 
         //THERE ARE CURRENTLY NO USAGES of INVALID_REQUEST

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -443,12 +443,42 @@ public class ClientException extends BaseException {
     /**
      * A NullPointerException was thrown.
      */
-    public static final String NULL_POINTER = "null_pointer";
+    public static final String NULL_POINTER_ERROR = "null_pointer_error";
+
+    /**
+     * An object was unexpectedly null. Used for explicit null checks, whereas NULL_POINTER_ERROR classifies NPEs.
+     */
+    public static final String NULL_OBJECT = "null_object";
+
+    /**
+     * An error related to the task Executor.
+     */
+    public static final String EXECUTOR_ERROR = "executor_error";
 
     /**
      * The JVM ran out of memory.
      */
     public static final String OUT_OF_MEMORY = "out_of_memory";
+
+    /**
+     * An error occurred in relation to the AuthorizationResult object.
+     */
+    public static final String AUTHORIZATION_RESULT_ERROR = "authorization_result_error";
+
+    /**
+     * An error occurred with the AccountChooser activity/logic.
+     */
+    public static final String ACCOUNT_CHOOSER_ERROR = "account_chooser_error";
+
+    /**
+     * An error related to a non-active broker.
+     */
+    public static final String NON_ACTIVE_BROKER_ERROR = "non_active_broker_error";
+
+    /**
+     * Error occurred in the process of installing a WPJ certificate.
+     */
+    public static final String INSTALL_CERT_ERROR = "install_cert_error";
 
     /**
      * Constructor of ClientException.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -461,14 +461,14 @@ public class ClientException extends BaseException {
     public static final String OUT_OF_MEMORY = "out_of_memory";
 
     /**
-     * An error occurred in relation to the AuthorizationResult object.
+     * The AuthorizationErrorResponse received was null.
      */
-    public static final String AUTHORIZATION_RESULT_ERROR = "authorization_result_error";
+    public static final String AUTHORIZATION_RESULT_NULL_ERROR_RESPONSE = "authorization_result_null_error_response";
 
     /**
-     * An error occurred with the AccountChooser activity/logic.
+     * There are parallel UI requests running.
      */
-    public static final String ACCOUNT_CHOOSER_ERROR = "account_chooser_error";
+    public static final String MULTIPLE_PARALLEL_INTERACTIVE_REQUEST_ERROR = "multiple_parallel_interactive_request_error";
 
     /**
      * An error related to a non-active broker.

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -188,7 +188,7 @@ public class ClientException extends BaseException {
     public static final String DUPLICATE_QUERY_PARAMETER = "duplicate_query_parameter";
 
     /**
-     * Extra query parameters set by the client app is already sent by the sdk.
+     * Used when base exception is not categorizable into any of the current error codes.
      */
     public static final String UNKNOWN_ERROR = "unknown_error";
 
@@ -439,6 +439,16 @@ public class ClientException extends BaseException {
      * A blocking operation has timed out.
      */
     public static final String TIMED_OUT = "timed_out";
+
+    /**
+     * A NullPointerException was thrown.
+     */
+    public static final String NULL_POINTER = "null_pointer";
+
+    /**
+     * The JVM ran out of memory.
+     */
+    public static final String OUT_OF_MEMORY = "out_of_memory";
 
     /**
      * Constructor of ClientException.

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/RawAuthorizationResult.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.providers;
 
+import com.microsoft.identity.common.java.controllers.ExceptionAdapter;
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -159,9 +160,7 @@ public class RawAuthorizationResult {
         }
         return RawAuthorizationResult.builder()
                 .resultCode(ResultCode.NON_OAUTH_ERROR)
-                .exception(new BaseException(ClientException.UNKNOWN_ERROR,
-                        "Unknown error with class: " + e.getClass().getSimpleName(),
-                        e))
+                .exception(ExceptionAdapter.baseExceptionFromException(e))
                 .build();
     }
 


### PR DESCRIPTION
### Summary
The error code `UNKNOWN_ERROR` appears frequently in our telemetry. We have a large amount of client exceptions going through the `clientExceptionFromException` method with an `UNKNOWN_ERROR` code, and there are also many places where `ClientException`s are being explicitly created with the code. 
After looking at the telemetry and doing some code searches in our codebase, I added some more specific error codes which will be used in the common and broker libraries. Any suggestions on name changes are welcomed.

### Related PRs