### PR TITLE
Fix - [CodeQL.SM03853] Removing  that accepts all certificates, Fixes AB#3064771

### DIFF
--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/ApiClient.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/ApiClient.java
@@ -69,7 +69,6 @@ public class ApiClient {
     private int dateLength;
 
     private InputStream sslCaCert;
-    private boolean verifyingSsl;
     private KeyManager[] keyManagers;
 
     private OkHttpClient httpClient;
@@ -91,8 +90,6 @@ public class ApiClient {
         httpClient = new OkHttpClient();
 
         basePath = basePathParam;
-
-        verifyingSsl = true;
 
         json = new JSON();
 
@@ -165,29 +162,6 @@ public class ApiClient {
      */
     public ApiClient setJSON(JSON json) {
         this.json = json;
-        return this;
-    }
-
-    /**
-     * True if isVerifyingSsl flag is on
-     *
-     * @return True if isVerifySsl flag is on
-     */
-    public boolean isVerifyingSsl() {
-        return verifyingSsl;
-    }
-
-    /**
-     * Configure whether to verify certificate and hostname when making https requests.
-     * Default to true.
-     * NOTE: Do NOT set to false in production code, otherwise you would face multiple types of cryptographic attacks.
-     *
-     * @param verifyingSsl True to verify TLS/SSL connection
-     * @return ApiClient
-     */
-    public ApiClient setVerifyingSsl(boolean verifyingSsl) {
-        this.verifyingSsl = verifyingSsl;
-        applySslSettings();
         return this;
     }
 
@@ -1159,28 +1133,13 @@ public class ApiClient {
 
     /**
      * Apply SSL related settings to httpClient according to the current values of
-     * verifyingSsl and sslCaCert.
+     * sslCaCert.
      */
     private void applySslSettings() {
         try {
             TrustManager[] trustManagers = null;
             HostnameVerifier hostnameVerifier = null;
-            if (!verifyingSsl) {
-                TrustManager trustAll = new X509TrustManager() {
-                    @Override
-                    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
-                    @Override
-                    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
-                    @Override
-                    public X509Certificate[] getAcceptedIssuers() { return null; }
-                };
-                SSLContext sslContext = SSLContext.getInstance("TLS");
-                trustManagers = new TrustManager[]{ trustAll };
-                hostnameVerifier = new HostnameVerifier() {
-                    @Override
-                    public boolean verify(String hostname, SSLSession session) { return true; }
-                };
-            } else if (sslCaCert != null) {
+            if (sslCaCert != null) {
                 char[] password = null; // Any password will work.
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(sslCaCert);


### PR DESCRIPTION
Fixing [issue reported by CodeQL](https://liquid.microsoft.com/codeql/issues/8f85582a-a4d1-46cc-bde2-b9ba9da93211)

Removing code path in testing libraries (keyvault and labapi) which uses TrustManager that accepts all certificates for SSL verification. This code path is not secure and can lead to potential security vulnerabilities and should not be used in production code.

[AB#3064771](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3064771)