### PR TITLE
Update Json Schema, put JavaScript API behind a flight, Fixes AB#3203956, Closed AB#3203956

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -46,7 +46,7 @@ class AuthUxJavaScriptInterface {
         val TAG = AuthUxJavaScriptInterface::class.java.simpleName
         private const val JAVASCRIPT_INTERFACE_NAME = "ClientBrokerJS"
 
-        fun getInterfaceName() : String {
+        fun getInterfaceName(): String {
             return JAVASCRIPT_INTERFACE_NAME
         }
 
@@ -61,7 +61,7 @@ class AuthUxJavaScriptInterface {
                 return false
             }
 
-            val url : URL
+            val url: URL
             try {
                 url = URL(urlString)
             } catch (e: MalformedURLException) {
@@ -110,7 +110,10 @@ class AuthUxJavaScriptInterface {
         try {
             val payloadObject = parseJsonToAuthUxJsonPayloadObject(jsonPayload)
 
-            Logger.info(methodTag, "Correlation ID during JavaScript Call: [${payloadObject.correlationId}]")
+            Logger.info(
+                methodTag,
+                "Correlation ID during JavaScript Call: [${payloadObject.correlationId}]"
+            )
 
 
             // TODO: Leaving these here, as these will be relevant for next WebCP feature
@@ -123,40 +126,53 @@ class AuthUxJavaScriptInterface {
                 return
             }
 
-            val function = parameters.function
+            val operation = parameters.operation
 
-            Logger.info(methodTag, "Function name: [$function]")
+            Logger.info(methodTag, "Function name: [$operation]")
 
-            val data = parameters.data
-            if (data == null) {
-                Logger.warn(methodTag, "Payload from AuthUX contained no \"data\" field.")
-                return
-            }
-
-            when (function) {
-                FunctionNames.NUMBER_MATCH.name ->
+            when (operation) {
+                OperationNames.NUMBER_MATCHING ->
                     NumberMatchHelper.storeNumberMatch(
-                        data.sessionId,
-                        data.numberMatch)
+                        parameters.sessionId,
+                        parameters.codeMatch
+                    )
+
                 else ->
-                    Logger.warn(methodTag, "Payload from AuthUX contained an unknown function name.")
+                    Logger.warn(
+                        methodTag,
+                        "Payload from AuthUX contained an unknown function name."
+                    )
             }
         } catch (e: Exception) { // If we run into exceptions, we don't want to kill the broker
             when (e) {
                 is NullPointerException -> {
-                    Logger.error(methodTag, "Payload with missing mandatory fields sent through JavaScriptInterface", e)
+                    Logger.error(
+                        methodTag,
+                        "Payload with missing mandatory fields sent through JavaScriptInterface",
+                        e
+                    )
                 }
+
                 is MalformedJsonException, is JsonSyntaxException, is JsonParseException -> {
-                    Logger.error(methodTag, "Error Parsing JSON payload sent through JavaScriptInterface", e)
+                    Logger.error(
+                        methodTag,
+                        "Error Parsing JSON payload sent through JavaScriptInterface",
+                        e
+                    )
                 }
+
                 else -> {
-                    Logger.error(methodTag, "Unknown error occurred while processing the payload.", e)
+                    Logger.error(
+                        methodTag,
+                        "Unknown error occurred while processing the payload.",
+                        e
+                    )
                 }
             }
         }
     }
 
-    private fun parseJsonToAuthUxJsonPayloadObject(jsonString: String): AuthUxJsonPayload{
+    private fun parseJsonToAuthUxJsonPayloadObject(jsonString: String): AuthUxJsonPayload {
         val gson = GsonBuilder()
             .registerTypeAdapter(AuthUxJsonPayload::class.java, AuthUxJsonPayloadKTDeserializer())
             .create()
@@ -164,9 +180,9 @@ class AuthUxJavaScriptInterface {
     }
 
     /**
-     * Enum class to hold function names
+     * Enum class representing the operation names that can be called from AuthUX.
      */
-    enum class FunctionNames {
-        NUMBER_MATCH
+    object OperationNames {
+        const val NUMBER_MATCHING = "number_matching"
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayload.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayload.kt
@@ -47,29 +47,18 @@ data class AuthUxJsonPayload(
 /**
  * Data class representing the parameters for the action, including function and data.
  *
- * @property function The function to be executed.
+ * @property operation The operation to be executed.
  * @property data The data associated with the function.
  */
 data class AuthUxParams(
-    @SerializedName(SerializedNames.FUNCTION)
-    val function: String?,
+    @SerializedName(SerializedNames.OPERATION)
+    val operation: String?,
 
-    @SerializedName(SerializedNames.DATA)
-    val data: AuthUxData?
-)
-
-/**
- * Data class representing the data associated with the JS API call.
- *
- * @property sessionId The session ID for the request.
- * @property numberMatch The number match value.
- */
-data class AuthUxData(
     @SerializedName(SerializedNames.SESSION_ID)
     val sessionId: String?,
 
-    @SerializedName(SerializedNames.NUMBER_MATCH)
-    val numberMatch: String?
+    @SerializedName(SerializedNames.CODE_MATCH)
+    val codeMatch: String?
 )
 
 class AuthUxJsonPayloadKTDeserializer : JsonDeserializer<AuthUxJsonPayload> {
@@ -103,8 +92,7 @@ object SerializedNames {
     const val ACTION_NAME = "action_name"
     const val ACTION_COMPONENT = "action_component"
     const val PARAMS = "params"
-    const val FUNCTION = "function"
-    const val DATA = "data"
+    const val OPERATION = "operation"
     const val SESSION_ID = "sessionID"
-    const val NUMBER_MATCH = "numberMatch"
+    const val CODE_MATCH = "code_match"
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayload.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayload.kt
@@ -48,7 +48,8 @@ data class AuthUxJsonPayload(
  * Data class representing the parameters for the action, including function and data.
  *
  * @property operation The operation to be executed.
- * @property data The data associated with the function.
+ * @property sessionId
+ * @property codeMatch
  */
 data class AuthUxParams(
     @SerializedName(SerializedNames.OPERATION)

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -49,7 +49,6 @@ import androidx.fragment.app.FragmentActivity;
 import com.microsoft.identity.common.R;
 import com.microsoft.identity.common.internal.fido.LegacyFidoActivityResultContract;
 import com.microsoft.identity.common.internal.fido.LegacyFido2ApiObject;
-import com.microsoft.identity.common.internal.broker.AuthUxJavaScriptInterface;
 import com.microsoft.identity.common.internal.ui.webview.ISendResultCallback;
 import com.microsoft.identity.common.internal.ui.webview.ProcessUtil;
 import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserProtocolCoordinator;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -147,7 +147,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean shouldExposeJavaScriptInterface(final String url) {
         return ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
                 && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
-                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -137,13 +137,17 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      * If both conditions are met, it adds the JavaScript interface to the WebView.
      */
     public void initializeAuthUxJavaScriptApi(@NonNull final WebView view, final String url) {
-        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
-                && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
-                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)) {
+        if (shouldExposeJavaScriptInterface(url)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(TAG, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
         }
+    }
+
+    private boolean shouldExposeJavaScriptInterface(final String url) {
+        return ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
+                && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)
     }
 
     /**
@@ -208,9 +212,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String formattedURL = url.toLowerCase(Locale.US);
 
         // Re-evaluate adding AuthUx JavaScript Interface
-        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
-                && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
-                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)) {
+        if (shouldExposeJavaScriptInterface(url)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(methodTag, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -137,7 +137,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      * If both conditions are met, it adds the JavaScript interface to the WebView.
      */
     public void initializeAuthUxJavaScriptApi(@NonNull final WebView view, final String url) {
-        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext()) && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)) {
+        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
+                && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(TAG, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
@@ -206,7 +208,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String formattedURL = url.toLowerCase(Locale.US);
 
         // Re-evaluate adding AuthUx JavaScript Interface
-        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext()) && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)) {
+        if (ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
+                && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(methodTag, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -36,18 +36,14 @@ class AuthUxJavaScriptInterfaceTest {
     private val mockNumberMatchValue = "00"
 
     private val numberMatchTestPayload = """
-        { 
-            "correlationID": "SOME_CORRELATION_ID" ,
-            "action_name":"write_data", 
-            "action_component":"broker", 
-            "params": 
-            { 
-                "function": "NUMBER_MATCH", 
-                "data": 
-                { 
-                    "sessionID": "$mockSessionId", 
-                    "numberMatch": "$mockNumberMatchValue" 
-                } 
+        {
+            correlationID: w.ServerData.correlationId,
+            action_name: "write_data",
+            action_component: "broker",
+            params: {
+                operation: "number_matching",
+                sessionID: $mockSessionId,
+                code_match: $mockNumberMatchValue
             }
         }
     """.trimIndent()

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayloadTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJsonPayloadTest.kt
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker
+
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
 import org.junit.Assert.*
@@ -36,15 +37,13 @@ class AuthUxJsonPayloadTest {
     fun `test deserialization of valid JSON`() {
         val json = """
             {
-                "correlationID": "12345",
-                "action_name": "write_data",
-                "action_component": "broker",
-                "params": {
-                    "function": "NUMBER_MATCH",
-                    "data": {
-                        "sessionID": "67890",
-                        "numberMatch": "123456"
-                    }
+                correlationID: 12345,
+                action_name: "write_data",
+                action_component: "broker",
+                params: {
+                    operation: "number_matching",
+                    sessionID: 67890,
+                    code_match: 123456
                 }
             }
         """.trimIndent()
@@ -58,24 +57,18 @@ class AuthUxJsonPayloadTest {
 
         val params = payload.params
         assertNotNull(params)
-        assertEquals("NUMBER_MATCH", params?.function)
-
-        val data = params?.data
-        assertNotNull(data)
-        assertEquals("67890", data?.sessionId)
-        assertEquals("123456", data?.numberMatch)
+        assertEquals("number_matching", params?.operation)
+        assertEquals("67890", params?.sessionId)
+        assertEquals("123456", params?.codeMatch)
     }
 
     @Test
     fun `test deserialization of JSON with missing optional fields`() {
         val json = """
             {
-                "correlationID": "12345",
-                "action_name": "write_data",
-                "action_component": "broker",
-                "params" : {
-                    "invalidField": "invalidField"
-                }
+                correlationID: 12345,
+                action_name: "write_data",
+                action_component: "broker"
             }
         """.trimIndent()
 
@@ -85,17 +78,15 @@ class AuthUxJsonPayloadTest {
         assertEquals("12345", payload.correlationId)
         assertEquals("write_data", payload.actionName)
         assertEquals("broker", payload.actionComponent)
-        assertNotNull(payload.params)
-        assertNull(payload.params?.data)
-        assertNull(payload.params?.function)
+        assertNull(payload.params)
     }
 
     @Test(expected = JsonParseException::class)
     fun `test deserialization of JSON with missing mandatory fields, exception expected`() {
         val json = """
             {
-                "correlationID": "12345",
-                "action_name": "write_data"
+                correlationID: 12345,
+                action_name: "write_data"
             }
         """.trimIndent()
 
@@ -108,7 +99,54 @@ class AuthUxJsonPayloadTest {
     fun `test deserialization of empty JSON, exception expected`() {
         val json = "{}"
 
-        // This should throw an exception because the JSON is empty
+        // This should throw an exception because the JSON is empty and does not contain required fields
+        gson.fromJson(json, AuthUxJsonPayload::class.java)
+    }
+
+    @Test
+    fun `test deserialization of JSON with unexpected fields`() {
+        val json = """
+            {
+                correlationID: 12345,
+                action_name: "write_data",
+                action_component: "broker",
+                "unexpected_field": "unexpected_value",
+                params: {
+                    operation: "number_matching",
+                    sessionID: 67890,
+                    code_match: 123456
+                }
+            }
+        """.trimIndent()
+
+        val payload = gson.fromJson(json, AuthUxJsonPayload::class.java)
+
+        assertNotNull(payload)
+        assertEquals("12345", payload.correlationId)
+        assertEquals("write_data", payload.actionName)
+        assertEquals("broker", payload.actionComponent)
+
+        val params = payload.params
+        assertNotNull(params)
+        assertEquals("number_matching", params?.operation)
+        assertEquals("67890", params?.sessionId)
+        assertEquals("123456", params?.codeMatch)
+    }
+
+    @Test(expected = JsonParseException::class)
+    fun `test deserialization of invalid JSON`() {
+        val json = """
+            {
+                "correlationID": "12345",
+                "action_name": "write_data",
+                "action_component": "broker",
+                "params": {
+                    "operation": "NUMBER_MATCH",
+                    "sessionID": "67890",
+                    "code_match": "123456"
+                }
+        """.trimIndent() // Missing closing brace
+
         gson.fromJson(json, AuthUxJsonPayload::class.java)
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -119,7 +119,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable exposing the JavaScript API for AuthUx requests
      */
-    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true),;
+    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -114,7 +114,12 @@ public enum CommonFlight implements IFlightConfig {
     /** Flight to enable the new key generation without PURPOSE_WRAP_KEY. Default is true.
      * This is applicable for API >= 23
      */
-    ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY("EnableNewKeyGenSpecForWrapWithoutPurposeWrapKey", true);
+    ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY("EnableNewKeyGenSpecForWrapWithoutPurposeWrapKey", true),
+
+    /**
+     * Flight to enable exposing the JavaScript API for AuthUx requests
+     */
+    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true),;
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
Minor change was made to the json schema, updated our code to match. Also put JavaScript API behind a flight.

New schema:
{ 
    "correlationID": "$UUID" 
     "action_name":"write_data", 
    "action_component":"broker", 
     "params": 
     {  
         "operation": "number_matching",
         "sessionID": "$sessionID",
         "code_match": "$number" 
    }  
 }  

Original numberMatch PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2617

[AB#3203956](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3203956)