### PR TITLE
Disable Network check by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ---------
+- [MINOR] Disable Network check by default (#2480)
 - [PATCH] Move MS STS Response handling to separate class (#2471)
 - [MINOR] Add support for email OTP MFA in native authentication (#2468)
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -75,6 +75,11 @@ public class DefaultConnectionService implements IConnectionService {
         ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_NETWORK_CONNECTIVITY_CHECK)){
+            // Skip the check.
+            return true;
+        }
+
         final boolean isConnectionAvailable;
         final boolean useNetworkCapabilityForNetworkCheck
                 = CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.USE_NETWORK_CAPABILITY_FOR_NETWORK_CHECK);

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -72,11 +72,6 @@ public class DefaultConnectionService implements IConnectionService {
      * @return True if network connection available, false otherwise.
      */
     public boolean isConnectionAvailable() {
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_NETWORK_CONNECTIVITY_CHECK)){
-            // Skip the check.
-            return true;
-        }
-
         final ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/net/DefaultConnectionService.java
@@ -72,13 +72,13 @@ public class DefaultConnectionService implements IConnectionService {
      * @return True if network connection available, false otherwise.
      */
     public boolean isConnectionAvailable() {
-        ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
-                .getSystemService(Context.CONNECTIVITY_SERVICE);
-
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_NETWORK_CONNECTIVITY_CHECK)){
             // Skip the check.
             return true;
         }
+
+        final ConnectivityManager connectivityManager = (ConnectivityManager) mConnectionContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
 
         final boolean isConnectionAvailable;
         final boolean useNetworkCapabilityForNetworkCheck

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java
@@ -126,6 +126,11 @@ public class AndroidPlatformUtil implements IPlatformUtil {
                             + "enabled. And the device is in doze mode or the app is standby");
         }
 
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_NETWORK_CONNECTIVITY_CHECK)){
+            // Skip the check.
+            return;
+        }
+
         if (!connectionService.isConnectionAvailable()) {
             throw new ClientException(
                     ErrorStrings.DEVICE_NETWORK_NOT_AVAILABLE,

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -68,7 +68,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to control the timeout duration for UrlConnection read timeout.
      */
-    URL_CONNECTION_READ_TIME_OUT("UrlConnectionReadTimeOut", DEFAULT_READ_TIME_OUT_MS);
+    URL_CONNECTION_READ_TIME_OUT("UrlConnectionReadTimeOut", DEFAULT_READ_TIME_OUT_MS),
+
+    /**
+     * Flight to disable the network connectivity check.
+     */
+    DISABLE_NETWORK_CONNECTIVITY_CHECK("DisableNetworkConnectivityCheck", true);;
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -73,7 +73,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to disable the network connectivity check.
      */
-    DISABLE_NETWORK_CONNECTIVITY_CHECK("DisableNetworkConnectivityCheck", true);;
+    DISABLE_NETWORK_CONNECTIVITY_CHECK("DisableNetworkConnectivityCheck", true);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
This network check doesn't seem reliable.
(a handful of broker requests failed with this check, but then succeeded with OneAuth.)

This PR will disable the test by default - bringing the behavior in BOTH Broker and Common to match with OneAuth's.

---

NOTE: [Doze mode network check](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/3bd7337d4bc0df4974cc30701b22a43b3a4d8059/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java#L122) is not in scope of this work.
(that check is set by SDK. 
- In MSAL, that's true by default (via MSAL config).
- In OneAuth, it's always false. There's no way for an app to set, and OneAuth never touches it).