### PR TITLE
Catch exceptions on get hinge

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
@@ -41,6 +41,7 @@ import androidx.fragment.app.FragmentTransaction;
 
 import com.microsoft.device.display.DisplayMask;
 import com.microsoft.identity.common.R;
+import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;
 
@@ -180,15 +181,21 @@ public class DualScreenActivity extends FragmentActivity {
      */
     private Rect getHinge(final Context context,
                           int rotation) {
+        final String methodTag = "DualScreenActivity:getHinge";
         // Hinge's coordinates of its 4 edges in different mode
         // Double Landscape Rect(0, 1350 - 1800, 1434)
         // Double Portrait  Rect(1350, 0 - 1434, 1800)
-        final DisplayMask displayMask = DisplayMask.fromResourcesRect(context);
-        List<Rect> boundings = displayMask.getBoundingRectsForRotation(rotation);
-        if (boundings.size() == 0) {
+        try {
+            final DisplayMask displayMask = DisplayMask.fromResourcesRect(context);
+            List<Rect> boundings = displayMask.getBoundingRectsForRotation(rotation);
+            if (boundings.size() == 0) {
+                return new Rect(0, 0, 0, 0);
+            }
+            return boundings.get(0);
+        } catch (final Throwable throwable) {
+            Logger.error(methodTag, "Failed to get hinge rect", throwable);
             return new Rect(0, 0, 0, 0);
         }
-        return boundings.get(0);
     }
 
     /**


### PR DESCRIPTION
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3094140

In certain cases, the getHinge method triggers a NullPointerException, resulting in a crash on Edge. To handle this more gracefully, instead of throwing the exception, we are returning the default Rect.

The full solution involves replacing DisplayMask with Jetpack Window Manager. However, for this release, we are implementing a temporary patch, with the complete fix planned for the next release.


https://learn.microsoft.com/en-us/previous-versions/dual-screen/android/api-reference/dualscreen-library/core/screen-info
