### PR TITLE
Add fallback mechanisms for keypair generation, Fixes AB#3146656

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [MINOR] Add support for OneBox Environment (#2559)
 - [MINOR] Add support for claims requests for native authentication (#2572)
 - [MINOR] Removing unnecessary attributes from keystore wrap operation (#2578)
+- [MINOR] Add fallback mechanisms for keypair generation (#2586)
 
 Version 19.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -37,6 +37,10 @@ import com.microsoft.identity.common.java.crypto.key.KeyUtil;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.util.CachedData;
 import com.microsoft.identity.common.java.util.FileUtil;
 import com.microsoft.identity.common.logging.Logger;
@@ -46,6 +50,7 @@ import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.ProviderException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Calendar;
 import java.util.Locale;
@@ -55,6 +60,9 @@ import javax.security.auth.x500.X500Principal;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import lombok.NonNull;
 
 /**
@@ -249,15 +257,62 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
          * stomping/overwriting one another's keypair.
          */
         KeyPair keyPair = AndroidKeyStoreUtil.readKey(mAlias);
-        if(keyPair == null){
+        if (keyPair == null) {
             Logger.info(methodTag, "No existing keypair. Generating a new one.");
-            keyPair = AndroidKeyStoreUtil.generateKeyPair(
-                    WRAP_KEY_ALGORITHM,
-                    getSpecForKeyStoreKey(mContext, mAlias));
+            final Span span = OTelUtility.createSpan(SpanName.KeyPairGeneration.name());
+            final long keypairGenStartTime = System.currentTimeMillis();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP)) {
+                try (Scope scope = SpanExtension.makeCurrentSpan(span)) {
+                    keyPair = attemptKeyPairGeneration(mAlias, true, keypairGenStartTime);
+                    Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_with_wrap");
+                    span.setStatus(StatusCode.OK);
+                } catch (final ProviderException e) {
+                    if ("SecureKeyImportUnavailableException".equals(e.getClass().getSimpleName())) {
+                        Logger.warn(methodTag, "Wrap purpose may not be supported. Retrying without wrap.");
+                        keyPair = attemptKeyPairGeneration(mAlias, false, keypairGenStartTime);
+                        Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_without_wrap");
+                        span.setStatus(StatusCode.OK);
+                    } else {
+                        // Some unknown exception occurred. Rethrow it so that legacy keygen spec logic can run.
+                        throw e;
+                    }
+                } catch (final Exception e) {
+                    Logger.warn(methodTag, "Unexpected error with new KeyPairGeneratorSpec. Falling back to legacy spec.");
+                    keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
+                    Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
+                    span.setStatus(StatusCode.OK);
+                } finally {
+                    span.end();
+                }
+            }
+            else {
+                // If flight for using new keygen spec is not enabled, use the legacy spec.
+                Logger.info(methodTag, "Using legacy spec for keypair generation directly.");
+                keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
+            }
         }
-
         final byte[] keyWrapped = AndroidKeyStoreUtil.wrap(unencryptedKey, keyPair, WRAP_ALGORITHM);
         FileUtil.writeDataToFile(keyWrapped, getKeyFile());
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    private KeyPair attemptKeyPairGeneration(@NonNull final String alias, boolean useWrapPurpose, long keypairGenStartTime) throws ClientException{
+        KeyPair keyPair = AndroidKeyStoreUtil.generateKeyPair(
+                WRAP_KEY_ALGORITHM, getSpecForKeyStoreKey(mContext, alias, useWrapPurpose));
+        recordKeyGenerationTime(keypairGenStartTime);
+        return keyPair;
+    }
+
+    private KeyPair generateKeyPairWithLegacySpec(@NonNull final String alias, long keypairGenStartTime) throws ClientException{
+        KeyPair keyPair = AndroidKeyStoreUtil.generateKeyPair(
+                WRAP_KEY_ALGORITHM, getLegacySpecForKeyStoreKey(mContext, alias));
+        recordKeyGenerationTime(keypairGenStartTime);
+        return keyPair;
+    }
+
+    private void recordKeyGenerationTime(long keypairGenStartTime) {
+        long elapsedTime = System.currentTimeMillis() - keypairGenStartTime;
+        SpanExtension.current().setAttribute(AttributeName.elapsed_time_keypair_generation.name(), elapsedTime);
     }
 
     /**
@@ -305,20 +360,21 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * This is for the key to be generated in {@link KeyStore} via {@link KeyPairGenerator}
      *
      * @param context an Android {@link Context} object.
+     * @param alias   the alias for the key.
+     * @param tryPurposeWrap whether to try to use the wrap purpose in the key generation spec.
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
      */
-    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias) {
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            int purposes =  KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
-            return new KeyGenParameterSpec.Builder(alias, purposes)
-                    .setKeySize(2048)
-                    .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                    .build();
-        } else {
-            return getLegacySpecForKeyStoreKey(context, alias);
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias, boolean tryPurposeWrap) {
+        int purposes = KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+        if (tryPurposeWrap) {
+            purposes |= KeyProperties.PURPOSE_WRAP_KEY;
         }
+        return new KeyGenParameterSpec.Builder(alias, purposes)
+                .setKeySize(2048)
+                .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                .build();
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -35,6 +35,8 @@ import com.microsoft.identity.common.internal.util.AndroidKeyStoreUtil;
 import com.microsoft.identity.common.java.crypto.key.AES256KeyLoader;
 import com.microsoft.identity.common.java.crypto.key.KeyUtil;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.util.CachedData;
 import com.microsoft.identity.common.java.util.FileUtil;
 import com.microsoft.identity.common.logging.Logger;
@@ -306,17 +308,16 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
      */
     private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            return getLegacySpecForKeyStoreKey(context, alias);
-        } else {
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             int purposes =  KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
                     .setKeySize(2048)
-                    .setUserAuthenticationRequired(false)
                     .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
                     .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                     .build();
+        } else {
+            return getLegacySpecForKeyStoreKey(context, alias);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -309,9 +309,10 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return getLegacySpecForKeyStoreKey(context, alias);
         } else {
-            int purposes = KeyProperties.PURPOSE_WRAP_KEY  | KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+            int purposes =  KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
             return new KeyGenParameterSpec.Builder(alias, purposes)
                     .setKeySize(2048)
+                    .setUserAuthenticationRequired(false)
                     .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
                     .setBlockModes(KeyProperties.BLOCK_MODE_ECB) // Ensure compatibility with RSA
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -264,17 +264,29 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP)) {
                 try (Scope scope = SpanExtension.makeCurrentSpan(span)) {
                     keyPair = attemptKeyPairGeneration(mAlias, true, keypairGenStartTime);
+                    Logger.info(methodTag, "Successfully generated keypair with new KeyPairGeneratorSpec with wrap purpose.");
                     Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_with_wrap");
                     span.setStatus(StatusCode.OK);
                 } catch (final ProviderException e) {
                     if ("SecureKeyImportUnavailableException".equals(e.getClass().getSimpleName())) {
                         Logger.warn(methodTag, "Wrap purpose may not be supported. Retrying without wrap.");
-                        keyPair = attemptKeyPairGeneration(mAlias, false, keypairGenStartTime);
-                        Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_without_wrap");
-                        span.setStatus(StatusCode.OK);
+                        try {
+                            keyPair = attemptKeyPairGeneration(mAlias, false, keypairGenStartTime);
+                            Logger.info(methodTag, "Successfully generated keypair with new KeyPairGeneratorSpec without wrap purpose.");
+                            Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_without_wrap");
+                            span.setStatus(StatusCode.OK);
+                        } catch (Exception ex) {
+                            // 2nd fallback to legacy keygen spec
+                            Logger.error(methodTag, "Second attempt without wrap also failed. Falling back to legacy spec.", ex);
+                            keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
+                            Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
+                            span.setStatus(StatusCode.OK);
+                        }
                     } else {
-                        // Some unknown exception occurred. Rethrow it so that legacy keygen spec logic can run.
-                        throw e;
+                        Logger.info(methodTag, "Some unknown exception occurred. Running legacy keygen spec logic.");
+                        keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
+                        Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
+                        span.setStatus(StatusCode.OK);
                     }
                 } catch (final Exception e) {
                     Logger.warn(methodTag, "Unexpected error with new KeyPairGeneratorSpec. Falling back to legacy spec.");

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -279,7 +279,10 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
                             // 2nd fallback to legacy keygen spec
                             Logger.error(methodTag, "Second attempt without wrap also failed. Falling back to legacy spec.", ex);
                             keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
-                            Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
+                            if (e.getMessage() != null) {
+                                span.setAttribute(AttributeName.keypair_gen_exception.name(), e.getMessage());
+                            }
+                            span.setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
                             span.setStatus(StatusCode.OK);
                         }
                     } else {
@@ -289,9 +292,12 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
                         span.setStatus(StatusCode.OK);
                     }
                 } catch (final Exception e) {
-                    Logger.warn(methodTag, "Unexpected error with new KeyPairGeneratorSpec. Falling back to legacy spec.");
+                    Logger.warn(methodTag, "Unexpected error with new KeyPairGeneratorSpec. Falling back to legacy spec. "+ e);
                     keyPair = generateKeyPairWithLegacySpec(mAlias, keypairGenStartTime);
-                    Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
+                    if (e.getMessage() != null) {
+                        span.setAttribute(AttributeName.keypair_gen_exception.name(), e.getMessage());
+                    }
+                    span.setAttribute(AttributeName.key_pair_gen_successful_method.name(), "legacy_key_gen_spec");
                     span.setStatus(StatusCode.OK);
                 } finally {
                     span.end();

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -262,7 +262,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
             final Span span = OTelUtility.createSpan(SpanName.KeyPairGeneration.name());
             final long keypairGenStartTime = System.currentTimeMillis();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP)) {
-                try (Scope scope = SpanExtension.makeCurrentSpan(span)) {
+                try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
                     keyPair = attemptKeyPairGeneration(mAlias, true, keypairGenStartTime);
                     Logger.info(methodTag, "Successfully generated keypair with new KeyPairGeneratorSpec with wrap purpose.");
                     Span.current().setAttribute(AttributeName.key_pair_gen_successful_method.name(), "new_key_gen_spec_with_wrap");

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -310,7 +310,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
     @RequiresApi(api = Build.VERSION_CODES.P)
     private KeyPair attemptKeyPairGeneration(@NonNull final String alias, boolean useWrapPurpose, long keypairGenStartTime) throws ClientException{
         KeyPair keyPair = AndroidKeyStoreUtil.generateKeyPair(
-                WRAP_KEY_ALGORITHM, getSpecForKeyStoreKey(mContext, alias, useWrapPurpose));
+                WRAP_KEY_ALGORITHM, getSpecForKeyStoreKey(alias, useWrapPurpose));
         recordKeyGenerationTime(keypairGenStartTime);
         return keyPair;
     }
@@ -371,7 +371,6 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * Generate a self-signed cert and derive an AlgorithmParameterSpec from that.
      * This is for the key to be generated in {@link KeyStore} via {@link KeyPairGenerator}
      *
-     * @param context an Android {@link Context} object.
      * @param alias   the alias for the key.
      * @param tryPurposeWrap whether to try to use the wrap purpose in the key generation spec.
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).

--- a/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/AndroidWrappedKeyLoader.java
@@ -377,7 +377,7 @@ public class AndroidWrappedKeyLoader extends AES256KeyLoader {
      * @return a {@link AlgorithmParameterSpec} for the keystore key (that we'll use to wrap the secret key).
      */
     @RequiresApi(api = Build.VERSION_CODES.P)
-    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final Context context, @NonNull final String alias, boolean tryPurposeWrap) {
+    private static AlgorithmParameterSpec getSpecForKeyStoreKey(@NonNull final String alias, boolean tryPurposeWrap) {
         int purposes = KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
         if (tryPurposeWrap) {
             purposes |= KeyProperties.PURPOSE_WRAP_KEY;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -88,7 +88,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the re-attachment of new PRT header logic. Default is true.
      */
-    ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED("EnableAttachNewPrtHeaderWhenNonceExpired", true);
+    ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED("EnableAttachNewPrtHeaderWhenNonceExpired", true),
+
+    /**
+     * Flight to enable the new key generation spec for wrap key. Default is true.
+     */
+    ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP("EnableNewKeyGenSpecForWrap", true);
     private String key;
     private Object defaultValue;
     CommonFlight(@NonNull String key, @NonNull Object defaultValue) {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -312,5 +312,14 @@ public enum AttributeName {
     /**
      * Indicates the new refresh token credential header attached in the eSTS request.
      */
-    is_new_refresh_token_cred_header_attached
+    is_new_refresh_token_cred_header_attached,
+
+    /**
+     * The time (in milliseconds) spent on generating a keypair.
+     */
+    elapsed_time_keypair_generation,
+    /**
+     * Indicates the successful method used to generate a keypair.
+     */
+    key_pair_gen_successful_method
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -318,6 +318,7 @@ public enum AttributeName {
      * The time (in milliseconds) spent on generating a keypair.
      */
     elapsed_time_keypair_generation,
+
     /**
      * Indicates the successful method used to generate a keypair.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -322,5 +322,10 @@ public enum AttributeName {
     /**
      * Indicates the successful method used to generate a keypair.
      */
-    key_pair_gen_successful_method
+    key_pair_gen_successful_method,
+
+    /**
+     * Indicates the exception in generating a keypair.
+     */
+    keypair_gen_exception
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -59,5 +59,6 @@ public enum SpanName {
     UpgradeDeviceRegistration,
     RemoveBrokerAccount,
     ProcessNonceFromEstsRedirect,
-    DataStoreCorruptionException
+    DataStoreCorruptionException,
+    KeyPairGeneration
 }


### PR DESCRIPTION
Issue : Some specific device models do not like the purpose "PURPOSE_WRAP_KEY" to be passed while doing a keypair generation.
Root cause : Changes made in this PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2558/files
IcM : https://portal.microsofticm.com/imp/v5/incidents/details/592800555/summary
Fix : 
1. Added fallback mechanism to skip using wrap_key purpose when the SecureKeyImportUnavailableException occurs.
2. If the fallback mentioned in step 1 fails, we fallback to legacy keygen spec method.
3. Added telemetry to capture which method was finally successful and also the time taken to generate the keypair
4. Also kept my changes behind a flight to turn it off in case of any failures


Manually tested below steps
1. Signed in with an AAD account with the flight for using the latest KeyGenParameterSpec as ON in MsalTestApp with BrokerHost as the broker
5. Tried  ATS ---> Succeeds
6. Tried getBrokerAccounts API from BrokerHost app ---> Succeeds
7. Did a device registration -- Succeeds
-----------------------------------------------------------------------------
8. Assuming some issue happened, I turned off the flight
9. Tried  ATS ---> Succeeds
10. Tried ATI with same UPN --> Succeeds
11. Tried getBrokerAccounts API from BrokerHost app ---> Succeeds
12. Tried to get WPJ entries --> Gets them correctly

Fixes [AB#3146656](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3146656)