### PR TITLE
Interrupt flow updates in broker

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -67,10 +67,5 @@ public enum SpanName {
     DeleteTransferToken,
     RestoreMsaAccounts,
     OnUpgradeReceiver,
-    UpgradeDeviceRegistration,
-
-    /**
-     * Span covering interrupt handling using PRT protocol.
-     */
-    PrtHandleInterrupt
+    UpgradeDeviceRegistration
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -67,5 +67,10 @@ public enum SpanName {
     DeleteTransferToken,
     RestoreMsaAccounts,
     OnUpgradeReceiver,
-    UpgradeDeviceRegistration
+    UpgradeDeviceRegistration,
+
+    /**
+     * Span covering interrupt handling using PRT protocol.
+     */
+    PrtHandleInterrupt
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
@@ -33,11 +33,13 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.experimental.Accessors;
 
 /**
@@ -231,6 +233,14 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
             return self();
         }
 
+        public B addExtraQueryParam(@NonNull final Map.Entry<String, String> extraQueryParam) {
+            if (mExtraQueryParams == null) {
+                mExtraQueryParams = new ArrayList<>();
+            }
+            mExtraQueryParams.add(extraQueryParam);
+            return self();
+        }
+
         public B setClaims(String claims) {
             mClaims = claims;
             return self();
@@ -238,6 +248,14 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
 
         public B setRequestHeaders(HashMap<String, String> requestHeaders) {
             mRequestHeaders = requestHeaders;
+            return self();
+        }
+
+        public B addRequestHeader(@NonNull final String key, final String value) {
+            if (mRequestHeaders == null) {
+                mRequestHeaders = new HashMap<>();
+            }
+            mRequestHeaders.put(key, value);
             return self();
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/AuthorizationRequest.java
@@ -233,6 +233,11 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
             return self();
         }
 
+        /**
+         * Adds entry to existing extra query param list. If list is null, creates and
+         * adds the entry.
+         * @param extraQueryParam a {@link Map.Entry<String, String>}
+         */
         public B addExtraQueryParam(@NonNull final Map.Entry<String, String> extraQueryParam) {
             if (mExtraQueryParams == null) {
                 mExtraQueryParams = new ArrayList<>();
@@ -251,6 +256,12 @@ public abstract class AuthorizationRequest<T extends AuthorizationRequest<T>> im
             return self();
         }
 
+        /**
+         * Adds key, value to existing headers. If headers are is null, creates and
+         * puts the key and value.
+         * @param key header key to be added
+         * @param value header value to be added
+         */
         public B addRequestHeader(@NonNull final String key, final String value) {
             if (mRequestHeaders == null) {
                 mRequestHeaders = new HashMap<>();


### PR DESCRIPTION
Details in https://github.com/AzureAD/ad-accounts-for-android/pull/2956

In Common
1. Added adders to AuthorizationRequest Builder to allow adding extra query parameters or headers to existing collections.