### PR TITLE
Setting flights to control UrlConnection timeout values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ V.Next
 ---------
 - [MINOR] Add null cursor BrokerCommunicationException error category (#2459)
 - [MINOR] Classifying more UNKNOWN_ERRORs (#2460)
+- [MINOR] Setting flights to control UrlConnection timeout values (#2473)
 
 Version 17.6.1
 ---------

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -24,6 +24,8 @@
 package com.microsoft.identity.common.java.flighting;
 
 import static com.microsoft.identity.common.java.commands.SilentTokenCommand.ACQUIRE_TOKEN_SILENT_DEFAULT_TIMEOUT_MILLISECONDS;
+import static com.microsoft.identity.common.java.net.UrlConnectionHttpClient.DEFAULT_CONNECT_TIME_OUT_MS;
+import static com.microsoft.identity.common.java.net.UrlConnectionHttpClient.DEFAULT_READ_TIME_OUT_MS;
 
 import lombok.NonNull;
 
@@ -56,7 +58,17 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to be able to disable/rollback the passkey feature in broker if necessary.
      * This will be set to true by default.
      */
-    ENABLE_PASSKEY_FEATURE("EnablePasskeyFeature", true);
+    ENABLE_PASSKEY_FEATURE("EnablePasskeyFeature", true),
+
+    /**
+     * Flight to control the timeout duration for UrlConnection connect timeout.
+     */
+    URL_CONNECTION_CONNECT_TIME_OUT("UrlConnectionConnectTimeOut", DEFAULT_CONNECT_TIME_OUT_MS),
+
+    /**
+     * Flight to control the timeout duration for UrlConnection read timeout.
+     */
+    URL_CONNECTION_READ_TIME_OUT("UrlConnectionReadTimeOut", DEFAULT_READ_TIME_OUT_MS);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -23,6 +23,8 @@
 package com.microsoft.identity.common.java.net;
 
 import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
@@ -86,8 +88,8 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
     private static final String TAG = UrlConnectionHttpClient.class.getSimpleName();
 
     protected static final int RETRY_TIME_WAITING_PERIOD_MSEC = 1000;
-    protected static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;
-    protected static final int DEFAULT_READ_TIME_OUT_MS = 30000;
+    public static final int DEFAULT_CONNECT_TIME_OUT_MS = 30000;
+    public static final int DEFAULT_READ_TIME_OUT_MS = 30000;
     protected static final int DEFAULT_STREAM_BUFFER_SIZE_BYTE = 1024;
 
     private static final transient AtomicReference<UrlConnectionHttpClient> defaultReference = new AtomicReference<>(null);
@@ -149,9 +151,9 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
         this.streamBufferSize = streamBufferSize != null ?
                 streamBufferSize : DEFAULT_STREAM_BUFFER_SIZE_BYTE;
         this.connectTimeoutMs = connectTimeoutMs != null ?
-                connectTimeoutMs : DEFAULT_CONNECT_TIME_OUT_MS;
+                connectTimeoutMs : CommonFlightsManager.INSTANCE.getFlightsProvider().getIntValue(CommonFlight.URL_CONNECTION_CONNECT_TIME_OUT);
         this.readTimeoutMs = readTimeoutMs != null ?
-                readTimeoutMs : DEFAULT_READ_TIME_OUT_MS;
+                readTimeoutMs : CommonFlightsManager.INSTANCE.getFlightsProvider().getIntValue(CommonFlight.URL_CONNECTION_READ_TIME_OUT);
         this.connectTimeoutMsSupplier = connectTimeoutMsSupplier;
         this.readTimeoutMsSupplier = readTimeoutMsSupplier;
 


### PR DESCRIPTION
### Summary
AcquireTokenSilent requests have a default timeout value of 30 seconds, after which a general TimeoutException will be thrown (see this line: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/dev/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java#L254).
To help distinguish some exceptions from the pool of TimeoutExceptions, we can decrease the connect and read timeouts of our HttpUrlConnection instance such that a SocketTimeoutException would get thrown before a general TimeoutException.
This PR sets a flight on the default connect and read timeout values for the purpose of gradually introducing lower timeout values and to provide a rollback solution. In telemetry, if this solution is effective, we would expect to see a rise in SocketTimeoutExceptions proportional to a decrease in general TimeoutExceptions.

I tested this flight with ECS dev, enabling the flight to 100% with 15000 ms, and then stopping the flight to mimic a rollback.