### PR TITLE
Adjust JsonUtil

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
@@ -50,8 +50,13 @@ public class JsonUtil {
         final Map<String, String> responseItems = new HashMap<>();
         while (keyIterator.hasNext()) {
             final String key = keyIterator.next();
-            final String value = jsonObject.get(key).toString();
-            responseItems.put(key, value);
+            final Object jsonValue = jsonObject.get(key);
+            
+            if (jsonValue == null) {
+                responseItems.put(key, null);
+            } else {
+                responseItems.put(key, jsonValue.toString());
+            }
         }
 
         return responseItems;

--- a/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/JsonUtil.java
@@ -50,7 +50,8 @@ public class JsonUtil {
         final Map<String, String> responseItems = new HashMap<>();
         while (keyIterator.hasNext()) {
             final String key = keyIterator.next();
-            responseItems.put(key, jsonObject.getString(key));
+            final String value = jsonObject.get(key).toString();
+            responseItems.put(key, value);
         }
 
         return responseItems;


### PR DESCRIPTION
Found a bug where broker4j and android seem to use different json versions, depending on what the json version shipped with android is. This change will make JsonUtil more resilient regardless of json version.