### PR TITLE
Move some test classes to test fixtures

### DIFF
--- a/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.microsoft.identity.common.java.net.util.MockConnection;
-import com.microsoft.identity.common.java.net.util.ResponseBody;
+import com.microsoft.identity.http.MockConnection;
+import com.microsoft.identity.http.ResponseBody;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/common4j/src/testFixtures/java/com/microsoft/identity/http/MockConnection.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/http/MockConnection.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.java.net.util;
+package com.microsoft.identity.http;
 
 import com.microsoft.identity.common.java.net.HttpResponse;
 
@@ -94,6 +94,12 @@ public class MockConnection {
         assertNotNull(httpResponse);
         assertEquals(httpResponse.getStatusCode(), HttpURLConnection.HTTP_OK);
         assertEquals(httpResponse.getBody(), ResponseBody.SUCCESS);
+    }
+
+    public static void verifyFailureHttpResponseWithGenericResponse(@NonNull final HttpResponse httpResponse) {
+        assertNotNull(httpResponse);
+        assertEquals(httpResponse.getStatusCode(), HttpURLConnection.HTTP_INTERNAL_ERROR);
+        assertEquals(httpResponse.getBody(), ResponseBody.GENERIC_ERROR);
     }
 
     private static InputStream createInputStream(final String input) {

--- a/common4j/src/testFixtures/java/com/microsoft/identity/http/MockConnection.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/http/MockConnection.java
@@ -96,12 +96,6 @@ public class MockConnection {
         assertEquals(httpResponse.getBody(), ResponseBody.SUCCESS);
     }
 
-    public static void verifyFailureHttpResponseWithGenericResponse(@NonNull final HttpResponse httpResponse) {
-        assertNotNull(httpResponse);
-        assertEquals(httpResponse.getStatusCode(), HttpURLConnection.HTTP_INTERNAL_ERROR);
-        assertEquals(httpResponse.getBody(), ResponseBody.GENERIC_ERROR);
-    }
-
     private static InputStream createInputStream(final String input) {
         return input == null ? null : new ByteArrayInputStream(input.getBytes());
     }

--- a/common4j/src/testFixtures/java/com/microsoft/identity/http/ResponseBody.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/http/ResponseBody.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.common.java.net.util;
+package com.microsoft.identity.http;
 
 public class ResponseBody {
 


### PR DESCRIPTION
Moving a couple classes to test fixtures to become usable in broker 4j test code.

Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2995