### PR TITLE
Native auth: network layer for JIT feature, Fixes AB#3188135

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -223,10 +223,11 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                         tokenApiResult = tokenApiResult
                     )
                 }
+                // TODO: this will need to change in JIT business logic PR
                 is SignInTokenApiResult.InvalidAuthenticationType,
                 is SignInTokenApiResult.MFARequired, is SignInTokenApiResult.CodeIncorrect,
                 is SignInTokenApiResult.UserNotFound, is SignInTokenApiResult.InvalidCredentials,
-                is SignInTokenApiResult.UnknownError -> {
+                is SignInTokenApiResult.UnknownError, is SignInTokenApiResult.JITRequired -> {
                     Logger.warnWithObject(
                         TAG,
                         tokenApiResult.correlationId,
@@ -298,10 +299,10 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                         correlationId = tokenApiResult.correlationId
                     )
                 }
-
+                // TODO: this will need to change in JIT business logic PR
                 is SignInTokenApiResult.UnknownError, is SignInTokenApiResult.InvalidAuthenticationType,
                 is SignInTokenApiResult.MFARequired, is SignInTokenApiResult.InvalidCredentials,
-                is SignInTokenApiResult.UserNotFound -> {
+                is SignInTokenApiResult.UserNotFound, is SignInTokenApiResult.JITRequired -> {
                     Logger.warnWithObject(
                         TAG,
                         tokenApiResult.correlationId,
@@ -351,6 +352,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 oAuth2Strategy = oAuth2Strategy,
                 parameters = parametersWithScopes
             )
+            // TODO: this will need to change in JIT business logic PR
             return when (tokenApiResult) {
                 is SignInTokenApiResult.Success -> {
                     saveAndReturnTokens(
@@ -370,7 +372,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 }
                 is SignInTokenApiResult.UnknownError, is SignInTokenApiResult.InvalidAuthenticationType,
                 is SignInTokenApiResult.InvalidCredentials, is SignInTokenApiResult.UserNotFound,
-                is SignInTokenApiResult.MFARequired -> {
+                is SignInTokenApiResult.MFARequired, is SignInTokenApiResult.JITRequired -> {
                     Logger.warnWithObject(
                         TAG,
                         tokenApiResult.correlationId,
@@ -2117,6 +2119,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parametersWithScopes: SignInStartCommandParameters,
     ): SignInStartCommandResult {
+        // TODO: this will need to change in JIT business logic PR
         return when (this) {
             is SignInTokenApiResult.InvalidCredentials -> {
                 SignInCommandResult.InvalidCredentials(
@@ -2145,7 +2148,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
             }
             is SignInTokenApiResult.CodeIncorrect,
             is SignInTokenApiResult.InvalidAuthenticationType, is SignInTokenApiResult.UserNotFound,
-            is SignInTokenApiResult.UnknownError -> {
+            is SignInTokenApiResult.UnknownError, is SignInTokenApiResult.JITRequired -> {
                 Logger.warnWithObject(
                     TAG,
                     this.correlationId,
@@ -2167,6 +2170,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         parametersWithScopes: SignInSubmitPasswordCommandParameters,
     ): SignInSubmitPasswordCommandResult {
+        // TODO: this will need to change in JIT business logic PR
         return when (this) {
             is SignInTokenApiResult.InvalidCredentials -> {
                 SignInCommandResult.InvalidCredentials(
@@ -2194,7 +2198,8 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 )
             }
             is SignInTokenApiResult.UserNotFound, is SignInTokenApiResult.CodeIncorrect,
-            is SignInTokenApiResult.InvalidAuthenticationType, is SignInTokenApiResult.UnknownError -> {
+            is SignInTokenApiResult.InvalidAuthenticationType, is SignInTokenApiResult.UnknownError,
+            is SignInTokenApiResult.JITRequired -> {
                 Logger.warnWithObject(
                     TAG,
                     this.correlationId,

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/ResetPasswordOAuth2StrategyTest.kt
@@ -114,6 +114,9 @@ class ResetPasswordOAuth2StrategyTest {
         whenever(mockConfig.getResetPasswordContinueEndpoint()).thenReturn(ApiConstants.MockApi.ssprContinueRequestUrl)
         whenever(mockConfig.getResetPasswordSubmitEndpoint()).thenReturn(ApiConstants.MockApi.ssprSubmitRequestUrl)
         whenever(mockConfig.getResetPasswordPollCompletionEndpoint()).thenReturn(ApiConstants.MockApi.ssprPollCompletionRequestUrl)
+        whenever(mockConfig.getJITIntrospectEndpoint()).thenReturn(ApiConstants.MockApi.jitIntrospectRequestUrl)
+        whenever(mockConfig.getJITChallengeEndpoint()).thenReturn(ApiConstants.MockApi.jitChallengeRequestUrl)
+        whenever(mockConfig.getJITContinueEndpoint()).thenReturn(ApiConstants.MockApi.jitContinueRequestUrl)
         whenever(mockConfig.challengeType).thenReturn(CHALLENGE_TYPE)
 
         nativeAuthOAuth2Strategy = NativeAuthOAuth2Strategy(

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignInOAuthStrategyTest.kt
@@ -102,6 +102,9 @@ class SignInOAuthStrategyTest {
         whenever(mockConfig.getResetPasswordContinueEndpoint()).thenReturn(ApiConstants.MockApi.ssprContinueRequestUrl)
         whenever(mockConfig.getResetPasswordSubmitEndpoint()).thenReturn(ApiConstants.MockApi.ssprSubmitRequestUrl)
         whenever(mockConfig.getResetPasswordPollCompletionEndpoint()).thenReturn(ApiConstants.MockApi.ssprPollCompletionRequestUrl)
+        whenever(mockConfig.getJITIntrospectEndpoint()).thenReturn(ApiConstants.MockApi.jitIntrospectRequestUrl)
+        whenever(mockConfig.getJITChallengeEndpoint()).thenReturn(ApiConstants.MockApi.jitChallengeRequestUrl)
+        whenever(mockConfig.getJITContinueEndpoint()).thenReturn(ApiConstants.MockApi.jitContinueRequestUrl)
         whenever(mockConfig.challengeType).thenReturn(CHALLENGE_TYPE)
 
         nativeAuthOAuth2Strategy = NativeAuthOAuth2Strategy(

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/SignUpOAuth2StrategyTest.kt
@@ -101,6 +101,9 @@ class SignUpOAuth2StrategyTest {
         whenever(mockConfig.getResetPasswordContinueEndpoint()).thenReturn(ApiConstants.MockApi.ssprContinueRequestUrl)
         whenever(mockConfig.getResetPasswordSubmitEndpoint()).thenReturn(ApiConstants.MockApi.ssprSubmitRequestUrl)
         whenever(mockConfig.getResetPasswordPollCompletionEndpoint()).thenReturn(ApiConstants.MockApi.ssprPollCompletionRequestUrl)
+        whenever(mockConfig.getJITIntrospectEndpoint()).thenReturn(ApiConstants.MockApi.jitIntrospectRequestUrl)
+        whenever(mockConfig.getJITChallengeEndpoint()).thenReturn(ApiConstants.MockApi.jitChallengeRequestUrl)
+        whenever(mockConfig.getJITContinueEndpoint()).thenReturn(ApiConstants.MockApi.jitContinueRequestUrl)
         whenever(mockConfig.challengeType).thenReturn(CHALLENGE_TYPE)
 
         nativeAuthOAuth2Strategy = NativeAuthOAuth2Strategy(

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/ResetPasswordScenarioTest.kt
@@ -84,6 +84,9 @@ class ResetPasswordScenarioTest {
         whenever(mockConfig.getResetPasswordContinueEndpoint()).thenReturn(ApiConstants.MockApi.ssprContinueRequestUrl)
         whenever(mockConfig.getResetPasswordSubmitEndpoint()).thenReturn(ApiConstants.MockApi.ssprSubmitRequestUrl)
         whenever(mockConfig.getResetPasswordPollCompletionEndpoint()).thenReturn(ApiConstants.MockApi.ssprPollCompletionRequestUrl)
+        whenever(mockConfig.getJITIntrospectEndpoint()).thenReturn(ApiConstants.MockApi.jitIntrospectRequestUrl)
+        whenever(mockConfig.getJITChallengeEndpoint()).thenReturn(ApiConstants.MockApi.jitChallengeRequestUrl)
+        whenever(mockConfig.getJITContinueEndpoint()).thenReturn(ApiConstants.MockApi.jitContinueRequestUrl)
         whenever(mockConfig.challengeType).thenReturn(challengeType)
 
         nativeAuthOAuth2Strategy = NativeAuthOAuth2Strategy(

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/microsoft/nativeauth/integration/scenario/SignUpScenarioTest.kt
@@ -78,6 +78,9 @@ class SignUpScenarioTest {
         whenever(mockConfig.getResetPasswordContinueEndpoint()).thenReturn(ApiConstants.MockApi.ssprContinueRequestUrl)
         whenever(mockConfig.getResetPasswordSubmitEndpoint()).thenReturn(ApiConstants.MockApi.ssprSubmitRequestUrl)
         whenever(mockConfig.getResetPasswordPollCompletionEndpoint()).thenReturn(ApiConstants.MockApi.ssprPollCompletionRequestUrl)
+        whenever(mockConfig.getJITIntrospectEndpoint()).thenReturn(ApiConstants.MockApi.jitIntrospectRequestUrl)
+        whenever(mockConfig.getJITChallengeEndpoint()).thenReturn(ApiConstants.MockApi.jitChallengeRequestUrl)
+        whenever(mockConfig.getJITContinueEndpoint()).thenReturn(ApiConstants.MockApi.jitContinueRequestUrl)
         whenever(mockConfig.challengeType).thenReturn(CHALLENGE_TYPE)
 
         nativeAuthOAuth2Strategy = NativeAuthOAuth2Strategy(

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -63,6 +63,9 @@ class NativeAuthOAuth2Configuration(
         private const val SIGN_IN_INTROSPECT_ENDPOINT_SUFFIX = "/oauth2/v2.0/introspect"
         private const val SIGN_IN_CHALLENGE_ENDPOINT_SUFFIX = "/oauth2/v2.0/challenge"
         private const val SIGN_IN_TOKEN_ENDPOINT_SUFFIX = "/oauth2/v2.0/token"
+        private const val JIT_INTROSPECT_ENDPOINT_SUFFIX = "/register/v1.0/introspect"
+        private const val JIT_CHALLENGE_ENDPOINT_SUFFIX = "/register/v1.0/challenge"
+        private const val JIT_CONTINUE_ENDPOINT_SUFFIX = "/register/v1.0/continue"
     }
 
     override fun getAuthorityUrl(): URL {
@@ -214,6 +217,42 @@ class NativeAuthOAuth2Configuration(
         return getEndpointUrlFromRootAndTenantAndSuffix(
             root = getAuthorityUrl(),
             endpointSuffix = SIGN_IN_TOKEN_ENDPOINT_SUFFIX
+        )
+    }
+
+    /**
+     * Get the endpoint to be used for making a register/v1.0/introspect request.
+     *
+     * @return URL the endpoint
+     */
+    fun getJITIntrospectEndpoint(): URL {
+        return getEndpointUrlFromRootAndTenantAndSuffix(
+            root = getAuthorityUrl(),
+            endpointSuffix = JIT_INTROSPECT_ENDPOINT_SUFFIX
+        )
+    }
+
+    /**
+     * Get the endpoint to be used for making a register/v1.0/challenge request.
+     *
+     * @return URL the endpoint
+     */
+    fun getJITChallengeEndpoint(): URL {
+        return getEndpointUrlFromRootAndTenantAndSuffix(
+            root = getAuthorityUrl(),
+            endpointSuffix = JIT_CHALLENGE_ENDPOINT_SUFFIX
+        )
+    }
+
+    /**
+     * Get the endpoint to be used for making a register/v1.0/continue request.
+     *
+     * @return URL the endpoint
+     */
+    fun getJITContinueEndpoint(): URL {
+        return getEndpointUrlFromRootAndTenantAndSuffix(
+            root = getAuthorityUrl(),
+            endpointSuffix = JIT_CONTINUE_ENDPOINT_SUFFIX
         )
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
@@ -297,4 +297,13 @@ class NativeAuthOAuth2Strategy(
             correlationId = correlationId
         )
     }
+
+    fun performJITIntrospect(
+        continuationToken: String,
+        correlationId: String
+    ): SignInIntrospectApiResult {
+        return signInInteractor.performJITIntrospect(
+            continuationToken = continuationToken,
+            correlationId = correlationId
+    )
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Strategy.kt
@@ -297,13 +297,4 @@ class NativeAuthOAuth2Strategy(
             correlationId = correlationId
         )
     }
-
-    fun performJITIntrospect(
-        continuationToken: String,
-        correlationId: String
-    ): SignInIntrospectApiResult {
-        return signInInteractor.performJITIntrospect(
-            continuationToken = continuationToken,
-            correlationId = correlationId
-    )
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -354,6 +354,7 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     }
     //endregion
 
+    now I need to call those methods
     //region /register/introspect
     internal fun createJITIntrospectRequest(
         continuationToken: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -36,6 +36,9 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpS
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpSubmitUserAttributesCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters
+import com.microsoft.identity.common.java.nativeauth.providers.requests.jit.JITChallengeRequest
+import com.microsoft.identity.common.java.nativeauth.providers.requests.jit.JITContinueRequest
+import com.microsoft.identity.common.java.nativeauth.providers.requests.jit.JITIntrospectRequest
 import com.microsoft.identity.common.java.net.HttpConstants
 import com.microsoft.identity.common.java.nativeauth.providers.requests.resetpassword.ResetPasswordChallengeRequest
 import com.microsoft.identity.common.java.nativeauth.providers.requests.resetpassword.ResetPasswordContinueRequest
@@ -71,6 +74,9 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     private val resetPasswordContinueEndpoint = config.getResetPasswordContinueEndpoint().toString()
     private val resetPasswordSubmitEndpoint = config.getResetPasswordSubmitEndpoint().toString()
     private val resetPasswordPollCompletionEndpoint = config.getResetPasswordPollCompletionEndpoint().toString()
+    private val jitIntrospectEndpoint = config.getJITIntrospectEndpoint().toString()
+    private val jitChallengeEndpoint = config.getJITChallengeEndpoint().toString()
+    private val jitContinueEndpoint = config.getJITContinueEndpoint().toString()
 
     //region /oauth/v2.0/initiate
     /**
@@ -343,6 +349,58 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
             clientId = config.clientId,
             challengeType = config.challengeType,
             requestUrl = signUpChallengeEndpoint,
+            headers = getRequestHeaders(correlationId)
+        )
+    }
+    //endregion
+
+    //region /register/introspect
+    internal fun createJITIntrospectRequest(
+        continuationToken: String,
+        correlationId: String
+    ): JITIntrospectRequest {
+        return JITIntrospectRequest.create(
+            continuationToken = continuationToken,
+            clientId = config.clientId,
+            requestUrl = jitIntrospectEndpoint,
+            headers = getRequestHeaders(correlationId)
+        )
+    }
+    //endregion
+
+    //region /register/challenge
+    internal fun createJITChallengeRequest(
+        continuationToken: String,
+        challengeType: String,
+        challengeTarget: String,
+        challengeChannel: String,
+        correlationId: String
+    ): JITChallengeRequest {
+        return JITChallengeRequest.create(
+            continuationToken = continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel = challengeChannel,
+            clientId = config.clientId,
+            requestUrl = jitChallengeEndpoint,
+            headers = getRequestHeaders(correlationId)
+        )
+    }
+    //endregion
+
+    //region /register/continue
+    internal fun createJITContinueRequest(
+        continuationToken: String,
+        grantType: String,
+        code: String,
+        correlationId: String
+    ): JITContinueRequest {
+        return JITContinueRequest.create(
+            continuationToken = continuationToken,
+            grantType = grantType,
+            oob = code,
+            clientId = config.clientId,
+            requestUrl = jitContinueEndpoint,
             headers = getRequestHeaders(correlationId)
         )
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -354,7 +354,6 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
     }
     //endregion
 
-    now I need to call those methods
     //region /register/introspect
     internal fun createJITIntrospectRequest(
         continuationToken: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -25,7 +25,8 @@ package com.microsoft.identity.common.java.nativeauth.providers
 import com.microsoft.identity.common.java.AuthenticationConstants
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.logging.LogSession
-import com.microsoft.identity.common.java.nativeauth.providers.requests.jit.JITIntrospectRequest
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITChallengeApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITContinueApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITIntrospectApiResponse
 import com.microsoft.identity.common.java.net.HttpResponse
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse
@@ -37,7 +38,6 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpa
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInChallengeApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInInitiateApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInIntrospectApiResponse
-import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInIntrospectApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInTokenApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.SignInTokenApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signup.SignUpChallengeApiResponse
@@ -699,8 +699,13 @@ class NativeAuthResponseHandler {
                 errorDescription = EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION,
                 errorUri = null,
                 continuationToken = null,
-                pollInterval = null,
-                subError = null,
+                challengeType = null,
+                bindingMethod = null,
+                challengeTarget = null,
+                challengeChannel = null,
+                codeLength = null,
+                interval = null,
+                errorCodes = null,
                 correlationId = correlationId
             )
         } else {
@@ -742,10 +747,9 @@ class NativeAuthResponseHandler {
                 statusCode = response.statusCode,
                 error = EMPTY_RESPONSE_ERROR,
                 errorDescription = EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION,
-                errorUri = null,
                 continuationToken = null,
-                pollInterval = null,
                 subError = null,
+                errorCodes = null,
                 correlationId = correlationId
             )
         } else {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.java.nativeauth.providers
 import com.microsoft.identity.common.java.AuthenticationConstants
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.nativeauth.providers.requests.jit.JITIntrospectRequest
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITIntrospectApiResponse
 import com.microsoft.identity.common.java.net.HttpResponse
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordChallengeApiResponse
@@ -75,14 +77,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getSignUpStartResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignUpStartApiResponse(
@@ -130,14 +125,7 @@ class NativeAuthResponseHandler {
             methodName ="${TAG}.getSignUpChallengeResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignUpChallengeApiResponse(
@@ -185,14 +173,7 @@ class NativeAuthResponseHandler {
             methodName ="${TAG}.getSignUpContinueResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignUpContinueApiResponse(
@@ -238,14 +219,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getSignInInitiateResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignInInitiateApiResponse(
@@ -289,14 +263,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getSignInChallengeResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignInChallengeApiResponse(
@@ -347,14 +314,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getSignInIntrospectResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             SignInIntrospectApiResponse(
@@ -398,14 +358,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getSignInTokenApiResultFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         // Use native-auth specific class in case of API error response,
         // or standard MicrosoftStsTokenResponse in case of success response
@@ -462,14 +415,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getResetPasswordStartApiResponseFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             ResetPasswordStartApiResponse(
@@ -494,6 +440,7 @@ class NativeAuthResponseHandler {
 
         return result
     }
+    //endregion
 
     //region /resetpassword/challenge
     /**
@@ -512,14 +459,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getResetPasswordChallengeApiResponseFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             ResetPasswordChallengeApiResponse(
@@ -549,6 +489,7 @@ class NativeAuthResponseHandler {
 
         return result
     }
+    //endregion
 
     //region /resetpassword/continue
     /**
@@ -567,14 +508,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getResetPasswordContinueApiResponseFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             ResetPasswordContinueApiResponse(
@@ -600,6 +534,7 @@ class NativeAuthResponseHandler {
         ApiResultUtil.logResponse(TAG, result)
         return result
     }
+    //endregion
 
     //region /resetpassword/submit
     /**
@@ -618,14 +553,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getResetPasswordSubmitApiResponseFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             ResetPasswordSubmitApiResponse(
@@ -651,6 +579,7 @@ class NativeAuthResponseHandler {
 
         return result
     }
+    //endregion
 
     //region /resetpassword/poll_completion
     /**
@@ -669,14 +598,7 @@ class NativeAuthResponseHandler {
             methodName = "${TAG}.getResetPasswordPollCompletionApiResponseFromHttpResponse"
         )
 
-        // If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
-        val correlationId: String = response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
-            if (responseCorrelationId.isNullOrBlank()) {
-                requestCorrelationId
-            } else {
-                responseCorrelationId
-            }
-        }
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
 
         val result = if (response.body.isNullOrBlank()) {
             ResetPasswordPollCompletionApiResponse(
@@ -702,5 +624,158 @@ class NativeAuthResponseHandler {
         ApiResultUtil.logResponse(TAG, result)
 
         return result
+    }
+    //endregion
+
+    //region /register/introspect
+    /**
+     * Converts the HTTP response for /register/introspect API to [JITIntrospectResponse] object
+     * @param response : HTTP response received from the API
+     * @return JITIntrospectApiResponse object
+     */
+    @Throws(ClientException::class)
+    fun getJITIntrospectApiResponseFromHttpResponse(
+        requestCorrelationId: String,
+        response: HttpResponse
+    ): JITIntrospectApiResponse {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.getJITIntrospectApiResponseFromHttpResponse"
+        )
+
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
+
+        val result = if (response.body.isNullOrBlank()) {
+            JITIntrospectApiResponse(
+                statusCode = response.statusCode,
+                error = EMPTY_RESPONSE_ERROR,
+                errorDescription = EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION,
+                errorUri = null,
+                continuationToken = null,
+                correlationId = correlationId,
+                challengeType = null,
+                methods = null,
+                errorCodes = null
+            )
+        } else {
+            ObjectMapper.deserializeJsonStringToObject(
+                response.body,
+                JITIntrospectApiResponse::class.java
+            )
+        }
+        result.statusCode = response.statusCode
+        result.correlationId = correlationId
+
+        ApiResultUtil.logResponse(TAG, result)
+
+        return result
+    }
+    //endregion
+
+    //region /register/challenge
+    /**
+     * Converts the HTTP response for /register/challenge API to [JITChallengeResponse] object
+     * @param response : HTTP response received from the API
+     * @return JITChallengeApiResponse object
+     */
+    @Throws(ClientException::class)
+    fun getJITChallengeResponseFromHttpResponse(
+        requestCorrelationId: String,
+        response: HttpResponse
+    ): JITChallengeApiResponse {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.getJITChallengeApiResponseFromHttpResponse"
+        )
+
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
+
+        val result = if (response.body.isNullOrBlank()) {
+            JITChallengeApiResponse(
+                statusCode = response.statusCode,
+                error = EMPTY_RESPONSE_ERROR,
+                errorDescription = EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION,
+                errorUri = null,
+                continuationToken = null,
+                pollInterval = null,
+                subError = null,
+                correlationId = correlationId
+            )
+        } else {
+            ObjectMapper.deserializeJsonStringToObject(
+                response.body,
+                JITChallengeApiResponse::class.java
+            )
+        }
+        result.statusCode = response.statusCode
+        result.correlationId = correlationId
+
+        ApiResultUtil.logResponse(TAG, result)
+
+        return result
+    }
+    //endregion
+
+    //region /register/continue
+    /**
+     * Converts the HTTP response for /register/continue API to [JITContinueApiResponse] object
+     * @param response : HTTP response received from the API
+     * @return JITContinueApiResponse object
+     */
+    @Throws(ClientException::class)
+    fun getJITContinueApiResponseFromHttpResponse(
+        requestCorrelationId: String,
+        response: HttpResponse
+    ): JITContinueApiResponse {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.getJITContinueApiResponseFromHttpResponse"
+        )
+
+        val correlationId = retrieveCorrelationId(response, requestCorrelationId)
+
+        val result = if (response.body.isNullOrBlank()) {
+            JITContinueApiResponse(
+                statusCode = response.statusCode,
+                error = EMPTY_RESPONSE_ERROR,
+                errorDescription = EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION,
+                errorUri = null,
+                continuationToken = null,
+                pollInterval = null,
+                subError = null,
+                correlationId = correlationId
+            )
+        } else {
+            ObjectMapper.deserializeJsonStringToObject(
+                response.body,
+                JITContinueApiResponse::class.java
+            )
+        }
+        result.statusCode = response.statusCode
+        result.correlationId = correlationId
+
+        ApiResultUtil.logResponse(TAG, result)
+
+        return result
+    }
+    //endregion
+
+    /**
+     * If the API doesn't return a correlation ID header value, use the correlation ID of the original API request
+     */
+    private fun retrieveCorrelationId(
+        response: HttpResponse,
+        requestCorrelationId: String
+    ): String {
+        return response.getHeaderValue(AuthenticationConstants.AAD.CLIENT_REQUEST_ID, 0).let {responseCorrelationId ->
+            if (responseCorrelationId.isNullOrBlank()) {
+                requestCorrelationId
+            } else {
+                responseCorrelationId
+            }
+        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
 
 import com.google.gson.annotations.SerializedName

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
@@ -11,7 +11,7 @@ import java.net.URL
 data class JITChallengeRequest private constructor(
     override var requestUrl: URL,
     override var headers: Map<String, String?>,
-    override val parameters: NativeAuthRequestParameters
+    override val parameters: NativeAuthJITChallengeRequestParameters
 ) : NativeAuthRequest() {
 
     companion object {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
@@ -90,8 +90,12 @@ data class JITChallengeRequest private constructor(
         @SerializedName("challenge_target") val challengeTarget: String,
         @SerializedName("challenge_channel") val challengeChannel: String
     ) : NativeAuthRequestParameters() {
-        override fun toUnsanitizedString(): String = "NativeAuthJITChallengeRequestParameters(clientId=$clientId)"
+        override fun toUnsanitizedString(): String = "NativeAuthJITChallengeRequestParameters(clientId=$clientId, " +
+                "challengeType=$challengeType, " +
+                "challengeTarget=$challengeTarget, " +
+                "challengeChannel=$challengeChannel)"
 
-        override fun toString(): String = toUnsanitizedString()
+        override fun toString(): String = "NativeAuthJITChallengeRequestParameters(clientId=$clientId, " +
+                "challengeType=$challengeType)"
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITChallengeRequest.kt
@@ -1,0 +1,75 @@
+package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
+
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAuthRequest
+import com.microsoft.identity.common.java.util.ArgUtils
+import java.net.URL
+
+/**
+ * Represents a request to the register/challenge endpoint, and provides a create() function to instantiate the request using the provided parameters.
+ */
+data class JITChallengeRequest private constructor(
+    override var requestUrl: URL,
+    override var headers: Map<String, String?>,
+    override val parameters: NativeAuthRequestParameters
+) : NativeAuthRequest() {
+
+    companion object {
+        /**
+         * Returns a request object using the provided parameters.
+         * The request URL and headers passed will be set directly.
+         * The clientId, continuation token, and challengeType will be mapped to the NativeAuthJITChallengeRequestParameters object.
+         *
+         * Parameters that are null or empty will throw a ClientException.
+         * @see com.microsoft.identity.common.java.exception.ClientException
+         */
+        fun create(
+            clientId: String,
+            continuationToken: String,
+            challengeType: String,
+            challengeTarget: String,
+            challengeChannel: String,
+            requestUrl: String,
+            headers: Map<String, String?>
+        ): JITChallengeRequest {
+            // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(clientId, "clientId")
+            ArgUtils.validateNonNullArg(continuationToken, "continuationToken")
+            ArgUtils.validateNonNullArg(challengeType, "challengeType")
+            ArgUtils.validateNonNullArg(challengeTarget, "challengeTarget")
+            ArgUtils.validateNonNullArg(challengeChannel, "challengeChannel")
+
+            return JITChallengeRequest(
+                requestUrl = URL(requestUrl),
+                headers = headers,
+                parameters = NativeAuthJITChallengeRequestParameters(
+                    clientId = clientId,
+                    continuationToken = continuationToken,
+                    challengeType = challengeType,
+                    challengeTarget = challengeTarget,
+                    challengeChannel = challengeChannel
+                )
+            )
+        }
+    }
+
+    override fun toUnsanitizedString(): String = "JITChallengeRequest(requestUrl=$requestUrl, headers=$headers, parameters=$parameters)"
+
+    override fun toString(): String = "JITChallengeRequest()"
+
+    /**
+     * NativeAuthJITChallengeRequestParameters represents the request parameters sent as part of
+     * /register/challenge API call
+     */
+    data class NativeAuthJITChallengeRequestParameters(
+        @SerializedName("client_id") override val clientId: String,
+        @SerializedName("continuation_token") val continuationToken: String,
+        @SerializedName("challenge_type") val challengeType: String,
+        @SerializedName("challenge_target") val challengeTarget: String,
+        @SerializedName("challenge_channel") val challengeChannel: String
+    ) : NativeAuthRequestParameters() {
+        override fun toUnsanitizedString(): String = "NativeAuthJITChallengeRequestParameters(clientId=$clientId)"
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
 
 import com.google.gson.annotations.SerializedName

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
@@ -1,0 +1,71 @@
+package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
+
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAuthRequest
+import com.microsoft.identity.common.java.util.ArgUtils
+import java.net.URL
+
+/**
+ * Represents a request to the register/continue endpoint, and provides a create() function to instantiate the request using the provided parameters.
+ */
+data class JITContinueRequest private constructor(
+    override var requestUrl: URL,
+    override var headers: Map<String, String?>,
+    override val parameters: NativeAuthRequestParameters
+) : NativeAuthRequest() {
+
+    companion object {
+        /**
+         * Returns a request object using the provided parameters.
+         * The request URL and headers passed will be set directly.
+         * The clientId, continuation token will be mapped to the NativeAuthJITContinueRequestParameters object.
+         *
+         * Parameters that are null or empty will throw a ClientException.
+         * @see com.microsoft.identity.common.java.exception.ClientException
+         */
+        fun create(
+            clientId: String,
+            continuationToken: String,
+            grantType: String,
+            oob: String,
+            requestUrl: String,
+            headers: Map<String, String?>
+        ): JITContinueRequest {
+            // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(clientId, "clientId")
+            ArgUtils.validateNonNullArg(continuationToken, "continuationToken")
+            ArgUtils.validateNonNullArg(grantType, "grantType")
+            ArgUtils.validateNonNullArg(oob, "oob")
+
+            return JITContinueRequest(
+                requestUrl = URL(requestUrl),
+                headers = headers,
+                parameters = NativeAuthJITContinueRequestParameters(
+                    clientId = clientId,
+                    continuationToken = continuationToken,
+                    grantType = grantType,
+                    oob = oob
+                )
+            )
+        }
+    }
+
+    override fun toUnsanitizedString(): String = "JITContinueRequest(requestUrl=$requestUrl, headers=$headers, parameters=$parameters)"
+
+    override fun toString(): String = "JITContinueRequest()"
+
+    /**
+     * NativeAuthJITContinueRequestParameters represents the request parameters sent as part of
+     * /register/continue API call
+     */
+    data class NativeAuthJITContinueRequestParameters(
+        @SerializedName("client_id") override val clientId: String,
+        @SerializedName("continuation_token") val continuationToken: String,
+        @SerializedName("grant_type") val grantType: String,
+        @SerializedName("oob") val oob: String
+    ) : NativeAuthRequestParameters() {
+        override fun toUnsanitizedString(): String = "NativeAuthJITContinueRequestParameters(clientId=$clientId)"
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
@@ -86,8 +86,8 @@ data class JITContinueRequest private constructor(
         @SerializedName("grant_type") val grantType: String,
         @SerializedName("oob") val oob: String
     ) : NativeAuthRequestParameters() {
-        override fun toUnsanitizedString(): String = "NativeAuthJITContinueRequestParameters(clientId=$clientId)"
+        override fun toUnsanitizedString(): String = "NativeAuthJITContinueRequestParameters(clientId=$clientId, grantType=$grantType, oob=$oob)"
 
-        override fun toString(): String = toUnsanitizedString()
+        override fun toString(): String = "NativeAuthJITContinueRequestParameters(clientId=$clientId, grantType=$grantType)"
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITContinueRequest.kt
@@ -11,7 +11,7 @@ import java.net.URL
 data class JITContinueRequest private constructor(
     override var requestUrl: URL,
     override var headers: Map<String, String?>,
-    override val parameters: NativeAuthRequestParameters
+    override val parameters: NativeAuthJITContinueRequestParameters
 ) : NativeAuthRequest() {
 
     companion object {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
 
 import com.google.gson.annotations.SerializedName

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
@@ -11,7 +11,7 @@ import java.net.URL
 data class JITIntrospectRequest private constructor(
     override var requestUrl: URL,
     override var headers: Map<String, String?>,
-    override val parameters: NativeAuthRequestParameters
+    override val parameters: NativeAuthJITIntrospectRequestParameters
 ) : NativeAuthRequest() {
 
     companion object {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/jit/JITIntrospectRequest.kt
@@ -1,0 +1,63 @@
+package com.microsoft.identity.common.java.nativeauth.providers.requests.jit
+
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAuthRequest
+import com.microsoft.identity.common.java.util.ArgUtils
+import java.net.URL
+
+/**
+ * Represents a request to the register/introspect endpoint, and provides a create() function to instantiate the request using the provided parameters.
+ */
+data class JITIntrospectRequest private constructor(
+    override var requestUrl: URL,
+    override var headers: Map<String, String?>,
+    override val parameters: NativeAuthRequestParameters
+) : NativeAuthRequest() {
+
+    companion object {
+        /**
+         * Returns a request object using the provided parameters.
+         * The request URL and headers passed will be set directly.
+         * The clientId, continuation token, and challengeType will be mapped to the NativeAuthJITIntrospectRequestParameters object.
+         *
+         * Parameters that are null or empty will throw a ClientException.
+         * @see com.microsoft.identity.common.java.exception.ClientException
+         */
+        fun create(
+            clientId: String,
+            continuationToken: String,
+            requestUrl: String,
+            headers: Map<String, String?>
+        ): JITIntrospectRequest {
+            // Check for empty Strings and empty Maps
+            ArgUtils.validateNonNullArg(clientId, "clientId")
+            ArgUtils.validateNonNullArg(continuationToken, "continuationToken")
+
+            return JITIntrospectRequest(
+                requestUrl = URL(requestUrl),
+                headers = headers,
+                parameters = NativeAuthJITIntrospectRequestParameters(
+                    clientId = clientId,
+                    continuationToken = continuationToken
+                )
+            )
+        }
+    }
+
+    override fun toUnsanitizedString(): String = "JITIntrospectRequest(requestUrl=$requestUrl, headers=$headers, parameters=$parameters)"
+
+    override fun toString(): String = "JITIntrospectRequest()"
+
+    /**
+     * NativeAuthJITIntrospectRequestParameters represents the request parameters sent as part of
+     * /register/introspect API call
+     */
+    data class NativeAuthJITIntrospectRequestParameters(
+        @SerializedName("client_id") override val clientId: String,
+        @SerializedName("continuation_token") val continuationToken: String
+    ) : NativeAuthRequestParameters() {
+        override fun toUnsanitizedString(): String = "NativeAuthJITIntrospectRequestParameters(clientId=$clientId)"
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -1,0 +1,111 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
+import com.microsoft.identity.common.java.nativeauth.util.isRedirect
+import java.net.HttpURLConnection
+
+/**
+ * Represents the raw response from the register/challenge endpoint.
+ * Can be converted to JITChallengeApiResult using the provided toResult() method.
+ */
+class JITChallengeApiResponse(
+    @Expose override var statusCode: Int,
+    correlationId: String,
+    @SerializedName("continuation_token") val continuationToken: String?,
+    @Expose @SerializedName("challenge_type") val challengeType: String?,
+    @Expose @SerializedName("binding_method") val bindingMethod: String?,
+    @Expose @SerializedName("challenge_target") val challengeTarget: String?,
+    @Expose @SerializedName("challenge_channel") val challengeChannel: String?,
+    @Expose @SerializedName("code_length") val codeLength: Int?,
+    @Expose @SerializedName("interval") val interval: Int?,
+    @SerializedName("error") val error: String?,
+    @SerializedName("error_codes") val errorCodes: List<Int>?,
+    @SerializedName("error_description") val errorDescription: String?,
+    @SerializedName("error_uri") val errorUri: String?,
+) : IApiResponse(statusCode, correlationId) {
+
+    override fun toUnsanitizedString(): String {
+        return "JITChallengeApiResponse(statusCode=$statusCode, " +
+                "correlationId=$correlationId " +
+                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription)"
+    }
+
+    override fun toString(): String = "JITChallengeApiResponse(statusCode=$statusCode, " +
+            "correlationId=$correlationId"
+
+    companion object {
+        private val TAG = JITChallengeApiResponse::class.java.simpleName
+    }
+
+    fun toResult(): JITChallengeApiResult {
+        return when (statusCode) {
+            // Handle 400 errors
+            HttpURLConnection.HTTP_BAD_REQUEST -> {
+                return when {
+                    error.isInvalidRequest() -> {
+                        // TODO: test what is the error code for invalid verification contact
+                        JITChallengeApiResult.InvalidVerificationContact(
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    else -> {
+                        JITChallengeApiResult.UnknownError(
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                }
+            }
+
+            // Handle success and redirect
+            HttpURLConnection.HTTP_OK -> {
+                return when {
+                    challengeType.isRedirect() -> {
+                        JITChallengeApiResult.Redirect(
+                            correlationId = correlationId
+                        )
+                    }
+                    continuationToken.isNullOrBlank() ||
+                    challengeType.isNullOrBlank() ||
+                            challengeTarget.isNullOrBlank() ||
+                            challengeChannel.isNullOrBlank() ||
+                            codeLength == null -> {
+                        JITChallengeApiResult.UnknownError(
+                            error = "invalid_state",
+                            errorDescription = "Register authentication method /challenge did not return all mandatory fields",
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    else -> {
+                        JITChallengeApiResult.Success(
+                            correlationId = correlationId,
+                            continuationToken = continuationToken,
+                            challengeType = challengeType,
+                            bindingMethod = bindingMethod,
+                            challengeTargetLabel = challengeTarget,
+                            challengeChannel = challengeChannel,
+                            codeLength = codeLength
+                        )
+                    }
+                }
+            }
+            else -> {
+                JITChallengeApiResult.UnknownError(
+                    error = error.orEmpty(),
+                    errorDescription = errorDescription.orEmpty(),
+                    errorCodes = errorCodes.orEmpty(),
+                    correlationId = correlationId
+                )
+            }
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.google.gson.annotations.Expose

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -53,7 +53,9 @@ class JITChallengeApiResponse(
     override fun toUnsanitizedString(): String {
         return "JITChallengeApiResponse(statusCode=$statusCode, " +
                 "correlationId=$correlationId " +
-                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription)"
+                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription, " +
+                "challengeType=$challengeType, challengeTarget=$challengeTarget, bindingMethod=$bindingMethod, " +
+                "challengeChannel=$challengeChannel, codeLength=$codeLength)"
     }
 
     override fun toString(): String = "JITChallengeApiResponse(statusCode=$statusCode, " +

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -3,6 +3,7 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.util.isInvalidChallengeTarget
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
 import java.net.HttpURLConnection
@@ -26,7 +27,6 @@ class JITChallengeApiResponse(
     @SerializedName("error_description") val errorDescription: String?,
     @SerializedName("error_uri") val errorUri: String?,
 ) : IApiResponse(statusCode, correlationId) {
-    private val INVALID_CHALLENGE_TARGET_CODE = 901001
     override fun toUnsanitizedString(): String {
         return "JITChallengeApiResponse(statusCode=$statusCode, " +
                 "correlationId=$correlationId " +
@@ -36,20 +36,16 @@ class JITChallengeApiResponse(
     override fun toString(): String = "JITChallengeApiResponse(statusCode=$statusCode, " +
             "correlationId=$correlationId"
 
-    companion object {
-        private val TAG = JITChallengeApiResponse::class.java.simpleName
-    }
-
     fun toResult(): JITChallengeApiResult {
         return when (statusCode) {
             // Handle 400 errors
             HttpURLConnection.HTTP_BAD_REQUEST -> {
                 return when {
-                    error.isInvalidRequest() && errorCodes?.contains(INVALID_CHALLENGE_TARGET_CODE) == true -> {
+                    error.isInvalidRequest() && errorCodes?.first().isInvalidChallengeTarget() -> {
                         JITChallengeApiResult.InvalidVerificationContact(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),
-                            errorCodes = errorCodes,
+                            errorCodes = errorCodes.orEmpty(),
                             correlationId = correlationId
                         )
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -72,6 +72,7 @@ class JITChallengeApiResponse(
                             correlationId = correlationId
                         )
                     }
+
                     else -> {
                         JITChallengeApiResult.UnknownError(
                             error = error.orEmpty(),
@@ -86,13 +87,8 @@ class JITChallengeApiResponse(
             // Handle success and redirect
             HttpURLConnection.HTTP_OK -> {
                 return when {
-                    challengeType.isRedirect() -> {
-                        JITChallengeApiResult.Redirect(
-                            correlationId = correlationId
-                        )
-                    }
                     continuationToken.isNullOrBlank() ||
-                    challengeType.isNullOrBlank() ||
+                            challengeType.isNullOrBlank() ||
                             challengeTarget.isNullOrBlank() ||
                             challengeChannel.isNullOrBlank() ||
                             codeLength == null -> {
@@ -103,6 +99,7 @@ class JITChallengeApiResponse(
                             correlationId = correlationId
                         )
                     }
+
                     else -> {
                         JITChallengeApiResult.Success(
                             correlationId = correlationId,
@@ -116,6 +113,7 @@ class JITChallengeApiResponse(
                     }
                 }
             }
+
             else -> {
                 JITChallengeApiResult.UnknownError(
                     error = error.orEmpty(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -26,7 +26,7 @@ class JITChallengeApiResponse(
     @SerializedName("error_description") val errorDescription: String?,
     @SerializedName("error_uri") val errorUri: String?,
 ) : IApiResponse(statusCode, correlationId) {
-
+    private val INVALID_CHALLENGE_TARGET_CODE = 901001
     override fun toUnsanitizedString(): String {
         return "JITChallengeApiResponse(statusCode=$statusCode, " +
                 "correlationId=$correlationId " +
@@ -45,12 +45,11 @@ class JITChallengeApiResponse(
             // Handle 400 errors
             HttpURLConnection.HTTP_BAD_REQUEST -> {
                 return when {
-                    error.isInvalidRequest() -> {
-                        // TODO: test what is the error code for invalid verification contact
+                    error.isInvalidRequest() && errorCodes?.contains(INVALID_CHALLENGE_TARGET_CODE) == true -> {
                         JITChallengeApiResult.InvalidVerificationContact(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),
-                            errorCodes = errorCodes.orEmpty(),
+                            errorCodes = errorCodes,
                             correlationId = correlationId
                         )
                     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -3,6 +3,7 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidChallengeTarget
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
@@ -74,7 +75,7 @@ class JITChallengeApiResponse(
                             challengeChannel.isNullOrBlank() ||
                             codeLength == null -> {
                         JITChallengeApiResult.UnknownError(
-                            error = "invalid_state",
+                            error = ApiErrorResult.INVALID_STATE,
                             errorDescription = "Register authentication method /challenge did not return all mandatory fields",
                             errorCodes = errorCodes.orEmpty(),
                             correlationId = correlationId

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
@@ -3,16 +3,15 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordContinueApiResult
-import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.AuthenticationMethodApiResult
 
 /**
- * Represents the potential result types returned from the register/introspect endpoint,
+ * Represents the potential result types returned from the register/challenge endpoint,
  * including a case for unexpected errors received from the server.
  */
-sealed interface JITIntrospectAPIResult: ApiResult {
+sealed interface JITChallengeApiResult: ApiResult {
     data class Redirect(
         override val correlationId: String
-    ) : JITIntrospectAPIResult {
+    ) : JITChallengeApiResult {
         override fun toUnsanitizedString(): String {
             return "Redirect(correlationId=$correlationId)"
         }
@@ -23,8 +22,12 @@ sealed interface JITIntrospectAPIResult: ApiResult {
     data class Success(
         override val correlationId: String,
         val continuationToken: String,
-        val methods: List<AuthenticationMethodApiResult>
-    ) : JITIntrospectAPIResult {
+        val challengeType: String,
+        val bindingMethod: String?,
+        val challengeTargetLabel: String,
+        val challengeChannel: String,
+        val codeLength: Int
+    ) : JITChallengeApiResult {
         override fun toUnsanitizedString(): String {
             return "Success(correlationId=$correlationId)"
         }
@@ -32,17 +35,34 @@ sealed interface JITIntrospectAPIResult: ApiResult {
         override fun toString(): String = toUnsanitizedString()
     }
 
-    data class UnknownError(
+    data class InvalidVerificationContact(
         override val correlationId: String,
         override val error: String,
         override val errorDescription: String,
-        override val errorCodes: List<Int>,
+        override val errorCodes: List<Int>
     ) : ApiErrorResult(
         error = error,
         errorDescription = errorDescription,
         errorCodes = errorCodes,
         correlationId = correlationId
-    ), JITIntrospectAPIResult {
+    ), JITChallengeApiResult {
+        override fun toUnsanitizedString() = "InvalidVerificationContact(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, subError=$subError)"
+
+        override fun toString(): String = "InvalidVerificationContact(correlationId=$correlationId)"
+    }
+
+    data class UnknownError(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), JITChallengeApiResult {
         override fun toUnsanitizedString() = "UnknownError(correlationId=$correlationId, " +
                 "error=$error, errorDescription=$errorDescription, errorCodes=$errorCodes)"
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
@@ -42,10 +42,20 @@ sealed interface JITChallengeApiResult: ApiResult {
         val codeLength: Int
     ) : JITChallengeApiResult {
         override fun toUnsanitizedString(): String {
-            return "Success(correlationId=$correlationId)"
+            return "Success(correlationId=$correlationId " +
+                    "challengeType=$challengeType, " +
+                    "bindingMethod=$bindingMethod, " +
+                    "challengeTargetLabel=$challengeTargetLabel, " +
+                    "challengeChannel=$challengeChannel, " +
+                    "codeLength=$codeLength)"
         }
 
-        override fun toString(): String = toUnsanitizedString()
+        override fun toString(): String {
+            return "Success(correlationId=$correlationId, " +
+                    "challengeType=$challengeType, " +
+                    "bindingMethod=$bindingMethod, " +
+                    "codeLength=$codeLength)"
+        }
     }
 
     data class InvalidVerificationContact(

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResult.kt
@@ -31,15 +31,6 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpa
  * including a case for unexpected errors received from the server.
  */
 sealed interface JITChallengeApiResult: ApiResult {
-    data class Redirect(
-        override val correlationId: String
-    ) : JITChallengeApiResult {
-        override fun toUnsanitizedString(): String {
-            return "Redirect(correlationId=$correlationId)"
-        }
-
-        override fun toString(): String = toUnsanitizedString()
-    }
 
     data class Success(
         override val correlationId: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
@@ -50,7 +50,7 @@ class JITContinueApiResponse(
     }
 
     override fun toString(): String = "JITContinueAPIResponse(statusCode=$statusCode, " +
-            "correlationId=$correlationId"
+            "correlationId=$correlationId)"
 
     fun toResult(): JITContinueApiResult {
         return when (statusCode) {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.google.gson.annotations.Expose

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
@@ -3,6 +3,7 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant
 import com.microsoft.identity.common.java.nativeauth.util.isOOBValueInvalid
 import java.net.HttpURLConnection
@@ -59,7 +60,7 @@ class JITContinueApiResponse(
                 return when {
                     continuationToken.isNullOrBlank() -> {
                         JITContinueApiResult.UnknownError(
-                            error = "invalid_state",
+                            error = ApiErrorResult.INVALID_STATE,
                             errorDescription = "Register authentication method /continue did not return continuationToken field",
                             errorCodes = errorCodes.orEmpty(),
                             correlationId = correlationId

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResponse.kt
@@ -1,0 +1,86 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant
+import com.microsoft.identity.common.java.nativeauth.util.isOOBValueInvalid
+import java.net.HttpURLConnection
+
+/**
+ * Represents the raw response from the register/continue endpoint.
+ * Can be converted to JITContinueAPIResult using the provided toResult() method.
+ */
+class JITContinueApiResponse(
+    @Expose override var statusCode: Int,
+    correlationId: String,
+    @SerializedName("continuation_token") val continuationToken: String?,
+    @SerializedName("error") val error: String?,
+    @SerializedName("error_codes") val errorCodes: List<Int>?,
+    @SerializedName("error_description") val errorDescription: String?,
+    @SerializedName("suberror") val subError: String?
+) : IApiResponse(statusCode, correlationId) {
+    override fun toUnsanitizedString(): String {
+        return "JITContinueAPIResponse(statusCode=$statusCode, " +
+                "correlationId=$correlationId " +
+                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription)"
+    }
+
+    override fun toString(): String = "JITContinueAPIResponse(statusCode=$statusCode, " +
+            "correlationId=$correlationId"
+
+    fun toResult(): JITContinueApiResult {
+        return when (statusCode) {
+            // Handle 400 errors
+            HttpURLConnection.HTTP_BAD_REQUEST -> {
+                return when {
+                    error.isInvalidGrant() && subError.isOOBValueInvalid() -> {
+                        JITContinueApiResult.CodeIncorrect(
+                            correlationId = correlationId,
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            subError = subError.orEmpty()
+                        )
+                    }
+                    else -> {
+                        JITContinueApiResult.UnknownError(
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                }
+            }
+
+            // Handle success and redirect
+            HttpURLConnection.HTTP_OK -> {
+                return when {
+                    continuationToken.isNullOrBlank() -> {
+                        JITContinueApiResult.UnknownError(
+                            error = "invalid_state",
+                            errorDescription = "Register authentication method /continue did not return continuationToken field",
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    else -> {
+                        JITContinueApiResult.Success(
+                            correlationId = correlationId,
+                            continuationToken = continuationToken
+                        )
+                    }
+                }
+            }
+            else -> {
+                JITContinueApiResult.UnknownError(
+                    error = error.orEmpty(),
+                    errorDescription = errorDescription.orEmpty(),
+                    errorCodes = errorCodes.orEmpty(),
+                    correlationId = correlationId
+                )
+            }
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
@@ -1,0 +1,66 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiResult
+
+/**
+ * Represents the potential result types returned from the register/continue endpoint,
+ * including a case for unexpected errors received from the server.
+ */
+sealed interface JITContinueApiResult: ApiResult {
+    data class Redirect(
+        override val correlationId: String
+    ) : JITContinueApiResult {
+        override fun toUnsanitizedString(): String {
+            return "Redirect(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class Success(
+        override val correlationId: String,
+        val continuationToken: String
+    ) : JITContinueApiResult {
+        override fun toUnsanitizedString(): String {
+            return "Success(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class CodeIncorrect(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>,
+        override val subError: String
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        correlationId = correlationId,
+        errorCodes = errorCodes
+    ), JITContinueApiResult {
+        override fun toUnsanitizedString() = "CodeIncorrect(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, subError=$subError)"
+
+        override fun toString(): String = "CodeIncorrect(correlationId=$correlationId)"
+    }
+
+    data class UnknownError(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), JITContinueApiResult {
+        override fun toUnsanitizedString() = "UnknownError(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, errorCodes=$errorCodes)"
+
+        override fun toString(): String = "UnknownError(correlationId=$correlationId)"
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITContinueApiResult.kt
@@ -30,15 +30,6 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiResu
  * including a case for unexpected errors received from the server.
  */
 sealed interface JITContinueApiResult: ApiResult {
-    data class Redirect(
-        override val correlationId: String
-    ) : JITContinueApiResult {
-        override fun toUnsanitizedString(): String {
-            return "Redirect(correlationId=$correlationId)"
-        }
-
-        override fun toString(): String = toUnsanitizedString()
-    }
 
     data class Success(
         override val correlationId: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectAPIResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectAPIResult.kt
@@ -1,0 +1,51 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordContinueApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.AuthenticationMethodApiResult
+
+/**
+ * Represents the potential result types returned from the register/introspect endpoint,
+ * including a case for unexpected errors received from the server.
+ */
+sealed interface JITIntrospectAPIResult: ApiResult {
+    data class Redirect(
+        override val correlationId: String
+    ) : JITIntrospectAPIResult {
+        override fun toUnsanitizedString(): String {
+            return "Redirect(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class Success(
+        override val correlationId: String,
+        val continuationToken: String,
+        val methods: List<AuthenticationMethodApiResult>
+    ) : JITIntrospectAPIResult {
+        override fun toUnsanitizedString(): String {
+            return "Success(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class UnknownError(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>,
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), JITIntrospectAPIResult {
+        override fun toUnsanitizedString() = "UnknownError(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, errorCodes=$errorCodes)"
+
+        override fun toString(): String = "UnknownError(correlationId=$correlationId)"
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -51,7 +51,8 @@ class JITIntrospectApiResponse(
     override fun toUnsanitizedString(): String {
         return "JITIntrospectApiResponse(statusCode=$statusCode, " +
                 "correlationId=$correlationId " +
-                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription)"
+                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription, " +
+                "methods=$methods, challengeType=$challengeType)"
     }
 
     override fun toString(): String = "JITIntrospectApiResponse(statusCode=$statusCode, " +

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.google.gson.annotations.Expose

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -1,0 +1,104 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import com.microsoft.identity.common.java.nativeauth.providers.IApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.AuthenticationMethodApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.toListOfAuthenticationMethodApiResult
+import com.microsoft.identity.common.java.nativeauth.util.isRedirect
+import java.lang.IllegalStateException
+import java.net.HttpURLConnection
+
+/**
+ * Represents the raw response from the register/introspect endpoint.
+ * Can be converted to JITIntrospectApiResult using the provided toResult() method.
+ */
+class JITIntrospectApiResponse(
+    @Expose override var statusCode: Int,
+    correlationId: String,
+    @SerializedName("continuation_token") val continuationToken: String?,
+    @Expose @SerializedName("methods") val methods: List<AuthenticationMethodApiResponse>?,
+    @Expose @SerializedName("challenge_type") val challengeType: String?,
+    @SerializedName("error") val error: String?,
+    @SerializedName("error_codes") val errorCodes: List<Int>?,
+    @SerializedName("error_description") val errorDescription: String?,
+    @SerializedName("error_uri") val errorUri: String?,
+) : IApiResponse(statusCode, correlationId) {
+
+    override fun toUnsanitizedString(): String {
+        return "JITIntrospectApiResponse(statusCode=$statusCode, " +
+                "correlationId=$correlationId " +
+                "error=$error, errorCodes=$errorCodes, errorDescription=$errorDescription)"
+    }
+
+    override fun toString(): String = "JITIntrospectApiResponse(statusCode=$statusCode, " +
+            "correlationId=$correlationId"
+
+    companion object {
+        private val TAG = JITIntrospectApiResponse::class.java.simpleName
+    }
+
+    fun toResult(): JITIntrospectAPIResult {
+        return when (statusCode) {
+            // Handle 400 errors
+            HttpURLConnection.HTTP_BAD_REQUEST -> {
+                JITIntrospectAPIResult.UnknownError(
+                    error = error.orEmpty(),
+                    errorDescription = errorDescription.orEmpty(),
+                    errorCodes = errorCodes.orEmpty(),
+                    correlationId = correlationId
+                )
+            }
+
+            // Handle success and redirect
+            HttpURLConnection.HTTP_OK -> {
+                return when {
+                    challengeType.isRedirect() -> {
+                        JITIntrospectAPIResult.Redirect(
+                            correlationId = correlationId
+                        )
+                    }
+                    methods.isNullOrEmpty() -> {
+                        JITIntrospectAPIResult.UnknownError(
+                            error = ApiErrorResult.INVALID_STATE,
+                            errorDescription = "register/introspect did not return methods",
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    else -> {
+                        try {
+                            JITIntrospectAPIResult.Success(
+                                correlationId = correlationId,
+                                continuationToken = continuationToken
+                                    ?: return JITIntrospectAPIResult.UnknownError(
+                                        error = ApiErrorResult.INVALID_STATE,
+                                        errorDescription = "register/introspect did not return a continuation token",
+                                        errorCodes = errorCodes.orEmpty(),
+                                        correlationId = correlationId
+                                    ),
+                                methods = methods.toListOfAuthenticationMethodApiResult()
+                            )
+                        } catch (e: IllegalStateException) {
+                            JITIntrospectAPIResult.UnknownError(
+                                error = ApiErrorResult.INVALID_STATE,
+                                errorDescription = "register/introspect did not return valid methods: ${e.message}",
+                                errorCodes = errorCodes.orEmpty(),
+                                correlationId = correlationId
+                            )
+                        }
+                    }
+                }
+            }
+            else -> {
+                JITIntrospectAPIResult.UnknownError(
+                    error = error.orEmpty(),
+                    errorDescription = errorDescription.orEmpty(),
+                    errorCodes = errorCodes.orEmpty(),
+                    correlationId = correlationId
+                )
+            }
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -39,11 +39,11 @@ class JITIntrospectApiResponse(
         private val TAG = JITIntrospectApiResponse::class.java.simpleName
     }
 
-    fun toResult(): JITIntrospectAPIResult {
+    fun toResult(): JITIntrospectApiResult {
         return when (statusCode) {
             // Handle 400 errors
             HttpURLConnection.HTTP_BAD_REQUEST -> {
-                JITIntrospectAPIResult.UnknownError(
+                JITIntrospectApiResult.UnknownError(
                     error = error.orEmpty(),
                     errorDescription = errorDescription.orEmpty(),
                     errorCodes = errorCodes.orEmpty(),
@@ -55,12 +55,12 @@ class JITIntrospectApiResponse(
             HttpURLConnection.HTTP_OK -> {
                 return when {
                     challengeType.isRedirect() -> {
-                        JITIntrospectAPIResult.Redirect(
+                        JITIntrospectApiResult.Redirect(
                             correlationId = correlationId
                         )
                     }
                     methods.isNullOrEmpty() -> {
-                        JITIntrospectAPIResult.UnknownError(
+                        JITIntrospectApiResult.UnknownError(
                             error = ApiErrorResult.INVALID_STATE,
                             errorDescription = "register/introspect did not return methods",
                             errorCodes = errorCodes.orEmpty(),
@@ -69,10 +69,10 @@ class JITIntrospectApiResponse(
                     }
                     else -> {
                         try {
-                            JITIntrospectAPIResult.Success(
+                            JITIntrospectApiResult.Success(
                                 correlationId = correlationId,
                                 continuationToken = continuationToken
-                                    ?: return JITIntrospectAPIResult.UnknownError(
+                                    ?: return JITIntrospectApiResult.UnknownError(
                                         error = ApiErrorResult.INVALID_STATE,
                                         errorDescription = "register/introspect did not return a continuation token",
                                         errorCodes = errorCodes.orEmpty(),
@@ -81,7 +81,7 @@ class JITIntrospectApiResponse(
                                 methods = methods.toListOfAuthenticationMethodApiResult()
                             )
                         } catch (e: IllegalStateException) {
-                            JITIntrospectAPIResult.UnknownError(
+                            JITIntrospectApiResult.UnknownError(
                                 error = ApiErrorResult.INVALID_STATE,
                                 errorDescription = "register/introspect did not return valid methods: ${e.message}",
                                 errorCodes = errorCodes.orEmpty(),
@@ -92,7 +92,7 @@ class JITIntrospectApiResponse(
                 }
             }
             else -> {
-                JITIntrospectAPIResult.UnknownError(
+                JITIntrospectApiResult.UnknownError(
                     error = error.orEmpty(),
                     errorDescription = errorDescription.orEmpty(),
                     errorCodes = errorCodes.orEmpty(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -35,10 +35,6 @@ class JITIntrospectApiResponse(
     override fun toString(): String = "JITIntrospectApiResponse(statusCode=$statusCode, " +
             "correlationId=$correlationId"
 
-    companion object {
-        private val TAG = JITIntrospectApiResponse::class.java.simpleName
-    }
-
     fun toResult(): JITIntrospectApiResult {
         return when (statusCode) {
             // Handle 400 errors

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResponse.kt
@@ -72,11 +72,6 @@ class JITIntrospectApiResponse(
             // Handle success and redirect
             HttpURLConnection.HTTP_OK -> {
                 return when {
-                    challengeType.isRedirect() -> {
-                        JITIntrospectApiResult.Redirect(
-                            correlationId = correlationId
-                        )
-                    }
                     methods.isNullOrEmpty() -> {
                         JITIntrospectApiResult.UnknownError(
                             error = ApiErrorResult.INVALID_STATE,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
 
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
@@ -1,0 +1,50 @@
+package com.microsoft.identity.common.java.nativeauth.providers.responses.jit
+
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.AuthenticationMethodApiResult
+
+/**
+ * Represents the potential result types returned from the register/introspect endpoint,
+ * including a case for unexpected errors received from the server.
+ */
+sealed interface JITIntrospectApiResult: ApiResult {
+    data class Redirect(
+        override val correlationId: String
+    ) : JITIntrospectApiResult {
+        override fun toUnsanitizedString(): String {
+            return "Redirect(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class Success(
+        override val correlationId: String,
+        val continuationToken: String,
+        val methods: List<AuthenticationMethodApiResult>
+    ) : JITIntrospectApiResult {
+        override fun toUnsanitizedString(): String {
+            return "Success(correlationId=$correlationId)"
+        }
+
+        override fun toString(): String = toUnsanitizedString()
+    }
+
+    data class UnknownError(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>,
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), JITIntrospectApiResult {
+        override fun toUnsanitizedString() = "UnknownError(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, errorCodes=$errorCodes)"
+
+        override fun toString(): String = "UnknownError(correlationId=$correlationId)"
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
@@ -31,15 +31,6 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.
  * including a case for unexpected errors received from the server.
  */
 sealed interface JITIntrospectApiResult: ApiResult {
-    data class Redirect(
-        override val correlationId: String
-    ) : JITIntrospectApiResult {
-        override fun toUnsanitizedString(): String {
-            return "Redirect(correlationId=$correlationId)"
-        }
-
-        override fun toString(): String = toUnsanitizedString()
-    }
 
     data class Success(
         override val correlationId: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITIntrospectApiResult.kt
@@ -38,10 +38,13 @@ sealed interface JITIntrospectApiResult: ApiResult {
         val methods: List<AuthenticationMethodApiResult>
     ) : JITIntrospectApiResult {
         override fun toUnsanitizedString(): String {
-            return "Success(correlationId=$correlationId)"
+            return "Success(correlationId=$correlationId, " +
+                    "methods=$methods)"
         }
 
-        override fun toString(): String = toUnsanitizedString()
+        override fun toString(): String {
+            return "Success(correlationId=$correlationId)"
+        }
     }
 
     data class UnknownError(

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.java.nativeauth.util.isInvalidCredentials
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidGrant
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidOOBValue
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
+import com.microsoft.identity.common.java.nativeauth.util.isJITRequired
 import com.microsoft.identity.common.java.nativeauth.util.isMFARequired
 import com.microsoft.identity.common.java.nativeauth.util.isPasswordChangeRequired
 import com.microsoft.identity.common.java.nativeauth.util.isUserNotFound
@@ -41,7 +42,6 @@ import com.microsoft.identity.common.java.nativeauth.util.isUserNotFound
  * Note: mainly used for representing error cases from the /token endpoint. Successful responses are otherwise mapped to MicrosoftStsTokenResponse instead.
  * @see com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse
  */
-class SignInTokenApiResponse(
     @Expose override var statusCode: Int,
     correlationId: String,
     @SerializedName("continuation_token") val continuationToken: String?,
@@ -114,6 +114,22 @@ class SignInTokenApiResponse(
                     }
                     subError.isMFARequired() -> {
                         SignInTokenApiResult.MFARequired(
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            continuationToken = continuationToken ?:
+                            return SignInTokenApiResult.UnknownError(
+                                error = ApiErrorResult.INVALID_STATE,
+                                errorDescription = "oauth/v2.0/token did not return a continuation token",
+                                errorCodes = errorCodes.orEmpty(),
+                                correlationId = correlationId
+                            ),
+                            subError = subError.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                    subError.isJITRequired() -> {
+                        SignInTokenApiResult.JITRequired(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),
                             continuationToken = continuationToken ?:

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResponse.kt
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.java.nativeauth.util.isUserNotFound
  * Note: mainly used for representing error cases from the /token endpoint. Successful responses are otherwise mapped to MicrosoftStsTokenResponse instead.
  * @see com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse
  */
+class SignInTokenApiResponse(
     @Expose override var statusCode: Int,
     correlationId: String,
     @SerializedName("continuation_token") val continuationToken: String?,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInTokenApiResult.kt
@@ -63,6 +63,26 @@ sealed interface SignInTokenApiResult: ApiResult, ILoggable {
         override fun toString(): String = "MFARequired(correlationId=$correlationId)"
     }
 
+    data class JITRequired(
+        override val correlationId: String,
+        val continuationToken: String,
+        override val error: String,
+        override val subError: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        subError = subError,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), SignInTokenApiResult {
+        override fun toUnsanitizedString() = "JITRequired(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, subError=$subError, errorCodes=$errorCodes)"
+
+        override fun toString(): String = "JITRequired(correlationId=$correlationId)"
+    }
+
     data class UserNotFound(
         override val correlationId: String,
         override val error: String,

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
@@ -93,6 +93,10 @@ internal fun String?.isExpiredToken(): Boolean {
     return this.contentEquals(other = "expired_token", ignoreCase = true)
 }
 
+internal fun String?.isOOBValueInvalid(): Boolean {
+    return this.contentEquals(other = "invalid_oob_value", ignoreCase = true)
+}
+
 internal fun Int?.isInvalidParameter() : Boolean {
     return this == 90100
 }
@@ -109,8 +113,16 @@ internal fun Int?.isInvalidAuthenticationType(): Boolean {
     return this == 400002
 }
 
+internal fun Int?.isInvalidChallengeTarget(): Boolean {
+    return this == 901001
+}
+
 fun String?.isMFARequired(): Boolean {
     return this.contentEquals(other = "mfa_required", ignoreCase = true)
+}
+
+fun String?.isJITRequired(): Boolean {
+    return this.contentEquals(other = "registration_required", ignoreCase = true)
 }
 
 internal fun String?.isVerificationRequired(): Boolean {

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -65,6 +65,8 @@ class NativeAuthRequestProviderTest {
     private val continuationToken = "uY29tL2F1dGhlbnRpY"
     private val challengeId = "902rnwfn3"
     private val correlationId = "jsdfo4nslkjsrg"
+    private val challengeTarget = "mail@contoso.com"
+    private val challengeChannel = "email"
     private val grantType = NativeAuthConstants.GrantType.OOB
 
     private val mockConfig = mockk<NativeAuthOAuth2Configuration> {
@@ -1254,4 +1256,231 @@ class NativeAuthRequestProviderTest {
         assertEquals(ApiConstants.MockApi.ssprPollCompletionRequestUrl, result.requestUrl)
         assertEquals(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID], correlationId)
     }
+
+    // region JIT tests
+
+    @Test(expected = ClientException::class)
+    fun testJITIntrospectWithEmptyContinuationTokenShouldThrowException() {
+        val continuationToken = ""
+
+        nativeAuthRequestProvider.createJITIntrospectRequest(
+            continuationToken,
+            correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITIntrospectWithEmptyClientIdShouldThrowException() {
+        every { mockConfig.clientId } returns emptyString
+
+        nativeAuthRequestProvider.createJITIntrospectRequest(
+            continuationToken,
+            correlationId
+        )
+    }
+
+    @Test
+    fun testJITIntrospectWithUnsetCorrelationIdShouldNotHaveHeader() {
+        val correlationId = "UNSET"
+
+        val result = nativeAuthRequestProvider.createJITIntrospectRequest(
+            continuationToken,
+            correlationId
+        )
+
+        assertNull(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID])
+    }
+
+    @Test
+    fun testJITIntrospectRequestSuccess() {
+        val result = nativeAuthRequestProvider.createJITIntrospectRequest(
+            continuationToken,
+            correlationId
+        )
+
+        assertEquals(clientId, result.parameters.clientId)
+        assertEquals(continuationToken, result.parameters.continuationToken)
+        assertEquals(ApiConstants.MockApi.jitIntrospectRequestUrl, result.requestUrl)
+        assertEquals(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID], correlationId)
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITChallengeWithEmptyContinuationTokenShouldThrowException() {
+        val continuationToken = ""
+
+        nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITChallengeWithEmptyChallengeTypeShouldThrowException() {
+        val challengeType = ""
+
+        nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITChallengeWithEmptyChallengeTargetShouldThrowException() {
+        val challengeTarget = ""
+
+        nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITChallengeWithEmptyChallengeChannelShouldThrowException() {
+        val challengeChannel = ""
+
+        nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+    }
+
+    @Test
+    fun testJITChallengeWithUnsetCorrelationIdShouldNotHaveHeader() {
+        val correlationId = "UNSET"
+
+        val result = nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+
+        assertNull(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID])
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITChallengeWithEmptyClientIdShouldThrowException() {
+        every { mockConfig.clientId } returns emptyString
+
+        nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+    }
+
+    @Test
+    fun testJITChallengeRequestSuccess() {
+        val result = nativeAuthRequestProvider.createJITChallengeRequest(
+            continuationToken =  continuationToken,
+            challengeType = challengeType,
+            challengeTarget = challengeTarget,
+            challengeChannel =  challengeChannel,
+            correlationId = correlationId
+        )
+
+        assertEquals(clientId, result.parameters.clientId)
+        assertEquals(continuationToken, result.parameters.continuationToken)
+        assertEquals(challengeType, result.parameters.challengeType)
+        assertEquals(challengeTarget, result.parameters.challengeTarget)
+        assertEquals(challengeChannel, result.parameters.challengeChannel)
+        assertEquals(ApiConstants.MockApi.jitChallengeRequestUrl, result.requestUrl)
+        assertEquals(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID], correlationId)
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITContinueWithEmptyContinuationTokenShouldThrowException() {
+        val continuationToken = ""
+
+        nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITContinueWithEmptyGrantTypeShouldThrowException() {
+        val grantType = ""
+
+        nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITContinueWithEmptyOOBCodeShouldThrowException() {
+        val oobCode = ""
+
+        nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+    }
+
+    @Test
+    fun testJITContinueWithUnsetCorrelationIdShouldNotHaveHeader() {
+        val correlationId = "UNSET"
+
+        val result = nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+
+        assertNull(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID])
+    }
+
+    @Test(expected = ClientException::class)
+    fun testJITContinueWithEmptyClientIdShouldThrowException() {
+        every { mockConfig.clientId } returns emptyString
+
+        nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+    }
+
+    @Test
+    fun testJITContinueRequestSuccess() {
+        val result = nativeAuthRequestProvider.createJITContinueRequest(
+            continuationToken =  continuationToken,
+            grantType = grantType,
+            code = oobCode,
+            correlationId = correlationId
+        )
+
+        assertEquals(clientId, result.parameters.clientId)
+        assertEquals(continuationToken, result.parameters.continuationToken)
+        assertEquals(grantType, result.parameters.grantType)
+        assertEquals(oobCode, result.parameters.oob)
+        assertEquals(ApiConstants.MockApi.jitContinueRequestUrl, result.requestUrl)
+        assertEquals(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID], correlationId)
+    }
+
+    //endregion
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -80,6 +80,9 @@ class NativeAuthRequestProviderTest {
         every { getResetPasswordContinueEndpoint() } returns ApiConstants.MockApi.ssprContinueRequestUrl
         every { getResetPasswordSubmitEndpoint() } returns ApiConstants.MockApi.ssprSubmitRequestUrl
         every { getResetPasswordPollCompletionEndpoint() } returns ApiConstants.MockApi.ssprPollCompletionRequestUrl
+        every { getJITIntrospectEndpoint() } returns ApiConstants.MockApi.jitIntrospectRequestUrl
+        every { getJITChallengeEndpoint() } returns ApiConstants.MockApi.jitChallengeRequestUrl
+        every { getJITContinueEndpoint() } returns ApiConstants.MockApi.jitContinueRequestUrl
         every { challengeType } returns this@NativeAuthRequestProviderTest.challengeType
         every { clientId } returns this@NativeAuthRequestProviderTest.clientId
         every { useMockApiForNativeAuth } returns true

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -3407,7 +3407,7 @@ class NativeAuthResponseHandlerTest {
     }
     // endregion
 
-    //region JIT responses
+    //region JIT introspect
 
     @Test
     fun testJITIntrospectApiSuccessButEmptyMethodList() {
@@ -3428,28 +3428,6 @@ class NativeAuthResponseHandlerTest {
             assertEquals(ApiErrorResult.INVALID_STATE, apiResult.error)
         } else {
             fail("Expected JITIntrospectApiResult.UnknownError but got $apiResult")
-        }
-    }
-
-    @Test
-    fun testJITIntrospectApiSuccessRedirect() {
-        val methods = emptyList<AuthenticationMethodApiResponse>()
-        val jitIntrospectApiResponse = JITIntrospectApiResponse(
-            statusCode = successStatusCode,
-            challengeType = redirect,
-            continuationToken = continuationToken,
-            error = null,
-            errorDescription = null,
-            methods = methods,
-            errorUri = null,
-            errorCodes = null,
-            correlationId = correlationId
-        )
-        val apiResult = jitIntrospectApiResponse.toResult()
-        if (apiResult is JITIntrospectApiResult.Redirect) {
-            assertEquals(correlationId, apiResult.correlationId)
-        } else {
-            fail("Expected JITIntrospectApiResult.Redirect but got $apiResult")
         }
     }
 
@@ -3511,6 +3489,10 @@ class NativeAuthResponseHandlerTest {
         }
     }
 
+    //endregion
+
+    //region JIT challenge
+
     @Test
     fun testJITChallengeApiSuccessButMissingMandatoryField() {
         val jitChallengeApiResponse = JITChallengeApiResponse(
@@ -3534,31 +3516,6 @@ class NativeAuthResponseHandlerTest {
             assertEquals(correlationId, apiResult.correlationId)
         } else {
             fail("Expected JITChallengeApiResult.UnknownError but got $apiResult")
-        }
-    }
-
-    @Test
-    fun testJITChallengeApiSuccessRedirect() {
-        val jitChallengeApiResponse = JITChallengeApiResponse(
-            statusCode = successStatusCode,
-            challengeType = redirect,
-            continuationToken = continuationToken,
-            error = null,
-            errorDescription = null,
-            errorUri = null,
-            errorCodes = null,
-            bindingMethod = null,
-            challengeChannel = null,
-            challengeTarget = null,
-            codeLength = null,
-            interval = null,
-            correlationId = correlationId
-        )
-        val apiResult = jitChallengeApiResponse.toResult()
-        if (apiResult is JITChallengeApiResult.Redirect) {
-            assertEquals(correlationId, apiResult.correlationId)
-        } else {
-            fail("Expected JITChallengeApiResult.Redirect but got $apiResult")
         }
     }
 
@@ -3619,7 +3576,7 @@ class NativeAuthResponseHandlerTest {
 
     @Test
     fun testJITChallengeApiInvalidRequestWithUnknownErrorCodeIsHandledCorrectly() {
-        val errorCodes = listOf(90100)
+        val errorCodes = listOf(100100)
         val jitChallengeApiResponse = JITChallengeApiResponse(
             statusCode = errorStatusCode,
             challengeType = null,
@@ -3675,6 +3632,10 @@ class NativeAuthResponseHandlerTest {
             fail("Expected JITChallengeApiResult.Success but got $apiResult")
         }
     }
+
+    //endregion
+
+    //region JIT continue
 
     @Test
     fun testJITContinueApiInvalidOOBIsHandledCorrectly() {

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -28,6 +28,12 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErro
 import com.microsoft.identity.common.java.net.HttpResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.UserAttributeApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.UserAttributeOptionsApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITChallengeApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITChallengeApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITContinueApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITContinueApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITIntrospectApiResponse
+import com.microsoft.identity.common.java.nativeauth.providers.responses.jit.JITIntrospectApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordChallengeApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordChallengeApiResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.resetpassword.ResetPasswordContinueApiResponse
@@ -60,6 +66,7 @@ import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -3399,4 +3406,378 @@ class NativeAuthResponseHandlerTest {
         Assert.assertEquals(NativeAuthResponseHandler.EMPTY_RESPONSE_ERROR_ERROR_DESCRIPTION, response.errorDescription)
     }
     // endregion
+
+    //region JIT responses
+
+    @Test
+    fun testJITIntrospectApiSuccessButEmptyMethodList() {
+        val methods = emptyList<AuthenticationMethodApiResponse>()
+        val jitIntrospectApiResponse = JITIntrospectApiResponse(
+            statusCode = successStatusCode,
+            challengeType = emailChallengeChannel,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            methods = methods,
+            errorUri = null,
+            errorCodes = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitIntrospectApiResponse.toResult()
+        if (apiResult is JITIntrospectApiResult.UnknownError) {
+            assertEquals(ApiErrorResult.INVALID_STATE, apiResult.error)
+        } else {
+            fail("Expected JITIntrospectApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITIntrospectApiSuccessRedirect() {
+        val methods = emptyList<AuthenticationMethodApiResponse>()
+        val jitIntrospectApiResponse = JITIntrospectApiResponse(
+            statusCode = successStatusCode,
+            challengeType = redirect,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            methods = methods,
+            errorUri = null,
+            errorCodes = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitIntrospectApiResponse.toResult()
+        if (apiResult is JITIntrospectApiResult.Redirect) {
+            assertEquals(correlationId, apiResult.correlationId)
+        } else {
+            fail("Expected JITIntrospectApiResult.Redirect but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITIntrospectApiSuccess() {
+        val method = AuthenticationMethodApiResponse(
+            id = "email",
+            challengeType = emailChallengeChannel,
+            loginHint = "email@contoso.com",
+            challengeChannel = ""
+        )
+        val methods = listOf(method)
+        val jitIntrospectApiResponse = JITIntrospectApiResponse(
+            statusCode = successStatusCode,
+            challengeType = emailChallengeChannel,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            methods = methods,
+            errorUri = null,
+            errorCodes = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitIntrospectApiResponse.toResult()
+        if (apiResult is JITIntrospectApiResult.Success) {
+            assertEquals(continuationToken, apiResult.continuationToken)
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(1, apiResult.methods.count())
+            val resultMethod = apiResult.methods.first()
+            assertEquals(method.id, resultMethod.id)
+            assertEquals(method.challengeType, resultMethod.challengeType)
+            assertEquals(method.loginHint, resultMethod.loginHint)
+            assertEquals(method.challengeChannel, resultMethod.challengeChannel)
+        } else {
+            fail("Expected JITIntrospectApiResult.Success but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITIntrospectApiResponseBadRequest() {
+        val jitIntrospectApiResponse = JITIntrospectApiResponse(
+            statusCode = errorStatusCode,
+            continuationToken = null,
+            error = invalidGrantError,
+            errorCodes = emptyList(),
+            errorDescription = unknownErrorDescription,
+            errorUri = null,
+            methods = null,
+            challengeType = null,
+            correlationId = correlationId
+        )
+
+        val apiResult = jitIntrospectApiResponse.toResult()
+        if (apiResult is JITIntrospectApiResult.UnknownError) {
+            assertEquals(invalidGrantError, apiResult.error)
+            assertEquals(unknownErrorDescription, apiResult.errorDescription)
+        } else {
+            fail("Expected JITIntrospectApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiSuccessButMissingMandatoryField() {
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = successStatusCode,
+            challengeType = emailChallengeChannel,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            errorUri = null,
+            errorCodes = null,
+            bindingMethod = null,
+            challengeChannel = null,
+            challengeTarget = null,
+            codeLength = null,
+            interval = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.UnknownError) {
+            assertEquals(ApiErrorResult.INVALID_STATE, apiResult.error)
+            assertEquals(correlationId, apiResult.correlationId)
+        } else {
+            fail("Expected JITChallengeApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiSuccessRedirect() {
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = successStatusCode,
+            challengeType = redirect,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            errorUri = null,
+            errorCodes = null,
+            bindingMethod = null,
+            challengeChannel = null,
+            challengeTarget = null,
+            codeLength = null,
+            interval = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.Redirect) {
+            assertEquals(correlationId, apiResult.correlationId)
+        } else {
+            fail("Expected JITChallengeApiResult.Redirect but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiUncommonStatusCodeShouldReturnError() {
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = uncommonErrorStatusCode,
+            challengeType = redirect,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            errorUri = null,
+            errorCodes = null,
+            bindingMethod = null,
+            challengeChannel = null,
+            challengeTarget = null,
+            codeLength = null,
+            interval = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.UnknownError) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(emptyString, apiResult.error)
+        } else {
+            fail("Expected JITChallengeApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiInvalidChallengeTargetIsHandledCorrectly() {
+        val errorCodes = listOf(901001)
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = errorStatusCode,
+            challengeType = null,
+            continuationToken = null,
+            error = invalidRequestError,
+            errorDescription = errorDescription,
+            errorUri = null,
+            errorCodes = errorCodes,
+            bindingMethod = null,
+            challengeChannel = null,
+            challengeTarget = null,
+            codeLength = null,
+            interval = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.InvalidVerificationContact) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(invalidRequestError, apiResult.error)
+            assertEquals(errorDescription, apiResult.errorDescription)
+            assertEquals(errorCodes, apiResult.errorCodes)
+        } else {
+            fail("Expected JITChallengeApiResult.InvalidVerificationContact but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiInvalidRequestWithUnknownErrorCodeIsHandledCorrectly() {
+        val errorCodes = listOf(90100)
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = errorStatusCode,
+            challengeType = null,
+            continuationToken = null,
+            error = invalidRequestError,
+            errorDescription = errorDescription,
+            errorUri = null,
+            errorCodes = errorCodes,
+            bindingMethod = null,
+            challengeChannel = null,
+            challengeTarget = null,
+            codeLength = null,
+            interval = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.UnknownError) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(invalidRequestError, apiResult.error)
+            assertEquals(errorDescription, apiResult.errorDescription)
+            assertEquals(errorCodes, apiResult.errorCodes)
+        } else {
+            fail("Expected JITChallengeApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITChallengeApiSuccessIsHandledCorrectly() {
+        val jitChallengeApiResponse = JITChallengeApiResponse(
+            statusCode = successStatusCode,
+            challengeType = challengeType,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            errorUri = null,
+            errorCodes = null,
+            bindingMethod = bindingMethod,
+            challengeChannel = emailChallengeChannel,
+            challengeTarget = challengeTargetLabel,
+            codeLength = codeLength,
+            interval = interval,
+            correlationId = correlationId
+        )
+        val apiResult = jitChallengeApiResponse.toResult()
+        if (apiResult is JITChallengeApiResult.Success) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(emailChallengeChannel, apiResult.challengeChannel)
+            assertEquals(challengeType, apiResult.challengeType)
+            assertEquals(codeLength, apiResult.codeLength)
+            assertEquals(challengeTargetLabel, apiResult.challengeTargetLabel)
+            assertEquals(bindingMethod, apiResult.bindingMethod)
+        } else {
+            fail("Expected JITChallengeApiResult.Success but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITContinueApiInvalidOOBIsHandledCorrectly() {
+        val jitContinueApiResponse = JITContinueApiResponse(
+            statusCode = errorStatusCode,
+            continuationToken = continuationToken,
+            error = invalidGrantError,
+            errorDescription = errorDescription,
+            errorCodes = null,
+            subError = invalidOOBValueError,
+            correlationId = correlationId
+        )
+        val apiResult = jitContinueApiResponse.toResult()
+        if (apiResult is JITContinueApiResult.CodeIncorrect) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(invalidGrantError, apiResult.error)
+            assertEquals(errorDescription, apiResult.errorDescription)
+        } else {
+            fail("Expected JITContinueApiResult.CodeIncorrect but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITContinueApiInvalidGrantGenericSubErrorIsHandledAsUnknownError() {
+        val jitContinueApiResponse = JITContinueApiResponse(
+            statusCode = errorStatusCode,
+            continuationToken = continuationToken,
+            error = invalidGrantError,
+            errorDescription = errorDescription,
+            errorCodes = null,
+            subError = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitContinueApiResponse.toResult()
+        if (apiResult is JITContinueApiResult.UnknownError) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(invalidGrantError, apiResult.error)
+            assertEquals(errorDescription, apiResult.errorDescription)
+        } else {
+            fail("Expected JITContinueApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITContinueApiUncommonErrorCodeIsHandledAsUnknownError() {
+        val jitContinueApiResponse = JITContinueApiResponse(
+            statusCode = uncommonErrorStatusCode,
+            continuationToken = continuationToken,
+            error = invalidGrantError,
+            errorDescription = errorDescription,
+            errorCodes = null,
+            subError = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitContinueApiResponse.toResult()
+        if (apiResult is JITContinueApiResult.UnknownError) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(invalidGrantError, apiResult.error)
+            assertEquals(errorDescription, apiResult.errorDescription)
+        } else {
+            fail("Expected JITContinueApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITContinueApiSuccessButMissingContinuationTokenIsHandledAsUnknownError() {
+        val jitContinueApiResponse = JITContinueApiResponse(
+            statusCode = successStatusCode,
+            continuationToken = null,
+            error = invalidGrantError,
+            errorDescription = errorDescription,
+            errorCodes = null,
+            subError = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitContinueApiResponse.toResult()
+        if (apiResult is JITContinueApiResult.UnknownError) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(ApiErrorResult.INVALID_STATE, apiResult.error)
+        } else {
+            fail("Expected JITContinueApiResult.UnknownError but got $apiResult")
+        }
+    }
+
+    @Test
+    fun testJITContinueApiSuccessIsHandledAsSuccess() {
+        val jitContinueApiResponse = JITContinueApiResponse(
+            statusCode = successStatusCode,
+            continuationToken = continuationToken,
+            error = null,
+            errorDescription = null,
+            errorCodes = null,
+            subError = null,
+            correlationId = correlationId
+        )
+        val apiResult = jitContinueApiResponse.toResult()
+        if (apiResult is JITContinueApiResult.Success) {
+            assertEquals(correlationId, apiResult.correlationId)
+            assertEquals(continuationToken, apiResult.continuationToken)
+        } else {
+            fail("Expected JITContinueApiResult.Success but got $apiResult")
+        }
+    }
+
+    //endregion
 }

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/ApiConstants.kt
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/ApiConstants.kt
@@ -45,6 +45,9 @@ interface ApiConstants {
         val ssprContinueRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/continue")
         val ssprSubmitRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/submit")
         val ssprPollCompletionRequestUrl = URL(BASE_REQUEST_PATH + "resetpassword/v1.0/poll_completion")
+        val jitIntrospectRequestUrl = URL(BASE_REQUEST_PATH + "register/v1.0/introspect")
+        val jitChallengeRequestUrl = URL(BASE_REQUEST_PATH + "register/v1.0/challenge")
+        val jitContinueRequestUrl = URL(BASE_REQUEST_PATH + "register/v1.0/continue")
         val tokenEndpoint = URL("https://contoso.com/1234/token")
     }
 


### PR DESCRIPTION
Adding network layer for JIT feature. Integration tests are written for the NativeAuthOAuth2Strategy class. To write tests for this class, I need to create new commandParameters classes. Since these classes are more related to the business logic, I decided to add them and the integration tests in the next PR.

[AB#3188135](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3188135)