### PR TITLE
Move camera logic to CameraPermissionRequestHandler and add SdmQrPinManager , Fixes AB#3121976

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Move camera logic to CameraPermissionRequestHandler and add SdmQrPinManager (#2630)
 - [MINOR] Pass Work Profile existence, OS Version, and Manufacturer to ESTS (#2627)
 - [MINOR] Add telemetry for the switch browser protocol (#2612)
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IBrokerRestrictionsManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IBrokerRestrictionsManager.kt
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker
+
+import android.os.Bundle
+
+/**
+ * Helper class to read the app restrictions manager of the current broker app or another broker app.
+ */
+interface IBrokerRestrictionsManager {
+    companion object BrokerRestrictionsManagerKeys {
+        /** Keys to group the values in the bundle. */
+        const val BOOLEAN_VALUES_KEY = "booleanValuesKey"
+        const val STRING_VALUES_KEY = "stringValuesKey"
+
+        /** Keys to be used in the app restrictions manager to read the values. */
+        // String keys
+        const val PREFERRED_AUTH_CONFIG = "preferred_auth_config"
+        // Boolean keys
+        const val SUPPRESS_CAMERA_CONSENT = "sdm_suppress_camera_consent"
+
+        /**
+         * Creates a request bundle with the keys to be requested from the app restrictions manager.
+         * The keys are filtered based on the type of the keys.
+         *
+         * @param stringKeys Keys to be requested from the app restrictions manager.
+         * @param booleanKeys Keys to be requested from the app restrictions manager.
+         * @return Bundle with the keys to be requested from the app restrictions manager.
+         */
+        @JvmOverloads
+        fun buildMultiValueRequest(stringKeys: Set<String>? = null, booleanKeys: Set<String>? = null): Bundle {
+            val stringList = stringKeys?.let { ArrayList(it) }
+            val booleanList = booleanKeys?.let { ArrayList(it) }
+            return Bundle().apply {
+                this.putStringArrayList(STRING_VALUES_KEY, stringList)
+                this.putStringArrayList(BOOLEAN_VALUES_KEY, booleanList)
+            }
+        }
+    }
+    /**
+     * Gets the [key] value from the [brokerAppPackageName] restrictions manager.
+     * Returns null if the key is not found or failed to read the value.
+     */
+    fun getString(key: String, brokerAppPackageName: String, defaultValue: String? = null): String?
+
+    /**
+     * Gets the [key] value from the [brokerAppPackageName] restrictions manager.
+     * Returns null if the key is not found or failed to read the value.
+     */
+    fun getBoolean(key: String, brokerAppPackageName: String, defaultValue: Boolean = false): Boolean
+
+    /**
+     * Reads the keys from the [bundleOfKeys] provided
+     * and returns a bundle with the values from the [brokerAppPackageName] restrictions manager.
+     * <p>
+     * The provided bundle should contain a key determining the type of the keys to be requested
+     * and the value should be an array list of keys.
+     * Example: if the bundle contains a key "stringValues" with an array list of keys ["key1s", "key2s"]
+     * and a key "booleanValues" with an array list of keys ["key0b"].
+     * Then the returned bundle will contain the values for the keys "key1s", "key2s" and "key0b".
+     *
+     *
+     * @param bundleOfKeys Bundle of keys to be requested from the app restrictions manager.
+     * @return Bundle with the values from the app restrictions manager.
+     */
+    fun getMultiValues(brokerAppPackageName: String, bundleOfKeys: Bundle) : Bundle
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IBrokerRestrictionsManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IBrokerRestrictionsManager.kt
@@ -47,6 +47,7 @@ interface IBrokerRestrictionsManager {
          * @param booleanKeys Keys to be requested from the app restrictions manager.
          * @return Bundle with the keys to be requested from the app restrictions manager.
          */
+        @JvmStatic
         @JvmOverloads
         fun buildMultiValueRequest(stringKeys: Set<String>? = null, booleanKeys: Set<String>? = null): Bundle {
             val stringList = stringKeys?.let { ArrayList(it) }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
@@ -25,9 +25,9 @@ package com.microsoft.identity.common.internal.broker
 import android.os.Bundle
 
 /**
- * Helper class to read the app restrictions manager of the current broker app or another broker app.
+ * Helper class to read the app restrictions manager.
  */
-interface IBrokerRestrictionsManager {
+interface IRestrictionsManager {
     companion object BrokerRestrictionsManagerKeys {
         /** Keys to group the values in the bundle. */
         const val BOOLEAN_VALUES_KEY = "booleanValuesKey"

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -38,7 +38,7 @@ import com.microsoft.identity.common.logging.Logger
  *
  * It is initialized each time `GetPreferredAuthMethodMsalBrokerOperation` is called,
  * since apps always contact the broker to get the preferred authentication method
- * before starting the authentication flow.
+ * before starting the QR + PIN authentication flow.
  *
  * Note: If this object is not initialized, both flags default to `false`,
  * meaning the device is not in SDM QR PIN mode.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -28,6 +28,7 @@ import com.microsoft.identity.common.logging.Logger
 
 /**
  * Manages the SDM QR PIN mode settings for the device.
+ * by reading the restrictions manager of the Authenticator app.
  *
  * This object contains functions to check"
  * - Whether camera consent should be suppressed.
@@ -42,6 +43,7 @@ object SdmQrPinManager {
 
     private const val TAG = "SdmQrPinManager"
 
+    private val authenticatorPackageName = BrokerData.prodMicrosoftAuthenticator.packageName
     private var restrictionsManager: IRestrictionsManager? = null
 
     /**
@@ -50,9 +52,7 @@ object SdmQrPinManager {
      * to ensure the manager is initialized with the correct broker restrictions manager.
      */
     fun initializeSdmQrPinManager(restrictionsManager: IRestrictionsManager) {
-        if (this.restrictionsManager == null) {
-            this.restrictionsManager = restrictionsManager
-        }
+        this.restrictionsManager = restrictionsManager
     }
 
     /**
@@ -64,7 +64,7 @@ object SdmQrPinManager {
         restrictionsManager?.let { manager ->
             return manager.getString(
                 key = PREFERRED_AUTH_CONFIG,
-                brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+                brokerAppPackageName = authenticatorPackageName,
                 defaultValue = defaultValue
             )
         } ?: run {
@@ -82,7 +82,7 @@ object SdmQrPinManager {
         restrictionsManager?.let { manager ->
             return manager.getBoolean(
                 key = SUPPRESS_CAMERA_CONSENT,
-                brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+                brokerAppPackageName = authenticatorPackageName,
                 defaultValue = defaultValue
             )
         } ?: run {

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -29,15 +29,29 @@ import com.microsoft.identity.common.java.ui.PreferredAuthMethod
 import com.microsoft.identity.common.logging.Logger
 
 /**
- * This object manages the SDM QR PIN mode for the device.
- * It contains flags to indicate if the device is on SDM QR PIN mode and if the camera consent should be suppressed.
- * This object is only initialized once in AndroidBrokerPlatformComponentsFactory
- * if this is not initialized, the default values are false, as the device is not on SDM QR PIN mode.
+ * Manages the SDM QR PIN mode settings for the device.
+ *
+ * This object contains flags that indicate:
+ * - Whether the device is currently in SDM QR PIN mode.
+ * - Whether camera consent should be suppressed.
+ * - The preferred authentication method for the device.
+ *
+ * It is initialized each time `GetPreferredAuthMethodMsalBrokerOperation` is called,
+ * since apps always contact the broker to get the preferred authentication method
+ * before starting the authentication flow.
+ *
+ * Note: If this object is not initialized, both flags default to `false`,
+ * meaning the device is not in SDM QR PIN mode.
  */
 object SdmQrPinManager {
 
     private const val TAG = "SdmQrPinManager"
-    private const val SIX_HOURS_IN_SECONDS = 21600L
+
+    /**
+     * This is the preferred authentication method for the device on SDM mode.
+     * This is set in the Authenticator app, using app configuration policies for managed Android Enterprise devices.
+     */
+    var preferredAuthMethod: String? = null
 
     /**
      * This is a flag to indicate if the device is on SDM QR PIN mode.
@@ -60,18 +74,14 @@ object SdmQrPinManager {
 
     /**
      * This method initializes the SDM QR PIN manager by checking the broker restrictions manager.
-     * It sets the [isDeviceOnSdmQrPinAuth] and [isCameraConsentSuppressed] flags.
-     * This method should be called only in AndroidBrokerPlatformComponentsFactory.create
+     * It sets the [isDeviceOnSdmQrPinAuth], [preferredAuthMethod] and [isCameraConsentSuppressed] flags.
+     * This method is called each time `GetPreferredAuthMethodMsalBrokerOperation` is called,
      * because the restrictions rarely change, only when a new policy is pushed to the device.
      *
      * @param brokerRestrictionsManager The broker restrictions manager to check the restrictions.
      */
     fun initializeSdmQrPinManager(brokerRestrictionsManager: IBrokerRestrictionsManager) {
         Logger.info(TAG, "Initializing SDM QR PIN manager.")
-        if (!needsUpdate()) {
-            Logger.info(TAG, "SDM QR PIN manager is already initialized.")
-            return
-        }
         val multiValueRequest = buildMultiValueRequest(
             booleanKeys = setOf(SUPPRESS_CAMERA_CONSENT),
             stringKeys = setOf(PREFERRED_AUTH_CONFIG)
@@ -80,33 +90,15 @@ object SdmQrPinManager {
             brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
             bundleOfKeys = multiValueRequest
         )
-        val preferredAuthConfig = multiValues.getString(PREFERRED_AUTH_CONFIG)
-        if (preferredAuthConfig != null && preferredAuthConfig == PreferredAuthMethod.QR.value) {
+        preferredAuthMethod = multiValues.getString(PREFERRED_AUTH_CONFIG)
+        if (preferredAuthMethod == PreferredAuthMethod.QR.value) {
             isDeviceOnSdmQrPinAuth = true
         }
         isCameraConsentSuppressed = multiValues.getBoolean(SUPPRESS_CAMERA_CONSENT)
         Logger.info(
             TAG,
-            "isDeviceOnSdmQrPinAuth: $isDeviceOnSdmQrPinAuth, isCameraConsentSuppressed: $isCameraConsentSuppressed"
+            "preferredAuthMethod: $preferredAuthMethod," +
+                    " isCameraConsentSuppressed: $isCameraConsentSuppressed"
         )
-    }
-
-    /**
-     * This method checks if the SDM QR PIN manager needs to be updated.
-     * It checks if the last update time is more than 6 hours ago.
-     *
-     * @return true if the SDM QR PIN manager needs to be updated, false otherwise.
-     */
-    private fun needsUpdate(): Boolean {
-        val methodTag = "$TAG:needsUpdate"
-        val currentTime = System.currentTimeMillis() / 1000 // current time in seconds
-        return if (currentTime - lastUpdateTime >= SIX_HOURS_IN_SECONDS) {
-            Logger.info(methodTag, "SDM QR PIN manager needs update.")
-            lastUpdateTime = currentTime
-            true
-        } else {
-            Logger.info(methodTag, "Update skipped: less than 6 hours since last update.")
-            false
-        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -36,19 +36,27 @@ import com.microsoft.identity.common.logging.Logger
  */
 object SdmQrPinManager {
 
-    const val TAG = "SdmQrPinManager"
+    private const val TAG = "SdmQrPinManager"
+    private const val SIX_HOURS_IN_SECONDS = 21600L
 
     /**
      * This is a flag to indicate if the device is on SDM QR PIN mode.
      * If this is true, the device should prompt the user for camera consent.
      */
     var isDeviceOnSdmQrPinAuth = false
+        private set
 
     /**
      * This is a flag to indicate if the camera consent should be suppressed.
      * If this is true, the device should not prompt the user for camera consent.
      */
     var isCameraConsentSuppressed = false
+        private set
+
+    /**
+     * This variable is used to store the last update time of the SDM QR PIN manager.
+     */
+    private var lastUpdateTime: Long = 0L
 
     /**
      * This method initializes the SDM QR PIN manager by checking the broker restrictions manager.
@@ -60,19 +68,45 @@ object SdmQrPinManager {
      */
     fun initializeSdmQrPinManager(brokerRestrictionsManager: IBrokerRestrictionsManager) {
         Logger.info(TAG, "Initializing SDM QR PIN manager.")
-        val multiValueRequest  = buildMultiValueRequest(
+        if (!needsUpdate()) {
+            Logger.info(TAG, "SDM QR PIN manager is already initialized.")
+            return
+        }
+        val multiValueRequest = buildMultiValueRequest(
             booleanKeys = setOf(SUPPRESS_CAMERA_CONSENT),
             stringKeys = setOf(PREFERRED_AUTH_CONFIG)
         )
         val multiValues = brokerRestrictionsManager.getMultiValues(
-            brokerAppPackageName =  BrokerData.prodMicrosoftAuthenticator.packageName,
+            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
             bundleOfKeys = multiValueRequest
         )
-        val preferredAuthConfig  = multiValues.getString(PREFERRED_AUTH_CONFIG)
-        if (preferredAuthConfig  != null && preferredAuthConfig  == PreferredAuthMethod.QR.value) {
+        val preferredAuthConfig = multiValues.getString(PREFERRED_AUTH_CONFIG)
+        if (preferredAuthConfig != null && preferredAuthConfig == PreferredAuthMethod.QR.value) {
             isDeviceOnSdmQrPinAuth = true
         }
         isCameraConsentSuppressed = multiValues.getBoolean(SUPPRESS_CAMERA_CONSENT)
-        Logger.info(TAG, "isDeviceOnSdmQrPinAuth: $isDeviceOnSdmQrPinAuth, isCameraConsentSuppressed: $isCameraConsentSuppressed")
+        Logger.info(
+            TAG,
+            "isDeviceOnSdmQrPinAuth: $isDeviceOnSdmQrPinAuth, isCameraConsentSuppressed: $isCameraConsentSuppressed"
+        )
+    }
+
+    /**
+     * This method checks if the SDM QR PIN manager needs to be updated.
+     * It checks if the last update time is more than 6 hours ago.
+     *
+     * @return true if the SDM QR PIN manager needs to be updated, false otherwise.
+     */
+    private fun needsUpdate(): Boolean {
+        val methodTag = "$TAG:needsUpdate"
+        val currentTime = System.currentTimeMillis() / 1000 // current time in seconds
+        return if (currentTime - lastUpdateTime >= SIX_HOURS_IN_SECONDS) {
+            Logger.info(methodTag, "SDM QR PIN manager needs update.")
+            lastUpdateTime = currentTime
+            true
+        } else {
+            Logger.info(methodTag, "Update skipped: less than 6 hours since last update.")
+            false
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -42,16 +42,16 @@ object SdmQrPinManager {
 
     private const val TAG = "SdmQrPinManager"
 
-    private var brokerRestrictionsManager: IRestrictionsManager? = null
+    private var restrictionsManager: IRestrictionsManager? = null
 
     /**
      * This method is used to initialize the SDM QR PIN manager with the broker restrictions manager.
      * This is called when brokerAndroidBrokerPlatformComponentsFactory.create is called
      * to ensure the manager is initialized with the correct broker restrictions manager.
      */
-    fun initializeSdmQrPinManager(brokerRestrictionsManager: IRestrictionsManager) {
-        if (this.brokerRestrictionsManager == null) {
-            this.brokerRestrictionsManager = brokerRestrictionsManager
+    fun initializeSdmQrPinManager(restrictionsManager: IRestrictionsManager) {
+        if (this.restrictionsManager == null) {
+            this.restrictionsManager = restrictionsManager
         }
     }
 
@@ -59,15 +59,17 @@ object SdmQrPinManager {
      * This method checks if the device preferred authentication config is set.
      */
     fun getPreferredAuthConfig(): String? {
-        val methodTag = "$TAG:getPreferredAuthMethod"
+        val methodTag = "$TAG:getPreferredAuthConfig"
         val defaultValue = null
-        return brokerRestrictionsManager?.getString(
-            key = PREFERRED_AUTH_CONFIG,
-            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
-            defaultValue = defaultValue
-        ) ?: run {
+        restrictionsManager?.let { manager ->
+            return manager.getString(
+                key = PREFERRED_AUTH_CONFIG,
+                brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+                defaultValue = defaultValue
+            )
+        } ?: run {
             Logger.warn(methodTag, "Broker restrictions manager is not initialized.")
-            defaultValue
+            return defaultValue
         }
     }
 
@@ -77,13 +79,15 @@ object SdmQrPinManager {
     fun isCameraConsentSuppressed(): Boolean {
         val methodTag = "$TAG:isCameraConsentSuppressed"
         val defaultValue = false
-        return brokerRestrictionsManager?.getBoolean(
-            key = SUPPRESS_CAMERA_CONSENT,
-            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
-            defaultValue = defaultValue
-        ) ?: run {
+        restrictionsManager?.let { manager ->
+            return manager.getBoolean(
+                key = SUPPRESS_CAMERA_CONSENT,
+                brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+                defaultValue = defaultValue
+            )
+        } ?: run {
             Logger.warn(methodTag, "Broker restrictions manager is not initialized.")
-            defaultValue
+            return defaultValue
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -22,83 +22,68 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker
 
-import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.PREFERRED_AUTH_CONFIG
-import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.SUPPRESS_CAMERA_CONSENT
-import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.buildMultiValueRequest
-import com.microsoft.identity.common.java.ui.PreferredAuthMethod
+import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.PREFERRED_AUTH_CONFIG
+import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.SUPPRESS_CAMERA_CONSENT
 import com.microsoft.identity.common.logging.Logger
 
 /**
  * Manages the SDM QR PIN mode settings for the device.
  *
- * This object contains flags that indicate:
- * - Whether the device is currently in SDM QR PIN mode.
+ * This object contains functions to check"
  * - Whether camera consent should be suppressed.
  * - The preferred authentication method for the device.
  *
- * It is initialized each time `GetPreferredAuthMethodMsalBrokerOperation` is called,
- * since apps always contact the broker to get the preferred authentication method
- * before starting the QR + PIN authentication flow.
+ * It is initialized each time `brokerAndroidBrokerPlatformComponentsFactory.create` is called.
  *
- * Note: If this object is not initialized, both flags default to `false`,
+ * Note: If this object is not initialized, values default to `false` and `null`,
  * meaning the device is not in SDM QR PIN mode.
  */
 object SdmQrPinManager {
 
     private const val TAG = "SdmQrPinManager"
 
-    /**
-     * This is the preferred authentication method for the device on SDM mode.
-     * This is set in the Authenticator app, using app configuration policies for managed Android Enterprise devices.
-     */
-    var preferredAuthMethod: String? = null
+    private var brokerRestrictionsManager: IRestrictionsManager? = null
 
     /**
-     * This is a flag to indicate if the device is on SDM QR PIN mode.
-     * If this is true, the device should prompt the user for camera consent.
+     * This method is used to initialize the SDM QR PIN manager with the broker restrictions manager.
+     * This is called when brokerAndroidBrokerPlatformComponentsFactory.create is called
+     * to ensure the manager is initialized with the correct broker restrictions manager.
      */
-    var isDeviceOnSdmQrPinAuth = false
-        private set
-
-    /**
-     * This is a flag to indicate if the camera consent should be suppressed.
-     * If this is true, the device should not prompt the user for camera consent.
-     */
-    var isCameraConsentSuppressed = false
-        private set
-
-    /**
-     * This variable is used to store the last update time of the SDM QR PIN manager.
-     */
-    private var lastUpdateTime: Long = 0L
-
-    /**
-     * This method initializes the SDM QR PIN manager by checking the broker restrictions manager.
-     * It sets the [isDeviceOnSdmQrPinAuth], [preferredAuthMethod] and [isCameraConsentSuppressed] flags.
-     * This method is called each time `GetPreferredAuthMethodMsalBrokerOperation` is called,
-     * because the restrictions rarely change, only when a new policy is pushed to the device.
-     *
-     * @param brokerRestrictionsManager The broker restrictions manager to check the restrictions.
-     */
-    fun initializeSdmQrPinManager(brokerRestrictionsManager: IBrokerRestrictionsManager) {
-        Logger.info(TAG, "Initializing SDM QR PIN manager.")
-        val multiValueRequest = buildMultiValueRequest(
-            booleanKeys = setOf(SUPPRESS_CAMERA_CONSENT),
-            stringKeys = setOf(PREFERRED_AUTH_CONFIG)
-        )
-        val multiValues = brokerRestrictionsManager.getMultiValues(
-            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
-            bundleOfKeys = multiValueRequest
-        )
-        preferredAuthMethod = multiValues.getString(PREFERRED_AUTH_CONFIG)
-        if (preferredAuthMethod == PreferredAuthMethod.QR.value) {
-            isDeviceOnSdmQrPinAuth = true
+    fun initializeSdmQrPinManager(brokerRestrictionsManager: IRestrictionsManager) {
+        if (this.brokerRestrictionsManager == null) {
+            this.brokerRestrictionsManager = brokerRestrictionsManager
         }
-        isCameraConsentSuppressed = multiValues.getBoolean(SUPPRESS_CAMERA_CONSENT)
-        Logger.info(
-            TAG,
-            "preferredAuthMethod: $preferredAuthMethod," +
-                    " isCameraConsentSuppressed: $isCameraConsentSuppressed"
-        )
+    }
+
+    /**
+     * This method checks if the device preferred authentication config is set.
+     */
+    fun getPreferredAuthConfig(): String? {
+        val methodTag = "$TAG:getPreferredAuthMethod"
+        val defaultValue = null
+        return brokerRestrictionsManager?.getString(
+            key = PREFERRED_AUTH_CONFIG,
+            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+            defaultValue = defaultValue
+        ) ?: run {
+            Logger.warn(methodTag, "Broker restrictions manager is not initialized.")
+            defaultValue
+        }
+    }
+
+    /**
+     * This method checks if the camera consent is suppressed.
+     */
+    fun isCameraConsentSuppressed(): Boolean {
+        val methodTag = "$TAG:isCameraConsentSuppressed"
+        val defaultValue = false
+        return brokerRestrictionsManager?.getBoolean(
+            key = SUPPRESS_CAMERA_CONSENT,
+            brokerAppPackageName = BrokerData.prodMicrosoftAuthenticator.packageName,
+            defaultValue = defaultValue
+        ) ?: run {
+            Logger.warn(methodTag, "Broker restrictions manager is not initialized.")
+            defaultValue
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.broker
+
+import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.PREFERRED_AUTH_CONFIG
+import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.SUPPRESS_CAMERA_CONSENT
+import com.microsoft.identity.common.internal.broker.IBrokerRestrictionsManager.BrokerRestrictionsManagerKeys.buildMultiValueRequest
+import com.microsoft.identity.common.java.ui.PreferredAuthMethod
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * This object manages the SDM QR PIN mode for the device.
+ * It contains flags to indicate if the device is on SDM QR PIN mode and if the camera consent should be suppressed.
+ * This object is only initialized once in AndroidBrokerPlatformComponentsFactory
+ * if this is not initialized, the default values are false, as the device is not on SDM QR PIN mode.
+ */
+object SdmQrPinManager {
+
+    const val TAG = "SdmQrPinManager"
+
+    /**
+     * This is a flag to indicate if the device is on SDM QR PIN mode.
+     * If this is true, the device should prompt the user for camera consent.
+     */
+    var isDeviceOnSdmQrPinAuth = false
+
+    /**
+     * This is a flag to indicate if the camera consent should be suppressed.
+     * If this is true, the device should not prompt the user for camera consent.
+     */
+    var isCameraConsentSuppressed = false
+
+    /**
+     * This method initializes the SDM QR PIN manager by checking the broker restrictions manager.
+     * It sets the [isDeviceOnSdmQrPinAuth] and [isCameraConsentSuppressed] flags.
+     * This method should be called only in AndroidBrokerPlatformComponentsFactory.create
+     * because the restrictions rarely change, only when a new policy is pushed to the device.
+     *
+     * @param brokerRestrictionsManager The broker restrictions manager to check the restrictions.
+     */
+    fun initializeSdmQrPinManager(brokerRestrictionsManager: IBrokerRestrictionsManager) {
+        Logger.info(TAG, "Initializing SDM QR PIN manager.")
+        val multiValueRequest  = buildMultiValueRequest(
+            booleanKeys = setOf(SUPPRESS_CAMERA_CONSENT),
+            stringKeys = setOf(PREFERRED_AUTH_CONFIG)
+        )
+        val multiValues = brokerRestrictionsManager.getMultiValues(
+            brokerAppPackageName =  BrokerData.prodMicrosoftAuthenticator.packageName,
+            bundleOfKeys = multiValueRequest
+        )
+        val preferredAuthConfig  = multiValues.getString(PREFERRED_AUTH_CONFIG)
+        if (preferredAuthConfig  != null && preferredAuthConfig  == PreferredAuthMethod.QR.value) {
+            isDeviceOnSdmQrPinAuth = true
+        }
+        isCameraConsentSuppressed = multiValues.getBoolean(SUPPRESS_CAMERA_CONSENT)
+        Logger.info(TAG, "isDeviceOnSdmQrPinAuth: $isDeviceOnSdmQrPinAuth, isCameraConsentSuppressed: $isCameraConsentSuppressed")
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
@@ -32,6 +32,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import com.microsoft.identity.common.R
 import com.microsoft.identity.common.internal.broker.SdmQrPinManager
+import com.microsoft.identity.common.java.ui.PreferredAuthMethod
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -157,7 +158,7 @@ class CameraPermissionRequestHandler(fragment: WebViewAuthorizationFragment) {
     private fun isQrPinRequest() : Boolean {
         return currentPermissionRequest?.origin != null
                 && MICROSOFT_CLOUD_URL.equals(currentPermissionRequest?.origin.toString(), ignoreCase = true)
-                && SdmQrPinManager.isDeviceOnSdmQrPinAuth
+                && PreferredAuthMethod.QR.value.equals(SdmQrPinManager.getPreferredAuthConfig())
     }
 
     /**
@@ -185,7 +186,7 @@ class CameraPermissionRequestHandler(fragment: WebViewAuthorizationFragment) {
         val  methodTag = "$TAG:handleQrPin"
         if (appHasCameraPermission(context)) {
             Logger.info(methodTag, "App level camera permission already granted.")
-            if (SdmQrPinManager.isCameraConsentSuppressed) {
+            if (SdmQrPinManager.isCameraConsentSuppressed()) {
                 Logger.info(methodTag, "Camera consent suppress is enabled.")
                 grant()
             } else {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
@@ -124,7 +124,7 @@ class CameraPermissionRequestHandler(fragment: WebViewAuthorizationFragment) {
      * To avoid unintentionally granting requests for not defined permissions
      */
     private fun isValid(request: PermissionRequest): Boolean {
-        val methodTag = "$TAG:setIfValid"
+        val methodTag = "$TAG:isValid"
         if (!isForCamera(request)) {
             Logger.warn(methodTag, "Permission request is not for camera.")
             request.deny()
@@ -214,7 +214,7 @@ class CameraPermissionRequestHandler(fragment: WebViewAuthorizationFragment) {
      * If the user denies the dialog, the camera permission request will be denied.
      */
     private fun showQrPinCameraRationale(context: Context) {
-        val methodTag = "$TAG:showCameraRationale"
+        val methodTag = "$TAG:showQrPinCameraRationale"
         val builder = AlertDialog.Builder(context)
         builder.setMessage(R.string.qr_code_rationale_message)
             .setTitle(R.string.qr_code_rationale_header)

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CameraPermissionRequestHandler.kt
@@ -22,7 +22,16 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2
 
+import android.Manifest
+import android.app.AlertDialog
+import android.content.Context
+import android.content.pm.PackageManager
 import android.webkit.PermissionRequest
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import com.microsoft.identity.common.R
+import com.microsoft.identity.common.internal.broker.SdmQrPinManager
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -30,25 +39,62 @@ import com.microsoft.identity.common.logging.Logger
  * Note: This class is compatible only with API level 21 and above;
  * functionality will not behave as expected on lower versions.
  */
-class CameraPermissionRequestHandler {
+class CameraPermissionRequestHandler(fragment: WebViewAuthorizationFragment) {
+
+    private companion object {
+        private const val TAG = "CameraPermissionRequestHandler"
+        private const val MICROSOFT_CLOUD_URL: String = "https://login.microsoftonline.com/"
+        private val cameraResource = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+    }
+
+    private val activityResultLauncher: ActivityResultLauncher<String> =
+        fragment.registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            permissionGranted: Boolean ->
+            Logger.info(TAG, "Camera permission granted: $permissionGranted")
+            if (permissionGranted) {
+                grant()
+            } else {
+                deny()
+            }
+        }
 
     private var currentPermissionRequest : PermissionRequest? = null
 
     /**
-     * Check if the permission was granted.
-     *
-     * @return true if the permission is granted.
+     * Keeps track of the camera permission request state.
      */
     private var isGranted = false
 
     /**
+     * Handles the camera permission request.
+     * <p>
+     * If the request is valid, it will be handled by the qrPinHandler or defaultHandler.
+     * If the request is not valid, it will be denied.
+     *
+     * @param request The permission request to handle.
+     */
+    fun handle(request: PermissionRequest, context: Context) {
+        val  methodTag = "$TAG:handle"
+        // Check if the request is valid.
+        if (isValid(request)) {
+            currentPermissionRequest = request
+            isGranted = false
+        } else {
+            Logger.warn(methodTag, "Permission request is not valid, returning.")
+            return
+        }
+        if(isQrPinRequest()) {
+            qrPinHandler(context)
+        } else {
+            defaultHandler(context)
+        }
+    }
+
+    /**
      * Call this method to grant the permission to access the camera resource.
      * The granted permission is only valid for the current WebView.
-     *
-     *
-     * Note: This method is only available on API level 21 or higher.
      */
-    fun grant() {
+    private fun grant() {
         currentPermissionRequest?.let {
             it.grant(cameraResource)
             isGranted = true
@@ -57,11 +103,8 @@ class CameraPermissionRequestHandler {
 
     /**
      * Call this method to deny the permission to access the camera resource.
-     *
-     *
-     * Note: This method is only available on API level 21 or higher.
      */
-    fun deny() {
+    private fun deny() {
         currentPermissionRequest?.let {
             it.deny()
             isGranted = false
@@ -70,15 +113,16 @@ class CameraPermissionRequestHandler {
 
     /**
      * Check if the given [PermissionRequest] is valid.
-     * If valid, set the current permission request and return true.
+     * If valid return true.
      * If not valid, deny the request and return false.
      * <p>
      * A request is considered valid if:
      * - The request is for the camera resource only.
      * - The request is not a repeated request (i.e., not for the same origin and resources).
-     *
+     * We can only grant or deny permissions for video capture/camera.
+     * To avoid unintentionally granting requests for not defined permissions
      */
-    fun setIfValid(request: PermissionRequest): Boolean {
+    private fun isValid(request: PermissionRequest): Boolean {
         val methodTag = "$TAG:setIfValid"
         if (!isForCamera(request)) {
             Logger.warn(methodTag, "Permission request is not for camera.")
@@ -97,19 +141,92 @@ class CameraPermissionRequestHandler {
             return false
         } else {
             Logger.info(methodTag, "Valid new request.")
-            setCurrentPermissionRequest(request)
             return true
         }
     }
 
     /**
-     * Set the current permission request.
+     * Check if the current permission request is a QR code pin request.
+     * <p>
+     * A request is considered a QR code pin request if:
+     * - The origin of the request is the Microsoft cloud URL.
+     * - The device is on SDM QR pin mode.
      *
-     * @param permissionRequest The permission request to set.
+     * @return true if the current permission request is a QR code pin request, false otherwise.
      */
-    private fun setCurrentPermissionRequest(permissionRequest: PermissionRequest) {
-        currentPermissionRequest = permissionRequest
-        isGranted = false
+    private fun isQrPinRequest() : Boolean {
+        return currentPermissionRequest?.origin != null
+                && MICROSOFT_CLOUD_URL.equals(currentPermissionRequest?.origin.toString(), ignoreCase = true)
+                && SdmQrPinManager.isDeviceOnSdmQrPinAuth
+    }
+
+    /**
+     * Handles the camera permission request for the app.
+     * If the camera permission is already granted, it will grant the permission.
+     * Otherwise, it will request the camera permission.
+     */
+    private fun defaultHandler(context: Context) {
+        val methodTag = "$TAG:defaultHandler"
+        if (appHasCameraPermission(context)) {
+            Logger.info(methodTag, "App level camera permission already granted, silent grant.")
+            grant()
+        } else {
+            requestCameraPermission()
+        }
+    }
+
+    /**
+     * Handles the camera permission request for QR code scanning.
+     * If the camera permission is already granted and the camera consent suppress is enabled,
+     * it will grant the permission. otherwise, it will explaining why the camera permission is required.
+     * If the camera permission is not granted, it will request the camera permission.
+     */
+    private fun qrPinHandler(context: Context) {
+        val  methodTag = "$TAG:handleQrPin"
+        if (appHasCameraPermission(context)) {
+            Logger.info(methodTag, "App level camera permission already granted.")
+            if (SdmQrPinManager.isCameraConsentSuppressed) {
+                Logger.info(methodTag, "Camera consent suppress is enabled.")
+                grant()
+            } else {
+                Logger.info(methodTag, "Camera consent suppress is not enabled.")
+                showQrPinCameraRationale(context)
+            }
+        } else {
+            requestCameraPermission()
+        }
+    }
+
+    /**
+     * Determines whatever if the camera permission has been granted.
+     *
+     * @return true if the camera permission has been granted, false otherwise.
+     */
+    private fun appHasCameraPermission(context: Context): Boolean {
+        return (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+                == PackageManager.PERMISSION_GRANTED)
+    }
+
+    /**
+     * Shows a dialog to the user explaining why the camera permission is required.
+     * If the user accepts the dialog, the camera permission request will be launched.
+     * If the user denies the dialog, the camera permission request will be denied.
+     */
+    private fun showQrPinCameraRationale(context: Context) {
+        val methodTag = "$TAG:showCameraRationale"
+        val builder = AlertDialog.Builder(context)
+        builder.setMessage(R.string.qr_code_rationale_message)
+            .setTitle(R.string.qr_code_rationale_header)
+            .setCancelable(false)
+            .setPositiveButton(R.string.qr_code_rationale_allow) { _, _ ->
+                Logger.info(methodTag, "User accepted camera permission rationale.")
+                requestCameraPermission()
+            }
+            .setNegativeButton(R.string.qr_code_rationale_block) { _, _ ->
+                Logger.info(methodTag, "User denied camera permission rationale.")
+                deny()
+            }
+        builder.show()
     }
 
     /**
@@ -154,10 +271,14 @@ class CameraPermissionRequestHandler {
                 PermissionRequest.RESOURCE_VIDEO_CAPTURE == request.resources[0]
     }
 
-    companion object {
-        private const val TAG = "CameraPermissionRequestHandler"
-        private val cameraResource = arrayOf(
-            PermissionRequest.RESOURCE_VIDEO_CAPTURE
-        )
+    /**
+     * Launches the camera permission request for the app.
+     * Note: if the permission was already granted or denied,
+     * the user will not be prompted and it will go directly to the callback.
+     * Using the current state of the permission.
+     *
+     */
+    private fun requestCameraPermission() {
+        activityResultLauncher.launch(Manifest.permission.CAMERA)
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -22,12 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Bundle;
@@ -42,11 +39,9 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import com.microsoft.identity.common.R;
@@ -96,7 +91,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     @VisibleForTesting
     private static final String PKEYAUTH_STATUS = "pkeyAuthStatus";
-    private static final String MICROSOFT_CLOUD_URL = "https://login.microsoftonline.com/";
 
     private WebView mWebView;
 
@@ -121,7 +115,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private boolean webViewZoomEnabled;
 
-    private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler();
+    private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
 
     // This is used by LegacyFido2ApiManager to launch a PendingIntent received by the legacy API.
     private ActivityResultLauncher<LegacyFido2ApiObject> mFidoLauncher;
@@ -240,7 +234,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 new OnPageLoadedCallback() {
                     @Override
                     public void onPageLoaded(final String url) {
-                        // Reset the camera permission request when a new page is loaded.
                         final String[] javascriptToExecute = new String[1];
                         mProgressBar.setVisibility(View.INVISIBLE);
                         try {
@@ -326,29 +319,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                             "Permission requested from:" +request.getOrigin() +
                                     " for resources:" + Arrays.toString(request.getResources())
                     );
-                    // We can only grant or deny permissions for video capture/camera.
-                    // To avoid unintentionally granting requests for not defined permissions
-                    // we check if the request is for camera.
-                    if (!mCameraPermissionRequestHandler.setIfValid(request)) {
-                        Logger.warn(methodTag, "Permission request is not valid, returning.");
-                        return;
-                    }
-
-                    // If the OS level permission was granted previously,
-                    // we show the rationale to confirm the consent with the current user.
-                    // Otherwise, show the system prompt.
-                    if (isAppCameraPermissionGranted()) {
-                        Logger.info(methodTag, "App level camera permission already granted.");
-                        if(request.getOrigin() != null &&  MICROSOFT_CLOUD_URL.equalsIgnoreCase(request.getOrigin().toString())) {
-                            Logger.info(methodTag, "Require rationale.");
-                            showCameraRationale();
-                        } else {
-                            Logger.info(methodTag, "Rationale not needed.");
-                            mCameraPermissionRequestHandler.grant();
-                        }
-                    } else {
-                        requestCameraPermission();
-                    }
+                    mCameraPermissionRequestHandler.handle(request, requireContext());
                 });
             }
 
@@ -362,62 +333,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 return Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
             }
         });
-    }
-
-    /**
-     * Determines whatever if the camera permission has been granted.
-     *
-     * @return true if the camera permission has been granted, false otherwise.
-     */
-    private boolean isAppCameraPermissionGranted() {
-        return ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
-                == PackageManager.PERMISSION_GRANTED;
-    }
-
-    private final ActivityResultLauncher<String> cameraRequestActivity = registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(),
-            permissionGranted   -> {
-                Logger.info(TAG, "Camera permission granted: " + permissionGranted);
-                if (permissionGranted) {
-                    mCameraPermissionRequestHandler.grant();
-                }
-                else {
-                    mCameraPermissionRequestHandler.deny();
-                }
-            }
-    );
-
-    /**
-     * Launches the camera permission request for the app.
-     * Note: if the permission was already granted or denied,
-     * the user will not be prompted and it will go directly to the callback.
-     * Using the current state of the permission.
-     *
-     */
-    private void requestCameraPermission() {
-        cameraRequestActivity.launch(Manifest.permission.CAMERA);
-    }
-
-    /**
-     * Shows a dialog to the user explaining why the camera permission is required.
-     * If the user accepts the dialog, the camera permission request will be launched.
-     * If the user denies the dialog, the camera permission request will be denied.
-     */
-    private void showCameraRationale() {
-        final String methodTag = TAG + ":showCameraRationale";
-        final AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
-        builder.setMessage(R.string.qr_code_rationale_message)
-                .setTitle(R.string.qr_code_rationale_header)
-                .setCancelable(false)
-                .setPositiveButton(R.string.qr_code_rationale_allow, (dialog, id) -> {
-                    Logger.info(methodTag, "User accepted camera permission rationale.");
-                    requestCameraPermission();
-                })
-                .setNegativeButton(R.string.qr_code_rationale_block, (dialog, id) -> {
-                    Logger.info(methodTag, "User denied camera permission rationale.");
-                    mCameraPermissionRequestHandler.deny();
-                });
-        builder.show();
     }
 
     /**


### PR DESCRIPTION
- Move IBrokerRestrictionsManager.kt from broker to common
- Add SdmQrPinManager 
- Move camera consent code from WebViewAuthorizationFragment.java to CameraPermissionRequestHandler.kt
- Camera logic change: previously we show camera QR PIN consent dialog if request origin is from MS, otherwise we use default behavior. Now we use the SdmQrPinManager to determine if we should show the camera QR PIN consent dialog.  (see:  CameraPermissionRequestHandler.handle(request: PermissionRequest, context: Context)

Related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/3089

Run manual UI test for validation https://identitydivision.visualstudio.com/Engineering/_testPlans/execute?planId=2007357&suiteId=2810290

[AB#3121976](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3121976)
 