### PR TITLE
Removing unnecessary attributes from keystore wrap operation, Fixes AB#3137956

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ vNext
 - [MINOR] Organize browser selection classes and change signature for get AuthorizationStrategy (#2564)
 - [MINOR] Add support for OneBox Environment (#2559)
 - [MINOR] Add support for claims requests for native authentication (#2572)
+- [MINOR] Removing unnecessary attributes from keystore wrap operation (#2578)
 
 Version 19.0.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -225,7 +225,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             // All tokens with previous SecretKey are not possible to decrypt.
             Logger.warn(methodTag, "Error when loading key from Storage, " +
                     "wipe all existing key data ");
-           // deleteSecretKeyFromStorage();
+            deleteSecretKeyFromStorage();
             throw e;
         }
     }
@@ -331,8 +331,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
                     .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                     .setUserAuthenticationRequired(false)
-                    .setUnlockedDeviceRequired(false)
-                    .setIsStrongBoxBacked(false)
+//                    .setUnlockedDeviceRequired(false)
+//                    .setIsStrongBoxBacked(false)
                     .build();
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -190,8 +190,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     @Nullable
     /* package */ synchronized SecretKey readSecretKeyFromStorage() throws ClientException {
         final String methodTag = TAG + ":readSecretKeyFromStorage";
-        final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
         try {
+            final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
             if (keyPair == null) {
                 Logger.info(methodTag, "key does not exist in keystore");
                 deleteSecretKeyFromStorage();
@@ -309,7 +309,6 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return getLegacySpecForKeyStoreKey(context, alias);
         } else {
-            Logger.info(TAG, "Using KeyGenParameterSpec for generating KeyStore key");
             int purposes = KeyProperties.PURPOSE_WRAP_KEY  | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
                     .setKeySize(2048)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -46,9 +46,10 @@ import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.crypto.SecretKey;
 import javax.security.auth.x500.X500Principal;
@@ -194,6 +195,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
         final String methodTag = TAG + ":readSecretKeyFromStorage";
         final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
         final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
+        Logger.info(methodTag, "KeyPair is loaded: " + (keyPair != null));
         try {
 
             if (keyPair == null) {
@@ -223,24 +225,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             // All tokens with previous SecretKey are not possible to decrypt.
             Logger.warn(methodTag, "Error when loading key from Storage, " +
                     "wipe all existing key data ");
-            try {
-                Thread.sleep(10000);
-                Logger.warn(methodTag, "Attempting to unwrap again");
-                assert keyPair != null;
-                final SecretKey key = AndroidKeyStoreUtil.unwrap(wrappedSecretKey, getKeySpecAlgorithm(), keyPair, WRAP_ALGORITHM);
-
-                Logger.info(methodTag, "Key is loaded with thumbprint: " +
-                        KeyUtil.getKeyThumbPrint(key));
-
-                return key;
-            } catch (InterruptedException ex) {
-                Logger.info(methodTag, "Thread interrupted while sleeping");
-                throw new RuntimeException(ex);
-            } catch (final ClientException e1) {
-                Logger.warn(methodTag, "Again same exception but we won't retry again.");
-                 //deleteSecretKeyFromStorage();
-                throw e;
-            }
+           // deleteSecretKeyFromStorage();
+            throw e;
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -197,7 +197,8 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
         final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
         Logger.info(methodTag, "KeyPair is loaded: " + (keyPair != null));
         try {
-
+            boolean isPixel5 = "Google".equalsIgnoreCase(Build.MANUFACTURER) && "Pixel 5".equalsIgnoreCase(Build.MODEL);
+            Logger.info(TAG, "is it a pixel 5 device? "+ isPixel5 + Build.MANUFACTURER + " "+ Build.MODEL);
             if (keyPair == null) {
                 Logger.info(methodTag, "key does not exist in keystore");
                 deleteSecretKeyFromStorage();
@@ -320,6 +321,9 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
 //                    alias,
 //                    context.getPackageName());
 //            final int certValidYears = 100;
+            // Check if the device is a Pixel 5
+            boolean isPixel5 = "Google".equalsIgnoreCase(Build.MANUFACTURER) && "Pixel 5".equalsIgnoreCase(Build.MODEL);
+            Logger.info(TAG, "is it a pixel 5 device? "+ isPixel5 + Build.MANUFACTURER + " "+ Build.MODEL);
             int purposes = KeyProperties.PURPOSE_WRAP_KEY  | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
 //                    .setCertificateSubject(new X500Principal(certInfo))

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -47,9 +47,6 @@ import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Calendar;
 import java.util.Locale;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.crypto.SecretKey;
 import javax.security.auth.x500.X500Principal;
@@ -194,18 +191,14 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     /* package */ synchronized SecretKey readSecretKeyFromStorage() throws ClientException {
         final String methodTag = TAG + ":readSecretKeyFromStorage";
         final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
-        final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
-        Logger.info(methodTag, "KeyPair is loaded: " + (keyPair != null));
         try {
-            boolean isPixel5 = "Google".equalsIgnoreCase(Build.MANUFACTURER) && "Pixel 5".equalsIgnoreCase(Build.MODEL);
-            Logger.info(TAG, "is it a pixel 5 device? "+ isPixel5 + Build.MANUFACTURER + " "+ Build.MODEL);
             if (keyPair == null) {
                 Logger.info(methodTag, "key does not exist in keystore");
                 deleteSecretKeyFromStorage();
                 return null;
             }
 
-            //final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
+            final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
             if (wrappedSecretKey == null) {
                 Logger.warn(methodTag, "Key file is empty");
                 // Do not delete the KeyStoreKeyPair even if the key file is empty. This caused credential cache
@@ -317,26 +310,12 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             return getLegacySpecForKeyStoreKey(context, alias);
         } else {
             Logger.info(TAG, "Using KeyGenParameterSpec for generating KeyStore key");
-//            final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
-//                    alias,
-//                    context.getPackageName());
-//            final int certValidYears = 100;
-            // Check if the device is a Pixel 5
-            boolean isPixel5 = "Google".equalsIgnoreCase(Build.MANUFACTURER) && "Pixel 5".equalsIgnoreCase(Build.MODEL);
-            Logger.info(TAG, "is it a pixel 5 device? "+ isPixel5 + Build.MANUFACTURER + " "+ Build.MODEL);
             int purposes = KeyProperties.PURPOSE_WRAP_KEY  | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
-//                    .setCertificateSubject(new X500Principal(certInfo))
-//                    .setCertificateSerialNumber(BigInteger.ONE)
-//                    .setCertificateNotBefore(new Date())
-//                    .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
                     .setKeySize(2048)
                     .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
                     .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                    .setUserAuthenticationRequired(false)
-//                    .setUnlockedDeviceRequired(false)
-//                    .setIsStrongBoxBacked(false)
                     .build();
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -192,15 +192,17 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     @Nullable
     /* package */ synchronized SecretKey readSecretKeyFromStorage() throws ClientException {
         final String methodTag = TAG + ":readSecretKeyFromStorage";
+        final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
+        final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
         try {
-            final KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
+
             if (keyPair == null) {
                 Logger.info(methodTag, "key does not exist in keystore");
                 deleteSecretKeyFromStorage();
                 return null;
             }
 
-            final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
+            //final byte[] wrappedSecretKey = FileUtil.readFromFile(getKeyFile(), KEY_FILE_SIZE);
             if (wrappedSecretKey == null) {
                 Logger.warn(methodTag, "Key file is empty");
                 // Do not delete the KeyStoreKeyPair even if the key file is empty. This caused credential cache
@@ -221,8 +223,24 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             // All tokens with previous SecretKey are not possible to decrypt.
             Logger.warn(methodTag, "Error when loading key from Storage, " +
                     "wipe all existing key data ");
-            deleteSecretKeyFromStorage();
-            throw e;
+            try {
+                Thread.sleep(10000);
+                Logger.warn(methodTag, "Attempting to unwrap again");
+                assert keyPair != null;
+                final SecretKey key = AndroidKeyStoreUtil.unwrap(wrappedSecretKey, getKeySpecAlgorithm(), keyPair, WRAP_ALGORITHM);
+
+                Logger.info(methodTag, "Key is loaded with thumbprint: " +
+                        KeyUtil.getKeyThumbPrint(key));
+
+                return key;
+            } catch (InterruptedException ex) {
+                Logger.info(methodTag, "Thread interrupted while sleeping");
+                throw new RuntimeException(ex);
+            } catch (final ClientException e1) {
+                Logger.warn(methodTag, "Again same exception but we won't retry again.");
+                 //deleteSecretKeyFromStorage();
+                throw e;
+            }
         }
     }
 
@@ -311,19 +329,24 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return getLegacySpecForKeyStoreKey(context, alias);
         } else {
-            final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
-                    alias,
-                    context.getPackageName());
-            final int certValidYears = 100;
-            int purposes = KeyProperties.PURPOSE_WRAP_KEY | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+            Logger.info(TAG, "Using KeyGenParameterSpec for generating KeyStore key");
+//            final String certInfo = String.format(Locale.ROOT, "CN=%s, OU=%s",
+//                    alias,
+//                    context.getPackageName());
+//            final int certValidYears = 100;
+            int purposes = KeyProperties.PURPOSE_WRAP_KEY  | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
-                    .setCertificateSubject(new X500Principal(certInfo))
-                    .setCertificateSerialNumber(BigInteger.ONE)
-                    .setCertificateNotBefore(new Date())
-                    .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
+//                    .setCertificateSubject(new X500Principal(certInfo))
+//                    .setCertificateSerialNumber(BigInteger.ONE)
+//                    .setCertificateNotBefore(new Date())
+//                    .setCertificateNotAfter(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365 * certValidYears)))
                     .setKeySize(2048)
                     .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                    .setUserAuthenticationRequired(false)
+                    .setUnlockedDeviceRequired(false)
+                    .setIsStrongBoxBacked(false)
                     .build();
         }
     }


### PR DESCRIPTION
In an older [PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2558), I replaced the deprecated Keystore API for Android 28+
But it did not fix the issue of unwrap keystore operation failing on some Pixel 5 devices. Since it is not reproducing on other devices, I am removing the unnecessary attributes from the keystore wrap operation to see if it fixes the issue. certificate parameters are no longer actively used in other parts of the code. Hence removed those.

I have already shared the test build with 2 customers and the issue has NOT reproduced on their devices so far with this fix.

Fixes [AB#3137956](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3137956)
