### PR TITLE
Construct broker app link redirect URI based on broker pkg name + move under /androidbroker path

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@ Version 21.3.0
 - [MINOR] changes accommodating the WrappedKeyAlgoIdentifier module (#2667)
 - [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
 - [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
-- [MINOR] Construct broker app link redirect based on broker pkg name
+- [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 
 Version 21.2.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 21.3.0
 - [MINOR] changes accommodating the WrappedKeyAlgoIdentifier module (#2667)
 - [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
 - [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
+- [MINOR] Construct broker app link redirect based on broker pkg name
 
 Version 21.2.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1484,39 +1484,19 @@ public final class AuthenticationConstants {
         public static final String POWERLIFT_TENANT_ID = "powerLiftTenantId";
 
         /**
-         * The App Link redirect URL for the Authenticator app.
+         * The scheme for the app link redirect URI used by the broker.
          */
-        public static final String AUTHENTICATOR_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/authenticator";
+        public static final String BROKER_APP_LINK_REDIRECT_URL_SCHEME = "https";
 
         /**
-         * The App Link redirect URL for the LTW app.
+         * The host for the app link redirect URIs used by the broker.
          */
-        public static final String LTW_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/ltw";
+        public static final String BROKER_APP_LINK_REDIRECT_URL_HOST = "login.microsoftonline.com";
 
         /**
-         * App Link redirect URL for the CP app.
+         * The path prefix for the app link redirect URIs used by the broker.
          */
-        public static final String COMPANY_PORTAL_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/cp";
-
-        /**
-         * App Link redirect URL for the BrokerHost app.
-         */
-        public static final String BROKER_HOST_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/brokerhost";
-
-        /**
-         * App Link redirect URL for the Mock Auth app.
-         */
-        public static final String MOCK_LTW_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/mockltw";
-
-        /**
-         * App Link redirect URL for the Mock CP app.
-         */
-        public static final String MOCK_CP_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/mockcp";
-
-        /**
-         * App Link redirect URL for the Mock Auth app.
-         */
-        public static final String MOCK_AUTH_APP_LINK_REDIRECT_URL = "https://login.microsoftonline.com/mockauth";
+        public static final String BROKER_APP_LINK_REDIRECT_URL_PATH_PREFIX = "androidbroker";
 
         /**
          * Bundle identifiers for x-ms-clitelem info.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -39,8 +39,7 @@ import java.util.Collections
  */
 data class BrokerData(val packageName : String,
                       val signingCertificateThumbprint : String,
-                      private val nickName: String?,
-                      val appLinkRedirectUri: String? = null) {
+                      private val nickName: String?) {
     constructor(packageName: String, signingCertificateThumbprint: String):
                 this(packageName, signingCertificateThumbprint, null)
 
@@ -66,6 +65,13 @@ data class BrokerData(val packageName : String,
         }
 
         return "$packageName::$signingCertificateThumbprint"
+    }
+
+    fun getAppLinkRedirectUri(): String {
+        val scheme = AuthenticationConstants.Broker.BROKER_APP_LINK_REDIRECT_URL_SCHEME
+        val host = AuthenticationConstants.Broker.BROKER_APP_LINK_REDIRECT_URL_HOST
+        val pathPrefix = AuthenticationConstants.Broker.BROKER_APP_LINK_REDIRECT_URL_PATH_PREFIX
+        return "$scheme://$host/$pathPrefix/$packageName"
     }
 
     companion object {
@@ -95,80 +101,70 @@ data class BrokerData(val packageName : String,
         val debugMicrosoftAuthenticator = BrokerData(
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE_SHA512,
-            "debugMicrosoftAuthenticator",
-            AuthenticationConstants.Broker.AUTHENTICATOR_APP_LINK_REDIRECT_URL
+            "debugMicrosoftAuthenticator"
         )
 
         @JvmStatic
         val prodMicrosoftAuthenticator = BrokerData(
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE_SHA512,
-            "prodMicrosoftAuthenticator",
-            AuthenticationConstants.Broker.AUTHENTICATOR_APP_LINK_REDIRECT_URL
+            "prodMicrosoftAuthenticator"
         )
 
         @JvmStatic
         val debugCompanyPortal = BrokerData(
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_DEBUG_SIGNATURE_SHA512,
-            "debugCompanyPortal",
-            AuthenticationConstants.Broker.COMPANY_PORTAL_APP_LINK_REDIRECT_URL
+            "debugCompanyPortal"
         )
 
         @JvmStatic
         val prodCompanyPortal = BrokerData(
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.COMPANY_PORTAL_APP_RELEASE_SIGNATURE_SHA512,
-            "prodCompanyPortal",
-            AuthenticationConstants.Broker.COMPANY_PORTAL_APP_LINK_REDIRECT_URL
+            "prodCompanyPortal"
         )
 
         @JvmStatic
         val debugBrokerHost = BrokerData(
             AuthenticationConstants.Broker.BROKER_HOST_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.BROKER_HOST_APP_SIGNATURE_SHA512,
-            "debugBrokerHost",
-            AuthenticationConstants.Broker.BROKER_HOST_APP_LINK_REDIRECT_URL
+            "debugBrokerHost"
         )
 
         @JvmStatic
         val debugMockCp = BrokerData(
             AuthenticationConstants.Broker.MOCK_CP_PACKAGE_NAME,
             AuthenticationConstants.Broker.MOCK_CP_SIGNATURE_SHA512,
-            "debugMockCp",
-            AuthenticationConstants.Broker.MOCK_CP_APP_LINK_REDIRECT_URL
+            "debugMockCp"
         )
 
         @JvmStatic
         val debugMockAuthApp = BrokerData(
             AuthenticationConstants.Broker.MOCK_AUTH_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.MOCK_AUTH_APP_SIGNATURE_SHA512,
-            "debugMockAuthApp",
-            AuthenticationConstants.Broker.MOCK_AUTH_APP_PACKAGE_NAME
+            "debugMockAuthApp"
         )
 
         @JvmStatic
         val debugMockLtw = BrokerData(
             AuthenticationConstants.Broker.MOCK_LTW_PACKAGE_NAME,
             AuthenticationConstants.Broker.MOCK_LTW_SIGNATURE_SHA512,
-            "debugMockLtw",
-            AuthenticationConstants.Broker.MOCK_LTW_APP_LINK_REDIRECT_URL
+            "debugMockLtw"
         )
 
         @JvmStatic
         val prodLTW = BrokerData(
             AuthenticationConstants.Broker.LTW_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.LTW_APP_SHA512_RELEASE_SIGNATURE,
-            "prodLTW",
-            AuthenticationConstants.Broker.LTW_APP_LINK_REDIRECT_URL
+            "prodLTW"
         )
 
         @JvmStatic
         val debugLTW = BrokerData(
             AuthenticationConstants.Broker.LTW_APP_PACKAGE_NAME,
             AuthenticationConstants.Broker.LTW_APP_SHA512_DEBUG_SIGNATURE,
-            "debugLTW",
-            AuthenticationConstants.Broker.LTW_APP_LINK_REDIRECT_URL
+            "debugLTW"
 
         )
 


### PR DESCRIPTION
This basically does a couple of changes:

- 1st: Received feedback from eSTS folks to move app links under `androidbroker/` path as opposed to the root of the eSTS domain.
- 2nd: for each broker app specific app link, we were using a friendly identifier at the end such as /authenticator to denote authapp and `/ltw` to denote ltw. I've moved away from these custom friendly names and decided to just put the pkg name into the path. This allows us to declare an intent filter for it directly in our broker's intent filter as opposed to asking partner teams to put an intent filter in their manifest. 

Related Broker PR: https://github.com/AzureAD/ad-accounts-for-android/pull/3139