### PR TITLE
Remove RT from AAD token responses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 V.Next
 ----------
+- [MAJOR] Remove RT from AAD token responses (#2483)
 - [MINOR] Add API in MicrosoftStsOAuthStrategy to request token and handle response with provided handler (@2478)
 - [MINOR] Setting flights to control UrlConnection timeout values (#2473)
 - [PATCH] Fix Native Auth authority data being persisted across different SDK instances (#2462)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -133,6 +133,7 @@ android {
 }
 
 dependencies {
+    testImplementation project(path: ':testutils')
     //Java 8 - Desugaring - Enabled/Disabled via plugin
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -605,7 +605,7 @@ public final class AuthenticationConstants {
          *
          * @see <a href="https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/%5BAndroid%5D%20Broker%20API/broker_protocol_versions.md">Android Auth Broker Protocol Versions</a>
          */
-        public static final String LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "15.0";
+        public static final String LATEST_MSAL_TO_BROKER_PROTOCOL_VERSION_CODE = "16.0";
 
         /**
          * The maximum msal-to-broker protocol version known by clients such as MSAL Android.

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -277,7 +277,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 // Cannot determine if this is AAD or MSA. Do not strip values.
                 SpanExtension.current().setAttribute(
                         AttributeName.stop_returning_rt_result.name(),
-                        "cannot_determine"
+                        "cannot_determine_account_type"
                 );
                 return false;
             } catch (final Throwable t) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -258,7 +258,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                     final boolean resultToReturn = !AzureActiveDirectoryAudience.MSA_MEGA_TENANT_ID.equalsIgnoreCase(result.getTenantId());
                     SpanExtension.current().setAttribute(
                             AttributeName.stop_returning_rt_result.name(),
-                            resultToReturn
+                            Boolean.toString(resultToReturn)
                     );
                     return resultToReturn;
                 }
@@ -269,7 +269,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                             !result.getAccessTokenRecord().getAuthority().contains(AzureActiveDirectoryAudience.CONSUMERS);
                     SpanExtension.current().setAttribute(
                             AttributeName.stop_returning_rt_result.name(),
-                            resultToReturn
+                            Boolean.toString(resultToReturn)
                     );
                     return resultToReturn;
                 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
@@ -1,0 +1,200 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.internal.request
+
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter.REMOVE_RT_FROM_AAD_RESULT_MSAL_PROTOCOL_VERSION
+import com.microsoft.identity.common.java.cache.CacheRecord
+import com.microsoft.identity.common.java.cache.ICacheRecord
+import com.microsoft.identity.common.java.request.SdkType
+import com.microsoft.identity.common.java.result.LocalAuthenticationResult
+import com.microsoft.identity.internal.testutils.MockRecords
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MsalBrokerResultAdapterTests {
+
+    fun getInstance(): MsalBrokerResultAdapter {
+        return MsalBrokerResultAdapter(true)
+    }
+
+    @Test
+    fun testShouldRemoveRefreshToken_MSAResponse() {
+        val mockCacheRecord = CacheRecord.builder()
+                .account(MockRecords.getMockAccountRecord_MSA())
+                .idToken(MockRecords.getMockIdTokenRecord_MSA())
+                .accessToken(MockRecords.getMockAccessTokenRecord_MSA())
+                .refreshToken(MockRecords.getMockRefreshTokenRecord_MSA())
+                .build()
+
+        val cacheRecords: MutableList<ICacheRecord> = ArrayList()
+        cacheRecords.add(mockCacheRecord)
+
+        val mockResult = LocalAuthenticationResult(
+                mockCacheRecord,
+                cacheRecords,
+                SdkType.MSAL,
+                true
+        )
+
+        // We'll return RT to older SDK
+        val resultWithOlderSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "15.0"
+        )
+
+        Assert.assertNotNull(resultWithOlderSdk.refreshToken)
+        for(tenantProfile in resultWithOlderSdk.tenantProfileData) {
+            Assert.assertNotNull(tenantProfile.refreshToken)
+        }
+
+        // With SDK >= 16, we would still return RT.
+        val resultWithProtocolVer16 = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                REMOVE_RT_FROM_AAD_RESULT_MSAL_PROTOCOL_VERSION
+        )
+
+        Assert.assertNotNull(resultWithProtocolVer16.refreshToken)
+        for(tenantProfile in resultWithProtocolVer16.tenantProfileData) {
+            Assert.assertNotNull(tenantProfile.refreshToken)
+        }
+
+        val resultWithNewerSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "17.1234"
+        )
+
+        Assert.assertNotNull(resultWithNewerSdk.refreshToken)
+        for(tenantProfile in resultWithNewerSdk.tenantProfileData) {
+            Assert.assertNotNull(tenantProfile.refreshToken)
+        }
+    }
+
+    @Test
+    fun testShouldRemoveRefreshToken_AADResponse() {
+        val mockCacheRecord = CacheRecord.builder()
+                .account(MockRecords.getMockAccountRecord_AAD())
+                .idToken(MockRecords.getMockIdTokenRecord_AAD())
+                .accessToken(MockRecords.getMockAccessTokenRecord_AAD())
+                .refreshToken(MockRecords.getMockRefreshTokenRecord_AAD())
+                .build()
+
+        val cacheRecords: MutableList<ICacheRecord> = ArrayList()
+        cacheRecords.add(mockCacheRecord)
+
+        val mockResult = LocalAuthenticationResult(
+                mockCacheRecord,
+                cacheRecords,
+                SdkType.MSAL,
+                true
+        )
+
+        // We'll still return RT to older SDK
+        val resultWithOlderSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "15.0"
+        )
+
+        Assert.assertNotNull(resultWithOlderSdk.refreshToken)
+        for(tenantProfile in resultWithOlderSdk.tenantProfileData) {
+            Assert.assertNotNull(tenantProfile.refreshToken)
+        }
+
+        // With SDK >= 16, we would NOT return RT.
+        val resultWithProtocolVer16 = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                REMOVE_RT_FROM_AAD_RESULT_MSAL_PROTOCOL_VERSION
+        )
+
+        Assert.assertNull(resultWithProtocolVer16.refreshToken)
+        for(tenantProfile in resultWithProtocolVer16.tenantProfileData) {
+            Assert.assertNull(tenantProfile.refreshToken)
+        }
+
+        val resultWithNewerSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "17.1234"
+        )
+
+        Assert.assertNull(resultWithNewerSdk.refreshToken)
+        for(tenantProfile in resultWithNewerSdk.tenantProfileData) {
+            Assert.assertNull(tenantProfile.refreshToken)
+        }
+    }
+
+    @Test
+    fun testShouldRemoveRefreshToken_MSAPassthroughResponse() {
+        val mockCacheRecord = CacheRecord.builder()
+                .account(MockRecords.getMockAccountRecord_MSAPassthrough())
+                .idToken(MockRecords.getMockIdTokenRecord_MSAPassthrough())
+                .accessToken(MockRecords.getMockAccessTokenRecord_MSAPassthrough())
+                .refreshToken(MockRecords.getMockRefreshTokenRecord_MSAPassthrough())
+                .build()
+
+        val cacheRecords: MutableList<ICacheRecord> = ArrayList()
+        cacheRecords.add(mockCacheRecord)
+
+        val mockResult = LocalAuthenticationResult(
+                mockCacheRecord,
+                cacheRecords,
+                SdkType.MSAL,
+                true
+        )
+
+        // We'll still return RT to older SDK
+        val resultWithOlderSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "15.0"
+        )
+
+        Assert.assertNotNull(resultWithOlderSdk.refreshToken)
+        for(tenantProfile in resultWithOlderSdk.tenantProfileData) {
+            Assert.assertNotNull(tenantProfile.refreshToken)
+        }
+
+        // With SDK >= 16, we would NOT return RT.
+        // (Because MSA passthrough = AAD guest scenario)
+        val resultWithProtocolVer16 = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                REMOVE_RT_FROM_AAD_RESULT_MSAL_PROTOCOL_VERSION
+        )
+
+        Assert.assertNull(resultWithProtocolVer16.refreshToken)
+        for(tenantProfile in resultWithProtocolVer16.tenantProfileData) {
+            Assert.assertNull(tenantProfile.refreshToken)
+        }
+
+        val resultWithNewerSdk = getInstance().buildBrokerResultFromAuthenticationResult(
+                mockResult,
+                "17.1234"
+        )
+
+        Assert.assertNull(resultWithNewerSdk.refreshToken)
+        for(tenantProfile in resultWithNewerSdk.tenantProfileData) {
+            Assert.assertNull(tenantProfile.refreshToken)
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -73,7 +73,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to disable the network connectivity check.
      */
-    DISABLE_NETWORK_CONNECTIVITY_CHECK("DisableNetworkConnectivityCheck", true);
+    DISABLE_NETWORK_CONNECTIVITY_CHECK("DisableNetworkConnectivityCheck", true),
+
+    /**
+     * Flight to stop returning AAD RT back to calling apps.
+     */
+    STOP_RETURNING_AAD_RT_BACK_TO_CALLING_APP("StopReturningAadRtBackToCallingApp", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -282,5 +282,10 @@ public enum AttributeName {
     /**
      * Indicates the prt's home authority.
      */
-    home_cloud_name
+    home_cloud_name,
+
+    /**
+     * Specify the result (or error stack trace) when determining if RT should be returned with AT response.
+     */
+    stop_returning_rt_result
 }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockRecords.kt
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/MockRecords.kt
@@ -1,0 +1,232 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.internal.testutils
+
+import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience.MSA_MEGA_TENANT_ID
+import com.microsoft.identity.common.java.dto.AccessTokenRecord
+import com.microsoft.identity.common.java.dto.AccountRecord
+import com.microsoft.identity.common.java.dto.IdTokenRecord
+import com.microsoft.identity.common.java.dto.RefreshTokenRecord
+import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAccount.AUTHORITY_TYPE_MS_STS
+import com.microsoft.identity.internal.testutils.mocks.MockTokenCreator.createMockRawClientInfo
+import java.util.concurrent.TimeUnit
+
+object MockRecords {
+
+    private const val MOCK_NAME = "MOCK_NAME"
+    private const val MOCK_MSA_USERNAME = "mock@outlook.com"
+    private const val MOCK_UID = "00000000-0000-0000-0000-000123456789"
+    private const val MOCK_ENVIRONMENT = "login.windows.net"
+    private const val MOCK_CLIENT_ID = "12345678-0000-0000-0000-000123456789"
+    private const val MOCK_MSA_AUTHORITY = "https://login.microsoftonline.com/$MSA_MEGA_TENANT_ID/oAuth2/v2.0/token"
+    private const val MOCK_SECRET = "TOKEN_SECRET"
+    private const val MOCK_APPLICATION_IDENTIFIER = "com.msft.identity.client.sample.local/xxAk8S05zu0Nkce+X2J6IKJ2e7YE4F9ZorZj0YnYUQ2vw8vLc8VGGOqJdTnVySbbcy9VY8UDbOfeOETSErYllw=="
+    private const val MOCK_TARGET = "User.Read openid profile"
+    private const val MOCK_LOCAL_GUEST_UID = "b985a3e2-457e-4d38-8f1d-354a949b802e"
+    private const val MOCK_AAD_TENANT_ID = "f645ad92-e38d-4d1a-b510-d1b09a74a8ca"
+    private const val MOCK_MSA_GUEST_AUTHORITY = "https://login.microsoftonline.com/$MOCK_AAD_TENANT_ID/oAuth2/v2.0/token"
+    private const val MOCK_AAD_ORGANIZATION_AUTHORITY = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/token"
+
+    //region MSA
+    fun getMockAccountRecord_MSA(): AccountRecord {
+        val accountRecord = AccountRecord()
+        accountRecord.authorityType = AUTHORITY_TYPE_MS_STS
+        accountRecord.clientInfo = createMockRawClientInfo(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accountRecord.environment = MOCK_ENVIRONMENT
+        accountRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accountRecord.localAccountId = MOCK_UID
+        accountRecord.name = MOCK_NAME
+        accountRecord.realm = MSA_MEGA_TENANT_ID
+        accountRecord.username = MOCK_MSA_USERNAME
+        return accountRecord
+    }
+
+    fun getMockIdTokenRecord_MSA(): IdTokenRecord {
+        val idToken = IdTokenRecord()
+        idToken.authority = MOCK_MSA_AUTHORITY
+        idToken.realm = MSA_MEGA_TENANT_ID
+        idToken.clientId = MOCK_CLIENT_ID
+        idToken.credentialType = "IdToken"
+        idToken.environment = MOCK_ENVIRONMENT
+        idToken.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        idToken.secret = MOCK_SECRET
+        return idToken
+    }
+
+    fun getMockAccessTokenRecord_MSA(): AccessTokenRecord {
+        val accessTokenRecord = AccessTokenRecord()
+        accessTokenRecord.accessTokenType = "bearer"
+        accessTokenRecord.applicationIdentifier = MOCK_APPLICATION_IDENTIFIER
+        accessTokenRecord.authority = MOCK_MSA_AUTHORITY
+        accessTokenRecord.expiresOn = getMockExpiresOn()
+        accessTokenRecord.realm = MSA_MEGA_TENANT_ID
+        accessTokenRecord.target = MOCK_TARGET
+        accessTokenRecord.cachedAt = getMockCachedAt()
+        accessTokenRecord.clientId = MOCK_CLIENT_ID
+        accessTokenRecord.credentialType = "AccessToken"
+        accessTokenRecord.environment = MOCK_ENVIRONMENT
+        accessTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accessTokenRecord.secret = MOCK_SECRET
+        return accessTokenRecord
+    }
+
+    fun getMockRefreshTokenRecord_MSA(): RefreshTokenRecord {
+        val refreshTokenRecord = RefreshTokenRecord()
+        refreshTokenRecord.familyId = "1"
+        refreshTokenRecord.target = MOCK_TARGET
+        refreshTokenRecord.cachedAt = getMockCachedAt()
+        refreshTokenRecord.clientId = MOCK_CLIENT_ID
+        refreshTokenRecord.credentialType = "RefreshToken"
+        refreshTokenRecord.environment = MOCK_ENVIRONMENT
+        refreshTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        refreshTokenRecord.secret = MOCK_SECRET
+        return refreshTokenRecord
+    }
+    //endregion
+
+    //region MSAPassthrough
+    fun getMockAccountRecord_MSAPassthrough(): AccountRecord {
+        val accountRecord = AccountRecord()
+        accountRecord.authorityType = AUTHORITY_TYPE_MS_STS
+        accountRecord.clientInfo = createMockRawClientInfo(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accountRecord.environment = MOCK_ENVIRONMENT
+        accountRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accountRecord.localAccountId = MOCK_LOCAL_GUEST_UID
+        accountRecord.name = MOCK_NAME
+        accountRecord.realm = MOCK_AAD_TENANT_ID
+        accountRecord.username = MOCK_MSA_USERNAME
+        return accountRecord
+    }
+
+    fun getMockIdTokenRecord_MSAPassthrough(): IdTokenRecord {
+        val idToken = IdTokenRecord()
+        idToken.authority = MOCK_MSA_GUEST_AUTHORITY
+        idToken.realm = MOCK_AAD_TENANT_ID
+        idToken.clientId = MOCK_CLIENT_ID
+        idToken.credentialType = "IdToken"
+        idToken.environment = MOCK_ENVIRONMENT
+        idToken.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        idToken.secret = MOCK_SECRET
+        return idToken
+    }
+
+    fun getMockAccessTokenRecord_MSAPassthrough(): AccessTokenRecord {
+        val accessTokenRecord = AccessTokenRecord()
+        accessTokenRecord.accessTokenType = "bearer"
+        accessTokenRecord.applicationIdentifier = MOCK_APPLICATION_IDENTIFIER
+        accessTokenRecord.authority = MOCK_MSA_GUEST_AUTHORITY
+        accessTokenRecord.expiresOn = getMockExpiresOn()
+        accessTokenRecord.realm = MOCK_AAD_TENANT_ID
+        accessTokenRecord.target = MOCK_TARGET
+        accessTokenRecord.cachedAt = getMockCachedAt()
+        accessTokenRecord.clientId = MOCK_CLIENT_ID
+        accessTokenRecord.credentialType = "AccessToken"
+        accessTokenRecord.environment = MOCK_ENVIRONMENT
+        accessTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        accessTokenRecord.secret = MOCK_SECRET
+        return accessTokenRecord
+    }
+
+    fun getMockRefreshTokenRecord_MSAPassthrough(): RefreshTokenRecord {
+        val refreshTokenRecord = RefreshTokenRecord()
+        refreshTokenRecord.familyId = "1"
+        refreshTokenRecord.target = MOCK_TARGET
+        refreshTokenRecord.cachedAt = getMockCachedAt()
+        refreshTokenRecord.clientId = MOCK_CLIENT_ID
+        refreshTokenRecord.credentialType = "RefreshToken"
+        refreshTokenRecord.environment = MOCK_ENVIRONMENT
+        refreshTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MSA_MEGA_TENANT_ID)
+        refreshTokenRecord.secret = MOCK_SECRET
+        return refreshTokenRecord
+    }
+    //endregion
+
+    //region AAD
+    fun getMockAccountRecord_AAD(): AccountRecord {
+        val accountRecord = AccountRecord()
+        accountRecord.authorityType = AUTHORITY_TYPE_MS_STS
+        accountRecord.clientInfo = createMockRawClientInfo(MOCK_UID, MOCK_AAD_TENANT_ID)
+        accountRecord.environment = MOCK_ENVIRONMENT
+        accountRecord.homeAccountId = getHomeAccountId(MOCK_UID, MOCK_AAD_TENANT_ID)
+        accountRecord.localAccountId = MOCK_UID
+        accountRecord.name = MOCK_NAME
+        accountRecord.realm = MOCK_AAD_TENANT_ID
+        accountRecord.username = MOCK_MSA_USERNAME
+        return accountRecord
+    }
+
+    fun getMockIdTokenRecord_AAD(): IdTokenRecord {
+        val idToken = IdTokenRecord()
+        idToken.authority = MOCK_AAD_ORGANIZATION_AUTHORITY
+        idToken.realm = MOCK_AAD_TENANT_ID
+        idToken.clientId = MOCK_CLIENT_ID
+        idToken.credentialType = "IdToken"
+        idToken.environment = MOCK_ENVIRONMENT
+        idToken.homeAccountId = getHomeAccountId(MOCK_UID, MOCK_AAD_TENANT_ID)
+        idToken.secret = MOCK_SECRET
+        return idToken
+    }
+
+    fun getMockAccessTokenRecord_AAD(): AccessTokenRecord {
+        val accessTokenRecord = AccessTokenRecord()
+        accessTokenRecord.accessTokenType = "bearer"
+        accessTokenRecord.applicationIdentifier = MOCK_APPLICATION_IDENTIFIER
+        accessTokenRecord.authority = MOCK_AAD_ORGANIZATION_AUTHORITY
+        accessTokenRecord.expiresOn = getMockExpiresOn()
+        accessTokenRecord.realm = MOCK_AAD_TENANT_ID
+        accessTokenRecord.target = MOCK_TARGET
+        accessTokenRecord.cachedAt = getMockCachedAt()
+        accessTokenRecord.clientId = MOCK_CLIENT_ID
+        accessTokenRecord.credentialType = "AccessToken"
+        accessTokenRecord.environment = MOCK_ENVIRONMENT
+        accessTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MOCK_AAD_TENANT_ID)
+        accessTokenRecord.secret = MOCK_SECRET
+        return accessTokenRecord
+    }
+
+    fun getMockRefreshTokenRecord_AAD(): RefreshTokenRecord {
+        val refreshTokenRecord = RefreshTokenRecord()
+        refreshTokenRecord.familyId = "1"
+        refreshTokenRecord.target = MOCK_TARGET
+        refreshTokenRecord.cachedAt = getMockCachedAt()
+        refreshTokenRecord.clientId = MOCK_CLIENT_ID
+        refreshTokenRecord.credentialType = "RefreshToken"
+        refreshTokenRecord.environment = MOCK_ENVIRONMENT
+        refreshTokenRecord.homeAccountId = getHomeAccountId(MOCK_UID, MOCK_AAD_TENANT_ID)
+        refreshTokenRecord.secret = MOCK_SECRET
+        return refreshTokenRecord
+    }
+    //endregion
+
+    fun getHomeAccountId(uid: String, utid:String) : String {
+        return "$uid:$utid"
+    }
+
+    fun getMockExpiresOn(): String {
+        return (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 100000).toString()
+    }
+
+    fun getMockCachedAt(): String {
+        return TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()).toString()
+    }
+}

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/mocks/MockTokenCreator.java
@@ -180,7 +180,7 @@ public class MockTokenCreator {
         );
     }
 
-    private static String createMockRawClientInfo(final String uid, final String utid) {
+    public static String createMockRawClientInfo(final String uid, final String utid) {
         final String claims = "{\"uid\":\"" + uid + "\",\"utid\":\"" + utid + "\"}";
 
         return new String(Base64.encode(claims.getBytes(


### PR DESCRIPTION
This change would kick in only if the OneAuth/MSAL side has the maximum hello() protocol version >= 16.0 AND the flight is enabled.

Otherwise, AAD RT would still be returned.

(No change if the caller is ADAL, or older versions of MSAL/OneAuth)