### PR TITLE
Fixing the sign in screens when edge to edge is enabled, Fixes AB#3293334

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [MINOR] changes accommodating the WrappedKeyAlgoIdentifier module (#2667)
+- [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
 
 Version 21.2.0
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.squareup.moshi:moshi:$rootProject.ext.moshiVersion"
     implementation "androidx.browser:browser:$rootProject.ext.browserVersion"
-    implementation "androidx.core:core:1.5.0"
+    implementation "androidx.core:core:$rootProject.ext.androidxCoreVersion"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     //For Executive Order work
     implementation "com.yubico.yubikit:android:$rootProject.ext.yubikitAndroidVersion"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.squareup.moshi:moshi:$rootProject.ext.moshiVersion"
     implementation "androidx.browser:browser:$rootProject.ext.browserVersion"
+    implementation "androidx.core:core:1.5.0"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     //For Executive Order work
     implementation "com.yubico.yubikit:android:$rootProject.ext.yubikitAndroidVersion"

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
@@ -63,15 +63,19 @@ public class DualScreenActivity extends FragmentActivity {
     private void initializeContentView(){
         super.setContentView(R.layout.dual_screen_layout);
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
-            ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (view, insets) -> {
-                int topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
-                int bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
-                int leftInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).left; // Get left system bar inset
-                int rightInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).right; // Get right system bar inset
+            try {
+                ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (view, insets) -> {
+                    int topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+                    int bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                    int leftInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).left;
+                    int rightInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).right;
 
-                view.setPadding(leftInset, topInset, rightInset, bottomInset);
-                return insets;
-            });
+                    view.setPadding(leftInset, topInset, rightInset, bottomInset);
+                    return insets;
+                });
+            } catch (final Throwable throwable) {
+                Logger.warn("DualScreenActivity:initializeContentView", "Failed to set OnApplyWindowInsetsListener");
+            }
         }
         adjustLayoutForDualScreenActivity();
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
@@ -35,12 +35,16 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentTransaction;
 
 import com.microsoft.device.display.DisplayMask;
 import com.microsoft.identity.common.R;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;
@@ -58,6 +62,17 @@ public class DualScreenActivity extends FragmentActivity {
 
     private void initializeContentView(){
         super.setContentView(R.layout.dual_screen_layout);
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
+            ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (view, insets) -> {
+                int topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                int bottomInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                int leftInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).left; // Get left system bar inset
+                int rightInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).right; // Get right system bar inset
+
+                view.setPadding(leftInset, topInset, rightInset, bottomInset);
+                return insets;
+            });
+        }
         adjustLayoutForDualScreenActivity();
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -119,7 +119,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable exposing the JavaScript API for AuthUx requests
      */
-    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true);
+    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true),
+
+    /**
+     * Flight to enable handling the UI in edge to edge mode
+     */
+    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true);
 
     private String key;
     private Object defaultValue;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,6 +25,7 @@ ext {
     androidxTestCoreVersion = "1.5.0"
     androidxJunitVersion = "1.1.3"
     annotationVersion = "1.0.0"
+    androidxCoreVersion = "1.5.0"
     appCompatVersion = "1.1.0"
     browserVersion = "1.0.0"
     constraintLayoutVersion = "1.1.3"


### PR DESCRIPTION
The Auth password page on LTW is edge-to-edge by default on devices running Android 15 if the app is targeting Android 15 (API level 35). Please refer to [this](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge) for more details. Because of this feature enabled by default, I am seeing below cropped screen.

Attached screenshot below.
![EdgeToEdge](https://github.com/user-attachments/assets/a3423b03-336d-45f8-ba27-647faa8ae65e)

Steps to reproduce:
1. set targetSdkVersion to 35 in BrokerHost app

2. launch MsalTestApp

3. click on Sign in button

4. See that the page is cropped on the top
-------------------------------------------------------------
Expected Behavior:
Should not be cropped

Fix : Adding padding in the activity showing the UI screens by getting the insets of the system bar as suggested in the  edge to edge documentation.

This is after fixing the issue
![image](https://github.com/user-attachments/assets/6637bd39-cdda-4701-a0bf-7ea1740c4d38)

Fixes [AB#3293334](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3293334)