### PR TITLE
Update codeowner file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,9 @@
 
 *       @AzureAD/androididentity
 
+# Shared Ownership
+#---------------------
+changelog.txt @AzureAD/androididentity @AzureAD/NativeAuthTeam
 
 # Area Owners
 #---------------------


### PR DESCRIPTION
Native auth and Android identity team should share ownership of the `changelog.txt` file.