### PR TITLE
[Has old changes] Showing webcp flow in webview

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1273,6 +1273,11 @@ public final class AuthenticationConstants {
         public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
         /**
+         * Redirect URL from WebCP that should launch the authorization flow.
+         */
+        public static final String WEBCP_AUTHORIZE_REDIRECT_URL = "authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
+
+        /**
          * A query param indicating that this is an intune device CA link.
          */
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1268,6 +1268,11 @@ public final class AuthenticationConstants {
         public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = BROWSER_EXT_WEB_CP + "enrollment";
 
         /**
+         * Redirect URL from WebCP that should launch the enrollment flow.
+         */
+        public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
+
+        /**
          * A query param indicating that this is an intune device CA link.
          */
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -55,7 +55,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizat
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractSmartcardCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
@@ -167,6 +167,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(url)) {
             throw new IllegalArgumentException("Redirect to empty url in web view.");
         }
+
         return handleUrl(view, url);
     }
 
@@ -223,7 +224,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             Logger.info(methodTag, "Removing AuthUx JavaScript Interface");
             view.removeJavascriptInterface(AuthUxJavaScriptInterface.Companion.getInterfaceName());
         }
-
 
         try {
             if (isPkeyAuthUrl(formattedURL)) {
@@ -303,11 +303,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
                 Logger.info(methodTag,"Navigation contains cross cloud redirect.");
                 processCloudRedirectAndPrtHeader(view, url);
-            }
-             else {
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpEnrollmentUrl(url)) {
+                Logger.info(methodTag,"Navigation contains web cp enrollment url.");
+                processWebCpEnrollmentUrl(view, url);
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpAuthorizeUrl(url)) {
+                processWebCpAuthorize(view, url);
+            } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
-
                 return false;
             }
         } catch (final ClientException exception) {
@@ -425,6 +428,15 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return url.startsWith(AMAZON_APP_REDIRECT_PREFIX);
     }
 
+    private boolean isWebCpEnrollmentUrl(@NonNull final String url) {
+        return url.startsWith(AuthenticationConstants.Broker.WEBCP_ENROLLMENT_URL);
+    }
+
+    private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
+        // URL is for an authorize request and contains the client_id of the WebCP app.
+        return url.contains("authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9");
+    }
+
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
         // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
         // This drops all the headers, which can have credentials useful for SSO and correlationIds useful for
@@ -476,20 +488,16 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private void processWebsiteRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processWebsiteRequest";
-
         view.stopLoading();
 
-        if (url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER)) {
+        if (isDeviceCaRequest(url)) {
             Logger.info(methodTag, "This is a device CA request.");
-            final PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
 
-            // If CP is installed, redirect to CP.
-            // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
-            //       CP is currently working on this.
-            //       Until that comes, we'll only handle this in ipphone.
-            if (packageHelper.isPackageInstalledAndEnabled(IPPHONE_APP_PACKAGE_NAME) &&
-                    IPPHONE_APP_SIGNATURE.equals(packageHelper.getSha1SignatureForPackage(IPPHONE_APP_PACKAGE_NAME)) &&
-                    packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME)) {
+            if (shouldLaunchCompanyPortal()) {
+                // If CP is installed, redirect to CP.
+                // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
+                //       CP is currently working on this.
+                //       Until that comes, we'll only handle this in ipphone.
                 try {
                     launchCompanyPortal();
                     return;
@@ -498,14 +506,62 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 }
             }
 
-            // Otherwise, launch in Browser.
-            openLinkInBrowser(url);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            return;
+            loadDeviceCaUrl(url, view);
         }
 
+        Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
         openLinkInBrowser(url);
         returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
+    }
+
+    private boolean isDeviceCaRequest(@NonNull final String url) {
+        return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
+    }
+
+    private boolean shouldLaunchCompanyPortal() {
+        PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
+
+        return packageHelper.isPackageInstalledAndEnabled(IPPHONE_APP_PACKAGE_NAME)
+                && IPPHONE_APP_SIGNATURE.equals(packageHelper.getSha1SignatureForPackage(IPPHONE_APP_PACKAGE_NAME))
+                && packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME);
+    }
+
+    private void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+        final String methodTag = TAG + ":loadDeviceCaUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Logger.info(methodTag, "Loading device CA request in WebView.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+            view.loadUrl(httpsUrl, mRequestHeaders);
+        } else {
+            Logger.info(methodTag, "Loading device CA request in browser.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+            openLinkInBrowser(originalUrl);
+            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        }
+    }
+
+
+    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+        view.stopLoading();
+        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+        openLinkInBrowser(url);
+        final int threadSleepForIntentToLaunch = 5000; // 5 secs pause before the intent is launched and flow is killed for smooth transition.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+        }, threadSleepForIntentToLaunch);
     }
 
     private boolean processPlayStoreURL(@NonNull final WebView view, @NonNull final String url) {
@@ -580,7 +636,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             Logger.warn(methodTag, "Unable to find an app to resolve the activity.");
         }
     }
-
     private void processWebCpRequest(@NonNull final WebView view, @NonNull final String url) {
 
         view.stopLoading();
@@ -688,7 +743,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private void processInvalidUrl(@NonNull final String url) {
         final String methodTag = TAG + ":processInvalidUrl";
 
-        Logger.infoPII(methodTag,"We are declining to override loading and redirect to invalid URL: '"
+        Logger.info(methodTag,"We are declining to override loading and redirect to invalid URL: '"
                 + removeQueryParametersOrRedact(url) + "' the user's url pattern is '" + mRedirectUrl + "'");
     }
 
@@ -735,6 +790,20 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     /**
+     * This method is used to process the webcp redirect and re-attach the PRT header to the request.
+     */
+    private void processWebCpAuthorize(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCPAuthorize";
+        Logger.info(methodTag, "Processing WebCP authorize request.");
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_authorize_request.name(), true);
+        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+    }
+
+    /**
      * This method is used to process the cross cloud redirect and attach the PRT header to the request.
      */
     private void processCloudRedirectAndPrtHeader(@NonNull final WebView view, @NonNull final String url) {
@@ -743,20 +812,20 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
-        final CrossCloudChallengeHandler crossCloudChallengeHandler = new CrossCloudChallengeHandler(view, mRequestHeaders, span);
-        processCloudRedirectAndPrtHeaderInternal(url, crossCloudChallengeHandler, view, methodTag, span);
+        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public void processCloudRedirectAndPrtHeaderInternal(@NonNull final String url, @NonNull final CrossCloudChallengeHandler crossCloudChallengeHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
+    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
-            crossCloudChallengeHandler.processChallenge(url);
+            reAttachPrtHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);
         } catch (final Exception e) {
             // No op if an exception happens
-            Logger.warn(methodTag, "Error processing cross cloud redirect and attaching PRT header." + e);
+            Logger.warn(methodTag, "Error attaching PRT header." + e);
             span.recordException(e);
-            view.loadUrl(url, mRequestHeaders);
+            view.loadUrl(url, mRequestHeaders); //
         } finally {
             span.end();
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -55,7 +55,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizat
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractSmartcardCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
@@ -167,7 +167,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(url)) {
             throw new IllegalArgumentException("Redirect to empty url in web view.");
         }
-
         return handleUrl(view, url);
     }
 
@@ -434,7 +433,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
         // URL is for an authorize request and contains the client_id of the WebCP app.
-        return url.contains("authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9");
+        return url.contains(AuthenticationConstants.Broker.WEBCP_AUTHORIZE_REDIRECT_URL);
     }
 
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
@@ -507,11 +506,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             loadDeviceCaUrl(url, view);
+        } else {
+            Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
+            openLinkInBrowser(url);
+            returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
         }
-
-        Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
-        openLinkInBrowser(url);
-        returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
     }
 
     private boolean isDeviceCaRequest(@NonNull final String url) {
@@ -799,8 +798,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
         span.setAttribute(AttributeName.is_webcp_authorize_request.name(), true);
-        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
-        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+        final ReAttachPrtHeaderHandler reAttachPrtHeaderHandler = new ReAttachPrtHeaderHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHeaderHandler, view, methodTag, span);
     }
 
     /**
@@ -812,12 +811,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
-        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
-        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+        final ReAttachPrtHeaderHandler reAttachPrtHeaderHandler = new ReAttachPrtHeaderHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHeaderHandler, view, methodTag, span);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
+    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHeaderHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             reAttachPrtHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHandler.kt
@@ -28,19 +28,17 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions
 import com.microsoft.identity.common.java.broker.CommonRefreshTokenCredentialProvider
 import com.microsoft.identity.common.java.opentelemetry.AttributeName
 import com.microsoft.identity.common.logging.Logger
-import io.opentelemetry.api.internal.StringUtils
 import io.opentelemetry.api.trace.Span
-import java.net.URL
 
 /**
- * Handler for attaching prt credential header on web view in cross cloud redirect scenarios.
+ * Handler for attaching prt credential header on web view in redirect scenarios.
  */
-class CrossCloudChallengeHandler(
+class ReAttachPrtHandler(
     private val webView: WebView,
     private val headers: HashMap<String, String>,
     private val span : Span
 ) : IChallengeHandler<String, Void> {
-    private val TAG = CrossCloudChallengeHandler::class.java.simpleName
+    private val TAG = ReAttachPrtHandler::class.java.simpleName
 
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge of a cross cloud request.")

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -33,15 +33,15 @@ import io.opentelemetry.api.trace.Span
 /**
  * Handler for attaching prt credential header on web view in redirect scenarios.
  */
-class ReAttachPrtHandler(
+class ReAttachPrtHeaderHandler(
     private val webView: WebView,
     private val headers: HashMap<String, String>,
     private val span : Span
 ) : IChallengeHandler<String, Void> {
-    private val TAG = ReAttachPrtHandler::class.java.simpleName
+    private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
 
     override fun processChallenge(inputUrl: String): Void? {
-        Logger.info(TAG, "Processing challenge of a cross cloud request.")
+        Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)
         webView.loadUrl(inputUrl, headers)
         return null

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -31,7 +31,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
@@ -93,6 +93,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_PUBLIC_CLOUD_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?x=10";
     private static final String TEST_PASSKEY_REDIRECT_URL = "http-auth:PassKey?challenge=challenge&version=1.0&submitUrl=https://login.microsoftonline.com/common/credential?passKeyAuth=1.0%2fpasskey&context=&relyingPartyIdentifier=login.microsoft.com&allowedCredentials=somevalue";
     private static final String TEST_INTENT_INSTALL_BROKER_REDIRECT_URL = "intent://play.google.com/store/apps/details?id=com.azure.authenticator&referrer=%20adjust_reftag%3Dc6f1p4ErudH2C%26utm_source%3DLanding%2BPage%2BOrganic%2B-%2Bapp%2Bstore%2Bbadges%26utm_campaign%3Dappstore_android&pcampaignid=web_auto_redirect&web_logged_in=0&redirect_entry_point=dp#Intent;scheme=https;action=android.intent.action.VIEW;package=com.android.vending;end";
+
+    private static final String TEST_WEB_CP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
     @Before
     public void setup() throws ClientException {
@@ -215,10 +217,15 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     @Test
+    public void testUrlOverrideHandleWebCPEnrollmentUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+    }
+
+    @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalSuccess() {
-        CrossCloudChallengeHandler mockCrossCloudChallengeHandler = Mockito.mock(CrossCloudChallengeHandler.class);
+        ReAttachPrtHandler mockCrossCloudChallengeHandler = Mockito.mock(ReAttachPrtHandler.class);
         try {
-            mWebViewClient.processCloudRedirectAndPrtHeaderInternal(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mMockWebView, "methodTag", Span.current());
+            mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mMockWebView, "methodTag", Span.current());
         } catch (Exception e) {
             Assert.fail("Unexpected exception occured " + e);
         }
@@ -226,12 +233,12 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalException() {
-        CrossCloudChallengeHandler mockCrossCloudChallengeHandler = Mockito.mock(CrossCloudChallengeHandler.class);
+        ReAttachPrtHandler mockReAttachPrtHandler = Mockito.mock(ReAttachPrtHandler.class);
         WebView mockWebView = Mockito.mock(WebView.class);
-        Mockito.doThrow(new RuntimeException("Test Exception")).when(mockCrossCloudChallengeHandler).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
+        Mockito.doThrow(new RuntimeException("Test Exception")).when(mockReAttachPrtHandler).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
         try {
-            mWebViewClient.processCloudRedirectAndPrtHeaderInternal(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mockWebView, "methodTag", Span.current());
-            Mockito.verify(mockCrossCloudChallengeHandler, Mockito.times(1)).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
+            mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockReAttachPrtHandler, mockWebView, "methodTag", Span.current());
+            Mockito.verify(mockReAttachPrtHandler, Mockito.times(1)).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
             Mockito.verify(mockWebView).loadUrl(Mockito.anyString(), Mockito.any());
         } catch (Exception e) {
             Assert.fail("Failure is not expected. We should have caught the exception and ignored it. " + e);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandlerTest.kt
@@ -35,25 +35,25 @@ import org.junit.Test
 import org.mockito.Mockito.*
 
 @RunWith(RobolectricTestRunner::class)
-class CrossCloudChallengeHandlerTest {
+class ReAttachPrtHeaderHandlerTest {
 
     private lateinit var webView: WebView
     private lateinit var headers: HashMap<String, String>
     private lateinit var span: Span
-    private lateinit var crossCloudChallengeHandler: CrossCloudChallengeHandler
+    private lateinit var reAttachPrtHeaderHandler: ReAttachPrtHeaderHandler
 
     @Before
     fun setUp() {
         webView = mock(WebView::class.java)
         headers = HashMap()
         span = mock(Span::class.java)
-        crossCloudChallengeHandler = CrossCloudChallengeHandler(webView, headers, span)
+        reAttachPrtHeaderHandler = ReAttachPrtHeaderHandler(webView, headers, span)
     }
 
     @Test
     fun `testProcessChallenge success`() {
         val testUrl = "https://example.com?login_hint=testuser"
-        crossCloudChallengeHandler.processChallenge(testUrl)
+        reAttachPrtHeaderHandler.processChallenge(testUrl)
         verify(webView).loadUrl(eq(testUrl), eq(headers))
     }
 
@@ -70,7 +70,7 @@ class CrossCloudChallengeHandlerTest {
         } throws Exception()
 
         try {
-            crossCloudChallengeHandler.processChallenge(testUrl)
+            reAttachPrtHeaderHandler.processChallenge(testUrl)
         } catch (e: Exception) {
             verify(webView, never()).loadUrl(eq(testUrl), eq(headers))
         }
@@ -91,7 +91,7 @@ class CrossCloudChallengeHandlerTest {
         } returns refreshTokenCredential
 
         // Call the method
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true
@@ -102,7 +102,7 @@ class CrossCloudChallengeHandlerTest {
     @Test
     fun `modifyHeadersWithRefreshTokenCredential should not update headers when login_hint is missing`() {
         val url = "https://login.microsoftonline.com"
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span, never()).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true
@@ -112,7 +112,7 @@ class CrossCloudChallengeHandlerTest {
     @Test
     fun `modifyHeadersWithRefreshTokenCredential null refresh token credential`() {
         val url = "https://login.microsoftonline.com?login_hint=testuser"
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span, never()).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -119,7 +119,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable exposing the JavaScript API for AuthUx requests
      */
-    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true);
+    ENABLE_JS_API_FOR_AUTHUX("EnableJsApiForAuthUx", true),
+
+    /**
+     * Flight to enable the Web CP in WebView.
+     */
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -363,5 +363,20 @@ public enum AttributeName {
     /**
      * Records the if the broker handled a switch browser resume,
      */
-    is_switch_browser_resume_handled
+    is_switch_browser_resume_handled,
+
+    /**
+     * Records if the request is a webcp authorize request.
+     */
+    is_webcp_authorize_request,
+
+    /**
+     * Records if the request is a webcp authorize request.
+     */
+    is_webcp_enrollment_request,
+
+    /**
+     * Records if the webcp is enabled in webview.
+     */
+    is_webcp_in_webview_enabled
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -64,4 +64,5 @@ public enum SpanName {
     ProcessCrossCloudRedirect,
     SwitchBrowserResume,
     SwitchBrowserProcess,
+    ProcessWebCpRedirects
 }


### PR DESCRIPTION
Intune's support for web enrollment for Android is scheduled to GA in Q3 CY2025.  
For the many customers who set up conditional access, users enter the web enrollment flow by being blocked from accessing a productivity app such as Teams or Outlook.  

From that block page, they are pushed out of their productivity app and sent to the default browser app on their Android device where they see a Company Portal website (webCP) page, which guides them to Settings where they can enroll in Intune management. 

**Problems** 

The problems with showing webCP in the browser app is: 

1. Additional sign in: During enrollment, it adds an additional authentication for the user (2nd auth for iOS and 3rd for Android). 
2. Context change: It is a jarring experience, taking the user out of the context of the productivity app and into the browser app, which can be disorienting. 

See snapshot below for current experience with WebCP flow enabled
![image](https://github.com/user-attachments/assets/d8aaf9a1-205b-4055-b85b-d7e2fdd592e8)

Note, the highlighted green pages indicate the 3 times the user must authenticate during this flow.  

The flow: 

1. The user signs-in to the productivity app and is blocked by MDM CA. 
2. The user must select the “Continue” button on the MDM CA page (which indicates they need to register their device). 
3. The user is navigated to WebCP in the browser, where they must sign-in again. 
4. The user is shown a page to kick-off WP enrollment directly from the browser. The user must select the button to “Get started”. 
5. The user is taken through the Google screens for creating the Work Profile.  
6. The user lands  
7. The user completes the enrollment flow in the Work Profile version of the Company Portal.  

**Fix**
Showing webcp in webview when user clicks on continue button on CA block page.
So with the fix, the screen shown in red in step 2 in below snapshot is removed
![image](https://github.com/user-attachments/assets/184a1eb1-565e-499c-b6a1-b5cb30e87bea)


