### PR TITLE
Return Family ID in LocalAuthenticationResult

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Return Family ID in LocalAuthenticationResult (#2479)
 - [PATCH] Move MS STS Response handling to separate class (#2471)
 - [MINOR] Add support for email OTP MFA in native authentication (#2468)
 

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -76,6 +76,7 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
 
         if (cacheRecord.getRefreshToken() != null) {
             mRefreshToken = cacheRecord.getRefreshToken().getSecret();
+            mFamilyId = cacheRecord.getRefreshToken().getFamilyId();
         }
 
         final IdTokenRecord idTokenRecord = sdkType == SdkType.ADAL ?


### PR DESCRIPTION
So that OneAuth can use this as a signal to put FoCl token in TSL.

(LocalAuthenticationResult is the object the broker return to SDKs when acquireToken/acquireTokenSilent is invoked)

Validate via MSALTestApp + BrokerHost.