### PR TITLE
Add capabilities parameter to the flow start operations, Fixes AB#3288182, Closed AB#3288182

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/BaseNativeAuthCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/BaseNativeAuthCommandParameters.java
@@ -56,6 +56,12 @@ public abstract class BaseNativeAuthCommandParameters extends CommandParameters 
     @Nullable
     public final List<String> challengeType;
 
+    /**
+     * The client capabilities to be sent with the request.
+     */
+    @Nullable
+    public final List<String> capabilities;
+
     @Override
     public void logParameters(String tag, String correlationId) {
         Logger.infoWithObject(tag, null, correlationId, this);

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -40,7 +40,7 @@ class NativeAuthOAuth2Configuration(
     private val authorityUrl: URL,
     val clientId: String,
     val challengeType: String,
-    val capabilities: List<String>? = null,
+    val capabilities: String? = null,
     // Need this to decide whether or not to return mock api authority or actual authority supplied in configuration
     // Turn this on if you plan to use web auth and/or open id configuration
     val useMockApiForNativeAuth: Boolean = BuildValues.shouldUseMockApiForNativeAuth(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthOAuth2Configuration.kt
@@ -40,6 +40,7 @@ class NativeAuthOAuth2Configuration(
     private val authorityUrl: URL,
     val clientId: String,
     val challengeType: String,
+    val capabilities: List<String>? = null,
     // Need this to decide whether or not to return mock api authority or actual authority supplied in configuration
     // Turn this on if you plan to use web auth and/or open id configuration
     val useMockApiForNativeAuth: Boolean = BuildValues.shouldUseMockApiForNativeAuth(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProvider.kt
@@ -91,7 +91,8 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
             clientId = config.clientId,
             challengeType = config.challengeType,
             requestUrl = signInInitiateEndpoint,
-            headers = getRequestHeaders(commandParameters.getCorrelationId())
+            headers = getRequestHeaders(commandParameters.getCorrelationId()),
+            capabilities = config.capabilities
         )
     }
     //endregion
@@ -221,7 +222,8 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
             username = commandParameters.username,
             challengeType = config.challengeType,
             requestUrl = resetPasswordStartEndpoint,
-            headers = getRequestHeaders(commandParameters.getCorrelationId())
+            headers = getRequestHeaders(commandParameters.getCorrelationId()),
+            capabilities = config.capabilities
         )
     }
     //endregion
@@ -263,10 +265,11 @@ class NativeAuthRequestProvider(private val config: NativeAuthOAuth2Configuratio
             username = commandParameters.username,
             password = commandParameters.password,
             attributes = commandParameters.userAttributes,
-            challengeType = config.challengeType,
             clientId = config.clientId,
+            challengeType = config.challengeType,
             requestUrl = signUpStartEndpoint,
-            headers = getRequestHeaders(commandParameters.getCorrelationId())
+            headers = getRequestHeaders(commandParameters.getCorrelationId()),
+            capabilities = config.capabilities
         )
     }
     //endregion

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
@@ -50,7 +50,8 @@ data class ResetPasswordStartRequest private constructor(
             username: String,
             challengeType: String,
             requestUrl: String,
-            headers: Map<String, String?>
+            headers: Map<String, String?>,
+            capabilities: List<String>? = null
         ): ResetPasswordStartRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -64,7 +65,8 @@ data class ResetPasswordStartRequest private constructor(
                 parameters = NativeAuthRequestResetPasswordStartParameters(
                     clientId = clientId,
                     username = username,
-                    challengeType = challengeType
+                    challengeType = challengeType,
+                    capabilities = capabilities
                 )
             )
         }
@@ -77,9 +79,10 @@ data class ResetPasswordStartRequest private constructor(
     data class NativeAuthRequestResetPasswordStartParameters(
         val username: String,
         @SerializedName("client_id") override val clientId: String,
-        @SerializedName("challenge_type") val challengeType: String?
+        @SerializedName("challenge_type") val challengeType: String?,
+        @SerializedName("capabilities") val capabilities: List<String>? = null
     ) : NativeAuthRequestParameters() {
-        override fun toUnsanitizedString(): String = "ResetPasswordStartRequest(clientId=$clientId, challengeType=$challengeType)"
+        override fun toUnsanitizedString(): String = "ResetPasswordStartRequest(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 
         override fun toString(): String = "ResetPasswordStartRequest(clientId=$clientId)"
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/resetpassword/ResetPasswordStartRequest.kt
@@ -51,7 +51,7 @@ data class ResetPasswordStartRequest private constructor(
             challengeType: String,
             requestUrl: String,
             headers: Map<String, String?>,
-            capabilities: List<String>? = null
+            capabilities: String?
         ): ResetPasswordStartRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -80,7 +80,7 @@ data class ResetPasswordStartRequest private constructor(
         val username: String,
         @SerializedName("client_id") override val clientId: String,
         @SerializedName("challenge_type") val challengeType: String?,
-        @SerializedName("capabilities") val capabilities: List<String>? = null
+        @SerializedName("capabilities") val capabilities: String?
     ) : NativeAuthRequestParameters() {
         override fun toUnsanitizedString(): String = "ResetPasswordStartRequest(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
@@ -50,7 +50,8 @@ data class SignInInitiateRequest private constructor(
             clientId: String,
             challengeType: String,
             requestUrl: String,
-            headers: Map<String, String?>
+            headers: Map<String, String?>,
+            capabilities: List<String>? = null
         ): SignInInitiateRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -62,7 +63,8 @@ data class SignInInitiateRequest private constructor(
                 parameters = NativeAuthRequestSignInInitiateRequestParameters(
                     username = username,
                     challengeType = challengeType,
-                    clientId = clientId
+                    clientId = clientId,
+                    capabilities = capabilities
                 ),
                 requestUrl = URL(requestUrl),
                 headers = headers
@@ -77,9 +79,10 @@ data class SignInInitiateRequest private constructor(
     data class NativeAuthRequestSignInInitiateRequestParameters(
         val username: String,
         @SerializedName("client_id") override val clientId: String,
-        @SerializedName("challenge_type") val challengeType: String
+        @SerializedName("challenge_type") val challengeType: String,
+        @SerializedName("capabilities") val capabilities: List<String>? = null
     ) : NativeAuthRequestParameters() {
-        override fun toUnsanitizedString(): String = "NativeAuthRequestSignInInitiateRequestParameters(clientId=$clientId, challengeType=$challengeType)"
+        override fun toUnsanitizedString(): String = "NativeAuthRequestSignInInitiateRequestParameters(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 
         override fun toString(): String = "NativeAuthRequestSignInInitiateRequestParameters(clientId=$clientId)"
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signin/SignInInitiateRequest.kt
@@ -51,7 +51,7 @@ data class SignInInitiateRequest private constructor(
             challengeType: String,
             requestUrl: String,
             headers: Map<String, String?>,
-            capabilities: List<String>? = null
+            capabilities: String?
         ): SignInInitiateRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -80,7 +80,7 @@ data class SignInInitiateRequest private constructor(
         val username: String,
         @SerializedName("client_id") override val clientId: String,
         @SerializedName("challenge_type") val challengeType: String,
-        @SerializedName("capabilities") val capabilities: List<String>? = null
+        @SerializedName("capabilities") val capabilities: String?
     ) : NativeAuthRequestParameters() {
         override fun toUnsanitizedString(): String = "NativeAuthRequestSignInInitiateRequestParameters(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
@@ -55,7 +55,7 @@ data class SignUpStartRequest private constructor(
             challengeType: String,
             requestUrl: String,
             headers: Map<String, String?>,
-            capabilities: List<String>? = null
+            capabilities: String?
         ): SignUpStartRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -92,7 +92,7 @@ data class SignUpStartRequest private constructor(
         val attributes: String? = null,
         @SerializedName("client_id") override val clientId: String,
         @SerializedName("challenge_type") val challengeType: String,
-        @SerializedName("capabilities") val capabilities: List<String>? = null
+        @SerializedName("capabilities") val capabilities: String?
     ) : NativeAuthRequestParameters() {
         override fun toUnsanitizedString(): String = "NativeAuthRequestSignUpStartRequestParameters(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/requests/signup/SignUpStartRequest.kt
@@ -54,7 +54,8 @@ data class SignUpStartRequest private constructor(
             clientId: String,
             challengeType: String,
             requestUrl: String,
-            headers: Map<String, String?>
+            headers: Map<String, String?>,
+            capabilities: List<String>? = null
         ): SignUpStartRequest {
             // Check for empty Strings and empty Maps
             ArgUtils.validateNonNullArg(clientId, "clientId")
@@ -68,7 +69,8 @@ data class SignUpStartRequest private constructor(
                     password = password,
                     attributes = attributes?.toJsonString(attributes),
                     challengeType = challengeType,
-                    clientId = clientId
+                    clientId = clientId,
+                    capabilities = capabilities
                 ),
                 requestUrl = URL(requestUrl),
                 headers = headers
@@ -89,9 +91,10 @@ data class SignUpStartRequest private constructor(
         @JsonAdapter(CharArrayJsonAdapter::class) val password: CharArray?,
         val attributes: String? = null,
         @SerializedName("client_id") override val clientId: String,
-        @SerializedName("challenge_type") val challengeType: String
+        @SerializedName("challenge_type") val challengeType: String,
+        @SerializedName("capabilities") val capabilities: List<String>? = null
     ) : NativeAuthRequestParameters() {
-        override fun toUnsanitizedString(): String = "NativeAuthRequestSignUpStartRequestParameters(clientId=$clientId, challengeType=$challengeType)"
+        override fun toUnsanitizedString(): String = "NativeAuthRequestSignUpStartRequestParameters(clientId=$clientId, challengeType=$challengeType, capabilities=$capabilities)"
 
         override fun toString(): String = "NativeAuthRequestSignUpStartRequestParameters(clientId=$clientId)"
     }

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -178,6 +178,24 @@ class NativeAuthRequestProviderTest {
     }
 
     @Test
+    fun testSignUpStartExpectedCapabilitiesStringAddedToRequestBody() {
+        every { mockConfig.capabilities } returns capabilities
+
+        val commandParameters = SignUpStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .clientId(clientId)
+            .correlationId(correlationId)
+            .build()
+
+        val result = nativeAuthRequestProvider.createSignUpStartRequest(
+            commandParameters = commandParameters
+        )
+
+        assertEquals(capabilities, result.parameters.capabilities)
+    }
+
+    @Test
     fun testSignUpStartWithUnsetCorrelationIdShouldNotHaveHeader() {
         val commandParameters = SignUpStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
@@ -517,9 +535,28 @@ class NativeAuthRequestProviderTest {
             .correlationId(correlationId)
             .build()
 
-        nativeAuthRequestProvider.createSignInInitiateRequest(
+        val result = nativeAuthRequestProvider.createSignInInitiateRequest(
             commandParameters = commandParameters
         )
+
+        assertEquals(capabilities, result.parameters.capabilities)
+    }
+
+    @Test
+    fun testSignInInitiateExpectedCapabilitiesStringAddedToRequestBody() {
+        every { mockConfig.capabilities } returns capabilities
+
+        val commandParameters = SignInStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .correlationId(correlationId)
+            .build()
+
+        val result = nativeAuthRequestProvider.createSignInInitiateRequest(
+            commandParameters = commandParameters
+        )
+
+        assertEquals(capabilities, result.parameters.capabilities)
     }
 
     @Test
@@ -1032,6 +1069,23 @@ class NativeAuthRequestProviderTest {
         nativeAuthRequestProvider.createResetPasswordStartRequest(
             commandParameters = commandParameters
         )
+    }
+
+    @Test
+    fun testResetPasswordStartExpectedCapabilitiesStringAddedToRequestBody() {
+        every { mockConfig.capabilities } returns capabilities
+
+        val commandParameters = ResetPasswordStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .correlationId(correlationId)
+            .build()
+
+        val result = nativeAuthRequestProvider.createResetPasswordStartRequest(
+            commandParameters = commandParameters
+        )
+
+        assertEquals(capabilities, result.parameters.capabilities)
     }
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -1611,7 +1611,7 @@ class NativeAuthRequestProviderTest {
         // Verify that the request object has null capabilities
         assertNull("Capabilities should be null in the request parameters", result.parameters.capabilities)
 
-        // Test the key scenario: ObjectMapper.serializeObjectToFormUrlEncoded should filter out null values
+        // Test that ObjectMapper.serializeObjectToFormUrlEncoded should filter out null values
         val serializedParams = ObjectMapper.serializeObjectToFormUrlEncoded(result.parameters)
         
         // Verify that capabilities parameter is not included in the serialized form

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -162,6 +162,22 @@ class NativeAuthRequestProviderTest {
     }
 
     @Test
+    fun testSignUpStartWithEmptyCapabilitiesShouldThrowNotException() {
+        every { mockConfig.capabilities } returns emptyString
+
+        val commandParameters = SignUpStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .clientId(clientId)
+            .correlationId(correlationId)
+            .build()
+
+        nativeAuthRequestProvider.createSignUpStartRequest(
+            commandParameters = commandParameters
+        )
+    }
+
+    @Test
     fun testSignUpStartWithUnsetCorrelationIdShouldNotHaveHeader() {
         val commandParameters = SignUpStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
@@ -479,6 +495,21 @@ class NativeAuthRequestProviderTest {
     @Test(expected = ClientException::class)
     fun testSignInInitiateWithEmptyChallengeTypesShouldThrowException() {
         every { mockConfig.challengeType } returns emptyString
+
+        val commandParameters = SignInStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .correlationId(correlationId)
+            .build()
+
+        nativeAuthRequestProvider.createSignInInitiateRequest(
+            commandParameters = commandParameters
+        )
+    }
+
+    @Test
+    fun testSignInInitiateWithEmptyCapabilitiesShouldThrowNotException() {
+        every { mockConfig.capabilities } returns emptyString
 
         val commandParameters = SignInStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())
@@ -976,6 +1007,21 @@ class NativeAuthRequestProviderTest {
     @Test(expected = ClientException::class)
     fun testResetPasswordStartWithEmptyChallengeTypeShouldThrowException() {
         every { mockConfig.challengeType } returns emptyString
+
+        val commandParameters = ResetPasswordStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .correlationId(correlationId)
+            .build()
+
+        nativeAuthRequestProvider.createResetPasswordStartRequest(
+            commandParameters = commandParameters
+        )
+    }
+
+    @Test
+    fun testResetPasswordStartWithEmptyCapabilitiesShouldNotThrowException() {
+        every { mockConfig.capabilities } returns emptyString
 
         val commandParameters = ResetPasswordStartCommandParameters.builder()
             .platformComponents(mock<PlatformComponents>())

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -38,6 +38,7 @@ import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.interfaces.PlatformComponents
 import com.microsoft.identity.common.java.nativeauth.providers.requests.NativeAuthRequest.Companion.toJsonString
 import com.microsoft.identity.common.java.nativeauth.providers.requests.signin.SignInTokenRequest
+import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.nativeauth.ApiConstants
 import io.mockk.every
 import io.mockk.mockk
@@ -1589,5 +1590,66 @@ class NativeAuthRequestProviderTest {
         assertEquals(result.headers[AuthenticationConstants.AAD.CLIENT_REQUEST_ID], correlationId)
     }
 
+    // Test for null capabilities filtering in serialization
+
+    @Test
+    fun testSignInInitiateWithNullCapabilitiesFiltersOutFromSerializedRequestBody() {
+        // Set capabilities to null in config
+        every { mockConfig.capabilities } returns null
+
+        val commandParameters = SignInStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .clientId(clientId)
+            .correlationId(correlationId)
+            .build()
+
+        val result = nativeAuthRequestProvider.createSignInInitiateRequest(
+            commandParameters = commandParameters
+        )
+
+        // Verify that the request object has null capabilities
+        assertNull("Capabilities should be null in the request parameters", result.parameters.capabilities)
+
+        // Test the key scenario: ObjectMapper.serializeObjectToFormUrlEncoded should filter out null values
+        val serializedParams = ObjectMapper.serializeObjectToFormUrlEncoded(result.parameters)
+        
+        // Verify that capabilities parameter is not included in the serialized form
+        Assert.assertFalse(
+            "Serialized request body should not contain 'capabilities' parameter when it is null",
+            serializedParams.contains("capabilities")
+        )
+    }
+
+    @Test
+    fun testSignInInitiateWithNonNullCapabilitiesIncludedInSerializedRequestBody() {
+        // Set capabilities to a valid value in config
+        every { mockConfig.capabilities } returns capabilities
+
+        val commandParameters = SignInStartCommandParameters.builder()
+            .platformComponents(mock<PlatformComponents>())
+            .username(username)
+            .clientId(clientId)
+            .correlationId(correlationId)
+            .build()
+
+        val result = nativeAuthRequestProvider.createSignInInitiateRequest(
+            commandParameters = commandParameters
+        )
+
+        // Verify that the request object has the expected capabilities
+        assertEquals("Capabilities should match the configured value", capabilities, result.parameters.capabilities)
+
+        // Test that ObjectMapper.serializeObjectToFormUrlEncoded includes non-null values
+        val serializedParams = ObjectMapper.serializeObjectToFormUrlEncoded(result.parameters)
+        
+        // Verify that capabilities parameter IS included in the serialized form when not null
+        Assert.assertTrue(
+            "Serialized request body should contain 'capabilities' parameter when it has a value",
+            serializedParams.contains("capabilities=${capabilities.replace(" ", "+")}")
+        )
+    }
+
     //endregion
+
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -535,11 +535,9 @@ class NativeAuthRequestProviderTest {
             .correlationId(correlationId)
             .build()
 
-        val result = nativeAuthRequestProvider.createSignInInitiateRequest(
+        nativeAuthRequestProvider.createSignInInitiateRequest(
             commandParameters = commandParameters
         )
-
-        assertEquals(capabilities, result.parameters.capabilities)
     }
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthRequestProviderTest.kt
@@ -55,6 +55,7 @@ class NativeAuthRequestProviderTest {
     private val tenant = "samtoso.onmicrosoft.com"
     private val tokenEndpoint = URL("https://contoso.com/1234/token")
     private val challengeType = "oob redirect"
+    private val capabilities = "mfa_required registration_required"
     private val userAttributes = mapOf("city" to "Dublin")
     private val emptyUserAttributes = emptyMap<String, String>()
     private val oobGrantType = "oob"
@@ -87,6 +88,7 @@ class NativeAuthRequestProviderTest {
         every { getJITContinueEndpoint() } returns ApiConstants.MockApi.jitContinueRequestUrl
         every { challengeType } returns this@NativeAuthRequestProviderTest.challengeType
         every { clientId } returns this@NativeAuthRequestProviderTest.clientId
+        every { capabilities } returns this@NativeAuthRequestProviderTest.capabilities
         every { useMockApiForNativeAuth } returns true
     }
 


### PR DESCRIPTION
Fixes [AB#3288182](https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3288182)

1. __BaseNativeAuthCommandParameters.java__ - Added `capabilities` field to the base command parameters class
2. __SignInInitiateRequest.kt__ - Added `capabilities` parameter to the sign-in initiate request
3. __SignUpStartRequest.kt__ - Added `capabilities` parameter to the sign-up start request
4. __ResetPasswordStartRequest.kt__ - Added `capabilities` parameter to the reset password start request
5. __NativeAuthRequestProvider.kt__ - Updated to pass capabilities from configuration to requests
6. __NativeAuthOAuth2Configuration.kt__ - Added `capabilities` property to the configuration class

pipeline failed due to the broker step.