### PR TITLE
Corrected error handling in cross cloud scenario, Fixes AB#3179147

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [PATCH] Fix multiple prompts issue in cross cloud request (#2599)
+- [PATCH] Corrected error handling in cross cloud scenario (#2602)
 
 Version 20.1.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -324,9 +324,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                     return true;
                 }
             }
-        } catch (final Exception e) {
+        } catch (final Throwable throwable) {
             // No op. If it fails, let it fail silently because this is not blocking the user.
-            Logger.warn(TAG, "Failure in detecting if it is a cross cloud redirect url." + e);
+            Logger.warn(TAG, "Failure in detecting if it is a cross cloud redirect url." + throwable);
         }
         return false;
     }
@@ -627,6 +627,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 Logger.error(methodTag, "Error processing nonce and re-attaching headers", throwable);
                 span.setStatus(StatusCode.ERROR, "Error processing nonce and re-attaching headers");
                 span.recordException(throwable);
+                view.loadUrl(url, mRequestHeaders);
             } finally {
                 span.end();
             }
@@ -650,6 +651,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // No op if an exception happens
             Logger.warn(methodTag, "Error processing cross cloud redirect and attaching PRT header." + e);
             span.recordException(e);
+            view.loadUrl(url, mRequestHeaders);
         } finally {
             span.end();
         }


### PR DESCRIPTION
In this PR, we fixed multiple prompt issue in cross cloud scenarios https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2599
But when an exception is thrown while loading PRT or when getting nonce, we are not handling the exception correctly. The expected case should be that the exception is ignored and the webview should be loaded correctly.
What is actually happening is, the webview stops loading.

 Fixes [AB#3179147](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3179147)