### PR TITLE
Showing webcp flow in webview , Fixes AB#3135912

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 21.3.0
 - [MINOR] changes accommodating the WrappedKeyAlgoIdentifier module (#2667)
 - [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
 - [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
+- [MINOR] Showing webcp flow in webview (#2673)
 
 Version 21.2.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1273,6 +1273,11 @@ public final class AuthenticationConstants {
         public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
         /**
+         * Redirect URL from WebCP that should launch the authorization flow.
+         */
+        public static final String WEBCP_AUTHORIZE_REDIRECT_URL = "authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
+
+        /**
          * A query param indicating that this is an intune device CA link.
          */
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1273,9 +1273,9 @@ public final class AuthenticationConstants {
         public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
         /**
-         * Redirect URL pattern of WebCP that should launch the authorization flow.
+         * WebCP clientId.
          */
-        public static final String WEBCP_AUTHORIZE_URL_PATTERN  = "authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
+        public static final String WEBCP_CLIENT_ID  = "74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
 
         /**
          * A query param indicating that this is an intune device CA link.

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1268,6 +1268,11 @@ public final class AuthenticationConstants {
         public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = BROWSER_EXT_WEB_CP + "enrollment";
 
         /**
+         * Redirect URL from WebCP that should launch the enrollment flow.
+         */
+        public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
+
+        /**
          * A query param indicating that this is an intune device CA link.
          */
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1273,9 +1273,9 @@ public final class AuthenticationConstants {
         public static final String WEBCP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
         /**
-         * Redirect URL from WebCP that should launch the authorization flow.
+         * Redirect URL pattern of WebCP that should launch the authorization flow.
          */
-        public static final String WEBCP_AUTHORIZE_REDIRECT_URL = "authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
+        public static final String WEBCP_AUTHORIZE_URL_PATTERN  = "authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9";
 
         /**
          * A query param indicating that this is an intune device CA link.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -326,7 +326,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 processHeaderForwardingRequiredUri(view, url);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
                 Logger.info(methodTag,"Navigation contains cross cloud redirect.");
-                processCloudRedirectAndPrtHeader(view, url);
+                processCrossCloudRedirect(view, url);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpEnrollmentUrl(url)) {
                 Logger.info(methodTag,"Navigation contains web cp enrollment url.");
                 processWebCpEnrollmentUrl(view, url);
@@ -458,7 +458,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
         // URL is for an authorize request and contains the client_id of the WebCP app.
-        return url.contains(AuthenticationConstants.Broker.WEBCP_AUTHORIZE_REDIRECT_URL);
+        return url.contains(AuthenticationConstants.Broker.WEBCP_AUTHORIZE_URL_PATTERN);
     }
 
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
@@ -580,6 +580,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
         // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
         openLinkInBrowser(url);
+        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
+        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -830,8 +832,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     /**
      * This method is used to process the cross cloud redirect and attach the PRT header to the request.
      */
-    private void processCloudRedirectAndPrtHeader(@NonNull final WebView view, @NonNull final String url) {
-        final String methodTag = TAG + ":processCloudRedirectAndPrtHeader";
+    private void processCrossCloudRedirect(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processCrossCloudRedirect";
 
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -81,6 +81,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.Principal;
@@ -457,9 +458,48 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
-        // URL is for an authorize request and contains the client_id of the WebCP app.
-        return url.contains(AuthenticationConstants.Broker.WEBCP_AUTHORIZE_URL_PATTERN);
+        // URL should be for authorize request for webcp.
+        final String methodTag = TAG + ":isWebCpAuthorizeUrl";
+        try {
+            final URI uri = new URI(url);
+            final String host = uri.getHost();
+            final String path = uri.getPath();
+
+            if (host == null || path == null) {
+                Logger.info(methodTag, "URL missing host or path");
+                return false;
+            }
+
+            if (!AzureActiveDirectory.isValidCloudHost(new URL(url))) {
+                Logger.info(methodTag, "URL host is not a valid Azure cloud host");
+                return false;
+            }
+
+            if (!path.contains("/authorize")) {
+                Logger.info(methodTag, "URL path does not contain /authorize");
+                return false;
+            }
+
+            final Map<String, String> queryParams = StringExtensions.getUrlParameters(url);
+            final String clientId = queryParams.get("client_id");
+
+            if (StringUtil.isNullOrEmpty(clientId)) {
+                Logger.info(methodTag, "Authorize URL does not contain client_id");
+                return false;
+            }
+
+            final boolean isWebCpClient = AuthenticationConstants.Broker.WEBCP_CLIENT_ID.equalsIgnoreCase(clientId);
+            Logger.info(methodTag, isWebCpClient
+                    ? "WebCP authorize URL contains valid WebCP client_id."
+                    : "Authorize URL contains different client_id.");
+            return isWebCpClient;
+
+        } catch (URISyntaxException | MalformedURLException e) {
+            Logger.info(methodTag, "Invalid URL: " + e.getMessage());
+            return false;
+        }
     }
+
 
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
         // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
@@ -542,14 +582,15 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }
 
+    // Decides whether to launch the Company Portal app based on the presence of the IPPhone app and its signature.
     private boolean shouldLaunchCompanyPortal() {
-        PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
-
+        final PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
         return packageHelper.isPackageInstalledAndEnabled(IPPHONE_APP_PACKAGE_NAME)
                 && IPPHONE_APP_SIGNATURE.equals(packageHelper.getSha1SignatureForPackage(IPPHONE_APP_PACKAGE_NAME))
                 && packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME);
     }
 
+    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
     @VisibleForTesting
     protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
         final String methodTag = TAG + ":loadDeviceCaUrl";
@@ -569,7 +610,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
-
+    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
+    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
     private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processWebCpEnrollmentUrl";
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -55,7 +55,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizat
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractSmartcardCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
@@ -187,7 +187,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(url)) {
             throw new IllegalArgumentException("Redirect to empty url in web view.");
         }
-
         return handleUrl(view, url);
     }
 
@@ -456,7 +455,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
         // URL is for an authorize request and contains the client_id of the WebCP app.
-        return url.contains("authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9");
+        return url.contains(AuthenticationConstants.Broker.WEBCP_AUTHORIZE_REDIRECT_URL);
     }
 
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
@@ -529,11 +528,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             loadDeviceCaUrl(url, view);
+        } else {
+            Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
+            openLinkInBrowser(url);
+            returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
         }
-
-        Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
-        openLinkInBrowser(url);
-        returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
     }
 
     private boolean isDeviceCaRequest(@NonNull final String url) {
@@ -821,8 +820,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
         span.setAttribute(AttributeName.is_webcp_authorize_request.name(), true);
-        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
-        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+        final ReAttachPrtHeaderHandler reAttachPrtHeaderHandler = new ReAttachPrtHeaderHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHeaderHandler, view, methodTag, span);
     }
 
     /**
@@ -834,12 +833,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
-        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
-        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+        final ReAttachPrtHeaderHandler reAttachPrtHeaderHandler = new ReAttachPrtHeaderHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHeaderHandler, view, methodTag, span);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
+    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHeaderHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             reAttachPrtHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -55,7 +55,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizat
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractSmartcardCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.AbstractCertBasedAuthChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.certbasedauth.CertBasedAuthFactory;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
@@ -187,6 +187,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(url)) {
             throw new IllegalArgumentException("Redirect to empty url in web view.");
         }
+
         return handleUrl(view, url);
     }
 
@@ -245,7 +246,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             view.removeJavascriptInterface(AuthUxJavaScriptInterface.Companion.getInterfaceName());
             mAuthUxJavaScriptInterfaceAdded = false;
         }
-
 
         try {
             if (isPkeyAuthUrl(formattedURL)) {
@@ -325,11 +325,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
                 Logger.info(methodTag,"Navigation contains cross cloud redirect.");
                 processCloudRedirectAndPrtHeader(view, url);
-            }
-             else {
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpEnrollmentUrl(url)) {
+                Logger.info(methodTag,"Navigation contains web cp enrollment url.");
+                processWebCpEnrollmentUrl(view, url);
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpAuthorizeUrl(url)) {
+                processWebCpAuthorize(view, url);
+            } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
-
                 return false;
             }
         } catch (final ClientException exception) {
@@ -447,6 +450,15 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return url.startsWith(AMAZON_APP_REDIRECT_PREFIX);
     }
 
+    private boolean isWebCpEnrollmentUrl(@NonNull final String url) {
+        return url.startsWith(AuthenticationConstants.Broker.WEBCP_ENROLLMENT_URL);
+    }
+
+    private boolean isWebCpAuthorizeUrl(@NonNull final String url) {
+        // URL is for an authorize request and contains the client_id of the WebCP app.
+        return url.contains("authorize?client_id=74bcdadc-2fdc-4bb3-8459-76d06952a0e9");
+    }
+
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
         // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
         // This drops all the headers, which can have credentials useful for SSO and correlationIds useful for
@@ -498,20 +510,16 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private void processWebsiteRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processWebsiteRequest";
-
         view.stopLoading();
 
-        if (url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER)) {
+        if (isDeviceCaRequest(url)) {
             Logger.info(methodTag, "This is a device CA request.");
-            final PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
 
-            // If CP is installed, redirect to CP.
-            // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
-            //       CP is currently working on this.
-            //       Until that comes, we'll only handle this in ipphone.
-            if (packageHelper.isPackageInstalledAndEnabled(IPPHONE_APP_PACKAGE_NAME) &&
-                    IPPHONE_APP_SIGNATURE.equals(packageHelper.getSha1SignatureForPackage(IPPHONE_APP_PACKAGE_NAME)) &&
-                    packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME)) {
+            if (shouldLaunchCompanyPortal()) {
+                // If CP is installed, redirect to CP.
+                // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
+                //       CP is currently working on this.
+                //       Until that comes, we'll only handle this in ipphone.
                 try {
                     launchCompanyPortal();
                     return;
@@ -520,14 +528,62 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 }
             }
 
-            // Otherwise, launch in Browser.
-            openLinkInBrowser(url);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            return;
+            loadDeviceCaUrl(url, view);
         }
 
+        Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
         openLinkInBrowser(url);
         returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
+    }
+
+    private boolean isDeviceCaRequest(@NonNull final String url) {
+        return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
+    }
+
+    private boolean shouldLaunchCompanyPortal() {
+        PackageHelper packageHelper = new PackageHelper(getActivity().getPackageManager());
+
+        return packageHelper.isPackageInstalledAndEnabled(IPPHONE_APP_PACKAGE_NAME)
+                && IPPHONE_APP_SIGNATURE.equals(packageHelper.getSha1SignatureForPackage(IPPHONE_APP_PACKAGE_NAME))
+                && packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME);
+    }
+
+    private void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+        final String methodTag = TAG + ":loadDeviceCaUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Logger.info(methodTag, "Loading device CA request in WebView.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+            view.loadUrl(httpsUrl, mRequestHeaders);
+        } else {
+            Logger.info(methodTag, "Loading device CA request in browser.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+            openLinkInBrowser(originalUrl);
+            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        }
+    }
+
+
+    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+        view.stopLoading();
+        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+        openLinkInBrowser(url);
+        final int threadSleepForIntentToLaunch = 5000; // 5 secs pause before the intent is launched and flow is killed for smooth transition.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+        }, threadSleepForIntentToLaunch);
     }
 
     private boolean processPlayStoreURL(@NonNull final WebView view, @NonNull final String url) {
@@ -602,7 +658,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             Logger.warn(methodTag, "Unable to find an app to resolve the activity.");
         }
     }
-
     private void processWebCpRequest(@NonNull final WebView view, @NonNull final String url) {
 
         view.stopLoading();
@@ -710,7 +765,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private void processInvalidUrl(@NonNull final String url) {
         final String methodTag = TAG + ":processInvalidUrl";
 
-        Logger.infoPII(methodTag,"We are declining to override loading and redirect to invalid URL: '"
+        Logger.info(methodTag,"We are declining to override loading and redirect to invalid URL: '"
                 + removeQueryParametersOrRedact(url) + "' the user's url pattern is '" + mRedirectUrl + "'");
     }
 
@@ -757,6 +812,20 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     /**
+     * This method is used to process the webcp redirect and re-attach the PRT header to the request.
+     */
+    private void processWebCpAuthorize(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCPAuthorize";
+        Logger.info(methodTag, "Processing WebCP authorize request.");
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_authorize_request.name(), true);
+        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
+    }
+
+    /**
      * This method is used to process the cross cloud redirect and attach the PRT header to the request.
      */
     private void processCloudRedirectAndPrtHeader(@NonNull final WebView view, @NonNull final String url) {
@@ -765,20 +834,20 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessCrossCloudRedirect.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessCrossCloudRedirect.name());
-        final CrossCloudChallengeHandler crossCloudChallengeHandler = new CrossCloudChallengeHandler(view, mRequestHeaders, span);
-        processCloudRedirectAndPrtHeaderInternal(url, crossCloudChallengeHandler, view, methodTag, span);
+        final ReAttachPrtHandler reAttachPrtHandler = new ReAttachPrtHandler(view, mRequestHeaders, span);
+        reAttachPrtHeader(url, reAttachPrtHandler, view, methodTag, span);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    public void processCloudRedirectAndPrtHeaderInternal(@NonNull final String url, @NonNull final CrossCloudChallengeHandler crossCloudChallengeHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
+    public void reAttachPrtHeader(@NonNull final String url, @NonNull final ReAttachPrtHandler reAttachPrtHandler, @NonNull final WebView view, @NonNull final String methodTag, @NonNull final Span span) {
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
-            crossCloudChallengeHandler.processChallenge(url);
+            reAttachPrtHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);
         } catch (final Exception e) {
             // No op if an exception happens
-            Logger.warn(methodTag, "Error processing cross cloud redirect and attaching PRT header." + e);
+            Logger.warn(methodTag, "Error attaching PRT header." + e);
             span.recordException(e);
-            view.loadUrl(url, mRequestHeaders);
+            view.loadUrl(url, mRequestHeaders); //
         } finally {
             span.end();
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -87,6 +87,7 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AMAZON_APP_REDIRECT_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
@@ -115,6 +116,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
     private static final String DEVICE_CERT_ISSUER = "CN=MS-Organization-Access";
+    // 3 secs wait for the intent to be launched and the current flow is killed for smooth transition.
+    private static final int THREAD_SLEEP_FOR_INTENT_LAUNCH_MS = 3;
     private final String mRedirectUrl;
     private final CertBasedAuthFactory mCertBasedAuthFactory;
     private AbstractCertBasedAuthChallengeHandler mCertBasedAuthChallengeHandler;
@@ -576,13 +579,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
         // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
         openLinkInBrowser(url);
-        final int threadSleepForIntentToLaunch = 5000; // 5 secs pause before the intent is launched and flow is killed for smooth transition.
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
                 returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
             }
-        }, threadSleepForIntentToLaunch);
+        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
     }
 
     private boolean processPlayStoreURL(@NonNull final WebView view, @NonNull final String url) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -481,7 +481,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             final Map<String, String> queryParams = StringExtensions.getUrlParameters(url);
-            final String clientId = queryParams.get("client_id");
+            final String clientId = queryParams.get(AuthenticationConstants.OAuth2.CLIENT_ID);
 
             if (StringUtil.isNullOrEmpty(clientId)) {
                 Logger.info(methodTag, "Authorize URL does not contain client_id");
@@ -494,12 +494,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                     : "Authorize URL contains different client_id.");
             return isWebCpClient;
 
-        } catch (URISyntaxException | MalformedURLException e) {
+        } catch (final URISyntaxException | MalformedURLException e) {
             Logger.info(methodTag, "Invalid URL: " + e.getMessage());
             return false;
         }
     }
-
 
     private boolean isHeaderForwardingRequiredUri(@NonNull final String url) {
         // MSAL makes MSA requests first to login.microsoftonline.com, and then gets redirected to login.live.com.
@@ -811,7 +810,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private void processInvalidUrl(@NonNull final String url) {
         final String methodTag = TAG + ":processInvalidUrl";
 
-        Logger.info(methodTag,"We are declining to override loading and redirect to invalid URL: '"
+        Logger.infoPII(methodTag,"We are declining to override loading and redirect to invalid URL: '"
                 + removeQueryParametersOrRedact(url) + "' the user's url pattern is '" + mRedirectUrl + "'");
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -550,7 +550,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 && packageHelper.isPackageInstalledAndEnabled(COMPANY_PORTAL_APP_PACKAGE_NAME);
     }
 
-    private void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+    @VisibleForTesting
+    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
         final String methodTag = TAG + ":loadDeviceCaUrl";
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
@@ -848,7 +849,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // No op if an exception happens
             Logger.warn(methodTag, "Error attaching PRT header." + e);
             span.recordException(e);
-            view.loadUrl(url, mRequestHeaders); //
+            view.loadUrl(url, mRequestHeaders);
         } finally {
             span.end();
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHandler.kt
@@ -28,19 +28,17 @@ import com.microsoft.identity.common.adal.internal.util.StringExtensions
 import com.microsoft.identity.common.java.broker.CommonRefreshTokenCredentialProvider
 import com.microsoft.identity.common.java.opentelemetry.AttributeName
 import com.microsoft.identity.common.logging.Logger
-import io.opentelemetry.api.internal.StringUtils
 import io.opentelemetry.api.trace.Span
-import java.net.URL
 
 /**
- * Handler for attaching prt credential header on web view in cross cloud redirect scenarios.
+ * Handler for attaching prt credential header on web view in redirect scenarios.
  */
-class CrossCloudChallengeHandler(
+class ReAttachPrtHandler(
     private val webView: WebView,
     private val headers: HashMap<String, String>,
     private val span : Span
 ) : IChallengeHandler<String, Void> {
-    private val TAG = CrossCloudChallengeHandler::class.java.simpleName
+    private val TAG = ReAttachPrtHandler::class.java.simpleName
 
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge of a cross cloud request.")

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -33,15 +33,15 @@ import io.opentelemetry.api.trace.Span
 /**
  * Handler for attaching prt credential header on web view in redirect scenarios.
  */
-class ReAttachPrtHandler(
+class ReAttachPrtHeaderHandler(
     private val webView: WebView,
     private val headers: HashMap<String, String>,
     private val span : Span
 ) : IChallengeHandler<String, Void> {
-    private val TAG = ReAttachPrtHandler::class.java.simpleName
+    private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
 
     override fun processChallenge(inputUrl: String): Void? {
-        Logger.info(TAG, "Processing challenge of a cross cloud request.")
+        Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)
         webView.loadUrl(inputUrl, headers)
         return null

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -33,6 +33,8 @@ import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
@@ -218,7 +220,22 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testUrlOverrideHandleWebCPEnrollmentUrl() {
-        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+        if(CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+        } else {
+            assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+        }
+    }
+
+    @Test
+    public void testLoadDeviceCaUrl() {
+        final WebView mockWebview = Mockito.mock(WebView.class);
+        mWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
+        if(CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
+        } else {
+            Mockito.verify(mockWebview, Mockito.never()).loadUrl(Mockito.anyString(), Mockito.any());
+        }
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -31,7 +31,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.CrossCloudChallengeHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
@@ -93,6 +93,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_PUBLIC_CLOUD_REDIRECT_URL = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize?x=10";
     private static final String TEST_PASSKEY_REDIRECT_URL = "http-auth:PassKey?challenge=challenge&version=1.0&submitUrl=https://login.microsoftonline.com/common/credential?passKeyAuth=1.0%2fpasskey&context=&relyingPartyIdentifier=login.microsoft.com&allowedCredentials=somevalue";
     private static final String TEST_INTENT_INSTALL_BROKER_REDIRECT_URL = "intent://play.google.com/store/apps/details?id=com.azure.authenticator&referrer=%20adjust_reftag%3Dc6f1p4ErudH2C%26utm_source%3DLanding%2BPage%2BOrganic%2B-%2Bapp%2Bstore%2Bbadges%26utm_campaign%3Dappstore_android&pcampaignid=web_auto_redirect&web_logged_in=0&redirect_entry_point=dp#Intent;scheme=https;action=android.intent.action.VIEW;package=com.android.vending;end";
+
+    private static final String TEST_WEB_CP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
     @Before
     public void setup() throws ClientException {
@@ -215,10 +217,15 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     @Test
+    public void testUrlOverrideHandleWebCPEnrollmentUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+    }
+
+    @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalSuccess() {
-        CrossCloudChallengeHandler mockCrossCloudChallengeHandler = Mockito.mock(CrossCloudChallengeHandler.class);
+        ReAttachPrtHandler mockCrossCloudChallengeHandler = Mockito.mock(ReAttachPrtHandler.class);
         try {
-            mWebViewClient.processCloudRedirectAndPrtHeaderInternal(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mMockWebView, "methodTag", Span.current());
+            mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mMockWebView, "methodTag", Span.current());
         } catch (Exception e) {
             Assert.fail("Unexpected exception occured " + e);
         }
@@ -226,12 +233,12 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalException() {
-        CrossCloudChallengeHandler mockCrossCloudChallengeHandler = Mockito.mock(CrossCloudChallengeHandler.class);
+        ReAttachPrtHandler mockReAttachPrtHandler = Mockito.mock(ReAttachPrtHandler.class);
         WebView mockWebView = Mockito.mock(WebView.class);
-        Mockito.doThrow(new RuntimeException("Test Exception")).when(mockCrossCloudChallengeHandler).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
+        Mockito.doThrow(new RuntimeException("Test Exception")).when(mockReAttachPrtHandler).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
         try {
-            mWebViewClient.processCloudRedirectAndPrtHeaderInternal(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mockWebView, "methodTag", Span.current());
-            Mockito.verify(mockCrossCloudChallengeHandler, Mockito.times(1)).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
+            mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockReAttachPrtHandler, mockWebView, "methodTag", Span.current());
+            Mockito.verify(mockReAttachPrtHandler, Mockito.times(1)).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
             Mockito.verify(mockWebView).loadUrl(Mockito.anyString(), Mockito.any());
         } catch (Exception e) {
             Assert.fail("Failure is not expected. We should have caught the exception and ignored it. " + e);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -31,7 +31,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
-import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHandler;
+import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
@@ -223,7 +223,7 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalSuccess() {
-        ReAttachPrtHandler mockCrossCloudChallengeHandler = Mockito.mock(ReAttachPrtHandler.class);
+        ReAttachPrtHeaderHandler mockCrossCloudChallengeHandler = Mockito.mock(ReAttachPrtHeaderHandler.class);
         try {
             mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockCrossCloudChallengeHandler, mMockWebView, "methodTag", Span.current());
         } catch (Exception e) {
@@ -233,7 +233,7 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalException() {
-        ReAttachPrtHandler mockReAttachPrtHandler = Mockito.mock(ReAttachPrtHandler.class);
+        ReAttachPrtHeaderHandler mockReAttachPrtHandler = Mockito.mock(ReAttachPrtHeaderHandler.class);
         WebView mockWebView = Mockito.mock(WebView.class);
         Mockito.doThrow(new RuntimeException("Test Exception")).when(mockReAttachPrtHandler).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
         try {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandlerTest.kt
@@ -35,25 +35,25 @@ import org.junit.Test
 import org.mockito.Mockito.*
 
 @RunWith(RobolectricTestRunner::class)
-class CrossCloudChallengeHandlerTest {
+class ReAttachPrtHeaderHandlerTest {
 
     private lateinit var webView: WebView
     private lateinit var headers: HashMap<String, String>
     private lateinit var span: Span
-    private lateinit var crossCloudChallengeHandler: CrossCloudChallengeHandler
+    private lateinit var reAttachPrtHeaderHandler: ReAttachPrtHeaderHandler
 
     @Before
     fun setUp() {
         webView = mock(WebView::class.java)
         headers = HashMap()
         span = mock(Span::class.java)
-        crossCloudChallengeHandler = CrossCloudChallengeHandler(webView, headers, span)
+        reAttachPrtHeaderHandler = ReAttachPrtHeaderHandler(webView, headers, span)
     }
 
     @Test
     fun `testProcessChallenge success`() {
         val testUrl = "https://example.com?login_hint=testuser"
-        crossCloudChallengeHandler.processChallenge(testUrl)
+        reAttachPrtHeaderHandler.processChallenge(testUrl)
         verify(webView).loadUrl(eq(testUrl), eq(headers))
     }
 
@@ -70,7 +70,7 @@ class CrossCloudChallengeHandlerTest {
         } throws Exception()
 
         try {
-            crossCloudChallengeHandler.processChallenge(testUrl)
+            reAttachPrtHeaderHandler.processChallenge(testUrl)
         } catch (e: Exception) {
             verify(webView, never()).loadUrl(eq(testUrl), eq(headers))
         }
@@ -91,7 +91,7 @@ class CrossCloudChallengeHandlerTest {
         } returns refreshTokenCredential
 
         // Call the method
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true
@@ -102,7 +102,7 @@ class CrossCloudChallengeHandlerTest {
     @Test
     fun `modifyHeadersWithRefreshTokenCredential should not update headers when login_hint is missing`() {
         val url = "https://login.microsoftonline.com"
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span, never()).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true
@@ -112,7 +112,7 @@ class CrossCloudChallengeHandlerTest {
     @Test
     fun `modifyHeadersWithRefreshTokenCredential null refresh token credential`() {
         val url = "https://login.microsoftonline.com?login_hint=testuser"
-        crossCloudChallengeHandler.modifyHeadersWithRefreshTokenCredential(url)
+        reAttachPrtHeaderHandler.modifyHeadersWithRefreshTokenCredential(url)
         verify(span, never()).setAttribute(
             AttributeName.is_new_refresh_token_cred_header_attached.name,
             true

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -124,7 +124,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable handling the UI in edge to edge mode
      */
-    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true);
+    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true),
+
+    /**
+     * Flight to enable the Web CP in WebView.
+     */
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -371,7 +371,7 @@ public enum AttributeName {
     is_webcp_authorize_request,
 
     /**
-     * Records if the request is a webcp authorize request.
+     * Records if the request is a webcp enrollment request.
      */
     is_webcp_enrollment_request,
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -363,5 +363,20 @@ public enum AttributeName {
     /**
      * Records the if the broker handled a switch browser resume,
      */
-    is_switch_browser_resume_handled
+    is_switch_browser_resume_handled,
+
+    /**
+     * Records if the request is a webcp authorize request.
+     */
+    is_webcp_authorize_request,
+
+    /**
+     * Records if the request is a webcp authorize request.
+     */
+    is_webcp_enrollment_request,
+
+    /**
+     * Records if the webcp is enabled in webview.
+     */
+    is_webcp_in_webview_enabled
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -64,5 +64,6 @@ public enum SpanName {
     ProcessCrossCloudRedirect,
     SwitchBrowserResume,
     SwitchBrowserProcess,
-    WrappedKeyAlgorithmIdentifier
+    WrappedKeyAlgorithmIdentifier,
+    ProcessWebCpRedirects
 }


### PR DESCRIPTION
Intune's support for web enrollment for Android is scheduled to GA in Q3 CY2025.
For the many customers who set up conditional access, users enter the web enrollment flow by being blocked from accessing a productivity app such as Teams or Outlook.

From that block page, they are pushed out of their productivity app and sent to the default browser app on their Android device where they see a Company Portal website (webCP) page, which guides them to Settings where they can enroll in Intune management.

**Problems**

The problems with showing webCP in the browser app is:

1. Additional sign in: During enrollment, it adds an additional authentication for the user (2nd auth for iOS and 3rd for Android).
2. Context change: It is a jarring experience, taking the user out of the context of the productivity app and into the browser app, which can be disorienting.

See snapshot below for current experience with WebCP flow enabled
![image](https://github.com/user-attachments/assets/7ea1ce0b-10c9-4592-b659-8abd9e40ce59)

Note, the highlighted green pages indicate the 3 times the user must authenticate during this flow.

**The flow:**

1. The user signs-in to the productivity app and is blocked by MDM CA.
2. The user must select the “Continue” button on the MDM CA page (which indicates they need to register their device).
3. The user is navigated to WebCP in the browser, where they must sign-in again.
4. The user is shown a page to kick-off WP enrollment directly from the browser. The user must select the button to “Get started”.
5. The user is taken through the Google screens for creating the Work Profile.
6. The user lands
7. The user completes the enrollment flow in the Work Profile version of the Company Portal.

**Fix**
Showing webcp in webview when user clicks on continue button on CA block page.
So with the fix, the screen shown in red in step 2 in below snapshot is removed
![image](https://github.com/user-attachments/assets/0f012cb8-d495-40e0-a235-f3032bd93b78)

Fixes [AB#3135912](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3135912)

Related broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/3130
