### PR TITLE
Add flight to preferImmediatelyAvailableCredentials

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
@@ -29,6 +29,8 @@ import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.PublicKeyCredential
 import androidx.credentials.exceptions.NoCredentialException
+import com.microsoft.identity.common.java.flighting.CommonFlight
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager.getFlightsProvider
 import com.microsoft.identity.common.java.opentelemetry.AttributeName
 import com.microsoft.identity.common.logging.Logger
 import io.opentelemetry.api.trace.Span
@@ -82,7 +84,7 @@ class CredManFidoManager (val context: Context,
             // We're setting preferImmediatelyAvailableCredentials in the CredMan getCredentialRequest object to true if the device OS is Android 13 or lower.
             // This ensures the behavior where no dialog from CredMan is shown if no passkey cred is present.
             // The end goal is for an Android <= 13 user who only has a security key to see one dialog which will allow them to authenticate.
-            preferImmediatelyAvailableCredentials = (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+            preferImmediatelyAvailableCredentials = (getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_PASSKEY_FEATURE) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
         )
         try {
             Logger.info(methodTag, "Calling Credential Manager with a GetCredentialRequest.")

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
@@ -84,7 +84,7 @@ class CredManFidoManager (val context: Context,
             // We're setting preferImmediatelyAvailableCredentials in the CredMan getCredentialRequest object to true if the device OS is Android 13 or lower.
             // This ensures the behavior where no dialog from CredMan is shown if no passkey cred is present.
             // The end goal is for an Android <= 13 user who only has a security key to see one dialog which will allow them to authenticate.
-            preferImmediatelyAvailableCredentials = (getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_PASSKEY_FEATURE) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+            preferImmediatelyAvailableCredentials = (getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
         )
         try {
             Logger.info(methodTag, "Calling Credential Manager with a GetCredentialRequest.")


### PR DESCRIPTION
### Summary
Need to wrap the `preferImmediatelyAvailableCredentials` parameter with the flight as well.