### PR TITLE
Remove triggers from pipelines and execute ABID validator on label change

### DIFF
--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -7,7 +7,7 @@
 name: 'AB#ID Check'
 on: 
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, labeled]
 
 jobs:
 # This action checks your pull request to make sure it is linked to a work item using AB# before you can merge.

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -6,8 +6,6 @@
 # Variable: 'skipConsumerValidationLabel' PR label used to skip the checks in this pipeline
 name: $(date:yyyyMMdd)$(rev:.r)
 
-trigger: none
-
 parameters:
   - name: shouldSkipLongRunningTest
     displayName: Should skip long running test?

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -6,14 +6,6 @@ name: $(date:yyyyMMdd)$(rev:.r)
 variables:
   - group: devex-ciam-test
 
-trigger:
-  branches:
-    include:
-    - dev
-    - master
-    - release/*
-  batch: True
-
 resources:
   repositories:
   - repository: self

--- a/azure-pipelines/pull-request-validation/common4j.yml
+++ b/azure-pipelines/pull-request-validation/common4j.yml
@@ -7,8 +7,6 @@ name: $(date:yyyyMMdd)$(rev:.r)
 variables:
   - group: devex-ciam-test
 
-trigger: none
-
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
Something changed on ADO and that caused the pipeline to stop running on PR, the solution was to remove the trigger tag.

If you didn't specify any triggers, and the [Disable implied YAML CI trigger](https://learn.microsoft.com/en-us/azure/devops/release-notes/2023/sprint-227-update#prevent-unintended-pipeline-runs) setting is not enabled, the default is as if you wrote:
````
trigger:
  branches:
    include:
    - '*'  # must quote since "*" is a YAML reserved character; we want a string