### PR TITLE
June 2025 Ui Automation Updates, Fixes AB#3304003

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/IOAuth2LoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/IOAuth2LoginComponentHandler.java
@@ -38,9 +38,10 @@ public interface IOAuth2LoginComponentHandler {
     /**
      * Enters the supplied password in the password field of a login page.
      *
-     * @param password the password of the user
+     * @param password     the password of the user
+     * @param isMsaAccount whether or not using msa account
      */
-    void handlePasswordField(final String password);
+    void handlePasswordField(final String password, final boolean isMsaAccount);
 
     /**
      * Clicks the back button on a login page.

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/B2CIdLabLocalLoginComponentHandler.java
@@ -45,7 +45,7 @@ public class B2CIdLabLocalLoginComponentHandler extends AbstractB2CLoginComponen
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
+    public void handlePasswordField(@NonNull final String password, final boolean isMsaAccount) {
         Logger.i(TAG, "Handle B2C IdLab Local Login Password UI..");
         UiAutomatorUtils.handleInput("password", password);
         handleNextButton();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/FacebookLoginComponentHandler.java
@@ -49,7 +49,7 @@ public class FacebookLoginComponentHandler extends AbstractB2CLoginComponentHand
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
+    public void handlePasswordField(@NonNull final String password, final boolean isMsaAccount) {
         Logger.i(TAG, "Handle Facebook Login Password UI..");
         UiAutomatorUtils.handleInput("m_login_password", password);
         handleNextButton();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/GoogleLoginComponentHandler.java
@@ -55,7 +55,7 @@ public class GoogleLoginComponentHandler extends AbstractB2CLoginComponentHandle
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
+    public void handlePasswordField(@NonNull final String password, final boolean isMsaAccount) {
         Logger.i(TAG, "Handle Google Login Password UI..");
         UiAutomatorUtils.handleInput("password", password);
         final UiObject passwordBox = UiAutomatorUtils.obtainUiObjectWithResourceId("password");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/b2c/IdLabB2cSisoPolicyPromptHandler.java
@@ -66,7 +66,7 @@ public class IdLabB2cSisoPolicyPromptHandler extends AbstractPromptHandler {
         }
 
         if (!parameters.isSessionExpected()) {
-            loginComponentHandler.handlePasswordField(password);
+            loginComponentHandler.handlePasswordField(password, false);
 
             if (loginComponentHandler instanceof GoogleLoginComponentHandler &&
                     b2CProvider == B2CProviderWrapper.Google){

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -26,7 +26,6 @@ import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
-import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 
@@ -42,7 +41,6 @@ import static org.junit.Assert.fail;
 
 import android.widget.Button;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -80,8 +78,26 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
+    public void handlePasswordField(@NonNull final String password, final boolean isMsaAccount) {
         Logger.i(TAG, "Handle Aad Login Password UI..");
+
+        // We need to temporarily handle both possible flows for msa accounts.
+        // 1. If the user is using an MSA account, we may see a screen prompting MFA or OTP, with an option that
+        // says "Other ways to sign in"
+        // 2. No OTP or MFA, just prompted for password right away.
+        if (isMsaAccount) {
+            final UiObject otherWays = UiAutomatorUtils.obtainUiObjectWithExactText("Other ways to sign in");
+            if (otherWays.exists()) {
+                try {
+                    otherWays.click();
+
+                    UiAutomatorUtils.handleButtonClickForObjectWithExactText("Use your password");
+                } catch (final UiObjectNotFoundException e) {
+                    throw new AssertionError(e);
+                }
+            }
+        }
+
         UiAutomatorUtils.obtainUiObjectWithText("password", mFindLoginUiElementTimeout);
         try {
             UiAutomatorUtils.handleInputByClass("android.widget.EditText", password, mFindLoginUiElementTimeout);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -86,7 +86,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         // says "Other ways to sign in"
         // 2. No OTP or MFA, just prompted for password right away.
         if (isMsaAccount) {
-            final UiObject otherWays = UiAutomatorUtils.obtainUiObjectWithExactText("Other ways to sign in");
+            final UiObject otherWays = UiAutomatorUtils.obtainUiObjectWithExactText("Other ways to sign in", CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
             if (otherWays.exists()) {
                 try {
                     otherWays.click();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AdfsLoginComponentHandler.java
@@ -48,7 +48,7 @@ public class AdfsLoginComponentHandler extends AadLoginComponentHandler {
     }
 
     @Override
-    public void handlePasswordField(@NonNull final String password) {
+    public void handlePasswordField(@NonNull final String password, final boolean isMsaAccount) {
         Logger.i(TAG, "Handle Adfs Login Password UI..");
         try {
             UiAutomatorUtils.handleInput("passwordInput", password, CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/MicrosoftStsPromptHandler.java
@@ -66,6 +66,8 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
         final IMicrosoftStsLoginComponentHandler aadLoginComponentHandler =
                 (IMicrosoftStsLoginComponentHandler) loginComponentHandler;
 
+        final Boolean isMsaAccount = isMsaAccount(username);
+
         // if login hint was not provided, then we need to handle either account picker or email
         // field. If it was provided, then we expect to go straight to password field.
         if (!loginHintProvided) {
@@ -89,7 +91,7 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
         }
 
         if (parameters.isPasswordPageExpected() || parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
-            loginComponentHandler.handlePasswordField(password);
+            loginComponentHandler.handlePasswordField(password, isMsaAccount);
         }
 
         if (parameters.isVerifyYourIdentityPageExpected()) {
@@ -142,10 +144,16 @@ public class MicrosoftStsPromptHandler extends AbstractPromptHandler {
 
         if (parameters.isSecondPasswordPageExpected()) {
             try {
-                loginComponentHandler.handlePasswordField(password);
+                loginComponentHandler.handlePasswordField(password, isMsaAccount);
             } catch (AssertionError e) {
                 // Let's not throw an error if we fail on the second password field, sometimes seems to not show up in tests that use it.
             }
         }
+    }
+
+    private Boolean isMsaAccount(@NonNull final String username) {
+        // We'll probably need to update this in the future, if additional MSA accounts get
+        // added to lab that don't have outlook domain
+        return username.contains("outlook.com");
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/TlsPromptHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/TlsPromptHandler.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.client.ui.automation.interaction.microsoftsts;
 
 import android.text.TextUtils;
-import android.widget.ImageButton;
 
 import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -41,8 +40,6 @@ import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import org.junit.Assert;
 
 import java.util.concurrent.TimeUnit;
-
-import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
 
 /**
  * A Prompt Handler for TLS login flows.
@@ -109,7 +106,7 @@ public class TlsPromptHandler extends AbstractPromptHandler {
         }
 
         if (parameters.isPasswordPageExpected() || parameters.getPrompt() == PromptParameter.LOGIN || !parameters.isSessionExpected()) {
-            loginComponentHandler.handlePasswordField(password);
+            loginComponentHandler.handlePasswordField(password, false);
         }
         // installing certificate.
         UiAutomatorUtils.handleButtonClick("android:id/button1");

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/PowerLiftIncidentRule.java
@@ -2,6 +2,8 @@ package com.microsoft.identity.client.ui.automation.rules;
 
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.powerlift.ThrowableWithPowerLiftIncident;
@@ -32,33 +34,41 @@ public class PowerLiftIncidentRule implements TestRule {
                 try {
                     base.evaluate();
                 } catch (final Throwable originalThrowable) {
-                    String powerLiftIncidentDetails = null;
-                    try {
-                        Logger.e(
-                                TAG,
-                                "Encountered error during test....creating PowerLift incident.",
-                                originalThrowable
-                        );
-                        powerLiftIncidentDetails = powerLiftIntegratedApp.createPowerLiftIncident();
-                    } catch (final Throwable powerLiftError) {
-                        Logger.e(
-                                TAG,
-                                "Oops...something went wrong...unable to create PowerLift incident.",
-                                powerLiftError
-                        );
-                    }
-                    if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
-                        throw originalThrowable;
-                    } else {
-                        assert powerLiftIncidentDetails != null;
-                        throw new ThrowableWithPowerLiftIncident(
-                                powerLiftIntegratedApp,
-                                powerLiftIncidentDetails,
-                                originalThrowable
-                        );
-                    }
+                    attemptPowerLiftIncident(originalThrowable, powerLiftIntegratedApp);
                 }
             }
         };
+    }
+
+    public static void attemptPowerLiftIncident(final Throwable originalThrowable, @Nullable final IPowerLiftIntegratedApp powerLiftIntegratedApp) throws Throwable {
+        if (powerLiftIntegratedApp == null) {
+            throw originalThrowable;
+        }
+
+        String powerLiftIncidentDetails = null;
+        try {
+            Logger.e(
+                    TAG,
+                    "Encountered error during test....creating PowerLift incident.",
+                    originalThrowable
+            );
+            powerLiftIncidentDetails = powerLiftIntegratedApp.createPowerLiftIncident();
+        } catch (final Throwable powerLiftError) {
+            Logger.e(
+                    TAG,
+                    "Oops...something went wrong...unable to create PowerLift incident.",
+                    powerLiftError
+            );
+        }
+        if (TextUtils.isEmpty(powerLiftIncidentDetails)) {
+            throw originalThrowable;
+        } else {
+            assert powerLiftIncidentDetails != null;
+            throw new ThrowableWithPowerLiftIncident(
+                    powerLiftIntegratedApp,
+                    powerLiftIncidentDetails,
+                    originalThrowable
+            );
+        }
     }
 }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
@@ -24,7 +24,9 @@ package com.microsoft.identity.client.ui.automation.rules;
 
 import com.microsoft.identity.client.ui.automation.BuildConfig;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -38,6 +40,12 @@ public class RetryTestRule implements TestRule {
 
     private final static String TAG = RetryTestRule.class.getSimpleName();
     private final static int MINIMUM_NUMBER_OF_ATTEMPTS = BuildConfig.MINIMUM_TEST_ATTEMPTS;
+
+    private ITestBroker mBroker;
+
+    public RetryTestRule(final ITestBroker broker) {
+        this.mBroker = broker;
+    }
 
     @Override
     public Statement apply(final Statement base, final Description description) {
@@ -64,9 +72,9 @@ public class RetryTestRule implements TestRule {
                 }
 
                 // If after evaluating annotation, we still have number of attempts less than minimum, increase number of attempts
-                if (numAttempts < MINIMUM_NUMBER_OF_ATTEMPTS) {
-                    numAttempts = MINIMUM_NUMBER_OF_ATTEMPTS;
-                }
+//                if (numAttempts < MINIMUM_NUMBER_OF_ATTEMPTS) {
+//                    numAttempts = MINIMUM_NUMBER_OF_ATTEMPTS;
+//                }
 
                 for (int i = 0; i < numAttempts; i++) {
                     try {
@@ -85,7 +93,13 @@ public class RetryTestRule implements TestRule {
                         " - Giving up after " + numAttempts + " attempts as all attempts have failed :(");
 
                 assert caughtThrowable != null;
-                throw caughtThrowable;
+
+                // Create powerlift incident at the end of retry attempts
+                if (mBroker != null && mBroker instanceof IPowerLiftIntegratedApp && BuildConfig.SEND_POWERLIFT_LOGS) {
+                    PowerLiftIncidentRule.attemptPowerLiftIncident(caughtThrowable, (IPowerLiftIntegratedApp) mBroker);
+                } else {
+                    throw caughtThrowable;
+                }
             }
         };
     }

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
@@ -72,9 +72,9 @@ public class RetryTestRule implements TestRule {
                 }
 
                 // If after evaluating annotation, we still have number of attempts less than minimum, increase number of attempts
-//                if (numAttempts < MINIMUM_NUMBER_OF_ATTEMPTS) {
-//                    numAttempts = MINIMUM_NUMBER_OF_ATTEMPTS;
-//                }
+                if (numAttempts < MINIMUM_NUMBER_OF_ATTEMPTS) {
+                    numAttempts = MINIMUM_NUMBER_OF_ATTEMPTS;
+                }
 
                 for (int i = 0; i < numAttempts; i++) {
                     try {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RulesHelper.java
@@ -69,7 +69,7 @@ public class RulesHelper {
         RuleChain ruleChain = RuleChain.outerRule(new AutomationLoggingRule());
 
         Log.i(TAG, "Adding RetryTestRule");
-        ruleChain = ruleChain.around(new RetryTestRule());
+        ruleChain = ruleChain.around(new RetryTestRule(broker));
 
         Log.i(TAG, "Adding Timeout Rule");
         ruleChain = ruleChain.around(timeout);
@@ -106,11 +106,6 @@ public class RulesHelper {
 
             Log.i(TAG, "Adding InstallBrokerTestRule");
             ruleChain = ruleChain.around(new InstallBrokerTestRule(broker));
-
-            if (broker instanceof IPowerLiftIntegratedApp && BuildConfig.SEND_POWERLIFT_LOGS) {
-                Log.i(TAG, "Adding PowerLiftIncidentRule");
-                ruleChain = ruleChain.around(new PowerLiftIncidentRule((IPowerLiftIntegratedApp) broker));
-            }
 
             Log.i(TAG, "Adding DeviceEnrollmentFailureRecoveryRule");
             ruleChain = ruleChain.around(new DeviceEnrollmentFailureRecoveryRule());


### PR DESCRIPTION
MSA Sign in flow was recently changed on server side. There is now a prompt being rolled out that asks user for MFA/OTP right after username entry rather than password prompt, deliberate choice to guide users away from passwords. Needed to update our ui to handle both the old MSA sign in flow as well as the new user experience until the rollout is complete.

Also including a change to only create a powerlift incident at the final retry for a test. This should help drive ui costs down a bit
 
[AB#3304003](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3304003)