### PR TITLE
Fix multiple prompts issue in cross cloud request, Fixes AB#3179147

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Fix multiple prompts issue in cross cloud request (#2599)
 
 Version 20.1.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -393,6 +393,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 Logger.infoPII(methodTag, "The start url is " + mAuthorizationRequestUrl);
 
                 mAADWebViewClient.setRequestHeaders(mRequestHeaders);
+                mAADWebViewClient.setRequestUrl(mAuthorizationRequestUrl);
                 mWebView.loadUrl(mAuthorizationRequestUrl, mRequestHeaders);
 
                 // The first page load could take time, and we do not want to just show a blank page.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -216,7 +216,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                         ViewTreeLifecycleOwner.get(view));
                 challengeHandler.processChallenge(challenge);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED) && isNonceRedirect(formattedURL)) {
-                Logger.info(methodTag,"Navigation contains new nonce within the redirect uri. "+ url);
+                Logger.info(methodTag,"Navigation contains new nonce within the redirect uri.");
                 processNonceAndReAttachHeaders(view, url);
              }
              else if (isRedirectUrl(formattedURL)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -51,10 +51,12 @@ import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizat
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractSmartcardCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserUriHelper;
+import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.exception.IErrorInformation;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
@@ -63,6 +65,7 @@ import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.opentelemetry.SpanName;
+import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallenge;
 import com.microsoft.identity.common.java.challengehandlers.PKeyAuthChallengeFactory;
@@ -114,6 +117,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private AbstractCertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
     private final SwitchBrowserHandler mSwitchBrowserHandler;
     private HashMap<String, String> mRequestHeaders;
+    private String mRequestUrl;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -161,6 +165,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     public void setRequestHeaders(final HashMap<String, String> requestHeaders) {
         mRequestHeaders = requestHeaders;
+    }
+
+    public void setRequestUrl(final String requestUrl) {
+        mRequestUrl = requestUrl;
     }
 
     /**
@@ -248,7 +256,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 processSSLProtectionCheck(view, url);
             } else if (isHeaderForwardingRequiredUri(url)) {
                 processHeaderForwardingRequiredUri(view, url);
-            } else {
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
+                Logger.info(methodTag,"Navigation contains cross cloud redirect.");
+                processCloudRedirectAndPrtHeader(view, url);
+            }
+             else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
 
@@ -298,6 +310,25 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isNonceRedirect(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.SSO_NONCE_PARAMETER);
+    }
+
+    private boolean isCrossCloudRedirect(@NonNull final String url) {
+        try {
+            final URL currentUrl = new URL(url);
+            final URL startUrl = new URL(mRequestUrl);
+            if (AzureActiveDirectory.isValidCloudHost(currentUrl) && AzureActiveDirectory.isValidCloudHost(startUrl)) {
+                final Authority startUrlAuthority = Authority.getAuthorityFromAuthorityUrl(mRequestUrl);
+                final Authority currentLoadedUrlAuthority = Authority.getAuthorityFromAuthorityUrl(url);
+                if (!startUrlAuthority.getAuthorityURL().getHost().equalsIgnoreCase(currentLoadedUrlAuthority.getAuthorityURL().getHost())) {
+                    Logger.info(TAG, "Detected a cross cloud redirect.");
+                    return true;
+                }
+            }
+        } catch (final Exception e) {
+            // No op. If it fails, let it fail silently because this is not blocking the user.
+            Logger.warn(TAG, "Failure in detecting if it is a cross cloud redirect url." + e);
+        }
+        return false;
     }
 
     private boolean isWebsiteRequestUrl(@NonNull final String url) {
@@ -599,6 +630,28 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } finally {
                 span.end();
             }
+        }
+    }
+
+    /**
+     * This method is used to process the cross cloud redirect and attach the PRT header to the request.
+     */
+    private void processCloudRedirectAndPrtHeader(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processCloudRedirectAndPrtHeader";
+
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            final CrossCloudChallengeHandler crossCloudChallengeHandler = new CrossCloudChallengeHandler(view, mRequestHeaders, span);
+            crossCloudChallengeHandler.processChallenge(new URL(url));
+            span.setStatus(StatusCode.OK);
+        } catch (final Exception e) {
+            // No op if an exception happens
+            Logger.warn(methodTag, "Error processing cross cloud redirect and attaching PRT header." + e);
+            span.recordException(e);
+        } finally {
+            span.end();
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -644,7 +644,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             final CrossCloudChallengeHandler crossCloudChallengeHandler = new CrossCloudChallengeHandler(view, mRequestHeaders, span);
-            crossCloudChallengeHandler.processChallenge(new URL(url));
+            crossCloudChallengeHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);
         } catch (final Exception e) {
             // No op if an exception happens

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CrossCloudChallengeHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CrossCloudChallengeHandler.kt
@@ -39,13 +39,13 @@ class CrossCloudChallengeHandler(
     private val webView: WebView,
     private val headers: HashMap<String, String>,
     private val span : Span
-) : IChallengeHandler<URL, Void> {
+) : IChallengeHandler<String, Void> {
     private val TAG = CrossCloudChallengeHandler::class.java.simpleName
 
-    override fun processChallenge(input: URL): Void? {
+    override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge of a cross cloud request.")
-        modifyHeadersWithRefreshTokenCredential(input.toString())
-        webView.loadUrl(input.toString(), headers)
+        modifyHeadersWithRefreshTokenCredential(inputUrl)
+        webView.loadUrl(inputUrl, headers)
         return null
     }
 
@@ -56,16 +56,16 @@ class CrossCloudChallengeHandler(
         val methodTag = "$TAG:modifyHeadersWithRefreshTokenCredential"
         val parameters: Map<String, String> = StringExtensions.getUrlParameters(url)
         val username = parameters["login_hint"]
-        if (!StringUtils.isNullOrEmpty(username)) {
+        if (!username.isNullOrEmpty()) {
             val updatedRefreshTokenCredentialHeader =
                 CommonRefreshTokenCredentialProvider.getRefreshTokenCredential(
-                    url, username!!
+                    url, username
                 )
-            if (!StringUtils.isNullOrEmpty(updatedRefreshTokenCredentialHeader)) {
+            if (!updatedRefreshTokenCredentialHeader.isNullOrEmpty()) {
                 Logger.info(methodTag, "Attaching refresh token credential in headers.")
                 span.setAttribute(AttributeName.is_new_refresh_token_cred_header_attached.name, true)
                 headers[AuthenticationConstants.Broker.PRT_RESPONSE_HEADER] =
-                    updatedRefreshTokenCredentialHeader!!
+                    updatedRefreshTokenCredentialHeader
             }
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CrossCloudChallengeHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/CrossCloudChallengeHandler.kt
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.challengehandlers
+
+import android.webkit.WebView
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants
+import com.microsoft.identity.common.adal.internal.util.StringExtensions
+import com.microsoft.identity.common.java.broker.CommonRefreshTokenCredentialProvider
+import com.microsoft.identity.common.java.opentelemetry.AttributeName
+import com.microsoft.identity.common.logging.Logger
+import io.opentelemetry.api.internal.StringUtils
+import io.opentelemetry.api.trace.Span
+import java.net.URL
+
+/**
+ * Handler for attaching prt credential header on web view in cross cloud redirect scenarios.
+ */
+class CrossCloudChallengeHandler(
+    private val webView: WebView,
+    private val headers: HashMap<String, String>,
+    private val span : Span
+) : IChallengeHandler<URL, Void> {
+    private val TAG = CrossCloudChallengeHandler::class.java.simpleName
+
+    override fun processChallenge(input: URL): Void? {
+        Logger.info(TAG, "Processing challenge of a cross cloud request.")
+        modifyHeadersWithRefreshTokenCredential(input.toString())
+        webView.loadUrl(input.toString(), headers)
+        return null
+    }
+
+    // Updates the headers by attaching a refresh token credential header.
+    private fun modifyHeadersWithRefreshTokenCredential(
+        url: String,
+    ) {
+        val methodTag = "$TAG:modifyHeadersWithRefreshTokenCredential"
+        val parameters: Map<String, String> = StringExtensions.getUrlParameters(url)
+        val username = parameters["login_hint"]
+        if (!StringUtils.isNullOrEmpty(username)) {
+            val updatedRefreshTokenCredentialHeader =
+                CommonRefreshTokenCredentialProvider.getRefreshTokenCredential(
+                    url, username!!
+                )
+            if (!StringUtils.isNullOrEmpty(updatedRefreshTokenCredentialHeader)) {
+                Logger.info(methodTag, "Attaching refresh token credential in headers.")
+                span.setAttribute(AttributeName.is_new_refresh_token_cred_header_attached.name, true)
+                headers[AuthenticationConstants.Broker.PRT_RESPONSE_HEADER] =
+                    updatedRefreshTokenCredentialHeader!!
+            }
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/CommonRefreshTokenCredentialProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/CommonRefreshTokenCredentialProvider.kt
@@ -49,4 +49,13 @@ object CommonRefreshTokenCredentialProvider : IRefreshTokenCredentialProvider {
         Logger.warn(methodTag, "mRefreshTokenCredentialHolder is not initialized!")
         return null
     }
+
+    override fun getRefreshTokenCredential(inputUrl : String, username : String) : String? {
+        val methodTag = "$TAG:getRefreshTokenCredential";
+        if (mRefreshTokenCredentialProvider != null) {
+            return mRefreshTokenCredentialProvider!!.getRefreshTokenCredential(inputUrl, username)
+        }
+        Logger.warn(methodTag, "mRefreshTokenCredentialHolder is not initialized!")
+        return null
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/CommonRefreshTokenCredentialProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/CommonRefreshTokenCredentialProvider.kt
@@ -53,7 +53,7 @@ object CommonRefreshTokenCredentialProvider : IRefreshTokenCredentialProvider {
     override fun getRefreshTokenCredential(inputUrl : String, username : String) : String? {
         val methodTag = "$TAG:getRefreshTokenCredential";
         if (mRefreshTokenCredentialProvider != null) {
-            return mRefreshTokenCredentialProvider!!.getRefreshTokenCredential(inputUrl, username)
+            return mRefreshTokenCredentialProvider?.getRefreshTokenCredential(inputUrl, username)
         }
         Logger.warn(methodTag, "mRefreshTokenCredentialHolder is not initialized!")
         return null

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -93,7 +93,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the new key generation spec for wrap key. Default is true.
      */
-    ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP("EnableNewKeyGenSpecForWrap", true);
+    ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP("EnableNewKeyGenSpecForWrap", true),
+
+    /**
+     * Flight to enable the attachment of PRT header in cross cloud requests. Default is true.
+     */
+    ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD("EnableAttachPrtHeaderWhenCrossCloud", true);
     private String key;
     private Object defaultValue;
     CommonFlight(@NonNull String key, @NonNull Object defaultValue) {

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/IRefreshTokenCredentialProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/IRefreshTokenCredentialProvider.kt
@@ -34,4 +34,9 @@ interface IRefreshTokenCredentialProvider {
      * Gets refresh token credential using nonce retrieved from webview.
      */
     fun getRefreshTokenCredentialUsingNewNonce(inputUrl : String, username : String, nonce : String) : String?
+
+    /**
+     * Gets refresh token credential.
+     */
+    fun getRefreshTokenCredential(inputUrl : String, username : String) : String?
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -60,5 +60,6 @@ public enum SpanName {
     RemoveBrokerAccount,
     ProcessNonceFromEstsRedirect,
     DataStoreCorruptionException,
-    KeyPairGeneration
+    KeyPairGeneration,
+    ProcessCrossCloudRedirect
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -95,7 +95,7 @@ public class AzureActiveDirectory
         return sAadClouds.containsKey(authorityUrl.getHost().toLowerCase(Locale.US));
     }
 
-    static synchronized boolean isValidCloudHost(@NonNull final URL authorityUrl) {
+    public static synchronized boolean isValidCloudHost(@NonNull final URL authorityUrl) {
         return hasCloudHost(authorityUrl) && getAzureActiveDirectoryCloud(authorityUrl).isValidated();
     }
 


### PR DESCRIPTION
**Issue** : https://portal.microsofticm.com/imp/v5/incidents/details/603998142/summary
When cross cloud authentication happens, webview could be redirected to a different cloud rather than the initial cloud loaded in the webview. When such a redirect happens, the request have no more PRT header attached that can be consumed by the new cloud. Therefore users will be asked to input credential when redirected to a new cloud.

**Fix** : In this PR, we are adding the support to attach cross domain PRT in embedded webview requests.
To improve the SSO experince, we are now making the change to detect redirects between clouds and attach available PRT for the new cloud if cross cloud authentication happens.

**Testing** : 
For testing the fix
1. Ran all UI tests to ensure existing tests are not breaking https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1442539&view=ms.vss-test-web.build-test-results-tab&runId=4591284&resultId=100022&paneView=debug
2. Ran below steps to repro the issue and fix it

- Install MsalTestApp and BrokrHost
- In MsalTestApp, use default config, loginhint [idlabxcg@msidlab4.onmicrosoft.com](mailto:idlabxcg@msidlab4.onmicrosoft.com) and deviceId claim attached. Complete the sign in.
- Next, change the config to Arlington, loginhint [idlabxcg@msidlab4.onmicrosoft.com](mailto:idlabxcg@msidlab4.onmicrosoft.com), deviceId claim attached, authority https://login.microsoftonline.us/45ff0c17-f8b5-489b-b7fd-2fedebbec0c4 and click on acquire token
- Without my fix, we would be prompted to enter password twice at this point.
- With my fix, we are no longer prompted to enter password at all.

Fixes [AB#3179147](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3179147)