### PR TITLE
Fixing error in construction of LegacyFido2ApiManager

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [MINOR] Add Get AAD device ID API for resource account (#2644)
 - [MINOR] Expose a JavaScript API in brokered Webviews to facilitate Improved Same Device NumberMatch (#2617)
 - [MINOR] Add API for resource account provisioning (API only) (#2640)
+- [PATCH] Fixing error in construction of LegacyFido2ApiManager (#2654)
 
 Version 21.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
@@ -84,7 +84,7 @@ class CredManFidoManager (val context: Context,
             // We're setting preferImmediatelyAvailableCredentials in the CredMan getCredentialRequest object to true if the device OS is Android 13 or lower.
             // This ensures the behavior where no dialog from CredMan is shown if no passkey cred is present.
             // The end goal is for an Android <= 13 user who only has a security key to see one dialog which will allow them to authenticate.
-            preferImmediatelyAvailableCredentials = (getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+            preferImmediatelyAvailableCredentials = (legacyManager != null && getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC) && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
         )
         try {
             Logger.info(methodTag, "Calling Credential Manager with a GetCredentialRequest.")

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -227,11 +227,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_PASSKEY_FEATURE) && isPasskeyUrl(formattedURL)) {
                 Logger.info(methodTag,"WebView detected request for passkey protocol.");
                 final FidoChallenge challenge = FidoChallenge.createFromRedirectUri(url);
-                final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity)getActivity()).getSpanContext() : null;
+                final Activity currentActivity = getActivity();
+                final SpanContext spanContext = currentActivity instanceof AuthorizationActivity ? ((AuthorizationActivity)currentActivity).getSpanContext() : null;
                 final IFidoManager legacyManager =
-                        CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC)
+                        currentActivity instanceof AuthorizationActivity
+                                && ((AuthorizationActivity) currentActivity).getFragment() instanceof WebViewAuthorizationFragment
+                                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC)
                                 && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-                                ? new LegacyFido2ApiManager(view.getContext(), (WebViewAuthorizationFragment)((AuthorizationActivity)getActivity()).getFragment())
+                                ? new LegacyFido2ApiManager(view.getContext(), (WebViewAuthorizationFragment)((AuthorizationActivity)currentActivity).getFragment())
                                 : null;
                 final AuthFidoChallengeHandler challengeHandler = new AuthFidoChallengeHandler(
                         new CredManFidoManager(

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -229,6 +229,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 final FidoChallenge challenge = FidoChallenge.createFromRedirectUri(url);
                 final Activity currentActivity = getActivity();
                 final SpanContext spanContext = currentActivity instanceof AuthorizationActivity ? ((AuthorizationActivity)currentActivity).getSpanContext() : null;
+                // The legacyManager should only be getting added if the device is on Android 13 or lower and the library is MSAL/OneAuth with fragment or dialog mode.
+                // The legacyManager logic should be removed once a larger majority of users are on Android 14+.
                 final IFidoManager legacyManager =
                         currentActivity instanceof AuthorizationActivity
                                 && ((AuthorizationActivity) currentActivity).getFragment() instanceof WebViewAuthorizationFragment

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -90,6 +91,7 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_NONCE_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?&sso_nonce=ABCD";
     private static final String TEST_CROSS_CLOUD_REDIRECT_URL = "https://login.microsoftonline.us/organizations/oAuth2/v2.0/authorize?x=10";
     private static final String TEST_PUBLIC_CLOUD_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?x=10";
+    private static final String TEST_PASSKEY_REDIRECT_URL = "http-auth:PassKey?challenge=challenge&version=1.0&submitUrl=https://login.microsoftonline.com/common/credential?passKeyAuth=1.0%2fpasskey&context=&relyingPartyIdentifier=login.microsoft.com&allowedCredentials=somevalue";
 
     @Before
     public void setup() throws ClientException {
@@ -232,6 +234,45 @@ public class AzureActiveDirectoryWebViewClientTest {
             Mockito.verify(mockWebView).loadUrl(Mockito.anyString(), Mockito.any());
         } catch (Exception e) {
             Assert.fail("Failure is not expected. We should have caught the exception and ignored it. " + e);
+        }
+    }
+
+    @Test
+    public void setTestPasskeyRedirectUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL));
+    }
+
+    @Test
+    public void testPasskeyActivityCastingNoException() {
+        try {
+            // Putting an explicit non-AuthorizationActivity activity here to test that an exception won't be thrown.
+            mActivity = Robolectric.buildActivity(DualScreenActivity.class).get();
+            mWebViewClient = new AzureActiveDirectoryWebViewClient(
+                    mActivity,
+                    new IAuthorizationCompletionCallback() {
+                        @Override
+                        public void onChallengeResponseReceived(@NonNull RawAuthorizationResult response) {
+
+                        }
+
+                        @Override
+                        public void setPKeyAuthStatus(boolean status) {
+                            return;
+                        }
+                    },
+                    new OnPageLoadedCallback() {
+                        @Override
+                        public void onPageLoaded(final String url) {
+                            return;
+                        }
+                    },
+                    TEST_REDIRECT_URI,
+                    Mockito.mock(SwitchBrowserRequestHandler.class));
+            mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL);
+        } catch (ClassCastException e) {
+            Assert.fail("Failure is not expected. The class checks should have prevented this." + e);
+        } catch (Exception e) {
+            Assert.fail("Failure is not expected." + e);
         }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -91,11 +91,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_NONCE_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?&sso_nonce=ABCD";
     private static final String TEST_CROSS_CLOUD_REDIRECT_URL = "https://login.microsoftonline.us/organizations/oAuth2/v2.0/authorize?x=10";
     private static final String TEST_PUBLIC_CLOUD_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?x=10";
-<<<<<<< HEAD
     private static final String TEST_PASSKEY_REDIRECT_URL = "http-auth:PassKey?challenge=challenge&version=1.0&submitUrl=https://login.microsoftonline.com/common/credential?passKeyAuth=1.0%2fpasskey&context=&relyingPartyIdentifier=login.microsoft.com&allowedCredentials=somevalue";
-=======
     private static final String TEST_INTENT_INSTALL_BROKER_REDIRECT_URL = "intent://play.google.com/store/apps/details?id=com.azure.authenticator&referrer=%20adjust_reftag%3Dc6f1p4ErudH2C%26utm_source%3DLanding%2BPage%2BOrganic%2B-%2Bapp%2Bstore%2Bbadges%26utm_campaign%3Dappstore_android&pcampaignid=web_auto_redirect&web_logged_in=0&redirect_entry_point=dp#Intent;scheme=https;action=android.intent.action.VIEW;package=com.android.vending;end";
->>>>>>> origin/dev
 
     @Before
     public void setup() throws ClientException {


### PR DESCRIPTION
### Summary
While testing for their passkey enablement rollout, the Office team found a bug where if they're using OneAuth with fragment or dialog mode (and thus using their own Activity instead of AuthorizationActivity), they run into a casting exception in the process of creating a LegacyFido2ApiManager, as we need to pass a WebViewAuthorizationFragment into the constructor. 
The devices which would run into this error would be:
- Running on Android 13
- Non-brokered auth
- Are using OneAuth, and specifically using fragment/dialog mode
    - According to OneAuth, this is currently only being used by the Office team, which is why the other apps which rolled out passkey support have not run into this issue.

The fix for this is to add explicit type checks before creating the LegacyFido2ApiManager. Because the legacy FIDO2 API does require a Fragment which has a particular object instantiated (which I had added into our WebViewAuthorizationFragment), we can't just pass any fragment from any activity. This means that for Office's case, for Android 13 and below devices, they are going to only use CredMan- which is actually a good thing, since CredMan now has support for security keys for all OS versions (we originally included the legacy API because this wasn't the case a while ago).

At some point, it would be best to just remove the legacy API logic, but that can be done once a larger majority of users are on Android 14+.

- Company Portal on Android 13 or below with security key -> Passed on real device (thanks to Ben)
- Company Portal on Android 13 or below without passkey -> passed on emulator; could still see the passkey dialogs
- Company Portal on Android 14 -> passed
- Office on Android 13 -> (Waiting for response)
- OneAuthTestApp on Android 13 -> (Waiting for response)
- MsalTestApp on Android 13 -> Passed on emulator
- Test basic brokered and nonbrokered scenarios on Android 14 -> Passed on real device

Noting again that brokered auth scenarios should remain unaffected because the legacy API path was never hit (the flight has remained off, and default value is false). The same should be the case for Android 14+.