### PR TITLE
DUNA. Prevent phish attack in “switch_browser” flow. , Fixes AB#3250169

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Adding a state parameter to prevent phish attacks, in “switch_browser” flow. (#2631)
 - [MINOR] Pass Work Profile existence, OS Version, and Manufacturer to ESTS (#2627)
 - [MINOR] Add telemetry for the switch browser protocol (#2612)
 

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -560,6 +560,10 @@ public final class AuthenticationConstants {
          */
         public static final String ACTION_URI = "action_uri";
 
+        /**
+         * String Query parameter key for the state blob.
+         */
+        public static final String STATE = "state";
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -184,6 +184,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         try {
             Logger.info(methodTag, "Resuming switch browser flow");
             getSwitchBrowserCoordinator().processSwitchBrowserResume(
+                    mAuthorizationRequestUrl,
                     extras,
                     (switchBrowserResumeUri, switchBrowserResumeHeaders) -> {
                         launchWebView(switchBrowserResumeUri.toString(), switchBrowserResumeHeaders);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -390,7 +390,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodTag = TAG + ":processSwitchBrowserRequest";
         try {
             mSwitchBrowserRequestHandler.processChallenge(
-                    SwitchBrowserChallenge.constructFromRedirectUrl(url)
+                    SwitchBrowserChallenge.constructFromRedirectUrl(url, mRequestUrl)
             );
         } catch (final Throwable throwable) {
             Logger.error(methodTag, "Switch browser challenge could not be processed.", throwable);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserChallenge.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserChallenge.kt
@@ -30,7 +30,8 @@ import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBro
  * It contains the URI to be opened in the new browser.
  */
 data class SwitchBrowserChallenge(
-    val uri: Uri,
+    val processUri: Uri,
+    val authorizationUrl: String
 ) {
 
     companion object {
@@ -46,10 +47,13 @@ data class SwitchBrowserChallenge(
          */
         @JvmStatic
         @Throws(Exception::class)
-        fun constructFromRedirectUrl(redirectUrl: String): SwitchBrowserChallenge {
+        fun constructFromRedirectUrl(redirectUrl: String, authorizationUrl: String): SwitchBrowserChallenge {
             Uri.parse(redirectUrl).let { redirectUri ->
                 SwitchBrowserUriHelper.buildProcessUri(redirectUri).let { processUri ->
-                    return SwitchBrowserChallenge(uri = processUri)
+                    return SwitchBrowserChallenge(
+                        processUri = processUri,
+                        authorizationUrl = authorizationUrl
+                    )
                 }
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandler.kt
@@ -28,6 +28,7 @@ import android.content.Intent
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
 import com.microsoft.identity.common.internal.ui.browser.AndroidBrowserSelector
 import com.microsoft.identity.common.internal.ui.browser.CustomTabsManager
+import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper
 import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper.isSwitchBrowserRedirectUrl
 import com.microsoft.identity.common.java.browser.IBrowserSelector
 import com.microsoft.identity.common.java.exception.ClientException
@@ -83,6 +84,9 @@ class SwitchBrowserRequestHandler(
     override fun processChallenge(switchBrowserChallenge: SwitchBrowserChallenge) {
         SpanExtension.makeCurrentSpan(span).use {
             val methodTag = "$TAG:processChallenge"
+            
+            val state = switchBrowserChallenge.processUri.getQueryParameter(SWITCH_BROWSER.STATE)
+            SwitchBrowserUriHelper.statesMatch(switchBrowserChallenge.authorizationUrl, state)
 
             // Select a browser to handle the switch browser challenge
             val browser = browserSelector.selectBrowser(
@@ -125,7 +129,7 @@ class SwitchBrowserRequestHandler(
                 "Launching switch browser request on browser: ${browser.packageName}"
             )
             browserIntent.setPackage(browser.packageName)
-            browserIntent.setData(switchBrowserChallenge.uri)
+            browserIntent.setData(switchBrowserChallenge.processUri)
             activity.startActivity(browserIntent)
             isChallengeHandled = true
             span.setAttribute(

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
@@ -37,7 +37,6 @@ import com.microsoft.identity.common.java.opentelemetry.AttributeName
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.SpanName
-import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest
 import com.microsoft.identity.common.java.ui.AuthorizationAgent
 import com.microsoft.identity.common.logging.Logger
 import io.opentelemetry.api.trace.Span
@@ -121,12 +120,11 @@ class SwitchBrowserProtocolCoordinator(
             val actionUri = extras.getString(SWITCH_BROWSER.ACTION_URI)
             val code = extras.getString(SWITCH_BROWSER.CODE)
             val state = extras.getString(SWITCH_BROWSER.STATE)
-            if (actionUri.isNullOrEmpty() || code.isNullOrEmpty() || state.isNullOrEmpty()) {
+            if (actionUri.isNullOrEmpty() || code.isNullOrEmpty()) {
                 val clientException = ClientException(
                     ClientException.MISSING_PARAMETER,
                     "Action URI is null/empty: ${actionUri.isNullOrEmpty()}," +
-                            " code is null/empty: ${code.isNullOrEmpty()}," +
-                            " state is null/empty: ${state.isNullOrEmpty()}"
+                            " code is null/empty: ${code.isNullOrEmpty()}."
                 )
                 span.setStatus(StatusCode.ERROR)
                 span.recordException(clientException)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
@@ -31,14 +31,13 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants.Autho
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
 import com.microsoft.identity.common.internal.providers.oauth2.BrokerAuthorizationActivity
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler
-import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper.buildResumeUri
-import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper.isSwitchBrowserRedirectUrl
 import com.microsoft.identity.common.java.AuthenticationConstants.AAD.AUTHORIZATION
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.opentelemetry.AttributeName
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.SpanName
+import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest
 import com.microsoft.identity.common.java.ui.AuthorizationAgent
 import com.microsoft.identity.common.logging.Logger
 import io.opentelemetry.api.trace.Span
@@ -69,7 +68,7 @@ class SwitchBrowserProtocolCoordinator(
          * Returns `true` if the URL matches the expected pattern, `false` otherwise.
          */
         fun isSwitchBrowserResume(url: String?, redirectUrl: String): Boolean {
-            return isSwitchBrowserRedirectUrl(url, redirectUrl, SWITCH_BROWSER.RESUME_PATH)
+            return SwitchBrowserUriHelper.isSwitchBrowserRedirectUrl(url, redirectUrl, SWITCH_BROWSER.RESUME_PATH)
         }
 
         /**
@@ -94,6 +93,10 @@ class SwitchBrowserProtocolCoordinator(
                 SWITCH_BROWSER.CODE,
                 uri.getQueryParameter(SWITCH_BROWSER.CODE)
             )
+            intent.putExtra(
+                SWITCH_BROWSER.STATE,
+                uri.getQueryParameter(SWITCH_BROWSER.STATE)
+            )
             return intent
         }
     }
@@ -109,6 +112,7 @@ class SwitchBrowserProtocolCoordinator(
      */
     @Throws(ClientException::class)
     fun processSwitchBrowserResume(
+        authorizationRequest: String,
         extras: Bundle,
         onSuccessAction: (Uri, HashMap<String, String>) -> Unit
     ) {
@@ -116,17 +120,22 @@ class SwitchBrowserProtocolCoordinator(
             val methodTag = "$TAG:processSwitchBrowserResume"
             val actionUri = extras.getString(SWITCH_BROWSER.ACTION_URI)
             val code = extras.getString(SWITCH_BROWSER.CODE)
-            if (actionUri.isNullOrEmpty() || code.isNullOrEmpty()) {
+            val state = extras.getString(SWITCH_BROWSER.STATE)
+            if (actionUri.isNullOrEmpty() || code.isNullOrEmpty() || state.isNullOrEmpty()) {
                 val clientException = ClientException(
                     ClientException.MISSING_PARAMETER,
-                    "Action URI is null/empty: ${actionUri == null}, code is null/empty: ${code == null}"
+                    "Action URI is null/empty: ${actionUri.isNullOrEmpty()}," +
+                            " code is null/empty: ${code.isNullOrEmpty()}," +
+                            " state is null/empty: ${state.isNullOrEmpty()}"
                 )
                 span.setStatus(StatusCode.ERROR)
                 span.recordException(clientException)
                 span.end()
                 throw clientException
             }
-            val resumeUri = buildResumeUri(actionUri)
+            SwitchBrowserUriHelper.statesMatch(authorizationRequest, state)
+            // Validate the state from auth request and redirect URL is the same
+            val resumeUri = SwitchBrowserUriHelper.buildResumeUri(actionUri, state)
             val headers = hashMapOf(AUTHORIZATION to code)
             onSuccessAction(resumeUri, headers)
             // Reset the challenge state after processing the resume action

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
@@ -25,6 +25,8 @@ package com.microsoft.identity.common.internal.ui.webview.switchbrowser
 import android.net.Uri
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
 import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.flighting.CommonFlight
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.logging.Logger
 import io.opentelemetry.api.trace.StatusCode
@@ -35,6 +37,13 @@ import io.opentelemetry.api.trace.StatusCode
 object SwitchBrowserUriHelper {
 
     private const val TAG = "SwitchBrowserUriHelper"
+
+    internal val STATE_VALIDATION_REQUIRED: Boolean by lazy {
+        CommonFlightsManager
+            .getFlightsProvider()
+            .isFlightEnabled(CommonFlight.SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE)
+    }
+
 
     /**
      * Build the process uri for the switch browser challenge.
@@ -70,20 +79,24 @@ object SwitchBrowserUriHelper {
             Logger.error(methodTag, errorMessage, exception)
             throw exception
         }
-        val state = uri.getQueryParameter(
-            SWITCH_BROWSER.STATE
-        )
-        if (state.isNullOrEmpty()) {
-            // This should never happen, but if it does, we should log it and throw.
-            val errorMessage = "switch browser action state is null or empty"
-            val exception = ClientException(ClientException.MALFORMED_URL, errorMessage)
-            Logger.error(methodTag, errorMessage, exception)
-            throw exception
-        }
+
         // Query parameters for the process uri.
         val queryParams = hashMapOf<String, String>()
         queryParams[SWITCH_BROWSER.CODE] = code
-        queryParams[SWITCH_BROWSER.STATE] = state
+        if (STATE_VALIDATION_REQUIRED) {
+            val state = uri.getQueryParameter(
+                SWITCH_BROWSER.STATE
+            )
+            if (state.isNullOrEmpty()) {
+                // This should never happen, but if it does, we should log it and throw.
+                val errorMessage = "switch browser action state is null or empty"
+                val exception = ClientException(ClientException.MALFORMED_URL, errorMessage)
+                Logger.error(methodTag, errorMessage, exception)
+                throw exception
+            } else {
+                queryParams[SWITCH_BROWSER.STATE] = state
+            }
+        }
         // Construct the uri to the process endpoint.
         return buildSwitchBrowserUri(actionUri, queryParams)
     }
@@ -97,9 +110,21 @@ object SwitchBrowserUriHelper {
      * @return The resume uri constructed from the bundle.
      * e.g. actionUri
      */
-    fun buildResumeUri(actionUri: String, state: String): Uri {
+    fun buildResumeUri(actionUri: String, state: String?): Uri {
+        val methodTag = "$TAG:buildResumeUri"
         // Construct the uri to the resume endpoint.
-        val queryParams = hashMapOf(SWITCH_BROWSER.STATE to state)
+        val queryParams = hashMapOf<String, String>()
+        if (STATE_VALIDATION_REQUIRED) {
+            if (state.isNullOrEmpty()) {
+                // This should never happen, but if it does, we should log it and throw.
+                val errorMessage = "State is null or empty"
+                val exception = ClientException(ClientException.MISSING_PARAMETER, errorMessage)
+                Logger.error(methodTag, errorMessage, exception)
+                throw exception
+            } else {
+                queryParams[SWITCH_BROWSER.STATE] = state
+            }
+        }
         return buildSwitchBrowserUri(actionUri, queryParams)
     }
 
@@ -126,10 +151,15 @@ object SwitchBrowserUriHelper {
      * Check if state in the auth request matches the state provided.
      */
     fun statesMatch(authorizationUrl: String, state: String?) {
+        val methodTag = "$TAG:statesMatch"
+        if (!STATE_VALIDATION_REQUIRED) {
+            Logger.info(methodTag, "State validation is not required.")
+            return
+        }
         val span = SpanExtension.current()
         // Validate the state from auth request and redirect URL is the same
         if (state.isNullOrEmpty()) {
-             val clientException = ClientException(
+            val clientException = ClientException(
                 ClientException.STATE_MISMATCH,
                 "State is null."
             )
@@ -139,6 +169,16 @@ object SwitchBrowserUriHelper {
             throw clientException
         }
         val authRequestState = Uri.parse(authorizationUrl).getQueryParameter(SWITCH_BROWSER.STATE)
+        if (authRequestState.isNullOrEmpty()) {
+            val clientException = ClientException(
+                ClientException.STATE_MISMATCH,
+                "Authorization request state is null."
+            )
+            span.setStatus(StatusCode.ERROR)
+            span.recordException(clientException)
+            span.end()
+            throw clientException
+        }
         if (state != authRequestState) {
             val clientException = ClientException(
                 ClientException.STATE_MISMATCH,
@@ -149,6 +189,7 @@ object SwitchBrowserUriHelper {
             span.end()
             throw clientException
         }
+        Logger.info(methodTag, "States match.")
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
@@ -79,24 +79,13 @@ object SwitchBrowserUriHelper {
             Logger.error(methodTag, errorMessage, exception)
             throw exception
         }
-
+        val state = uri.getQueryParameter(
+            SWITCH_BROWSER.STATE
+        )
         // Query parameters for the process uri.
         val queryParams = hashMapOf<String, String>()
         queryParams[SWITCH_BROWSER.CODE] = code
-        if (STATE_VALIDATION_REQUIRED) {
-            val state = uri.getQueryParameter(
-                SWITCH_BROWSER.STATE
-            )
-            if (state.isNullOrEmpty()) {
-                // This should never happen, but if it does, we should log it and throw.
-                val errorMessage = "switch browser action state is null or empty"
-                val exception = ClientException(ClientException.MALFORMED_URL, errorMessage)
-                Logger.error(methodTag, errorMessage, exception)
-                throw exception
-            } else {
-                queryParams[SWITCH_BROWSER.STATE] = state
-            }
-        }
+        addStateToQueryParams(queryParams, state, methodTag)
         // Construct the uri to the process endpoint.
         return buildSwitchBrowserUri(actionUri, queryParams)
     }
@@ -114,17 +103,7 @@ object SwitchBrowserUriHelper {
         val methodTag = "$TAG:buildResumeUri"
         // Construct the uri to the resume endpoint.
         val queryParams = hashMapOf<String, String>()
-        if (STATE_VALIDATION_REQUIRED) {
-            if (state.isNullOrEmpty()) {
-                // This should never happen, but if it does, we should log it and throw.
-                val errorMessage = "State is null or empty"
-                val exception = ClientException(ClientException.MISSING_PARAMETER, errorMessage)
-                Logger.error(methodTag, errorMessage, exception)
-                throw exception
-            } else {
-                queryParams[SWITCH_BROWSER.STATE] = state
-            }
-        }
+        addStateToQueryParams(queryParams, state, methodTag)
         return buildSwitchBrowserUri(actionUri, queryParams)
     }
 
@@ -190,6 +169,25 @@ object SwitchBrowserUriHelper {
             throw clientException
         }
         Logger.info(methodTag, "States match.")
+    }
+
+    /**
+     * Add state to the query parameters If STATE_VALIDATION_REQUIRED is enabled.
+     * If STATE_VALIDATION_REQUIRED is disabled, this method does nothing.
+     * If STATE_VALIDATION_REQUIRED is enabled and state is null or empty, this method throws an exception.
+     */
+    private fun addStateToQueryParams(queryParams: HashMap<String, String>, state: String?, methodTag: String) {
+        if (STATE_VALIDATION_REQUIRED) {
+            if (state.isNullOrEmpty()) {
+                // This should never happen, but if it does, we should log it and throw.
+                val errorMessage = "State is null or empty"
+                val exception = ClientException(ClientException.MISSING_PARAMETER, errorMessage)
+                Logger.error(methodTag, errorMessage, exception)
+                throw exception
+            } else {
+                queryParams[SWITCH_BROWSER.STATE] = state
+            }
+        }
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
@@ -24,9 +24,10 @@ package com.microsoft.identity.common.internal.ui.webview.switchbrowser
 
 import android.net.Uri
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
-import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2
 import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.logging.Logger
+import io.opentelemetry.api.trace.StatusCode
 
 /**
  * SwitchBrowserUriHelper is a helper class to build URIs for the switch browser challenge.
@@ -69,11 +70,85 @@ object SwitchBrowserUriHelper {
             Logger.error(methodTag, errorMessage, exception)
             throw exception
         }
+        val state = uri.getQueryParameter(
+            SWITCH_BROWSER.STATE
+        )
+        if (state.isNullOrEmpty()) {
+            // This should never happen, but if it does, we should log it and throw.
+            val errorMessage = "switch browser action state is null or empty"
+            val exception = ClientException(ClientException.MALFORMED_URL, errorMessage)
+            Logger.error(methodTag, errorMessage, exception)
+            throw exception
+        }
         // Query parameters for the process uri.
         val queryParams = hashMapOf<String, String>()
         queryParams[SWITCH_BROWSER.CODE] = code
+        queryParams[SWITCH_BROWSER.STATE] = state
         // Construct the uri to the process endpoint.
         return buildSwitchBrowserUri(actionUri, queryParams)
+    }
+
+    /**
+     * Build the resume uri for the switch browser challenge.
+     *
+     * @param actionUri The action uri to be opened.
+     * @param state The state to be included in the switch browser uri.
+     *
+     * @return The resume uri constructed from the bundle.
+     * e.g. actionUri
+     */
+    fun buildResumeUri(actionUri: String, state: String): Uri {
+        // Construct the uri to the resume endpoint.
+        val queryParams = hashMapOf(SWITCH_BROWSER.STATE to state)
+        return buildSwitchBrowserUri(actionUri, queryParams)
+    }
+
+    /**
+     * Check if the url is a switch browser redirect url
+     *
+     * The request is considered "switch_browser" if the URL
+     * starts with the following pattern: {redirectUrl}/{switchBrowserPath}
+     *
+     * @param url The URL to be checked.
+     * @param redirectUrl The redirect URL to be checked against.
+     * @param switchBrowserPath The path to be checked against.
+     * @return True if the request matches the pattern, false otherwise.
+     */
+    fun isSwitchBrowserRedirectUrl(url: String?, redirectUrl: String, switchBrowserPath: String): Boolean {
+        if (url == null) {
+            return false
+        }
+        val expectedUrl = "$redirectUrl/$switchBrowserPath"
+        return url.startsWith(expectedUrl, ignoreCase = true)
+    }
+
+    /**
+     * Check if state in the auth request matches the state provided.
+     */
+    fun statesMatch(authorizationUrl: String, state: String?) {
+        val span = SpanExtension.current()
+        // Validate the state from auth request and redirect URL is the same
+        if (state.isNullOrEmpty()) {
+             val clientException = ClientException(
+                ClientException.STATE_MISMATCH,
+                "State is null."
+            )
+            span.setStatus(StatusCode.ERROR)
+            span.recordException(clientException)
+            span.end()
+            throw clientException
+        }
+        val authRequestState = Uri.parse(authorizationUrl).getQueryParameter(SWITCH_BROWSER.STATE)
+        if (state != authRequestState) {
+            val clientException = ClientException(
+                ClientException.STATE_MISMATCH,
+                "State does not match with the auth request state."
+            )
+            span.setStatus(StatusCode.ERROR)
+            span.recordException(clientException)
+            span.end()
+            throw clientException
+        }
     }
 
     /**
@@ -101,37 +176,5 @@ object SwitchBrowserUriHelper {
             uriBuilder.appendQueryParameter(key, value)
         }
         return uriBuilder.build()
-    }
-
-    /**
-     * Build the resume uri for the switch browser challenge.
-     *
-     * @param actionUri The action uri to be opened.
-     *
-     * @return The resume uri constructed from the bundle.
-     * e.g. actionUri
-     */
-    fun buildResumeUri(actionUri: String): Uri {
-        // Construct the uri to the resume endpoint.
-        return buildSwitchBrowserUri(actionUri)
-    }
-
-    /**
-     * Check if the url is a switch browser redirect url
-     *
-     * The request is considered "switch_browser" if the URL
-     * starts with the following pattern: {redirectUrl}/{switchBrowserPath}
-     *
-     * @param url The URL to be checked.
-     * @param redirectUrl The redirect URL to be checked against.
-     * @param switchBrowserPath The path to be checked against.
-     * @return True if the request matches the pattern, false otherwise.
-     */
-    fun isSwitchBrowserRedirectUrl(url: String?, redirectUrl: String, switchBrowserPath: String): Boolean {
-        if (url == null) {
-            return false
-        }
-        val expectedUrl = "$redirectUrl/$switchBrowserPath"
-        return url.startsWith(expectedUrl, ignoreCase = true)
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandlerTest.kt
@@ -57,7 +57,8 @@ class SwitchBrowserRequestHandlerTest {
         val context = mock(Context::class.java)
         val customTabsManager = mock(CustomTabsManager::class.java)
         val challenge = mock(SwitchBrowserChallenge::class.java)
-        `when`(challenge.uri).thenReturn(Uri.parse("https://example.com"))
+        `when`(challenge.processUri).thenReturn(Uri.parse("https://example.com?state=123"))
+        `when`(challenge.authorizationUrl).thenReturn("https://auth.com?state=123")
         val browserSelector = // Browser available
             IBrowserSelector { _, _ -> Browser("fakeBrowser", emptySet(), "browser", false) }
         val handler = SwitchBrowserRequestHandler(mockActivity, context, customTabsManager, browserSelector, null)
@@ -73,7 +74,8 @@ class SwitchBrowserRequestHandlerTest {
         val context = mock(Context::class.java)
         val customTabsManager = mock(CustomTabsManager::class.java)
         val challenge = mock(SwitchBrowserChallenge::class.java)
-        `when`(challenge.uri).thenReturn(Uri.parse("https://example.com"))
+        `when`(challenge.processUri).thenReturn(Uri.parse("https://example.com?state=123"))
+        `when`(challenge.authorizationUrl).thenReturn("https://auth.com?state=123")
         val browserSelector = IBrowserSelector { _, _ -> null } // No browser available
         val handler = SwitchBrowserRequestHandler(activity, context, customTabsManager, browserSelector, null)
         val exception = Assert.assertThrows(ClientException::class.java) {
@@ -81,5 +83,29 @@ class SwitchBrowserRequestHandlerTest {
         }
         Assert.assertEquals(ClientException.NO_BROWSERS_AVAILABLE, exception.errorCode)
         Assert.assertEquals("No browser found for SwitchBrowserChallenge.", exception.message)
+    }
+
+    @Test
+    fun `test processChallenge states mismatch`() {
+        // Mock parameters
+        val mockActivity = mock<Activity>()
+        var activityExecuted = false
+        doAnswer {
+            activityExecuted = true
+            null
+        }.whenever(mockActivity).startActivity(any())
+        val context = mock(Context::class.java)
+        val customTabsManager = mock(CustomTabsManager::class.java)
+        val challenge = mock(SwitchBrowserChallenge::class.java)
+        `when`(challenge.processUri).thenReturn(Uri.parse("https://example.com?state=123"))
+        `when`(challenge.authorizationUrl).thenReturn("https://auth.com?state=456")
+        val browserSelector = // Browser available
+            IBrowserSelector { _, _ -> Browser("fakeBrowser", emptySet(), "browser", false) }
+        val handler = SwitchBrowserRequestHandler(mockActivity, context, customTabsManager, browserSelector, null)
+        val exception = Assert.assertThrows(ClientException::class.java) {
+            handler.processChallenge(challenge)
+        }
+        Assert.assertEquals(ClientException.STATE_MISMATCH, exception.errorCode)
+        Assert.assertEquals("State does not match with the auth request state.", exception.message)
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserRequestHandlerTest.kt
@@ -27,9 +27,12 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import com.microsoft.identity.common.internal.ui.browser.CustomTabsManager
+import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper
 import com.microsoft.identity.common.java.browser.Browser
 import com.microsoft.identity.common.java.browser.IBrowserSelector
 import com.microsoft.identity.common.java.exception.ClientException
+import io.mockk.every
+import io.mockk.mockkObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,7 +49,8 @@ import org.robolectric.RobolectricTestRunner
 class SwitchBrowserRequestHandlerTest {
 
     @Test
-    fun `test processChallenge success`() {
+    fun `test processChallenge success (stateRequired)`() {
+        isStateRequired(true)
         // Mock parameters
         val mockActivity = mock<Activity>()
         var activityExecuted = false
@@ -59,6 +63,28 @@ class SwitchBrowserRequestHandlerTest {
         val challenge = mock(SwitchBrowserChallenge::class.java)
         `when`(challenge.processUri).thenReturn(Uri.parse("https://example.com?state=123"))
         `when`(challenge.authorizationUrl).thenReturn("https://auth.com?state=123")
+        val browserSelector = // Browser available
+            IBrowserSelector { _, _ -> Browser("fakeBrowser", emptySet(), "browser", false) }
+        val handler = SwitchBrowserRequestHandler(mockActivity, context, customTabsManager, browserSelector, null)
+        handler.processChallenge(challenge)
+        Assert.assertTrue(activityExecuted)
+    }
+
+    @Test
+    fun `test processChallenge success (StateNotRequired)`() {
+        isStateRequired(false)
+        // Mock parameters
+        val mockActivity = mock<Activity>()
+        var activityExecuted = false
+        doAnswer {
+            activityExecuted = true
+            null
+        }.whenever(mockActivity).startActivity(any())
+        val context = mock(Context::class.java)
+        val customTabsManager = mock(CustomTabsManager::class.java)
+        val challenge = mock(SwitchBrowserChallenge::class.java)
+        `when`(challenge.processUri).thenReturn(Uri.parse("https://example.com"))
+        `when`(challenge.authorizationUrl).thenReturn("https://auth.com")
         val browserSelector = // Browser available
             IBrowserSelector { _, _ -> Browser("fakeBrowser", emptySet(), "browser", false) }
         val handler = SwitchBrowserRequestHandler(mockActivity, context, customTabsManager, browserSelector, null)
@@ -87,13 +113,9 @@ class SwitchBrowserRequestHandlerTest {
 
     @Test
     fun `test processChallenge states mismatch`() {
+        isStateRequired(true)
         // Mock parameters
         val mockActivity = mock<Activity>()
-        var activityExecuted = false
-        doAnswer {
-            activityExecuted = true
-            null
-        }.whenever(mockActivity).startActivity(any())
         val context = mock(Context::class.java)
         val customTabsManager = mock(CustomTabsManager::class.java)
         val challenge = mock(SwitchBrowserChallenge::class.java)
@@ -107,5 +129,10 @@ class SwitchBrowserRequestHandlerTest {
         }
         Assert.assertEquals(ClientException.STATE_MISMATCH, exception.errorCode)
         Assert.assertEquals("State does not match with the auth request state.", exception.message)
+    }
+
+    private fun isStateRequired(isStateRequired: Boolean) {
+        mockkObject(SwitchBrowserUriHelper)
+        every { SwitchBrowserUriHelper.STATE_VALIDATION_REQUIRED } returns isStateRequired
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserUriHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/SwitchBrowserUriHelperTest.kt
@@ -38,13 +38,15 @@ class SwitchBrowserUriHelperTest {
     companion object {
         private const val CODE = "your-switch-browser-code"
         private const val ACTION_URI = "login.microsoftonline.com/switchbrowser/process"
+        private const val STATE = "123"
     }
 
     @Test
     fun `test constructFromRedirectUri with valid redirect uri`() {
         val redirectString = "${Broker.NEW_BROKER_REDIRECT_URI}?" +
                 "${SWITCH_BROWSER.CODE}=$CODE&" +
-                "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI"
+                "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI&" +
+                "${SWITCH_BROWSER.STATE}=$STATE"
         val redirectUri = Uri.parse(redirectString)
 
         val switchBrowserProcessUri = SwitchBrowserUriHelper.buildProcessUri(redirectUri)
@@ -95,12 +97,41 @@ class SwitchBrowserUriHelperTest {
     @Test
     fun `test buildResumeUri valid params`() {
         val uri = SwitchBrowserUriHelper.buildResumeUri(
-            ACTION_URI
+            ACTION_URI, STATE
         )
         Assert.assertNotNull(uri)
         Assert.assertEquals(
             ACTION_URI,
             uri.host + uri.path
+        )
+        Assert.assertEquals(
+            STATE,
+            uri.getQueryParameter(SWITCH_BROWSER.STATE)
+        )
+    }
+
+    @Test
+    fun `test states match`() {
+        SwitchBrowserUriHelper.statesMatch(
+            "https://example.auth.com/path?${SWITCH_BROWSER.STATE}=$STATE", STATE
+        )
+    }
+
+    @Test
+    fun `test states don't match`() {
+        val exception = Assert.assertThrows(
+            ClientException::class.java) {
+            SwitchBrowserUriHelper.statesMatch(
+                "https://example.auth.com/path?${SWITCH_BROWSER.STATE}=$STATE", "error"
+            )
+        }
+        Assert.assertEquals(
+            ClientException.STATE_MISMATCH,
+            exception.errorCode
+        )
+        Assert.assertEquals(
+            "State does not match with the auth request state.",
+            exception.message
         )
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
@@ -32,6 +32,8 @@ import com.microsoft.identity.common.internal.ui.webview.challengehandlers.Switc
 import com.microsoft.identity.common.java.AuthenticationConstants.AAD.AUTHORIZATION
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.ui.AuthorizationAgent
+import io.mockk.every
+import io.mockk.mockkObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +46,8 @@ import org.robolectric.RobolectricTestRunner
 class SwitchBrowserProtocolCoordinatorTest {
 
     @Test
-    fun `test processSwitchBrowserResume with valid extras`() {
+    fun `test processSwitchBrowserResume with valid extras (stateRequired)`() {
+        isStateRequired(true)
         // Mock parameters
         val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
         doNothing().`when`(mockSwitchBrowserRequestHandler).resetChallengeState()
@@ -68,7 +71,56 @@ class SwitchBrowserProtocolCoordinatorTest {
     }
 
     @Test
+    fun `test processSwitchBrowserResume with valid extras (StateNotRequired)`() {
+        isStateRequired(false)
+        // Mock parameters
+        val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
+        doNothing().`when`(mockSwitchBrowserRequestHandler).resetChallengeState()
+        val code = "switch_browser_code"
+        val actionUrl = "test.example.com/switchbrowser/path"
+        val extras = Bundle().apply {
+            putString(SWITCH_BROWSER.CODE, code)
+            putString(SWITCH_BROWSER.ACTION_URI, actionUrl)
+        }
+        // Create an instance of SwitchBrowserProtocolCoordinator
+        val coordinator = SwitchBrowserProtocolCoordinator(mockSwitchBrowserRequestHandler)
+
+        // Call the method to be tested
+        coordinator.processSwitchBrowserResume("https://auth.com",extras) { uri, headers ->
+            // Verify the resume URI
+            Assert.assertEquals(actionUrl, uri.host + uri.path)
+            Assert.assertEquals(code, headers[AUTHORIZATION])
+        }
+    }
+
+    @Test
+    fun `test processSwitchBrowserResume with missing state (stateRequired)`() {
+        isStateRequired(true)
+        // Mock parameters
+        val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
+        val code = "switch_browser_code"
+        val actionUrl = "test.example.com/switchbrowser/path"
+        val extras = Bundle().apply {
+            putString(SWITCH_BROWSER.CODE, code)
+            putString(SWITCH_BROWSER.ACTION_URI, actionUrl)
+        }
+        // Create an instance of SwitchBrowserProtocolCoordinator
+        val coordinator = SwitchBrowserProtocolCoordinator(mockSwitchBrowserRequestHandler)
+
+        val exception = Assert.assertThrows(ClientException::class.java) {
+            // Call the method to be tested
+            coordinator.processSwitchBrowserResume("",extras) { _, _ ->
+                // This block should not be executed
+                Assert.fail()
+            }
+        }
+        Assert.assertEquals(ClientException.STATE_MISMATCH, exception.errorCode)
+        Assert.assertEquals("State is null.", exception.message)
+    }
+
+    @Test
     fun `test processSwitchBrowserResume with missing extras`() {
+        isStateRequired(false)
         // Mock parameters
         val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
         val extras = Bundle().apply {
@@ -86,7 +138,7 @@ class SwitchBrowserProtocolCoordinatorTest {
             }
         }
         Assert.assertEquals(ClientException.MISSING_PARAMETER, exception.errorCode)
-        Assert.assertEquals("Action URI is null/empty: true, code is null/empty: true, state is null/empty: true", exception.message)
+        Assert.assertEquals("Action URI is null/empty: true, code is null/empty: true.", exception.message)
     }
 
     @Test
@@ -169,5 +221,10 @@ class SwitchBrowserProtocolCoordinatorTest {
             AuthorizationAgent.WEBVIEW,
             intent.getSerializableExtra(AUTHORIZATION_AGENT) as AuthorizationAgent
         )
+    }
+
+    private fun isStateRequired(isStateRequired: Boolean) {
+        mockkObject(SwitchBrowserUriHelper)
+        every { SwitchBrowserUriHelper.STATE_VALIDATION_REQUIRED } returns isStateRequired
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
@@ -50,15 +50,17 @@ class SwitchBrowserProtocolCoordinatorTest {
         doNothing().`when`(mockSwitchBrowserRequestHandler).resetChallengeState()
         val code = "switch_browser_code"
         val actionUrl = "test.example.com/switchbrowser/path"
+        val state = "123"
         val extras = Bundle().apply {
             putString(SWITCH_BROWSER.CODE, code)
             putString(SWITCH_BROWSER.ACTION_URI, actionUrl)
+            putString(SWITCH_BROWSER.STATE, state)
         }
         // Create an instance of SwitchBrowserProtocolCoordinator
         val coordinator = SwitchBrowserProtocolCoordinator(mockSwitchBrowserRequestHandler)
 
         // Call the method to be tested
-        coordinator.processSwitchBrowserResume(extras) { uri, headers ->
+        coordinator.processSwitchBrowserResume("https://auth.com?state=$state",extras) { uri, headers ->
             // Verify the resume URI
             Assert.assertEquals(actionUrl, uri.host + uri.path)
             Assert.assertEquals(code, headers[AUTHORIZATION])
@@ -78,13 +80,13 @@ class SwitchBrowserProtocolCoordinatorTest {
 
         val exception = Assert.assertThrows(ClientException::class.java) {
             // Call the method to be tested
-            coordinator.processSwitchBrowserResume(extras) { _, _ ->
+            coordinator.processSwitchBrowserResume("",extras) { _, _ ->
                 // This block should not be executed
                 Assert.fail()
             }
         }
         Assert.assertEquals(ClientException.MISSING_PARAMETER, exception.errorCode)
-        Assert.assertEquals("Action URI is null/empty: true, code is null/empty: true", exception.message)
+        Assert.assertEquals("Action URI is null/empty: true, code is null/empty: true, state is null/empty: true", exception.message)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
@@ -88,7 +88,7 @@ class SwitchBrowserUriHelperTest {
     }
 
     @Test
-    fun `test constructFromRedirectUri with missing code`() {
+    fun `test buildProcessUri with missing code`() {
         val redirectString = "${Broker.NEW_BROKER_REDIRECT_URI}?" +
                 "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI"
         val redirectUri = Uri.parse(redirectString)
@@ -98,6 +98,21 @@ class SwitchBrowserUriHelperTest {
         }
         Assert.assertEquals(ClientException.MALFORMED_URL, exception.errorCode)
         Assert.assertEquals("switch browser code is null or empty", exception.message)
+    }
+
+    @Test
+    fun `test buildProcessUri with missing sate (StateRequired)`() {
+        isStateRequired(true)
+        val redirectString = "${Broker.NEW_BROKER_REDIRECT_URI}?" +
+                "${SWITCH_BROWSER.CODE}=$CODE&" +
+                "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI"
+        val redirectUri = Uri.parse(redirectString)
+
+        val exception = Assert.assertThrows(ClientException::class.java) {
+            SwitchBrowserUriHelper.buildProcessUri(redirectUri)
+        }
+        Assert.assertEquals(ClientException.MISSING_PARAMETER, exception.errorCode)
+        Assert.assertEquals("State is null or empty", exception.message)
     }
 
     @Test
@@ -121,7 +136,21 @@ class SwitchBrowserUriHelperTest {
     }
 
     @Test
-    fun `test buildResumeUri valid params`() {
+    fun `test buildResumeUri valid params (stateNotRequired)`() {
+        isStateRequired(false)
+        val uri = SwitchBrowserUriHelper.buildResumeUri(
+            ACTION_URI, null
+        )
+        Assert.assertNotNull(uri)
+        Assert.assertEquals(
+            ACTION_URI,
+            uri.host + uri.path
+        )
+        Assert.assertNull(uri.getQueryParameter(SWITCH_BROWSER.STATE))
+    }
+
+    @Test
+    fun `test buildResumeUri valid params (stateRequired)`() {
         val uri = SwitchBrowserUriHelper.buildResumeUri(
             ACTION_URI, STATE
         )
@@ -134,6 +163,16 @@ class SwitchBrowserUriHelperTest {
             STATE,
             uri.getQueryParameter(SWITCH_BROWSER.STATE)
         )
+    }
+
+    @Test
+    fun `test buildResumeUri missing state (stateRequired)`() {
+        isStateRequired(true)
+        val exception = Assert.assertThrows(ClientException::class.java) {
+            SwitchBrowserUriHelper.buildResumeUri(ACTION_URI, null)
+        }
+        Assert.assertEquals(ClientException.MISSING_PARAMETER, exception.errorCode)
+        Assert.assertEquals("State is null or empty", exception.message)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
@@ -20,13 +20,14 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.common.internal.ui.webview.challengehandlers
+package com.microsoft.identity.common.internal.ui.webview.switchbrowser
 
 import android.net.Uri
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
-import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUriHelper
 import com.microsoft.identity.common.java.exception.ClientException
+import io.mockk.every
+import io.mockk.mockkObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,11 +43,36 @@ class SwitchBrowserUriHelperTest {
     }
 
     @Test
-    fun `test constructFromRedirectUri with valid redirect uri`() {
+    fun `test constructFromRedirectUri with valid redirect uri (StateRequired)`() {
+        isStateRequired(true)
         val redirectString = "${Broker.NEW_BROKER_REDIRECT_URI}?" +
                 "${SWITCH_BROWSER.CODE}=$CODE&" +
                 "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI&" +
                 "${SWITCH_BROWSER.STATE}=$STATE"
+        val redirectUri = Uri.parse(redirectString)
+
+        val switchBrowserProcessUri = SwitchBrowserUriHelper.buildProcessUri(redirectUri)
+        Assert.assertNotNull(switchBrowserProcessUri)
+        Assert.assertEquals(
+            CODE,
+            switchBrowserProcessUri.getQueryParameter(SWITCH_BROWSER.CODE)
+        )
+        Assert.assertEquals(
+            ACTION_URI,
+            switchBrowserProcessUri.host + switchBrowserProcessUri.path
+        )
+        Assert.assertEquals(
+            STATE,
+            switchBrowserProcessUri.getQueryParameter(SWITCH_BROWSER.STATE)
+        )
+    }
+
+    @Test
+    fun `test constructFromRedirectUri with valid redirect uri (StateNotRequired)`() {
+        isStateRequired(false)
+        val redirectString = "${Broker.NEW_BROKER_REDIRECT_URI}?" +
+                "${SWITCH_BROWSER.CODE}=$CODE&" +
+                "${SWITCH_BROWSER.ACTION_URI}=$ACTION_URI"
         val redirectUri = Uri.parse(redirectString)
 
         val switchBrowserProcessUri = SwitchBrowserUriHelper.buildProcessUri(redirectUri)
@@ -111,7 +137,16 @@ class SwitchBrowserUriHelperTest {
     }
 
     @Test
+    fun `test states match (statesNotRequired)`() {
+        isStateRequired(false)
+        SwitchBrowserUriHelper.statesMatch(
+            "", null
+        )
+    }
+
+    @Test
     fun `test states match`() {
+        isStateRequired(true)
         SwitchBrowserUriHelper.statesMatch(
             "https://example.auth.com/path?${SWITCH_BROWSER.STATE}=$STATE", STATE
         )
@@ -119,6 +154,7 @@ class SwitchBrowserUriHelperTest {
 
     @Test
     fun `test states don't match`() {
+        isStateRequired(true)
         val exception = Assert.assertThrows(
             ClientException::class.java) {
             SwitchBrowserUriHelper.statesMatch(
@@ -133,5 +169,10 @@ class SwitchBrowserUriHelperTest {
             "State does not match with the auth request state.",
             exception.message
         )
+    }
+
+    private fun isStateRequired(isStateRequired: Boolean) {
+        mockkObject(SwitchBrowserUriHelper)
+        every { SwitchBrowserUriHelper.STATE_VALIDATION_REQUIRED } returns isStateRequired
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -98,7 +98,13 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the attachment of PRT header in cross cloud requests. Default is true.
      */
-    ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD("EnableAttachPrtHeaderWhenCrossCloud", true);
+    ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD("EnableAttachPrtHeaderWhenCrossCloud", true),
+
+    /**
+     * Flight to make the state parameter required for the switch browser protocol.
+     */
+    SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE("SwitchBrowserProtocolRequiresState", false);
+
     private String key;
     private Object defaultValue;
     CommonFlight(@NonNull String key, @NonNull Object defaultValue) {


### PR DESCRIPTION
DOC: https://microsoft-my.sharepoint-df.com/:w:/r/personal/sedemche_microsoft_com/_layouts/15/Doc.aspx?sourcedoc=%7B29055A71-DD9A-4E95-9E2D-6DBFB77F7823%7D&file=DUNA-switch_browser-phish%20attack.docx&action=default&mobileredirect=true&share=IQFxWgUpmt2VTp4tbb-3f3gjAb1Z62agYgf-0Tl4zsGqDBE

The document highlights a security vulnerability where malicious applications can exploit the "switch_browser" and "switch_browser_resume" endpoints, leading to phishing attacks through mimicked UI pages. The proposed mitigations include adding a state parameter to prevent such attacks, ensuring that both actions occur within a valid authentication flow. 

This state parameter allows the client application to validate the actions, by comparing the state in the in the authorization request against the state in the response (broker redirect).
<img width="698" alt="image" src="https://github.com/user-attachments/assets/98eaa284-68df-4a5e-9795-0453a3339022" />


[AB#3250169](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3250169)





