### PR TITLE
Add switch_browser toMicrosoftStsAuthorizationRequest, Fixes AB#3079799

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Add switch_browser toMicrosoftStsAuthorizationRequest (#2550)
 - [PATCH] Translate MFA token error to UIRequiredException instead of ServiceException (#2538)
 - [MINOR] Add Child Spans for Interactive Span (#2516)
 - [MINOR] For MSAL CPP flows, match exact claims when deleting AT with intersecting scopes (#2548)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Add switch_browser toMicrosoftStsAuthorizationRequest (#2550)
+- [MINOR] Add switch_browser toMicrosoftStsAuthorizationRequest (#2550)
 - [PATCH] Translate MFA token error to UIRequiredException instead of ServiceException (#2538)
 - [MINOR] Add Child Spans for Interactive Span (#2516)
 - [MINOR] For MSAL CPP flows, match exact claims when deleting AT with intersecting scopes (#2548)

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequest.java
@@ -125,6 +125,13 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
     // TODO private transient InstanceDiscoveryMetadata mInstanceDiscoveryMetadata;
     // TODO private boolean mIsExtendedLifetimeEnabled = false;
 
+    // The value 1 indicates that client supports DUNA flow.
+    @Getter
+    @Accessors(prefix = "m")
+    @SerializedName("switch_browser")
+    private final String mSwitchBrowser;
+
+
     public static final class Prompt {
         /**
          * AcquireToken will send prompt=select_account to the authorize endpoint. Shows a list of users from which can be
@@ -170,6 +177,7 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         mApplicationIdentifier = builder.mApplicationIdentifier;
         mMamEnrollmentIdentifier = builder.mMamEnrollmentIdentifier;
         mOpenIdProviderConfiguration = builder.mOpenIdProviderConfiguration;
+        mSwitchBrowser = builder.mSwitchBrowser;
     }
 
     public static class Builder extends MicrosoftAuthorizationRequest.Builder<MicrosoftStsAuthorizationRequest.Builder> {
@@ -185,6 +193,8 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
         private AzureActiveDirectorySlice mSlice;
         private Map<String, String> mFlightParameters = new HashMap<>();
         private OpenIdProviderConfiguration mOpenIdProviderConfiguration;
+
+        private String mSwitchBrowser;
 
         public MicrosoftStsAuthorizationRequest.Builder setUid(String uid) {
             mUid = uid;
@@ -238,6 +248,11 @@ public class MicrosoftStsAuthorizationRequest extends MicrosoftAuthorizationRequ
 
         public MicrosoftStsAuthorizationRequest.Builder setOpenIdProviderConfiguration(OpenIdProviderConfiguration config) {
             mOpenIdProviderConfiguration = config;
+            return self();
+        }
+
+        public MicrosoftStsAuthorizationRequest.Builder setSwitchBrowser(final String value) {
+            mSwitchBrowser = value;
             return self();
         }
 

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationRequestTests.java
@@ -296,4 +296,15 @@ public class MicrosoftStsAuthorizationRequestTests {
         assertTrue("Flight Param 1", actualCodeRequestUrl.contains(MOCK_FLIGHT_QUERY_1 + "=" + MOCK_FLIGHT_VALUE_1));
         assertTrue("Flight Param 2", actualCodeRequestUrl.contains(MOCK_FLIGHT_QUERY_2 + "=" + MOCK_FLIGHT_VALUE_2));
     }
+
+    @Test
+    public void testRequestWithSwitchBrowser() throws ClientException, MalformedURLException {
+        final MicrosoftStsAuthorizationRequest request = new MicrosoftStsAuthorizationRequest.Builder()
+                .setAuthority(getValidRequestUrl())
+                .setSwitchBrowser("1")
+                .build();
+
+        final String actualCodeRequestUrl = request.getAuthorizationRequestAsHttpRequest().toString();
+        assertTrue(actualCodeRequestUrl.contains("switch_browser=1"));
+    }
 }


### PR DESCRIPTION
[AB#3079799](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3079799)

MicrosoftStsAuthorizationRequest is the object used to represent the request parameters on an authorization request, here we add the new property to represent the parameter switch_browser that will be sent to STS when DUNA is enabled.
https://github.com/AzureAD/ad-accounts-for-android/pull/3012
