### PR TITLE
Cherrypick JavaScript api change for ESTS validation

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -44,7 +44,7 @@ class AuthUxJavaScriptInterface {
     // long enough for AuthApp to call the broker api to fetch the number match
     companion object {
         val TAG = AuthUxJavaScriptInterface::class.java.simpleName
-        private const val JAVASCRIPT_INTERFACE_NAME = "ClientBrokerJS"
+        private const val JAVASCRIPT_INTERFACE_NAME = "broker"
 
         fun getInterfaceName(): String {
             return JAVASCRIPT_INTERFACE_NAME

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -103,8 +103,8 @@ class AuthUxJavaScriptInterface {
      * https://microsoft-my.sharepoint-df.com/:w:/p/veenasoman/EY1AZIeT8X5KrXVz97Vx520B3Jj0fBLSPlklnoRvcmbh0Q?e=VzNFd1&ovuser=72f988bf-86f1-41af-91ab-2d7cd011db47%2Cfadidurah%40microsoft.com&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNTA1MDQwMTYwOSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D
      */
     @JavascriptInterface
-    fun postMessageToBroker(jsonPayload: String) {
-        val methodTag = "$TAG:postMessageToBroker"
+    fun receiveAuthUxMessage(jsonPayload: String) {
+        val methodTag = "$TAG:receiveAuthUxMessage"
         Logger.info(methodTag, "Received a payload from AuthUX through JavaScript API.")
 
         try {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -34,7 +34,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.PermissionRequest;
-import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -121,6 +121,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private final SwitchBrowserRequestHandler mSwitchBrowserRequestHandler;
     private HashMap<String, String> mRequestHeaders;
     private String mRequestUrl;
+    private boolean mAuthUxJavaScriptInterfaceAdded = false;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -143,6 +144,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(TAG, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
+            mAuthUxJavaScriptInterfaceAdded = true;
         }
     }
 
@@ -150,6 +152,22 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())
                 && AuthUxJavaScriptInterface.Companion.isValidUrlForInterface(url)
                 && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX);
+    }
+
+    @Override
+    public void onPageFinished(final WebView view,
+                               final String url) {
+        super.onPageFinished(view, url);
+
+        if (mAuthUxJavaScriptInterfaceAdded) {
+            // Inject JavaScript to define `window.postMessageToBroker`
+            String wrapAuthUxJsScript = "window.postMessageToBroker = function(message) { ClientBrokerJS.postMessageToBroker(message) }";
+
+            // Need this if statement, because our min api is 16, this is only supported in 19+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                view.evaluateJavascript(wrapAuthUxJsScript, null);
+            }
+        }
     }
 
     /**
@@ -218,10 +236,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(methodTag, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
-        } else {
+            mAuthUxJavaScriptInterfaceAdded = true;
+        } else if (mAuthUxJavaScriptInterfaceAdded) {
             // Remove AuthUx JavaScript Interface
             Logger.info(methodTag, "Removing AuthUx JavaScript Interface");
             view.removeJavascriptInterface(AuthUxJavaScriptInterface.Companion.getInterfaceName());
+            mAuthUxJavaScriptInterfaceAdded = false;
         }
 
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -154,6 +154,24 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX);
     }
 
+    @Override
+    public void onPageFinished(final WebView view,
+                               final String url) {
+        super.onPageFinished(view, url);
+
+        if (mAuthUxJavaScriptInterfaceAdded) {
+            // Add a function to the api to . Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
+            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending in a dict
+            String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
+                    "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
+                    "};";
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                view.evaluateJavascript(jsScript, null);
+            }
+        }
+    }
+
     /**
      * Give the host application a chance to take over the control when a new url is about to be loaded in the current WebView.
      * This method was deprecated in API level 24.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -160,8 +160,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         super.onPageFinished(view, url);
 
         if (mAuthUxJavaScriptInterfaceAdded) {
-            // Add a function to the api to . Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
-            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending in a dict
+            // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
+            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending message in a dict
             String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
                     "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
                     "};";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -154,22 +154,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_JS_API_FOR_AUTHUX);
     }
 
-    @Override
-    public void onPageFinished(final WebView view,
-                               final String url) {
-        super.onPageFinished(view, url);
-
-        if (mAuthUxJavaScriptInterfaceAdded) {
-            // Inject JavaScript to define `window.postMessageToBroker`
-            String wrapAuthUxJsScript = "window.postMessageToBroker = function(message) { ClientBrokerJS.postMessageToBroker(message) }";
-
-            // Need this if statement, because our min api is 16, this is only supported in 19+
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                view.evaluateJavascript(wrapAuthUxJsScript, null);
-            }
-        }
-    }
-
     /**
      * Give the host application a chance to take over the control when a new url is about to be loaded in the current WebView.
      * This method was deprecated in API level 24.

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -60,9 +60,9 @@ class AuthUxJavaScriptInterfaceTest {
     }
 
     @Test
-    fun `test postMessageToBroker with NUMBER_MATCH function`() {
+    fun `test receiveAuthUxMessage with NUMBER_MATCH function`() {
         // Call the method
-        authUxJavaScriptInterface.postMessageToBroker(numberMatchTestPayload)
+        authUxJavaScriptInterface.receiveAuthUxMessage(numberMatchTestPayload)
 
         // Verify that the data was stored in NumberMatchHelper
         val storedValue = NumberMatchHelper.numberMatchMap[mockSessionId]
@@ -70,17 +70,17 @@ class AuthUxJavaScriptInterfaceTest {
     }
 
     @Test
-    fun `test postMessageToBroker with empty json`() {
+    fun `test receiveAuthUxMessage with empty json`() {
         // Call the method
-        authUxJavaScriptInterface.postMessageToBroker("{}")
+        authUxJavaScriptInterface.receiveAuthUxMessage("{}")
 
         // Should not get an exception
     }
 
     @Test
-    fun `test postMessageToBroker with non-json string`() {
+    fun `test receiveAuthUxMessage with non-json string`() {
         // Call the method
-        authUxJavaScriptInterface.postMessageToBroker("NotAJson")
+        authUxJavaScriptInterface.receiveAuthUxMessage("NotAJson")
 
         // Should not get an exception
     }


### PR DESCRIPTION
Need to update our JavaScript api's exposed name in Webview to align with platform-agnostic approach (have parity with ios).