### PR TITLE
Re-order arguments when logging objects to fix incorrect formatting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version 17.7.0
 - [MINOR] Classifying more UNKNOWN_ERRORs (#2460)
 - [MINOR] Setting flights to control UrlConnection timeout values (#2473)
 - [PATCH] Fix Native Auth authority data being persisted across different SDK instances (#2462)
+- [PATCH] Fix incorrect formatting when logging native auth objects
 
 Version 17.6.1
 ---------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ---------
 - [MINOR] Add null cursor BrokerCommunicationException error category (#2459)
 - [MINOR] Classifying more UNKNOWN_ERRORs (#2460)
+- [MINOR] Fix incorrect formatting when logging native auth objects
 
 Version 17.6.1
 ---------

--- a/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/logging/Logger.java
@@ -358,13 +358,13 @@ public class Logger {
      *
      * @param tag           Used to identify the source of a log message. It usually identifies the class
      *                      or activity where the log call occurs.
-     * @param message       The message to log.
      * @param correlationId Unique identifier for a request or flow used to trace program execution.
+     * @param message       The message to log.
      * @param object        The object to be printed.
      */
     public static void infoWithObject(final String tag,
-                            final String message,
                             final String correlationId,
+                            final String message,
                             final ILoggable object) {
         if (isAllowPii()) {
             log(tag, Logger.LogLevel.INFO, correlationId, message, object.toUnsanitizedString(), null, object.containsPii());


### PR DESCRIPTION
Events in native auth code have been passing arguments in the incorrect order, leading to logged messages appearing with an incorrect format. By swapping the order of the arguments to match other methods, this fixes the incorrect formatting. 

Before:
`[2024-08-08 12:08:33 - thread_id: 128, correlation_id: rawApiResponse = - Android 33] ea8e94b0-58a8-468f-8d39-cdf5ef239333 SignInInitiateAPIResponse(...`
After:
`[2024-08-08 12:08:33 - thread_id: 128, correlation_id: ea8e94b0-58a8-468f-8d39-cdf5ef239333 - Android 33] rawApiResponse =  SignInInitiateAPIResponse(...`