### PR TITLE
fix MFA redirect response

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -555,7 +555,12 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                         codeLength = result.codeLength
                     )
                 }
-                is SignInChallengeApiResult.PasswordRequired, is SignInChallengeApiResult.Redirect -> {
+                is SignInChallengeApiResult.Redirect -> {
+                    INativeAuthCommandResult.Redirect(
+                        correlationId = result.correlationId
+                    )
+                }
+                is SignInChallengeApiResult.PasswordRequired,  -> {
                     Logger.warnWithObject(
                         TAG,
                         result.correlationId,

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -538,7 +538,7 @@ class NativeAuthControllerTest {
 
     // region sign in MFA
     @Test
-    fun testMFAChallengeWithIntrospectRequiredSuccessShouldReturnSelectionRequired() {
+    fun `testMFAChallenge challenge returns introspect_required and introspect returns success should return SelectionRequiredResult`() {
         val correlationId = UUID.randomUUID().toString()
         MockApiUtils.configureMockApi(
             endpointType = MockApiEndpoint.SignInChallenge,
@@ -557,7 +557,7 @@ class NativeAuthControllerTest {
     }
 
     @Test
-    fun testMFAChallengeWithRedirectShouldReturnRedirect() {
+    fun `testMFAChallenge challenge returns introspect_required and introspect returns redirect should return RedirectResult`() {
         val correlationId = UUID.randomUUID().toString()
         MockApiUtils.configureMockApi(
             endpointType = MockApiEndpoint.SignInChallenge,
@@ -576,7 +576,21 @@ class NativeAuthControllerTest {
     }
 
     @Test
-    fun testMFAChallengeWithSuccessShouldReturnVerificationRequired() {
+    fun `testMFAChallenge challenge returns redirect should return RedirectResult`() {
+        val correlationId = UUID.randomUUID().toString()
+        MockApiUtils.configureMockApi(
+            endpointType = MockApiEndpoint.SignInChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.CHALLENGE_TYPE_REDIRECT
+        )
+
+        val parameters = createMFAChallengeCommandParameters(correlationId)
+        val result = controller.signInChallenge(parameters)
+        assert(result is INativeAuthCommandResult.Redirect)
+    }
+
+    @Test
+    fun `testMFAChallenge challenge returns success should return VerificationRequired`() {
         val correlationId = UUID.randomUUID().toString()
         MockApiUtils.configureMockApi(
             endpointType = MockApiEndpoint.SignInChallenge,


### PR DESCRIPTION
when /challenge returns browser_required, the SDK should return Redirect result, not APIError