### PR TITLE
Fadi/amwp cherrypick, Fixes AB#3261502

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -109,7 +109,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable adding x-client-MN and x-client-WPAvailable extra query parameters
      */
-    ENABLE_AM_API_WORKPROFILE_EXTRA_QUERY_PARAMETERS("EnableAmApiWorkProfileExtraQueryParameters", false),
+    ENABLE_AM_API_WORKPROFILE_EXTRA_QUERY_PARAMETERS("EnableAmApiWorkProfileExtraQueryParameters", true),
 
     /** Flight to enable the new key generation without PURPOSE_WRAP_KEY. Default is true.
      * This is applicable for API >= 23

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -79,7 +79,7 @@ public class Device {
     }
 
     @GuardedBy("sLock")
-    public static void setIsInPersonalProfileButClouddpcWorkProfileAvailable(final boolean isWorkProfileAvailable) {
+    public static void setIsInPersonalProfileButClouddpcWorkProfileAvailable(final Boolean isWorkProfileAvailable) {
         sLock.writeLock().lock();
         try {
             sIsInPersonalProfileButClouddpcWorkProfileAvailable = isWorkProfileAvailable;
@@ -89,7 +89,7 @@ public class Device {
     }
 
     @GuardedBy("sLock")
-    public static boolean isInPersonalProfileButClouddpcWorkProfileAvailable() {
+    public static Boolean isInPersonalProfileButClouddpcWorkProfileAvailable() {
         sLock.readLock().lock();
         try {
             return sIsInPersonalProfileButClouddpcWorkProfileAvailable;

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/DeviceTest.java
@@ -45,6 +45,7 @@ public class DeviceTest {
     @After
     public void tearDown() {
         Device.clearDeviceMetadata();
+        Device.setIsInPersonalProfileButClouddpcWorkProfileAvailable(null);
     }
 
     @Test
@@ -134,6 +135,20 @@ public class DeviceTest {
                 MockDeviceMetadata.TEST_OS_ESTS + METADATA_SEPARATOR +
                 MockDeviceMetadata.TEST_OS_DRS;
         Assert.assertEquals(expectedResult, deviceMetadata.getAllMetadata());
+    }
+
+    @Test
+    public void testGetWorkProfileField(){
+        Assert.assertNull(Device.isInPersonalProfileButClouddpcWorkProfileAvailable());
+
+        Device.setIsInPersonalProfileButClouddpcWorkProfileAvailable(false);
+        Assert.assertFalse(Device.isInPersonalProfileButClouddpcWorkProfileAvailable());
+
+        Device.setIsInPersonalProfileButClouddpcWorkProfileAvailable(true);
+        Assert.assertTrue(Device.isInPersonalProfileButClouddpcWorkProfileAvailable());
+
+        Device.setIsInPersonalProfileButClouddpcWorkProfileAvailable(null);
+        Assert.assertNull(Device.isInPersonalProfileButClouddpcWorkProfileAvailable());
     }
 }
 


### PR DESCRIPTION
Cherrypick, same as: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2635

[AB#3261502](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3261502)