### PR TITLE
Restore getAuthorizationFragmentFromStartIntentWithState

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -242,6 +242,7 @@ object AuthorizationActivityFactory {
      * @param bundle the bundle to add to the Fragment if it is an AuthorizationFragment.
      * @return returns an Fragment that's used as to authorize a token request.
      */
+    @JvmStatic
     fun getAuthorizationFragmentFromStartIntentWithState(intent: Intent, bundle: Bundle): Fragment {
         val fragment = getAuthorizationFragmentFromStartIntent(intent)
         if (fragment is AuthorizationFragment) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.internal.providers.oauth2
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants
 import com.microsoft.identity.common.internal.msafederation.getIdProviderExtraQueryParamForAuthorization
@@ -226,5 +227,26 @@ object AuthorizationActivityFactory {
             requestHeader = requestHeadersWithGoogleAuthCredential
         )
         return getAuthorizationActivityIntent(newAuthorizationActivityParameters)
+    }
+
+    /**
+     * OnaAuth method
+     * Returns the correct authorization fragment for local (non-broker) authorization flows,
+     * supplying a start bundle for the Fragment state.
+     * Fragments include:
+     * [WebViewAuthorizationFragment]
+     * [BrowserAuthorizationFragment]
+     * [CurrentTaskBrowserAuthorizationFragment]
+     *
+     * @param intent the intent to use to create the fragment.
+     * @param bundle the bundle to add to the Fragment if it is an AuthorizationFragment.
+     * @return returns an Fragment that's used as to authorize a token request.
+     */
+    fun getAuthorizationFragmentFromStartIntentWithState(intent: Intent, bundle: Bundle): Fragment {
+        val fragment = getAuthorizationFragmentFromStartIntent(intent)
+        if (fragment is AuthorizationFragment) {
+            fragment.setInstanceState(bundle)
+        }
+        return fragment
     }
 }


### PR DESCRIPTION
Removed this method on this PR #2557 and this broke OneAuth, this is used there https://office.visualstudio.com/OneAuth/_git/OneAuth?path=/msal/source/android/msal/app/src/main/java/com/microsoft/identity/internal/ui/BrowserContainerDialog.java