### PR TITLE
Log verbose PII result bundle from broker

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -614,7 +614,6 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     private IntuneAppProtectionPolicyRequiredException getIntuneProtectionRequiredException(
             @NonNull final BrokerResult brokerResult) {
         final String methodTag = TAG + ":getIntuneProtectionRequiredException";
-        Logger.infoPII(methodTag, brokerResult.toString());
         final IntuneAppProtectionPolicyRequiredException exception =
                 new IntuneAppProtectionPolicyRequiredException(
                         brokerResult.getErrorCode(),

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -416,7 +416,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (BrokerProtocolVersionUtil.canCompressBrokerPayloads(negotiatedBrokerProtocolVersion)) {
             try {
                 byte[] compressedBytes = compressString(brokerResultString);
-                Logger.infoPII(methodTag, brokerResultString);
+                Logger.verbosePII(methodTag, brokerResultString);
                 Logger.info(methodTag, "Broker Result, raw payload size:"
                         + brokerResultString.getBytes(AuthenticationConstants.CHARSET_UTF8).length + " ,compressed bytes " + compressedBytes.length
                 );

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -416,6 +416,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (BrokerProtocolVersionUtil.canCompressBrokerPayloads(negotiatedBrokerProtocolVersion)) {
             try {
                 byte[] compressedBytes = compressString(brokerResultString);
+                Logger.infoPII(methodTag, brokerResultString);
                 Logger.info(methodTag, "Broker Result, raw payload size:"
                         + brokerResultString.getBytes(AuthenticationConstants.CHARSET_UTF8).length + " ,compressed bytes " + compressedBytes.length
                 );
@@ -613,6 +614,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     private IntuneAppProtectionPolicyRequiredException getIntuneProtectionRequiredException(
             @NonNull final BrokerResult brokerResult) {
         final String methodTag = TAG + ":getIntuneProtectionRequiredException";
+        Logger.infoPII(methodTag, brokerResult.toString());
         final IntuneAppProtectionPolicyRequiredException exception =
                 new IntuneAppProtectionPolicyRequiredException(
                         brokerResult.getErrorCode(),

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -67,8 +67,6 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
                                                       final String errorMessage,
                                                       final BrokerInteractiveTokenCommandParameters originalParameters) {
         super(errorCode, errorMessage, null);
-        Logger.info(TAG, "Login hint" + originalParameters.getLoginHint());
-
 
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
@@ -125,7 +123,6 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
                 originalParameters.getLoginHint();
-        Logger.info(TAG, "Login hint" + originalParameters.getLoginHint());
 
         setAccountUpn(upn);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -67,8 +67,8 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
                                                       final String errorMessage,
                                                       final BrokerInteractiveTokenCommandParameters originalParameters) {
         super(errorCode, errorMessage, null);
-        //REMOVE
-        Logger.info(TAG, "BrokerInteractiveTokenCommandParameters" + originalParameters.toString());
+        Logger.info(TAG, "Login hint" + originalParameters.getLoginHint());
+
 
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
@@ -125,8 +125,7 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
                 originalParameters.getLoginHint();
-        //REMOVE
-        Logger.info(TAG, "BrokerSilentTokenCommandParameters" + originalParameters.toString());
+        Logger.info(TAG, "Login hint" + originalParameters.getLoginHint());
 
         setAccountUpn(upn);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/IntuneAppProtectionPolicyRequiredException.java
@@ -67,6 +67,8 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
                                                       final String errorMessage,
                                                       final BrokerInteractiveTokenCommandParameters originalParameters) {
         super(errorCode, errorMessage, null);
+        //REMOVE
+        Logger.info(TAG, "BrokerInteractiveTokenCommandParameters" + originalParameters.toString());
 
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
@@ -123,6 +125,8 @@ public class IntuneAppProtectionPolicyRequiredException extends ServiceException
         final String upn = (originalParameters.getBrokerAccount() != null) ?
                 originalParameters.getBrokerAccount().getUsername() :
                 originalParameters.getLoginHint();
+        //REMOVE
+        Logger.info(TAG, "BrokerSilentTokenCommandParameters" + originalParameters.toString());
 
         setAccountUpn(upn);
 


### PR DESCRIPTION
With this change if PII and verbose is enabled we can see all the bundles returned from the broker to client.