### PR TITLE
Missing exception_cause_error_locationfor NPE on ATS

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -436,7 +436,8 @@ public class ExceptionAdapter {
         if (e instanceof NullPointerException) {
             return new ClientException(
                     ClientException.NULL_POINTER_ERROR,
-                    e.getMessage()
+                    e.getMessage(),
+                    e
             );
         }
 


### PR DESCRIPTION
Current status:
AllAndroidSpans
| where PipelineInfo_IngestionTime between (ago(7d) .. now())
| where error_type == "ClientException"
| where error_code == "null_pointer_error"
| where broker_version in  ("13.7.0", "13.8.0")
| summarize count() by span_name, error_message, exception_cause_error_code, exception_cause_error_location, broker_version 
| top 10 by count_

<img width="743" alt="image" src="https://github.com/user-attachments/assets/3635a1b7-0d89-4435-9bae-1f2d69231b8e">

With his change:

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/21f8ae08-4696-44dd-8db5-c0a4265e6f04">
