### PR TITLE
Correlated suberrors with how OneAuth categorizes them.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add suberror for network errors (#2537)
+- [MAJOR] Add suberror for network errors (#2537)
 - [PATCH] Translate MFA token error to UIRequiredException instead of ServiceException (#2538)
 - [MINOR] Add Child Spans for Interactive Span (#2516)
 - [MINOR] For MSAL CPP flows, match exact claims when deleting AT with intersecting scopes (#2548)

--- a/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/net/UrlConnectionHttpClientTest.java
@@ -1218,7 +1218,7 @@ public final class UrlConnectionHttpClientTest {
             );
             Assert.fail();
         } catch (ClientException e){
-            Assert.assertTrue(ConnectionError.FAILED_TO_GET_RESPONSE_CODE.compare(e));
+            Assert.assertTrue(ConnectionError.NETWORK_TEMPORARILY_UNAVAILABLE.compare(e));
         }
     }
 


### PR DESCRIPTION
https://office.visualstudio.com/OneAuth/_git/OneAuth?path=%2Fmsal%2Fsource%2Fandroid%2Fmsal%2Fapp%2Fsrc%2Fmain%2Fjava%2Fcom%2Fmicrosoft%2Fidentity%2Finternal%2Fhttp%2FHttpClient.java&_a=contents&version=GBmaster

so that us and oneauth has the same understanding of what happens.

There are 2 minor differences.
1. We have a separate timeout error (for our retry logic)
2. we have a separate "unknown exception" suberror, so that we can properly identify and assign any errors that falls into this bracket in the future.