### PR TITLE
Add more details when reset password required error is received, Fixes AB#3084603

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Add native auth instructions to error description when reset password required is returned (#2532)
 - [MINOR] Camera permission request behavior changes for QR + PIN Auth (#2524)
 - [MINOR] Migrate Base64 away from Msebera httpclient (#2389)
 - [PATCH] Provide empty image when no video is present on QR +PIN auth (#2424)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -236,6 +236,19 @@ public class ExceptionAdapter {
                     developerDescription,
                     apiError
             );
+        } else if (isNativeAuthenticationResetPasswordRequiredError(errorResponse)) {
+            ServiceException apiError = new ServiceException(
+                    errorResponse.getError(),
+                    errorResponse.getErrorDescription(),
+                    null);
+
+            String developerDescription = "Password change is required, which can't be fulfilled as part of this flow."+
+                    "Please reset the password and perform a new sign in operation. Please see exception details for more information.";
+            outErr = new ServiceException(
+                    errorResponse.getError(),
+                    developerDescription,
+                    apiError
+            );
         }
         else if (shouldBeConvertedToUiRequiredException(errorResponse.getError())) {
             outErr = new UiRequiredException(
@@ -506,6 +519,28 @@ public class ExceptionAdapter {
      */
     private static boolean isNativeAuthenticationMFAError(
             @NonNull final TokenErrorResponse errorResponse) {
+        return doesErrorContainsErrorCode(50076, errorResponse);
+    }
+
+    /**
+     * Identifies whether an error is specific to native authentication reset password required scenarios.
+     * @param errorResponse
+     * @return true if errorResponse is a native authentication reset password required error
+     */
+    private static boolean isNativeAuthenticationResetPasswordRequiredError(
+            @NonNull final TokenErrorResponse errorResponse) {
+        return doesErrorContainsErrorCode(50142, errorResponse);
+    }
+
+    /**
+     * Identifies whether an error contains a specific error code.
+     * @param errorCode Error code to check
+     * @param errorResponse A TokenErrorResponse from which we will check the error code
+     * @return true if errorResponse contains the error code
+     */
+    private static boolean doesErrorContainsErrorCode(
+            int errorCode,
+            @NonNull final TokenErrorResponse errorResponse) {
         if (!(errorResponse instanceof MicrosoftTokenErrorResponse)) {
             return false;
         }
@@ -513,6 +548,6 @@ public class ExceptionAdapter {
         MicrosoftTokenErrorResponse microsoftTokenErrorResponse = ((MicrosoftTokenErrorResponse) errorResponse);
         return microsoftTokenErrorResponse.getErrorCodes() != null &&
                 !microsoftTokenErrorResponse.getErrorCodes().isEmpty() &&
-                microsoftTokenErrorResponse.getErrorCodes().contains((long) 50076);
+                microsoftTokenErrorResponse.getErrorCodes().contains((long) errorCode);
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -242,7 +242,7 @@ public class ExceptionAdapter {
                     errorResponse.getErrorDescription(),
                     null);
 
-            String developerDescription = "Password change is required, which can't be fulfilled as part of this flow."+
+            String developerDescription = "User password change is required, which can't be fulfilled as part of this flow."+
                     "Please reset the password and perform a new sign in operation. Please see exception details for more information.";
             outErr = new ServiceException(
                     errorResponse.getError(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -83,7 +83,7 @@ class SignInTokenApiResponse(
                         )
                     }
                     errorCodes[0].isPasswordChangeRequired() -> {
-                        val customDescription = "Password change is required, which can't be fulfilled as part of this flow. " +
+                        val customDescription = "User password change is required, which can't be fulfilled as part of this flow. " +
                                 "Please reset the password and perform a new sign in operation. More information:" + errorDescription.orEmpty()
                         SignInTokenApiResult.UnknownError(
                             error = error.orEmpty(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -32,6 +32,7 @@ import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidOOBValue
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
 import com.microsoft.identity.common.java.nativeauth.util.isMFARequired
+import com.microsoft.identity.common.java.nativeauth.util.isPasswordChangeRequired
 import com.microsoft.identity.common.java.nativeauth.util.isUserNotFound
 
 /**
@@ -78,6 +79,16 @@ class SignInTokenApiResponse(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),
                             errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    errorCodes[0].isPasswordChangeRequired() -> {
+                        val customDescription = "Password change is required, which can't be fulfilled as part of this flow. " +
+                                "Please reset the password and perform a new sign in operation. More information:" + errorDescription.orEmpty()
+                        SignInTokenApiResult.UnknownError(
+                            error = error.orEmpty(),
+                            errorDescription = customDescription,
+                            errorCodes = errorCodes,
                             correlationId = correlationId
                         )
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
@@ -101,6 +101,9 @@ internal fun Int?.isInvalidCredentials(): Boolean {
     return this == 50126
 }
 
+internal fun Int?.isPasswordChangeRequired(): Boolean {
+    return this == 50142
+}
 
 internal fun Int?.isInvalidAuthenticationType(): Boolean {
     return this == 400002

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -3021,7 +3021,7 @@ class NativeAuthResponseHandlerTest {
 
         val apiResult = signInTokenApiResponse.toErrorResult()
 
-        val expectedDescription = "Password change is required, which can't be fulfilled as part of this flow. " +
+        val expectedDescription = "User password change is required, which can't be fulfilled as part of this flow. " +
                 "Please reset the password and perform a new sign in operation. More information:" + resetPasswordRequiredErrorDescription
         assertTrue(apiResult is SignInTokenApiResult.UnknownError)
         assertEquals(expectedDescription, (apiResult as SignInTokenApiResult.UnknownError).errorDescription)

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -107,6 +107,7 @@ class NativeAuthResponseHandlerTest {
     private val userAlreadyExistsError = "user_already_exists"
     private val invalidErrorCode = 0
     private val invalidParameterErrorCode = 90100
+    private val resetPasswordRequiredErrorCode = 50142
     private val userNotFoundErrorCode = 50034
     private val errorStatusCode = 400
     private val successStatusCode = 200
@@ -160,6 +161,7 @@ class NativeAuthResponseHandlerTest {
     private val incorrectOtpDescription = "Incorrect OTP code"
     private val credentialRequiredTokenErrorDescription = "Credential is required by the API"
     private val mfaRequiredTokenErrorDescription = "MFA is required by the API"
+    private val resetPasswordRequiredErrorDescription = "Password change is required due to a conditional access policy."
     private val tokenType = "Bearer"
     private val scope = "openid profile"
     private val refreshToken = "5678"
@@ -3002,6 +3004,27 @@ class NativeAuthResponseHandlerTest {
         assertEquals(invalidGrantError, (apiResult as SignInTokenApiResult.MFARequired).error)
         assertEquals(mfaRequiredTokenErrorDescription, apiResult.errorDescription)
         assertEquals(mfaRequiredSubError, apiResult.subError)
+    }
+
+    @Test
+    fun testSignInTokenApiResponseResetPasswordRequired() {
+        val signInTokenApiResponse = SignInTokenApiResponse(
+            statusCode = errorStatusCode,
+            continuationToken = continuationToken,
+            error = invalidRequestError,
+            errorCodes = listOf(resetPasswordRequiredErrorCode),
+            errorDescription = resetPasswordRequiredErrorDescription,
+            errorUri = null,
+            subError = null,
+            correlationId = correlationId
+        )
+
+        val apiResult = signInTokenApiResponse.toErrorResult()
+
+        val expectedDescription = "Password change is required, which can't be fulfilled as part of this flow. " +
+                "Please reset the password and perform a new sign in operation. More information:" + resetPasswordRequiredErrorDescription
+        assertTrue(apiResult is SignInTokenApiResult.UnknownError)
+        assertEquals(expectedDescription, (apiResult as SignInTokenApiResult.UnknownError).errorDescription)
     }
 
     @Test


### PR DESCRIPTION
When reset password is required during a call to /token, we need some native auth specific handling to inform developers on how to handle this error.

[AB#3084603](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3084603)