### PR TITLE
Replace Deprecated Keystore API for Android 28+, Fixes AB#3110184

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ vNext
 - [PATCH] Translate MFA token error to UIRequiredException instead of ServiceException (#2538)
 - [MINOR] Add Child Spans for Interactive Span (#2516)
 - [MINOR] For MSAL CPP flows, match exact claims when deleting AT with intersecting scopes (#2548)
+- [MINOR] Replace Deprecated Keystore API for Android 28+ (#2558)
 
 Version 18.2.2
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -26,6 +26,8 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 
 import androidx.annotation.RequiresApi;
 
@@ -44,7 +46,9 @@ import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import javax.crypto.SecretKey;
 import javax.security.auth.x500.X500Principal;
@@ -273,25 +277,43 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * @param context an Android {@link Context} object.
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
      */
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context,
-                                                                @NonNull final String alias) {
+//    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+//    private static AlgorithmParameterSpec getLegacySpecForKeyStoreKey(@NonNull final Context context,
+//                                                                @NonNull final String alias) {
+//        // Generate a self-signed cert.
+//        final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
+//                alias,
+//                context.getPackageName());
+//
+//        final Calendar start = Calendar.getInstance();
+//        final Calendar end = Calendar.getInstance();
+//        final int certValidYears = 100;
+//        end.add(Calendar.YEAR, certValidYears);
+//
+//        return new KeyPairGeneratorSpec.Builder(context)
+//                .setAlias(alias)
+//                .setSubject(new X500Principal(certInfo))
+//                .setSerialNumber(BigInteger.ONE)
+//                .setStartDate(start.getTime())
+//                .setEndDate(end.getTime())
+//                .build();
+//    }
+
+
+    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias) {
         // Generate a self-signed cert.
         final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
                 alias,
                 context.getPackageName());
-
-        final Calendar start = Calendar.getInstance();
-        final Calendar end = Calendar.getInstance();
         final int certValidYears = 100;
-        end.add(Calendar.YEAR, certValidYears);
-
-        return new KeyPairGeneratorSpec.Builder(context)
-                .setAlias(alias)
-                .setSubject(new X500Principal(certInfo))
-                .setSerialNumber(BigInteger.ONE)
-                .setStartDate(start.getTime())
-                .setEndDate(end.getTime())
+        return new KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_WRAP_KEY | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setCertificateSubject(new X500Principal(certInfo))
+                .setCertificateSerialNumber(BigInteger.ONE)
+                .setCertificateNotBefore(new Date())
+                .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
+                .setKeySize(2048)
+                .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                 .build();
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -273,48 +273,59 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     /**
      * Generate a self-signed cert and derive an AlgorithmParameterSpec from that.
      * This is for the key to be generated in {@link KeyStore} via {@link KeyPairGenerator}
+     * Note : This is now only for API level < 28
      *
      * @param context an Android {@link Context} object.
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
      */
-//    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-//    private static AlgorithmParameterSpec getLegacySpecForKeyStoreKey(@NonNull final Context context,
-//                                                                @NonNull final String alias) {
-//        // Generate a self-signed cert.
-//        final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
-//                alias,
-//                context.getPackageName());
-//
-//        final Calendar start = Calendar.getInstance();
-//        final Calendar end = Calendar.getInstance();
-//        final int certValidYears = 100;
-//        end.add(Calendar.YEAR, certValidYears);
-//
-//        return new KeyPairGeneratorSpec.Builder(context)
-//                .setAlias(alias)
-//                .setSubject(new X500Principal(certInfo))
-//                .setSerialNumber(BigInteger.ONE)
-//                .setStartDate(start.getTime())
-//                .setEndDate(end.getTime())
-//                .build();
-//    }
-
-
-    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias) {
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
+    private static AlgorithmParameterSpec getLegacySpecForKeyStoreKey(@NonNull final Context context,
+                                                                @NonNull final String alias) {
         // Generate a self-signed cert.
         final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
                 alias,
                 context.getPackageName());
+
+        final Calendar start = Calendar.getInstance();
+        final Calendar end = Calendar.getInstance();
         final int certValidYears = 100;
-        return new KeyGenParameterSpec.Builder(alias, KeyProperties.PURPOSE_WRAP_KEY | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
-                .setCertificateSubject(new X500Principal(certInfo))
-                .setCertificateSerialNumber(BigInteger.ONE)
-                .setCertificateNotBefore(new Date())
-                .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
-                .setKeySize(2048)
-                .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+        end.add(Calendar.YEAR, certValidYears);
+
+        return new KeyPairGeneratorSpec.Builder(context)
+                .setAlias(alias)
+                .setSubject(new X500Principal(certInfo))
+                .setSerialNumber(BigInteger.ONE)
+                .setStartDate(start.getTime())
+                .setEndDate(end.getTime())
                 .build();
+    }
+
+    /**
+     * Generate a self-signed cert and derive an AlgorithmParameterSpec from that.
+     * This is for the key to be generated in {@link KeyStore} via {@link KeyPairGenerator}
+     *
+     * @param context an Android {@link Context} object.
+     * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
+     */
+    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return getLegacySpecForKeyStoreKey(context, alias);
+        } else {
+            final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
+                    alias,
+                    context.getPackageName());
+            final int certValidYears = 100;
+            int purposes = KeyProperties.PURPOSE_WRAP_KEY | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+            return new KeyGenParameterSpec.Builder(alias, purposes)
+                    .setCertificateSubject(new X500Principal(certInfo))
+                    .setCertificateSerialNumber(BigInteger.ONE)
+                    .setCertificateNotBefore(new Date())
+                    .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
+                    .setKeySize(2048)
+                    .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                    .build();
+        }
     }
 
     /**


### PR DESCRIPTION
Issue : https://portal.microsofticm.com/imp/v5/incidents/details/540463066/summary
Keystore operation "unwrap" is failing on Pixel 5 Android 14 devices. It is still not clear why the operation would fail specifically on Pixel 5 devices but it could be some bug on google side which is fixed for all other devices through a patch. Updates for Pixel 5 are stopped hence it may not have the google fix. 
However, the getSpecForKeyStoreKey method used while wrapping the key was using a deprecated API (KeyPairGeneratorSpec). It was deprecated in Android 23. Updating it to latest one has somehow resolved the issue for 1 customer (Since there are no updates from other customers, we assumed that it is the fix).

Exception : [YPC] 2024-11-14 17:34:29.29 [25795][917] ERROR [AndroidKeyStoreUtil:unwrap] [2024-11-14 12:04:29 - thread_id: 911, correlation_id: UNSET - Android 34] invalid_key  
java.security.InvalidKeyException: Keystore operation failed
	at android.security.keystore2.KeyStoreCryptoOperationUtils.getInvalidKeyException(KeyStoreCryptoOperationUtils.java:128)
	at android.security.keystore2.KeyStoreCryptoOperationUtils.getExceptionForCipherInit(KeyStoreCryptoOperationUtils.java:152)
	at android.security.keystore2.AndroidKeyStoreCipherSpiBase.ensureKeystoreOperationInitialized(AndroidKeyStoreCipherSpiBase.java:354)

Fix : Removed the deprecated API KeyPairGeneratorSpec and using the new one KeyGenParameterSpec which lets us set the purpose as PURPOSE_WRAP_KEY

Testing : Ran the pipeline to confirm if the instrumented and UI tests are running as expected https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1401690&view=ms.vss-test-web.build-test-results-tab&runId=4352544&resultId=100000&paneView=debug and https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1401664&view=logs&s=60296c01-192d-58d3-82b8-da4d468e44bd

Fixes [AB#3110184](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3110184) 