### PR TITLE
Flighting webcp in webview, Fixes AB#3307594

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 vNext
 ----------
+- [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
+- [MINOR] Showing webcp flow in webview (#2673)
+- [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
+- [MINOR] Flighting webcp in webview (#2686)
+- [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 
 Version 21.3.0
 ----------
@@ -7,7 +12,6 @@ Version 21.3.0
 - [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
 - [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
 - [MINOR] Showing webcp flow in webview (#2673)
-- [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 
 Version 21.2.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,9 +9,6 @@ vNext
 Version 21.3.0
 ----------
 - [MINOR] changes accommodating the WrappedKeyAlgoIdentifier module (#2667)
-- [MINOR] Fixing the sign in screens when edge to edge is enabled (#2665)
-- [MINOR] Native auth: Make native auth MFA feature more backward compatible(#2669)
-- [MINOR] Showing webcp flow in webview (#2673)
 
 Version 21.2.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -644,20 +644,24 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
 
         // Else, check if the tenant is in the list of tenants that have this feature enabled.
-        final String username = StringExtensions.getUrlParameters(originalUrl).get(AuthenticationConstants.AAD.LOGIN_HINT);
-        if (!StringUtil.isNullOrEmpty(username)) {
-            final String tenantId = CommonTenantInfoProvider.INSTANCE.getTenantId(username);
-            if (StringUtil.isNullOrEmpty(tenantId)) {
-                return false;
-            }
-            final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
-            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
-            Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
-            mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
-            return isFlightEnabledForCurrentTenant;
+        final String tenantId = getTenantIdFromUrl(originalUrl);
+        if (StringUtil.isNullOrEmpty(tenantId)) {
+            return false;
         }
+        
+        final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
+        final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
+        Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
+        mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
+        return isFlightEnabledForCurrentTenant;
+    }
 
-        return false;
+    private String getTenantIdFromUrl(@NonNull final String url) {
+        final String username = StringExtensions.getUrlParameters(url).get(AuthenticationConstants.AAD.LOGIN_HINT);
+        if (StringUtil.isNullOrEmpty(username)) {
+            return null;
+        }
+        return CommonTenantInfoProvider.INSTANCE.getTenantId(username);
     }
 
     // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
@@ -693,7 +697,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             getActivity().startActivity(intent);
         } catch (android.content.ActivityNotFoundException e) {
-            Logger.error(methodTag,"Failed to open the Authenticator application.", e);
+            Logger.error(methodTag,"Failed to open the intent for google enrollment.", e);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -641,29 +641,35 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     protected boolean isWebCpInWebviewFeatureEnabled(@NonNull final String originalUrl) {
         final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
-        if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
-            // Enabling webcp in webview feature for brokered flows only for now.
+        try {
+            if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
+                // Enabling webcp in webview feature for brokered flows only for now.
+                return false;
+            }
+
+            if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+                // Directly enabled via flight rollout.
+                Logger.info(methodTag, "WebCP in WebView feature is enabled.");
+                mIsWebCpInWebViewFeatureEnabled = true;
+                return true;
+            }
+
+            // Else, check if the home tenant is in the list of tenants that have this feature enabled.
+            final String tenantId = getHomeTenantIdFromUrl(originalUrl);
+            if (StringUtil.isNullOrEmpty(tenantId)) {
+                return false;
+            }
+
+            final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
+            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
+            Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
+            mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
+            return isFlightEnabledForCurrentTenant;
+        } catch (final Throwable throwable) {
+            // Catching any unexpected exceptions to avoid breaking the flow. We will anyway remove this block once the feature is fully rolled out.
+            Logger.error(methodTag, "Failed to check if WebCP in WebView feature is enabled.", throwable);
             return false;
         }
-
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            // Directly enabled via flight rollout.
-            Logger.info(methodTag, "WebCP in WebView feature is enabled.");
-            mIsWebCpInWebViewFeatureEnabled = true;
-            return true;
-        }
-
-        // Else, check if the home tenant is in the list of tenants that have this feature enabled.
-        final String tenantId = getHomeTenantIdFromUrl(originalUrl);
-        if (StringUtil.isNullOrEmpty(tenantId)) {
-            return false;
-        }
-        
-        final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
-        final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
-        Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
-        mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
-        return isFlightEnabledForCurrentTenant;
     }
 
     private String getHomeTenantIdFromUrl(@NonNull final String url) {
@@ -716,8 +722,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // Important for the enrollment flow to work correctly.
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             getActivity().startActivity(intent);
-        } catch (android.content.ActivityNotFoundException e) {
+        } catch (final ActivityNotFoundException e) {
             Logger.error(methodTag,"Failed to open the intent for google enrollment.", e);
+            throw e;
         }
     }
 
@@ -759,15 +766,18 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             getActivity().startActivity(intent);
             view.stopLoading();
-            if (appPackageName.equalsIgnoreCase(COMPANY_PORTAL_APP_PACKAGE_NAME) && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            if (appPackageName.equalsIgnoreCase(COMPANY_PORTAL_APP_PACKAGE_NAME) && (mIsWebCpInWebViewFeatureEnabled)) {
                 // If the flight for webcp is enabled, we will return the result code to the activity to indicate that the MDM flow has started.
                 // Note that this is only for CP app as we are not aware of any other flows (other than webcp) reaching this code path.
                 returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
             }
+
             return true;
-        } catch (android.content.ActivityNotFoundException e) {
+        } catch (final ActivityNotFoundException e) {
             //if GooglePlay is not present on the device.
             Logger.error(methodTag, "PlayStore is not present on the device", e);
+        } catch(final Exception e) {
+            Logger.error(methodTag, "Failed to intercept install broker playstore URL and launch the intent", e);
         }
 
         return false;
@@ -1005,10 +1015,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             reAttachPrtHandler.processChallenge(url);
             span.setStatus(StatusCode.OK);
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             // No op if an exception happens
             Logger.warn(methodTag, "Error attaching PRT header." + e);
             span.recordException(e);
+            span.setStatus(StatusCode.ERROR);
             view.loadUrl(url);
         } finally {
             span.end();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -597,48 +597,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
-    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
-    @VisibleForTesting
-    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
-        final String methodTag = TAG + ":loadDeviceCaUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            Logger.info(methodTag, "Loading device CA request in WebView.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
-            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
-            view.loadUrl(httpsUrl, mRequestHeaders);
-        } else {
-            Logger.info(methodTag, "Loading device CA request in browser.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
-            openLinkInBrowser(originalUrl);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-        }
-    }
-
-    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
-    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
-    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
-        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
-        view.stopLoading();
-        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
-        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
-        openLinkInBrowser(url);
-        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
-        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            }
-        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
-    }
-
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -60,6 +61,8 @@ import com.microsoft.identity.common.internal.ui.webview.challengehandlers.Switc
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
 import com.microsoft.identity.common.java.authorities.Authority;
+import com.microsoft.identity.common.java.broker.CommonRefreshTokenCredentialProvider;
+import com.microsoft.identity.common.java.broker.CommonTenantInfoProvider;
 import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.exception.IErrorInformation;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
@@ -128,6 +131,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private HashMap<String, String> mRequestHeaders;
     private String mRequestUrl;
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
+    private boolean mIsWebCpInWebViewFeatureEnabled = false;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -333,10 +337,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
                 Logger.info(methodTag,"Navigation contains cross cloud redirect.");
                 processCrossCloudRedirect(view, url);
-            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpEnrollmentUrl(url)) {
+            } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpEnrollmentUrl(url)) {
                 Logger.info(methodTag,"Navigation contains web cp enrollment url.");
                 processWebCpEnrollmentUrl(view, url);
-            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW) && isWebCpAuthorizeUrl(url)) {
+            } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpAuthorizeUrl(url)) {
                 processWebCpAuthorize(view, url);
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
@@ -508,7 +512,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             final boolean isWebCpClient = AuthenticationConstants.Broker.WEBCP_CLIENT_ID.equalsIgnoreCase(clientId);
             Logger.info(methodTag, isWebCpClient
                     ? "WebCP authorize URL contains valid WebCP client_id."
-                    : "Authorize URL contains different client_id.");
+                    : "Not running WebCP flow as client_id in authorize is not webcp client_id");
             return isWebCpClient;
         } catch (final URISyntaxException | MalformedURLException e) {
             Logger.info(methodTag, "Invalid URL: " + e.getMessage());
@@ -654,7 +658,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+        if (isWebCpInWebviewFeatureEnabled(originalUrl)) {
             Logger.info(methodTag, "Loading device CA request in WebView.");
             span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
             String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
@@ -665,6 +669,28 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             openLinkInBrowser(originalUrl);
             returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
         }
+    }
+
+    // Method to decide if the WebView should load the WebCP URL based on the flights.
+    private boolean isWebCpInWebviewFeatureEnabled(@NonNull final String originalUrl) {
+        final String methodTag = TAG + ":shouldLoadWebCpUrlInWebView";
+        if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
+            // Enabling webcp in webview feature for brokered flows only for now.
+            return false;
+        }
+        final String username = StringExtensions.getUrlParameters(originalUrl).get(AuthenticationConstants.AAD.LOGIN_HINT);
+        if (username == null) {
+            return false;
+        }
+        final String tenantId = CommonTenantInfoProvider.INSTANCE.getTenantId(username);
+        if (StringUtil.isNullOrEmpty(tenantId)) {
+            return false;
+        }
+        final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
+        final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
+        Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
+        mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant || CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW);
+        return mIsWebCpInWebViewFeatureEnabled;
     }
 
     // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
@@ -678,7 +704,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         view.stopLoading();
         Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
         // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
-        openLinkInBrowser(url);
+        openGoogleEnrollmentUrl(url);
         // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
         // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
         new Handler().postDelayed(new Runnable() {
@@ -687,6 +713,21 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
             }
         }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
+    }
+
+    // Opens the Google enrollment URL in the browser or the default intent handler (like DPC)
+    private void openGoogleEnrollmentUrl(@NonNull final String url) {
+        final String methodTag = TAG + ":openGoogleEnrollmentUrl";
+        Logger.info(methodTag, "Opening Google enrollment URL");
+        try {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            // Add flags to ensure the activity is launched in a new task and clears the current task stack.
+            // Important for the enrollment flow to work correctly.
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            getActivity().startActivity(intent);
+        } catch (android.content.ActivityNotFoundException e) {
+            Logger.error(methodTag,"Failed to open the Authenticator application.", e);
+        }
     }
 
     private boolean processPlayStoreURL(@NonNull final WebView view, @NonNull final String url) {
@@ -781,13 +822,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String link = url
                 .replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(link));
-
         if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
             getActivity().startActivity(intent);
         } else {
             Logger.warn(methodTag, "Unable to find an app to resolve the activity.");
         }
     }
+
     private void processWebCpRequest(@NonNull final WebView view, @NonNull final String url) {
 
         view.stopLoading();

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -595,6 +595,48 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
+    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
+    @VisibleForTesting
+    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+        final String methodTag = TAG + ":loadDeviceCaUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Logger.info(methodTag, "Loading device CA request in WebView.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+            view.loadUrl(httpsUrl, mRequestHeaders);
+        } else {
+            Logger.info(methodTag, "Loading device CA request in browser.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+            openLinkInBrowser(originalUrl);
+            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        }
+    }
+
+    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
+    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
+    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+        view.stopLoading();
+        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+        openLinkInBrowser(url);
+        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
+        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
+    }
+
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -61,7 +60,6 @@ import com.microsoft.identity.common.internal.ui.webview.challengehandlers.Switc
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NonceRedirectHandler;
 import com.microsoft.identity.common.java.authorities.Authority;
-import com.microsoft.identity.common.java.broker.CommonRefreshTokenCredentialProvider;
 import com.microsoft.identity.common.java.broker.CommonTenantInfoProvider;
 import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.exception.IErrorInformation;
@@ -631,24 +629,34 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     // Method to decide if the WebView should load the WebCP URL based on the flights.
     private boolean isWebCpInWebviewFeatureEnabled(@NonNull final String originalUrl) {
-        final String methodTag = TAG + ":shouldLoadWebCpUrlInWebView";
+        final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
         if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
             // Enabling webcp in webview feature for brokered flows only for now.
             return false;
         }
+
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            // Directly enabled via flight rollout.
+            Logger.info(methodTag, "WebCP in WebView feature is enabled.");
+            mIsWebCpInWebViewFeatureEnabled = true;
+            return true;
+        }
+
+        // Else, check if the tenant is in the list of tenants that have this feature enabled.
         final String username = StringExtensions.getUrlParameters(originalUrl).get(AuthenticationConstants.AAD.LOGIN_HINT);
-        if (username == null) {
-            return false;
+        if (!StringUtil.isNullOrEmpty(username)) {
+            final String tenantId = CommonTenantInfoProvider.INSTANCE.getTenantId(username);
+            if (StringUtil.isNullOrEmpty(tenantId)) {
+                return false;
+            }
+            final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
+            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
+            Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
+            mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
+            return isFlightEnabledForCurrentTenant;
         }
-        final String tenantId = CommonTenantInfoProvider.INSTANCE.getTenantId(username);
-        if (StringUtil.isNullOrEmpty(tenantId)) {
-            return false;
-        }
-        final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
-        final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
-        Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
-        mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant || CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW);
-        return mIsWebCpInWebViewFeatureEnabled;
+
+        return false;
     }
 
     // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -510,7 +510,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                     ? "WebCP authorize URL contains valid WebCP client_id."
                     : "Authorize URL contains different client_id.");
             return isWebCpClient;
-
         } catch (final URISyntaxException | MalformedURLException e) {
             Logger.info(methodTag, "Invalid URL: " + e.getMessage());
             return false;
@@ -592,6 +591,48 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             openLinkInBrowser(url);
             returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
         }
+    }
+
+    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
+    @VisibleForTesting
+    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+        final String methodTag = TAG + ":loadDeviceCaUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Logger.info(methodTag, "Loading device CA request in WebView.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+            view.loadUrl(httpsUrl, mRequestHeaders);
+        } else {
+            Logger.info(methodTag, "Loading device CA request in browser.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+            openLinkInBrowser(originalUrl);
+            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        }
+    }
+
+    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
+    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
+    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+        view.stopLoading();
+        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+        openLinkInBrowser(url);
+        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
+        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
     }
 
     private boolean isDeviceCaRequest(@NonNull final String url) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -628,7 +628,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     // Method to decide if the WebView should load the WebCP URL based on the flights.
-    private boolean isWebCpInWebviewFeatureEnabled(@NonNull final String originalUrl) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    protected boolean isWebCpInWebviewFeatureEnabled(@NonNull final String originalUrl) {
         final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
         if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
             // Enabling webcp in webview feature for brokered flows only for now.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -596,48 +596,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
-    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
-    @VisibleForTesting
-    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
-        final String methodTag = TAG + ":loadDeviceCaUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            Logger.info(methodTag, "Loading device CA request in WebView.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
-            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
-            view.loadUrl(httpsUrl, mRequestHeaders);
-        } else {
-            Logger.info(methodTag, "Loading device CA request in browser.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
-            openLinkInBrowser(originalUrl);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-        }
-    }
-
-    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
-    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
-    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
-        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
-        view.stopLoading();
-        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
-        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
-        openLinkInBrowser(url);
-        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
-        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            }
-        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
-    }
-
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -643,8 +643,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             return true;
         }
 
-        // Else, check if the tenant is in the list of tenants that have this feature enabled.
-        final String tenantId = getTenantIdFromUrl(originalUrl);
+        // Else, check if the home tenant is in the list of tenants that have this feature enabled.
+        final String tenantId = getHomeTenantIdFromUrl(originalUrl);
         if (StringUtil.isNullOrEmpty(tenantId)) {
             return false;
         }
@@ -656,12 +656,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         return isFlightEnabledForCurrentTenant;
     }
 
-    private String getTenantIdFromUrl(@NonNull final String url) {
+    private String getHomeTenantIdFromUrl(@NonNull final String url) {
         final String username = StringExtensions.getUrlParameters(url).get(AuthenticationConstants.AAD.LOGIN_HINT);
         if (StringUtil.isNullOrEmpty(username)) {
             return null;
         }
-        return CommonTenantInfoProvider.INSTANCE.getTenantId(username);
+        return CommonTenantInfoProvider.INSTANCE.getHomeTenantId(username);
     }
 
     // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -614,16 +614,26 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        if (isWebCpInWebviewFeatureEnabled(originalUrl)) {
-            Logger.info(methodTag, "Loading device CA request in WebView.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
-            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
-            view.loadUrl(httpsUrl, mRequestHeaders);
-        } else {
-            Logger.info(methodTag, "Loading device CA request in browser.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
-            openLinkInBrowser(originalUrl);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            if (isWebCpInWebviewFeatureEnabled(originalUrl)) {
+                Logger.info(methodTag, "Loading device CA request in WebView.");
+                span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+                String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+                view.loadUrl(httpsUrl, mRequestHeaders);
+            } else {
+                Logger.info(methodTag, "Loading device CA request in browser.");
+                span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+                openLinkInBrowser(originalUrl);
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+            span.setStatus(StatusCode.OK);
+        } catch (final Throwable throwable) {
+            Logger.error(methodTag, "Failed to load device CA URL in WebView.", throwable);
+            span.recordException(throwable);
+            span.setStatus(StatusCode.ERROR);
+            returnError(UNKNOWN_ERROR, throwable.getMessage());
+        } finally {
+            span.end();
         }
     }
 
@@ -671,19 +681,29 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
-        view.stopLoading();
-        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
-        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
-        openGoogleEnrollmentUrl(url);
-        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
-        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            }
-        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+            view.stopLoading();
+            Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+            // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+            openGoogleEnrollmentUrl(url);
+            // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent due to slowness on the device.
+            // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+                }
+            }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
+            span.setStatus(StatusCode.OK);
+        } catch (final Throwable throwable) {
+            Logger.error(methodTag, "Failed to process WebCP enrollment URL.", throwable);
+            span.recordException(throwable);
+            span.setStatus(StatusCode.ERROR);
+            returnError(UNKNOWN_ERROR, throwable.getMessage());
+        } finally {
+            span.end();
+        }
     }
 
     // Opens the Google enrollment URL in the browser or the default intent handler (like DPC)
@@ -989,7 +1009,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             // No op if an exception happens
             Logger.warn(methodTag, "Error attaching PRT header." + e);
             span.recordException(e);
-            view.loadUrl(url, mRequestHeaders);
+            view.loadUrl(url);
         } finally {
             span.end();
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -39,6 +39,7 @@ class ReAttachPrtHeaderHandler(
     private val span : Span
 ) : IChallengeHandler<String, Void> {
     private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
+
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -39,7 +39,6 @@ class ReAttachPrtHeaderHandler(
     private val span : Span
 ) : IChallengeHandler<String, Void> {
     private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
-
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)

--- a/common/src/test/java/com/microsoft/identity/common/internal/mocks/MockCommonFlightsManager.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/mocks/MockCommonFlightsManager.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.mocks;
+
+import com.microsoft.identity.common.java.flighting.IFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
+
+import org.jetbrains.annotations.NotNull;
+
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Setter
+@Accessors(prefix = "m")
+public class MockCommonFlightsManager implements IFlightsManager {
+    private IFlightsProvider mMockCommonFlightsProvider;
+
+    @NotNull
+    @Override
+    public IFlightsProvider getFlightsProvider() {
+        return mMockCommonFlightsProvider;
+    }
+
+    @NotNull
+    @Override
+    public IFlightsProvider getFlightsProviderForTenant(@NotNull String tenantId) {
+        return mMockCommonFlightsProvider;
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -129,7 +129,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                     }
                 },
                 TEST_REDIRECT_URI,
-                Mockito.mock(SwitchBrowserRequestHandler.class));
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId");
         HashMap<String, String> dummyHeaders = new HashMap<>();
         dummyHeaders.put("key", "value");
         mWebViewClient.setRequestHeaders(dummyHeaders);
@@ -335,7 +336,7 @@ public class AzureActiveDirectoryWebViewClientTest {
         try {
             mWebViewClient.reAttachPrtHeader(TEST_CROSS_CLOUD_REDIRECT_URL, mockReAttachPrtHandler, mockWebView, "methodTag", Span.current());
             Mockito.verify(mockReAttachPrtHandler, Mockito.times(1)).processChallenge(TEST_CROSS_CLOUD_REDIRECT_URL);
-            Mockito.verify(mockWebView).loadUrl(Mockito.anyString(), Mockito.any());
+            Mockito.verify(mockWebView).loadUrl(Mockito.anyString());
         } catch (Exception e) {
             Assert.fail("Failure is not expected. We should have caught the exception and ignored it. " + e);
         }
@@ -374,7 +375,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                         }
                     },
                     TEST_REDIRECT_URI,
-                    Mockito.mock(SwitchBrowserRequestHandler.class));
+                    Mockito.mock(SwitchBrowserRequestHandler.class),
+                    "homeTenantId");
             mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL);
         } catch (ClassCastException e) {
             Assert.fail("Failure is not expected. The class checks should have prevented this." + e);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -30,15 +30,18 @@ import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.mocks.MockCommonFlightsManager;
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
+import com.microsoft.identity.common.shadows.ShadowProcessUtil;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,12 +50,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 
@@ -225,23 +230,91 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     @Test
-    public void testUrlOverrideHandleWebCPEnrollmentUrl() {
-        if(CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
-        } else {
-            assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
-        }
+    @Config(shadows = {
+            ShadowProcessUtil.class})
+    public void testUrlOverrideHandleWebCPEnrollmentUrlEnabled() {
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = Mockito.spy(mWebViewClient);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+
+        assertTrue(mockWebViewClient.isWebCpInWebviewFeatureEnabled(TEST_WEB_CP_ENROLLMENT_URL));
+        assertTrue(mockWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
     }
 
     @Test
-    public void testLoadDeviceCaUrl() {
+    @Config(shadows = {
+            ShadowProcessUtil.class})
+    public void testUrlOverrideHandleWebCPEnrollmentUrlDisabled() {
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = Mockito.spy(mWebViewClient);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(false);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+
+        assertFalse(mockWebViewClient.isWebCpInWebviewFeatureEnabled(TEST_WEB_CP_ENROLLMENT_URL));
+        assertFalse(mockWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+    }
+
+    @Test
+    @Config(shadows = {
+            ShadowProcessUtil.class})
+    public void testLoadDeviceCaUrlInWebView() {
+        // Mocks
         final WebView mockWebview = Mockito.mock(WebView.class);
-        mWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
-        if(CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
-        } else {
-            Mockito.verify(mockWebview, Mockito.never()).loadUrl(Mockito.anyString(), Mockito.any());
-        }
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = Mockito.spy(mWebViewClient);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+        // Actual call
+        mockWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
+        // Verify
+        Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
+    }
+
+    @Test
+    @Config(shadows = {
+            ShadowProcessUtil.class})
+    public void testLoadDeviceCaUrlInBrowser() {
+        // Mocks
+        final WebView mockWebview = Mockito.mock(WebView.class);
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = Mockito.spy(mWebViewClient);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(false);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+        // Actual call
+        mockWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
+        // Verify
+        Mockito.verify(mockWebview, Mockito.never()).loadUrl(Mockito.anyString(), Mockito.any());
+    }
+
+    @Test
+    public void testLoadDeviceCaUrlInBrowserInBrokelessFlow() {
+        // Mocks
+        final WebView mockWebview = Mockito.mock(WebView.class);
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = Mockito.spy(mWebViewClient);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+        // Actual call
+        mockWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
+        // Verify
+        Mockito.verify(mockFlightsProvider, Mockito.never()).isFlightEnabled(Mockito.any());
+        Mockito.verify(mockWebview, Mockito.never()).loadUrl(Mockito.anyString(), Mockito.any());
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -129,8 +129,7 @@ public class AzureActiveDirectoryWebViewClientTest {
                     }
                 },
                 TEST_REDIRECT_URI,
-                Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId");
+                Mockito.mock(SwitchBrowserRequestHandler.class));
         HashMap<String, String> dummyHeaders = new HashMap<>();
         dummyHeaders.put("key", "value");
         mWebViewClient.setRequestHeaders(dummyHeaders);
@@ -375,8 +374,7 @@ public class AzureActiveDirectoryWebViewClientTest {
                         }
                     },
                     TEST_REDIRECT_URI,
-                    Mockito.mock(SwitchBrowserRequestHandler.class),
-                    "homeTenantId");
+                    Mockito.mock(SwitchBrowserRequestHandler.class));
             mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL);
         } catch (ClassCastException e) {
             Assert.fail("Failure is not expected. The class checks should have prevented this." + e);

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowProcessUtil.java
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowProcessUtil.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.shadows;
+
+
+import android.content.Context;
+
+import com.microsoft.identity.common.internal.ui.webview.ProcessUtil;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(ProcessUtil.class)
+public class ShadowProcessUtil {
+    public static boolean isRunningOnAuthService(final Context context) {
+        // This is a shadow class, so we can return true to simulate that the process is running on the auth service.
+        // In a real scenario, this would check the actual process name.
+        return true;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
@@ -33,7 +33,6 @@ object CommonTenantInfoProvider : ITenantInfoProvider{
     private val TAG = CommonTenantInfoProvider::class.java.simpleName
     private var mTenantInfoProvider: ITenantInfoProvider? = null
 
-    // Note : This method should only be invoked by broker module.
     fun initializeCommonTenantInfoProvider(tenantInfoProvider: ITenantInfoProvider) {
         val methodTag = "$TAG:initializeCommonTenantInfoProvider"
         Logger.info(methodTag, "Initializing common tenant information provider with " + tenantInfoProvider.javaClass.simpleName)

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.broker
+import com.microsoft.identity.common.java.interfaces.ITenantInfoProvider
+import com.microsoft.identity.common.java.logging.Logger
+
+/**
+ * Consumer of commons needs to implement [ITenantInfoProvider] interface
+ * and set it using CommonTenantInfoProvider.initializeCommonTenantInfoProvider(@NonNull tenantInfoProvider: ITenantInfoProvider)
+ * to provide tenantInfo to common module.
+ */
+object CommonTenantInfoProvider : ITenantInfoProvider{
+    private val TAG = CommonTenantInfoProvider::class.java.simpleName
+    private var mTenantInfoProvider: ITenantInfoProvider? = null
+
+    // Note : This method should only be invoked by broker module.
+    fun initializeCommonTenantInfoProvider(tenantInfoProvider: ITenantInfoProvider) {
+        val methodTag = "$TAG:initializeCommonTenantInfoProvider"
+        Logger.info(methodTag, "Initializing common tenant information provider with " + tenantInfoProvider.javaClass.simpleName)
+        mTenantInfoProvider = tenantInfoProvider
+    }
+
+    override fun getTenantId(username: String): String? {
+        val methodTag = "$TAG:getTenantId";
+        if (mTenantInfoProvider != null) {
+            return mTenantInfoProvider!!.getTenantId(username)
+        }
+        Logger.warn(methodTag, "mTenantInfoProvider is not initialized!")
+        return null
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/broker/CommonTenantInfoProvider.kt
@@ -39,10 +39,10 @@ object CommonTenantInfoProvider : ITenantInfoProvider{
         mTenantInfoProvider = tenantInfoProvider
     }
 
-    override fun getTenantId(username: String): String? {
+    override fun getHomeTenantId(username: String): String? {
         val methodTag = "$TAG:getTenantId";
         if (mTenantInfoProvider != null) {
-            return mTenantInfoProvider!!.getTenantId(username)
+            return mTenantInfoProvider!!.getHomeTenantId(username)
         }
         Logger.warn(methodTag, "mTenantInfoProvider is not initialized!")
         return null

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -135,6 +135,10 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable the Playstore URL launch for broker apps.
      */
     ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true),
+    
+    /**
+     * Flight to enable the Web CP for a tenant list.
+     */
     TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW("TenantListToEnableWebCpInWebView", "");
 
     private String key;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -134,7 +134,8 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Playstore URL launch for broker apps.
      */
-    ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true);
+    ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true),
+    TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW("TenantListToEnableWebCpInWebView", "");
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/ITenantInfoProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/ITenantInfoProvider.kt
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.interfaces
+
+/**
+ * Consumer of commons needs to implement [ITenantInfoProvider] interface
+ * and set it using CommonTenantInfoProvider.initializeCommonTenantInfoProvider(@NonNull tenantInfoProvider: ITenantInfoProvider)
+ * to provide tenantInfo holder to common module.
+ */
+interface ITenantInfoProvider {
+    // Returns the tenant ID for the account with given username.
+    fun getTenantId(username: String): String?
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/interfaces/ITenantInfoProvider.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/interfaces/ITenantInfoProvider.kt
@@ -28,6 +28,6 @@ package com.microsoft.identity.common.java.interfaces
  * to provide tenantInfo holder to common module.
  */
 interface ITenantInfoProvider {
-    // Returns the tenant ID for the account with given username.
-    fun getTenantId(username: String): String?
+    // Returns the home tenant ID for the account with given username.
+    fun getHomeTenantId(username: String): String?
 }


### PR DESCRIPTION
1. Flighting for webcp in webview is divided into 3 parts
- Not flighting this feature for brokerless scenarios. The flight will be off by default for brokerless scenarios as Intune team is ok to only target brokered flows since this is the majority case.
- Now coming to brokered scenarios, we have below
    -      Simple flighting with ENABLE_WEB_CP_IN_WEBVIEW which will be used for rollout starting October.
    -      Using tenantId list TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW. This flight will be used first in the months of August and September. This will be 100% rolled out in the beginning itself. This flight will hold upto 25 tenantIds. See below snapshot 
![image](https://github.com/user-attachments/assets/4eff53a6-3977-4ba2-88c0-5529fe5f69c9)


2. I intentionally added a global variable to keep the flight value instead of calling isWebCpInWebviewFeatureEnabled method because I do not want to invoke code to get tenantId multiple times. Also, this value must remain the same once the webcp url is loaded in webview. 

3. Apart from this, I have added a special method to handle google enrollment URL which has extra intent flags needed for this scenario.

Related PR : https://github.com/AzureAD/ad-accounts-for-android/pull/3140

Fixes [AB#3307594](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3307594)