### PR TITLE
Add support for testing with OneDrive, make TempUser exception handling generic, Fixes AB#2985854

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -180,21 +180,20 @@ public class LabClient implements ILabClient {
         // Adding a second attempt here, api sometimes fails to create the temp user.
         try {
             return createTempAccountInternal(tempUserType);
-        } catch (final LabApiException e){
-            if (LabError.FAILED_TO_CREATE_TEMP_USER.equals(e.getErrorCode())){
+        } catch (final Exception e){
+            // Seems new Lab API may fail temp user creation, without throwing a lab exception
+            // (we may get a non-error response, with a null temp user field)
+            // So, we will make this exception handling generic, and retry in all failure cases
 
-                // Wait for a bit
-                try {
-                    Thread.sleep(LAB_API_RETRY_WAIT);
-                } catch (final InterruptedException e2) {
-                    e2.printStackTrace();
-                }
-
-                // Try to create the temp account again
-                return createTempAccountInternal(tempUserType);
-            } else {
-                throw e;
+            // Wait for a bit
+            try {
+                Thread.sleep(LAB_API_RETRY_WAIT);
+            } catch (final InterruptedException e2) {
+                e2.printStackTrace();
             }
+
+            // Try to create the temp account again
+            return createTempAccountInternal(tempUserType);
         }
     }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
@@ -94,7 +94,11 @@ public class OneDriveApp extends App implements IFirstPartyApp {
 
         Logger.i(TAG, "Checking that sign-up through phone number is available in OneDrive...");
 
-        // Check for "phone" UI option, we can conclude phone option is available
-        return UiAutomatorUtils.obtainUiObjectWithText("phone").exists();
+        // Click on account creation button
+        UiAutomatorUtils.handleButtonClick("com.microsoft.skydrive:id/sign_up_button");
+
+        // Check for "phoneCountry" UI option (Country code, part of phone input),
+        // we can conclude phone option is available
+        return UiAutomatorUtils.obtainUiObjectWithResourceId("phoneCountry").exists();
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
@@ -24,12 +24,11 @@ package com.microsoft.identity.client.ui.automation.app;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.client.ui.automation.BuildConfig;
 import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
-import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
 import com.microsoft.identity.client.ui.automation.installer.PlayStore;
 import com.microsoft.identity.client.ui.automation.interaction.FirstPartyAppPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 /**
@@ -59,7 +58,11 @@ public class OneDriveApp extends App implements IFirstPartyApp {
 
     @Override
     public void handleFirstRun() {
-        // Not yet implemented
+        if (shouldHandleFirstRun) {
+            // Grant permissions requested by OneDrive App
+            CommonUtils.grantPackagePermission();
+            shouldHandleFirstRun = false;
+        }
     }
 
     @Override
@@ -88,6 +91,7 @@ public class OneDriveApp extends App implements IFirstPartyApp {
      */
     public boolean checkPhoneSignUpIsAvailable() {
         launch();
+        handleFirstRun();
 
         Logger.i(TAG, "Checking that sign-up through phone number is available in OneDrive...");
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
@@ -41,12 +41,9 @@ public class OneDriveApp extends App implements IFirstPartyApp {
     public static final String ONEDRIVE_PACKAGE_NAME = "com.microsoft.skydrive";
     public static final String ONEDRIVE_APP_NAME = "Microsoft OneDrive";
     public final static String ONEDRIVE_APK = "OneDrive.apk";
-    public final static IAppInstaller DEFAULT_WORD_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
-            .equalsIgnoreCase(BuildConfig.WORD_APP_INSTALL_SOURCE)
-            ? new LocalApkInstaller() : new PlayStore();
 
     public OneDriveApp() {
-        super(ONEDRIVE_PACKAGE_NAME, ONEDRIVE_APP_NAME, DEFAULT_WORD_APP_INSTALLER);
+        super(ONEDRIVE_PACKAGE_NAME, ONEDRIVE_APP_NAME, new PlayStore());
         localApkFileName = ONEDRIVE_APK;
     }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OneDriveApp.java
@@ -1,0 +1,100 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.ui.automation.app;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.ui.automation.BuildConfig;
+import com.microsoft.identity.client.ui.automation.installer.IAppInstaller;
+import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
+import com.microsoft.identity.client.ui.automation.installer.PlayStore;
+import com.microsoft.identity.client.ui.automation.interaction.FirstPartyAppPromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+
+/**
+ * A model for interacting with the OneDrive Android App during UI Test.
+ */
+public class OneDriveApp extends App implements IFirstPartyApp {
+
+    private final static String TAG = OneDriveApp.class.getSimpleName();
+    public static final String ONEDRIVE_PACKAGE_NAME = "com.microsoft.skydrive";
+    public static final String ONEDRIVE_APP_NAME = "Microsoft OneDrive";
+    public final static String ONEDRIVE_APK = "OneDrive.apk";
+    public final static IAppInstaller DEFAULT_WORD_APP_INSTALLER = BuildConfig.INSTALL_SOURCE_LOCAL_APK
+            .equalsIgnoreCase(BuildConfig.WORD_APP_INSTALL_SOURCE)
+            ? new LocalApkInstaller() : new PlayStore();
+
+    public OneDriveApp() {
+        super(ONEDRIVE_PACKAGE_NAME, ONEDRIVE_APP_NAME, DEFAULT_WORD_APP_INSTALLER);
+        localApkFileName = ONEDRIVE_APK;
+    }
+
+    public OneDriveApp(@NonNull final IAppInstaller appInstaller) {
+        super(ONEDRIVE_PACKAGE_NAME, ONEDRIVE_APP_NAME, appInstaller);
+        localApkFileName = ONEDRIVE_APK;
+    }
+
+    @Override
+    protected void initialiseAppImpl() {
+        // Not yet implemented
+    }
+
+    @Override
+    public void handleFirstRun() {
+        // Not yet implemented
+    }
+
+    @Override
+    public void addFirstAccount(@NonNull String username, @NonNull String password, @NonNull FirstPartyAppPromptHandlerParameters promptHandlerParameters) {
+        // Not yet implemented
+    }
+
+    @Override
+    public void addAnotherAccount(@NonNull String username, @NonNull String password, @NonNull FirstPartyAppPromptHandlerParameters promptHandlerParameters) {
+        // Not yet implemented
+    }
+
+    @Override
+    public void onAccountAdded() {
+        // Not yet implemented
+    }
+
+    @Override
+    public void confirmAccount(@NonNull String username) {
+        // Not yet implemented
+    }
+
+    /**
+     * Check that OneDrive has an option for phone sign-up
+     * @return true if the option is available, false otherwise
+     */
+    public boolean checkPhoneSignUpIsAvailable() {
+        launch();
+
+        Logger.i(TAG, "Checking that sign-up through phone number is available in OneDrive...");
+
+        // Check for "phone" UI option, we can conclude phone option is available
+        return UiAutomatorUtils.obtainUiObjectWithText("phone").exists();
+    }
+}

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -185,4 +185,28 @@ public class OutlookApp extends App implements IFirstPartyApp {
         // Check if the sign in SnackBar is present
         return UiAutomatorUtils.obtainUiObjectWithResourceId("com.microsoft.office.outlook:id/snackbar_action", TimeUnit.SECONDS.toMillis(5)).exists();
     }
+
+    /**
+     * Check that outlook does not have an option for phone sign-up
+     * @return true if the option is not available, false otherwise
+     */
+    public boolean checkPhoneSignUpIsNotAvailable() {
+        launch();
+
+        Logger.i(TAG, "Checking that sign-up through phone number is not available in Outlook...");
+        // Click start btn
+        UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/btn_secondary_button");
+
+        // Check for "phone" UI option
+        final Boolean check1 = UiAutomatorUtils.obtainUiObjectWithText("phone").exists();
+
+        // Check for "Phone" UI option
+        final Boolean check2 = UiAutomatorUtils.obtainUiObjectWithText("Phone").exists();
+
+        // Check for "PHONE" UI option
+        final Boolean check3 = UiAutomatorUtils.obtainUiObjectWithText("PHONE").exists();
+
+        // If none of those options are found, we can conclude phone option is not available
+        return !(check1 || check2 || check3);
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/WordApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/WordApp.java
@@ -159,4 +159,17 @@ public class WordApp extends App implements IFirstPartyApp {
                 testAccountLabelWord.exists()
         );
     }
+
+    /**
+     * Check that word (as an office app) has an option for phone sign-up
+     * @return true if the option is available, false otherwise
+     */
+    public boolean checkPhoneSignUpIsAvailable() {
+        launch();
+
+        Logger.i(TAG, "Checking that sign-up through phone number is available in Word...");
+
+        // Check for "phone" UI option, we can conclude phone option is available
+        return UiAutomatorUtils.obtainUiObjectWithText("phone").exists();
+    }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/CopyFileRule.java
@@ -27,6 +27,7 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.app.OneAuthTestApp;
 import com.microsoft.identity.client.ui.automation.app.MsalTestApp;
+import com.microsoft.identity.client.ui.automation.app.OneDriveApp;
 import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.app.TeamsApp;
 import com.microsoft.identity.client.ui.automation.app.WordApp;
@@ -66,6 +67,7 @@ public class CopyFileRule implements TestRule {
             BrokerCompanyPortal.OLD_COMPANY_PORTAL_APK,
             TeamsApp.TEAMS_APK,
             OutlookApp.OUTLOOK_APK,
+            OneDriveApp.ONEDRIVE_APK,
             WordApp.WORD_APK,
             BrowserEdge.EDGE_APK,
             BrokerLTW.BROKER_LTW_APK,

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RemoveFirstPartyAppsTestRule.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client.ui.automation.rules;
 
 import com.microsoft.identity.client.ui.automation.app.OneAuthTestApp;
+import com.microsoft.identity.client.ui.automation.app.OneDriveApp;
 import com.microsoft.identity.client.ui.automation.app.OutlookApp;
 import com.microsoft.identity.client.ui.automation.app.TeamsApp;
 import com.microsoft.identity.client.ui.automation.app.WordApp;
@@ -51,6 +52,7 @@ public class RemoveFirstPartyAppsTestRule implements TestRule {
                 new WordApp().uninstall();
                 new BrowserEdge().uninstall();
                 new OneAuthTestApp().uninstall();
+                new OneDriveApp().uninstall();
                 // Commenting this until new msalAutomationApp name is added
                 // new MsalTestApp().uninstall();
                 base.evaluate();


### PR DESCRIPTION
Add support for testing phone sign up in our ui automation validation

Seems new Lab API may fail temp user creation, without throwing a lab exception (we may get a non-error response, with a null temp user field). So, we will make this exception handling generic, and retry in all failure cases

[AB#2985854](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/2985854)