### PR TITLE
Native auth: Add support for claims request in getAccessToken and signIn after signUp/SSPR, Fixes AB#3188133

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ vNext
 - [PATCH] Track MAM flow in telemetry (#2608)
 - [PATCH] Fix multiple prompts issue in cross cloud request (#2599)
 - [PATCH] Corrected error handling in cross cloud scenario (#2602)
+- [MINOR] Native auth: Add claimsRequest also to getAccessToken and signIn after signUp/SSPR flows (#2622)
 
 Version 20.1.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/BaseSignInTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/BaseSignInTokenCommandParameters.java
@@ -26,6 +26,8 @@ import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationSchem
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -43,6 +45,12 @@ public abstract class BaseSignInTokenCommandParameters extends BaseNativeAuthCom
     * The scopes for the token being fetched.
     */
    public final List<String> scopes;
+
+   /**
+    * Claims to send to the token endpoint.
+    */
+   @Nullable
+   public final String claimsRequestJson;
 
    private final AbstractAuthenticationScheme authenticationScheme;
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/MFADefaultChallengeCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/MFADefaultChallengeCommandParameters.java
@@ -47,12 +47,6 @@ public class MFADefaultChallengeCommandParameters extends BaseSignInTokenCommand
     @NonNull
     public final String continuationToken;
 
-    /**
-     * Claims to send to the token endpoint.
-     */
-    @Nullable
-    public final String claimsRequestJson;
-
     @NonNull
     @Override
     public String toUnsanitizedString() {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/MFASubmitChallengeCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/MFASubmitChallengeCommandParameters.java
@@ -51,12 +51,6 @@ public class MFASubmitChallengeCommandParameters extends BaseSignInTokenCommandP
     @NonNull
     public final String continuationToken;
 
-    /**
-     * Claims to send to the token endpoint.
-     */
-    @Nullable
-    public final String claimsRequestJson;
-
     @NonNull
     @Override
     public String toUnsanitizedString() {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInStartCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInStartCommandParameters.java
@@ -54,12 +54,6 @@ public class SignInStartCommandParameters extends BaseSignInTokenCommandParamete
     @Nullable
     public final char[] password;
 
-    /**
-     * Claims to send to the token endpoint.
-     */
-    @Nullable
-    public final String claimsRequestJson;
-
     @NonNull
     @Override
     public String toUnsanitizedString() {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInSubmitCodeCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInSubmitCodeCommandParameters.java
@@ -51,12 +51,6 @@ public class SignInSubmitCodeCommandParameters extends BaseSignInTokenCommandPar
     @NonNull
     public final String continuationToken;
 
-    /**
-     * Claims to send to the token endpoint.
-     */
-    @Nullable
-    public final String claimsRequestJson;
-
     @NonNull
     @Override
     public String toUnsanitizedString() {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInSubmitPasswordCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/SignInSubmitPasswordCommandParameters.java
@@ -53,12 +53,6 @@ public class SignInSubmitPasswordCommandParameters extends BaseSignInTokenComman
 	@NonNull
 	public final String continuationToken;
 
-	/**
-	 * Claims to send to the token endpoint.
-	 */
-	@Nullable
-	public final String claimsRequestJson;
-
 	@NonNull
 	@Override
 	public String toUnsanitizedString() {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -181,7 +181,8 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
             username = commandParameters.username,
             challengeType = config.challengeType,
             requestUrl = signInTokenEndpoint,
-            headers = getRequestHeaders(commandParameters.getCorrelationId())
+            headers = getRequestHeaders(commandParameters.getCorrelationId()),
+            claimsRequestJson = commandParameters.claimsRequestJson
         )
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInTokenRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInTokenRequest.kt
@@ -139,7 +139,8 @@ data class SignInTokenRequest private constructor(
             scopes: List<String>? = null,
             challengeType: String? = null,
             requestUrl: String,
-            headers: Map<String, String?>
+            headers: Map<String, String?>,
+            claimsRequestJson: String?
         ): SignInTokenRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(continuationToken, "continuationToken")
@@ -157,7 +158,7 @@ data class SignInTokenRequest private constructor(
                     grantType = NativeAuthConstants.GrantType.CONTINUATION_TOKEN,
                     challengeType = challengeType,
                     scope = scopes?.joinToString(" "),
-                    claimsRequestJson = null
+                    claimsRequestJson = claimsRequestJson
                 ),
                 requestUrl = URL(requestUrl),
                 headers = headers

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -823,6 +823,7 @@ class NativeAuthRequestProviderTest {
     fun testSignInTokenContinuationShouldContainsCorrectParams() {
         val scopes = arrayListOf("OOB", "PASSWORD")
         val headers = mapOf("key" to "value")
+        val claims = "claims"
         val request = SignInTokenRequest.createContinuationTokenRequest(
             continuationToken,
             clientId,
@@ -830,10 +831,11 @@ class NativeAuthRequestProviderTest {
             scopes,
             challengeType,
             ApiConstants.MockApi.signInTokenRequestUrl.toString(),
-            headers
+            headers,
+            claimsRequestJson = claims
         )
         assertNull(request.parameters.password)
-        assertNull(request.parameters.claimsRequestJson)
+        assertEquals(request.parameters.claimsRequestJson, claims)
         assertEquals(request.parameters.scope, "OOB PASSWORD")
         assertEquals(request.parameters.continuationToken, continuationToken)
         assertEquals(request.parameters.challengeType, challengeType)


### PR DESCRIPTION
Adding support on native authentication for claims request for getAccessToken and signIn after signUp/SSPR flows. 

MSAL Android PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2278

[AB#3188133](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3188133)