### PR TITLE
Add server client id to SignInWithGoogleParameters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add server client id to SignInWithGoogleParameters
+- [MINOR] Add server client id to SignInWithGoogleParameters (#2581)
 - [MAJOR] Pass google id token to broker for enabling Sign in with Google (#2573)
 - [MINOR] Organize browser selection classes and change signature for get AuthorizationStrategy (#2564)
 - [MINOR] Add support for OneBox Environment (#2559)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add server client id to SignInWithGoogleParameters
 - [MAJOR] Pass google id token to broker for enabling Sign in with Google (#2573)
 - [MINOR] Organize browser selection classes and change signature for get AuthorizationStrategy (#2564)
 - [MINOR] Add support for OneBox Environment (#2559)

--- a/common/src/main/java/com/microsoft/identity/common/internal/msafederation/MsaFederatedSignInProviderFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/msafederation/MsaFederatedSignInProviderFactory.kt
@@ -36,7 +36,7 @@ internal object MsaFederatedSignInProviderFactory {
      */
     fun getProvider(parameters: MsaFederatedSignInParameters): IMsaFederatedSignInProvider {
         return when (parameters.providerName) {
-            MsaFederatedSignInProviderName.GOOGLE -> GoogleSignInProvider.create(parameters as SignInWithGoogleParameters, MsaFederationConstants.GOOGLE_MSA_WEB_CLIENT_ID)
+            MsaFederatedSignInProviderName.GOOGLE -> GoogleSignInProvider.create(parameters as SignInWithGoogleParameters)
 
             else -> {
                 throw IllegalArgumentException("Unsupported provider type")

--- a/common/src/main/java/com/microsoft/identity/common/internal/msafederation/MsaFederationConstants.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/msafederation/MsaFederationConstants.kt
@@ -26,8 +26,8 @@ package com.microsoft.identity.common.internal.msafederation
  * Constants used in MSA federation.
  */
 internal object MsaFederationConstants {
-    internal const val SIWG_TEST_WEBCLIENT_ID = "421268256362-r39ud27ddaajrcio0c8iq6snv3po43fb.apps.googleusercontent.com"
-    internal const val GOOGLE_MSA_WEB_CLIENT_ID = "1057459215779-l3uvdm899ucea09atcc09d9rq6uvkilv.apps.googleusercontent.com"
+    internal const val SIWG_TEST_SERVER_CLIENT_ID = "421268256362-r39ud27ddaajrcio0c8iq6snv3po43fb.apps.googleusercontent.com"
+    internal const val GOOGLE_MSA_SERVER_CLIENT_ID = "1057459215779-l3uvdm899ucea09atcc09d9rq6uvkilv.apps.googleusercontent.com"
     internal const val MSA_ID_TOKEN_HEADER_KEY = "x-ms-fidp-idtoken"
     internal const val MSA_ID_PROVIDER_EXTRA_QUERY_PARAM_KEY = "id_provider"
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/msafederation/google/GoogleSignInProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/msafederation/google/GoogleSignInProvider.kt
@@ -46,8 +46,7 @@ import java.security.SecureRandom
  * Call [GoogleSignInProvider.create] to create an instance of GoogleSignInProvider.
  */
 internal class GoogleSignInProvider(private val credentialManager: CredentialManager,
-                           private val parameters: SignInWithGoogleParameters,
-                           private val webClientId: String
+                           private val signInWithGoogleParameters: SignInWithGoogleParameters
 ) : IMsaFederatedSignInProvider {
 
     companion object {
@@ -57,12 +56,11 @@ internal class GoogleSignInProvider(private val credentialManager: CredentialMan
          * Creates an instance of GoogleSignInProvider.
          *
          * @param parameters The parameters required for signing in with Google.
-         * @param webClientId The web client ID for Google sign-in.
          * @return A new instance of GoogleSignInProvider. Prod must use MSA client ID.
          */
         @JvmStatic
-        fun create(parameters: SignInWithGoogleParameters, webClientId: String): GoogleSignInProvider {
-            return GoogleSignInProvider(CredentialManager.create(parameters.activity.applicationContext), parameters, webClientId)
+        fun create(parameters: SignInWithGoogleParameters): GoogleSignInProvider {
+            return GoogleSignInProvider(CredentialManager.create(parameters.activity.applicationContext), parameters)
         }
     }
 
@@ -75,7 +73,7 @@ internal class GoogleSignInProvider(private val credentialManager: CredentialMan
      * or an exception on failure.
      */
     override suspend fun signIn(): Result<SignInWithGoogleCredential> {
-        return if (parameters.useBottomSheet) {
+        return if (signInWithGoogleParameters.useBottomSheet) {
             signInWithGoogleBottomSheet()
         } else {
             signInWithGoogle()
@@ -90,7 +88,7 @@ internal class GoogleSignInProvider(private val credentialManager: CredentialMan
     private suspend fun signInWithGoogleBottomSheet(): Result<SignInWithGoogleCredential> {
         val googleIdOption: GetGoogleIdOption = GetGoogleIdOption.Builder()
             .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(webClientId)
+            .setServerClientId(signInWithGoogleParameters.serverClientId)
             .setAutoSelectEnabled(false)
             .setNonce(generateNonce())
             .build()
@@ -104,7 +102,7 @@ internal class GoogleSignInProvider(private val credentialManager: CredentialMan
      * @return A Result containing the SignInWithGoogleCredential on success, or an exception on failure.
      */
     private suspend fun signInWithGoogle(): Result<SignInWithGoogleCredential> {
-        val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(webClientId)
+        val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(signInWithGoogleParameters.serverClientId)
             .setNonce(generateNonce())
             .build()
 
@@ -134,7 +132,7 @@ internal class GoogleSignInProvider(private val credentialManager: CredentialMan
         try {
             val getCredentialResponse = credentialManager.getCredential(
                 request = getCredentialRequest,
-                context = parameters.activity
+                context = signInWithGoogleParameters.activity
             )
 
             // handle the result

--- a/common/src/main/java/com/microsoft/identity/common/internal/msafederation/google/SignInWithGoogleParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/msafederation/google/SignInWithGoogleParameters.kt
@@ -25,29 +25,39 @@ package com.microsoft.identity.common.internal.msafederation.google
 import android.app.Activity
 import com.microsoft.identity.common.internal.msafederation.MsaFederatedSignInParameters
 import com.microsoft.identity.common.internal.msafederation.MsaFederatedSignInProviderName
+import com.microsoft.identity.common.internal.msafederation.MsaFederationConstants
 
 /**
  * SignInWithGoogleParameters holds the parameters required for signing in with Google.
  *
  * @property activity The Activity context used for the sign-in process.
+ * @property serverClientId The target server OAuth2.0 client (backend) ID generated in google console project.
+ *                          Authenticates backend server with Google's APIs. Default value MSA's server client id.
  * UI for the sign-in process.
  */
-data class SignInWithGoogleParameters(
-    internal val activity: Activity
+data class SignInWithGoogleParameters @JvmOverloads constructor(
+    internal val activity: Activity,
+    internal val serverClientId: String = MsaFederationConstants.GOOGLE_MSA_SERVER_CLIENT_ID
 ) : MsaFederatedSignInParameters() {
 
     /**
      * Secondary constructor to initialize the parameters with an option to use a bottom sheet UI.
      * Current requirement do not use bottom sheet UI, so this constructor is kept internal
      * @param activity The Activity context used for the sign-in process.
+     * @param serverClientId The server client ID used for the sign-in process.
      * @param useBottomSheet A flag indicating whether to use a bottom sheet UI for the sign-in process.
      */
-    internal constructor(activity: Activity, useBottomSheet: Boolean) : this(activity) {
+    internal constructor(
+        activity: Activity,
+        serverClientId: String = MsaFederationConstants.GOOGLE_MSA_SERVER_CLIENT_ID,
+        useBottomSheet: Boolean
+    ) : this(activity, serverClientId) {
         this.useBottomSheet = useBottomSheet
     }
 
     /**
      * A flag indicating whether to use a bottom sheet UI for the sign-in process.
+     * Internal for now, as the current requirement do not use bottom sheet UI.
      */
     internal var useBottomSheet: Boolean = false
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/msafederation/google/GoogleSignInProviderTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/msafederation/google/GoogleSignInProviderTest.kt
@@ -55,9 +55,8 @@ class GoogleSignInProviderTest {
         val mockCredentialManager = mockk<CredentialManager>()
         val mockActivity = mockk<Activity>()
         val mockParameters = SignInWithGoogleParameters(mockActivity)
-        val webClientId = MsaFederationConstants.GOOGLE_MSA_WEB_CLIENT_ID
         val mockIdToken = "mockIdToken"
-        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters, webClientId)
+        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters)
 
         val mockCredential = GoogleIdTokenCredential(
             GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL,
@@ -79,7 +78,7 @@ class GoogleSignInProviderTest {
         val capturedRequest = getCredentialRequestSlot.captured
         assertNotNull(capturedRequest)
         assertEquals(1, capturedRequest.credentialOptions.size)
-        assertEquals(webClientId, (capturedRequest.credentialOptions[0] as GetSignInWithGoogleOption).serverClientId)
+        assertEquals(MsaFederationConstants.GOOGLE_MSA_SERVER_CLIENT_ID, (capturedRequest.credentialOptions[0] as GetSignInWithGoogleOption).serverClientId)
         val capturedActivity = activitySlot.captured
         assertSame(mockActivity, capturedActivity)
     }
@@ -88,10 +87,11 @@ class GoogleSignInProviderTest {
     fun testSignInBottomSheet() {
         val mockCredentialManager = mockk<CredentialManager>()
         val mockActivity = mockk<Activity>()
-        val mockParameters = SignInWithGoogleParameters(mockActivity, true)
-        val webClientId = MsaFederationConstants.GOOGLE_MSA_WEB_CLIENT_ID
+        val mockServerClientId = "mockServerClientId"
+        val mockParameters = SignInWithGoogleParameters(mockActivity, mockServerClientId, true)
+
         val mockIdToken = "mockIdToken"
-        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters, webClientId)
+        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters)
 
         val mockCredential = GoogleIdTokenCredential(
             GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL,
@@ -115,7 +115,7 @@ class GoogleSignInProviderTest {
         assertEquals(1, capturedRequest.credentialOptions.size)
 
         val capturedGoogleIdOption = capturedRequest.credentialOptions[0] as GetGoogleIdOption
-        assertEquals(webClientId, capturedGoogleIdOption.serverClientId)
+        assertEquals(mockServerClientId, capturedGoogleIdOption.serverClientId)
         assertEquals(false, capturedGoogleIdOption.filterByAuthorizedAccounts)
         assertEquals(false, capturedGoogleIdOption.autoSelectEnabled)
         val capturedActivity = activitySlot.captured
@@ -127,8 +127,7 @@ class GoogleSignInProviderTest {
         val mockCredentialManager = mockk<CredentialManager>()
         val mockActivity = mockk<Activity>()
         val mockParameters = SignInWithGoogleParameters(mockActivity)
-        val webClientId = MsaFederationConstants.GOOGLE_MSA_WEB_CLIENT_ID
-        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters, webClientId)
+        val googleSignInProvider = GoogleSignInProvider(mockCredentialManager, mockParameters)
 
         coEvery { mockCredentialManager.clearCredentialState(any()) } returns Unit
         runBlocking { googleSignInProvider.signOut() }

--- a/common/src/test/java/com/microsoft/identity/common/internal/msafederation/google/SignInWithGoogleParametersTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/msafederation/google/SignInWithGoogleParametersTest.kt
@@ -48,9 +48,20 @@ class SignInWithGoogleParametersTest {
     }
 
     @Test
+    fun testSignInWithGoogleParameters_WithServerClientId() {
+        val activity = Robolectric.buildActivity(Activity::class.java).get()
+        val serverClientId = "serverClientId"
+        val signInWithGoogleParameters = SignInWithGoogleParameters(activity, serverClientId)
+        assertEquals(MsaFederatedSignInProviderName.GOOGLE, signInWithGoogleParameters.providerName)
+        assertEquals(activity, signInWithGoogleParameters.activity)
+        assertFalse(signInWithGoogleParameters.useBottomSheet)
+        assertEquals(serverClientId, signInWithGoogleParameters.serverClientId)
+    }
+
+    @Test
     fun testSignInWithGoogleParametersUseBottomSheet() {
         val activity = Robolectric.buildActivity(Activity::class.java).get()
-        val signInWithGoogleParameters = SignInWithGoogleParameters(activity, true)
+        val signInWithGoogleParameters = SignInWithGoogleParameters(activity, useBottomSheet = true)
         assertEquals(MsaFederatedSignInProviderName.GOOGLE, signInWithGoogleParameters.providerName)
         assertEquals(activity, signInWithGoogleParameters.activity)
         assertTrue(signInWithGoogleParameters.useBottomSheet)


### PR DESCRIPTION
This PR has changes to allow caller to pass server client id as part of SignInWithGoogleParameters.

Adding this change in case we end up using App's own server client id instead of MSA's. In either case MSA service would validate it. The default stays MSA's server client id.

This client id identifies the backend to which google id token is sent. "sub" claim in the id token is this client id.

Added tests. 