### PR TITLE
Add a telemetry field to track whether or not we are creating an IntuneAppProtectionPolicyRequiredException, Fixes AB#3183025

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Track MAM flow in telemetry (#2608)
 - [PATCH] Fix multiple prompts issue in cross cloud request (#2599)
 - [PATCH] Corrected error handling in cross cloud scenario (#2602)
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -339,7 +339,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
         if (exception instanceof IntuneAppProtectionPolicyRequiredException) {
             // Record MAM flow in telemetry
-            SpanExtension.current().setAttribute(AttributeName.is_mam_flow.name(),true);
+            SpanExtension.current().setAttribute(AttributeName.is_mam_flow.name(), true);
 
             builder.userName(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUpn())
                     .localAccountId(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUserId())

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -338,11 +338,8 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         if (exception instanceof IntuneAppProtectionPolicyRequiredException) {
-            // Record presence of exception in telemetry
-            SpanExtension.current().setAttribute(
-                    AttributeName.is_mam_flow.name(),
-                    Boolean.toString(true)
-            );
+            // Record MAM flow in telemetry
+            SpanExtension.current().setAttribute(AttributeName.is_mam_flow.name(),true);
 
             builder.userName(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUpn())
                     .localAccountId(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUserId())

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -340,7 +340,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (exception instanceof IntuneAppProtectionPolicyRequiredException) {
             // Record presence of exception in telemetry
             SpanExtension.current().setAttribute(
-                    AttributeName.intune_protection_policy_exception_present.name(),
+                    AttributeName.is_mam_flow.name(),
                     Boolean.toString(true)
             );
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -338,6 +338,12 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         if (exception instanceof IntuneAppProtectionPolicyRequiredException) {
+            // Record presence of exception in telemetry
+            SpanExtension.current().setAttribute(
+                    AttributeName.intune_protection_policy_exception_present.name(),
+                    Boolean.toString(true)
+            );
+
             builder.userName(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUpn())
                     .localAccountId(((IntuneAppProtectionPolicyRequiredException) exception).getAccountUserId())
                     .authority(((IntuneAppProtectionPolicyRequiredException) exception).getAuthorityUrl())

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -333,5 +333,10 @@ public enum AttributeName {
     /**
      * Records the stacktrace for an out-of-memory exception.
      */
-    out_of_memory_exception_stacktrace
+    out_of_memory_exception_stacktrace,
+
+    /**
+     * Records if an IntuneAppProtectionPolicyRequiredException is received as part of this request.
+     */
+    intune_protection_policy_exception_present
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -336,7 +336,7 @@ public enum AttributeName {
     out_of_memory_exception_stacktrace,
 
     /**
-     * Records if if current flow is a mam flow.
+     * Records if current flow is a mam flow.
      */
     is_mam_flow
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -336,7 +336,7 @@ public enum AttributeName {
     out_of_memory_exception_stacktrace,
 
     /**
-     * Records if an IntuneAppProtectionPolicyRequiredException is received as part of this request.
+     * Records if if current flow is a mam flow.
      */
-    intune_protection_policy_exception_present
+    is_mam_flow
 }


### PR DESCRIPTION
Add a telemetry field to track whether or not we are creating an IntuneAppProtectionPolicyRequiredException

[AB#3183025](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3183025)