### PR TITLE
Updating handling of SSL error in WebView, Fixes AB#3268908

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Updating handling of ssl error received in Android WebView's onReceivedSslError callback
 
 Version 21.3.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -2023,6 +2023,8 @@ public final class AuthenticationConstants {
         public static final String WEB_VIEW_ZOOM_CONTROLS_ENABLED = "com.microsoft.identity.web.view.zoom.controls.enabled";
 
         public static final String WEB_VIEW_ZOOM_ENABLED = "com.microsoft.identity.web.view.zoom.enabled";
+
+        public static final String WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED = "com.microsoft.identity.web.view.new.ssl.error.handler.enabled";
     }
 
     public static final class AuthorizationIntentAction {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -22,6 +22,17 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2;
 
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.AUTH_INTENT;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.POST_PAGE_LOADED_URL;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REDIRECT_URI;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_HEADERS;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
+import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
+import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -36,7 +47,6 @@ import android.view.ViewGroup;
 import android.webkit.PermissionRequest;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
-import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -46,40 +56,31 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentActivity;
 
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.internal.fido.LegacyFidoActivityResultContract;
-import com.microsoft.identity.common.internal.fido.LegacyFido2ApiObject;
-import com.microsoft.identity.common.internal.ui.webview.ISendResultCallback;
-import com.microsoft.identity.common.internal.ui.webview.ProcessUtil;
-import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserProtocolCoordinator;
-import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.fido.LegacyFido2ApiObject;
+import com.microsoft.identity.common.internal.fido.LegacyFidoActivityResultContract;
+import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebView;
 import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient;
+import com.microsoft.identity.common.internal.ui.webview.ISendResultCallback;
 import com.microsoft.identity.common.internal.ui.webview.OnPageLoadedCallback;
+import com.microsoft.identity.common.internal.ui.webview.ProcessUtil;
 import com.microsoft.identity.common.internal.ui.webview.WebViewUtil;
+import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserProtocolCoordinator;
+import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
-import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
+import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.java.util.ClientExtraSku;
 import com.microsoft.identity.common.logging.Logger;
 
-import java.util.Arrays;
-import java.util.HashMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.AUTH_INTENT;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.POST_PAGE_LOADED_URL;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REDIRECT_URI;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_HEADERS;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
-import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
+import java.util.Arrays;
+import java.util.HashMap;
 
 import io.opentelemetry.api.trace.SpanContext;
 
@@ -93,7 +94,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     @VisibleForTesting
     private static final String PKEYAUTH_STATUS = "pkeyAuthStatus";
 
-    private WebView mWebView;
+    private AzureActiveDirectoryWebView mWebView;
 
     private AzureActiveDirectoryWebViewClient mAADWebViewClient;
 
@@ -115,6 +116,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     private boolean webViewZoomControlsEnabled;
 
     private boolean webViewZoomEnabled;
+
+    /**
+     * This is used to determine whether the new SSL error handler should be used.
+     * If null, means that the value has not provide. Use default logic.
+     * If true, the new SSL error handler will be used.
+     * If false, the old SSL error handler will be used.
+     */
+    private Boolean webViewNewSslErrorHandlerEnabled;
 
     private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
 
@@ -206,6 +215,10 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
+        if (webViewNewSslErrorHandlerEnabled != null) {
+            // save only if not null, otherwise it will be false by default
+            outState.putBoolean(WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED, webViewNewSslErrorHandlerEnabled);
+        }
     }
 
     @Override
@@ -223,6 +236,10 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
+        if (state.containsKey(WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED)) {
+            // If the key exists, we retrieve the value.
+            webViewNewSslErrorHandlerEnabled = state.getBoolean(WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED, false);
+        }
     }
 
     @Nullable
@@ -260,12 +277,27 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     }
                 },
                 mRedirectUri,
-                getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler()
+                getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
+                shouldUseWebViewNewSslErrorHandler()
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);
         launchWebView(mAuthorizationRequestUrl, mRequestHeaders);
         return view;
+    }
+
+    /**
+     * Determines whether the new SSL error handler should be used.
+     *
+     * @return true if the new SSL error handler should be used, false otherwise.
+     */
+    private boolean shouldUseWebViewNewSslErrorHandler() {
+        if (webViewNewSslErrorHandlerEnabled == null) {
+            // if the value was not provided in intent extra, then use from flight.
+            return CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_VIEW_NEW_SSL_HANDLER);
+        }
+
+        return webViewNewSslErrorHandlerEnabled;
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -291,7 +291,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
      *
      * @return true if the new SSL error handler should be used, false otherwise.
      */
-    private boolean shouldUseWebViewNewSslErrorHandler() {
+    protected boolean shouldUseWebViewNewSslErrorHandler() {
         if (webViewNewSslErrorHandlerEnabled == null) {
             // if the value was not provided in intent extra, then use from flight.
             return CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_VIEW_NEW_SSL_HANDLER);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebView.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebView.kt
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview
+
+import android.webkit.WebView
+import android.content.Context
+import android.util.AttributeSet
+import android.webkit.WebViewClient
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * WebView implementation used for authentication in client libraries.
+ */
+class AzureActiveDirectoryWebView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : WebView(context,attrs, defStyleAttr) {
+
+    private var azureActiveDirectoryWebViewClient: AzureActiveDirectoryWebViewClient? = null
+
+    companion object {
+        private const val TAG = "AzureActiveDirectoryWebView"
+    }
+
+    /**
+     * Sets the URL to load on the webview client and continues loading the URL.
+     */
+    override fun loadUrl(url: String) {
+        azureActiveDirectoryWebViewClient?.setActiveLoadUrl(url)
+        super.loadUrl(url)
+    }
+
+    /**
+     * Sets the URL to load on the webview client and continues loading the URL.
+     */
+    override fun loadUrl(url: String, additionalHttpHeaders: Map<String, String>) {
+        azureActiveDirectoryWebViewClient?.setActiveLoadUrl(url)
+        super.loadUrl(url, additionalHttpHeaders)
+    }
+
+    /**
+     * Sets the [WebViewClient] for this WebView and tracks the [AzureActiveDirectoryWebViewClient]
+     * instance for further use.
+     */
+    override fun setWebViewClient(webViewClient: WebViewClient) {
+        val methodTag = "$TAG:setWebViewClient"
+        // Add custom logic here if needed
+        super.setWebViewClient(webViewClient)
+        azureActiveDirectoryWebViewClient = webViewClient as? AzureActiveDirectoryWebViewClient
+        Logger.info(methodTag, "AzureActiveDirectoryWebViewClient set: ${azureActiveDirectoryWebViewClient != null}")
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -132,7 +132,20 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @NonNull final OnPageLoadedCallback pageLoadedCallback,
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler) {
-        super(activity, completionCallback, pageLoadedCallback);
+        super(activity, completionCallback, pageLoadedCallback, false);
+        mRedirectUrl = redirectUrl;
+        mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
+        mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
+    }
+
+    public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
+                                             @NonNull final IAuthorizationCompletionCallback completionCallback,
+                                             @NonNull final OnPageLoadedCallback pageLoadedCallback,
+                                             @NonNull final String redirectUrl,
+                                             @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
+                                             final boolean enableNewSslErrorHandling
+    ) {
+        super(activity, completionCallback, pageLoadedCallback, enableNewSslErrorHandling);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
@@ -336,6 +349,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
+                // By return false, deferring to WebView to continue loading the url. This does not call webview.loadUrl()
+                // so setting the url as next url to load and marking active.
+                setActiveLoadUrl(url);
                 return false;
             }
         } catch (final ClientException exception) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -41,13 +41,13 @@ import androidx.annotation.VisibleForTesting;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ChallengeFactory;
-import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.IChallengeHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NtlmChallenge;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.NtlmChallengeHandler;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
+import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.logging.Logger;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Browser.SSL_HELP_URL;
@@ -61,6 +61,13 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     private final IAuthorizationCompletionCallback mCompletionCallback;
     private final OnPageLoadedCallback mPageLoadedCallback;
     private final Activity mActivity;
+
+    /**
+     *  Used to verify that the page loaded in the webview is the expected page.
+     */
+    private String mActiveLoadUrl;
+
+    private final boolean mEnableNewSslErrorHandling;
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "This is only exposed in testing")
     @VisibleForTesting
@@ -89,12 +96,24 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
      */
     OAuth2WebViewClient(@NonNull final Activity activity,
                         @NonNull final IAuthorizationCompletionCallback completionCallback,
-                        @NonNull final OnPageLoadedCallback pageLoadedCallback) {
-        //the validation of redirect url and authorization request should be in upper level before launching the webview.
+                        @NonNull final OnPageLoadedCallback pageLoadedCallback,
+                        boolean enableNewSslErrorHandling
+    ) {
+        // the validation of redirect url and authorization request should be in upper level before launching the webview.
         mActivity = activity;
         mCompletionCallback = completionCallback;
         mPageLoadedCallback = pageLoadedCallback;
-     }
+        mEnableNewSslErrorHandling = enableNewSslErrorHandling;
+    }
+
+    /**
+     * Sets the expected page to be loaded in the webview.
+     *
+     * @param activeLoadUrl The expected page to be loaded.
+     */
+    public void setActiveLoadUrl(String activeLoadUrl) {
+        mActiveLoadUrl = activeLoadUrl;
+    }
 
     @Override
     public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler,
@@ -170,6 +189,18 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     public void onReceivedSslError(final WebView view,
                                    final SslErrorHandler handler,
                                    final SslError error) {
+        final String methodTag = TAG + ":onReceivedSslError";
+        if (this.mEnableNewSslErrorHandling) {
+            onReceivedSslErrorInternal(view, handler, error);
+        } else {
+            // Legacy flow
+            onReceivedSslErrorInternalLegacy(view, handler, error);
+        }
+    }
+
+    private void onReceivedSslErrorInternalLegacy(final WebView view,
+                                                  final SslErrorHandler handler,
+                                                  final SslError error) {
         // Developer does not have option to control this for now
         super.onReceivedSslError(view, handler, error);
         handler.cancel();
@@ -182,6 +213,57 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         mCompletionCallback.onChallengeResponseReceived(
                 RawAuthorizationResult.fromException(
                         new ClientException("Code:" + ERROR_FAILED_SSL_HANDSHAKE, error.toString())));
+    }
+
+    private void onReceivedSslErrorInternal(final WebView view,
+                                   final SslErrorHandler handler,
+                                   final SslError error) {
+        // Developer does not have option to control this for now
+        final String methodTag = TAG + ":onReceivedSslErrorInternal";
+        super.onReceivedSslError(view, handler, error);
+        handler.cancel();
+
+        // only if the error is for the main frame URL, cancel the flow.
+        // otherwise only handler.cancel() is called (above) to stop loading affected resource.
+        if (isMainFrameUrl(error.getUrl())) {
+            final String errMsg = "Received SSL Error during request. For more info see: " + SSL_HELP_URL;
+
+            Logger.error(methodTag, errMsg, null);
+
+            // Send the result back to the calling activity
+            mCompletionCallback.onChallengeResponseReceived(
+                    RawAuthorizationResult.fromException(
+                            new ClientException("Code:" + ERROR_FAILED_SSL_HANDSHAKE, error.toString())));
+        }
+    }
+
+    /**
+     * Check if the error url is the same as the main url to load. Compares host
+     * as SSL errors apply to the domain
+     */
+    private boolean isMainFrameUrl(final String errorUrl) {
+        final String methodTag = TAG + ":isMainFrameUrl";
+        if (StringUtil.isEmpty(mActiveLoadUrl)) {
+            Logger.warn(methodTag, "Main url is empty.");
+            return false;
+        }
+        if (StringUtil.isEmpty(errorUrl)) {
+            Logger.warn(methodTag, "Received SSL error with null or empty URL.");
+            return false;
+        }
+
+        final String mainUrlHost = Uri.parse(mActiveLoadUrl).getHost();
+        if (StringUtil.isEmpty(mainUrlHost)) {
+            Logger.warn(methodTag, "Main url is malformed: " + mActiveLoadUrl);
+            return false;
+        }
+
+        final String errorUrlHost = Uri.parse(errorUrl).getHost();
+        if (StringUtil.isEmpty(errorUrlHost)) {
+            Logger.warn(methodTag, "Received SSL error with malformed URL: " + errorUrl);
+            return false;
+        }
+        return errorUrlHost.equalsIgnoreCase(mainUrlHost);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -115,6 +115,13 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         mActiveLoadUrl = activeLoadUrl;
     }
 
+    /**
+     * For Testing
+     */
+    String getActiveLoadUrl() {
+        return mActiveLoadUrl;
+    }
+
     @Override
     public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler,
                                           String host, String realm) {
@@ -202,8 +209,8 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
                                                   final SslErrorHandler handler,
                                                   final SslError error) {
         // Developer does not have option to control this for now
+        // this calls handler.cancel() to stop loading the affected resource.
         super.onReceivedSslError(view, handler, error);
-        handler.cancel();
 
         final String errMsg = "Received SSL Error during request. For more info see: " + SSL_HELP_URL;
 
@@ -218,10 +225,9 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
     private void onReceivedSslErrorInternal(final WebView view,
                                    final SslErrorHandler handler,
                                    final SslError error) {
-        // Developer does not have option to control this for now
         final String methodTag = TAG + ":onReceivedSslErrorInternal";
+        // this calls handler.cancel() to stop loading the affected resource.
         super.onReceivedSslError(view, handler, error);
-        handler.cancel();
 
         // only if the error is for the main frame URL, cancel the flow.
         // otherwise only handler.cancel() is called (above) to stop loading affected resource.

--- a/common/src/main/res/layout/common_activity_authentication.xml
+++ b/common/src/main/res/layout/common_activity_authentication.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="@android:color/white">
 
-    <WebView
+    <com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebView
         android:id="@+id/common_auth_webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentTest.kt
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.providers.oauth2
+
+import android.os.Bundle
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED
+import com.microsoft.identity.common.java.flighting.CommonFlight
+import com.microsoft.identity.common.java.flighting.IFlightsManager
+import com.microsoft.identity.common.java.flighting.IFlightsProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewAuthorizationFragmentTest {
+    @Test
+    fun testExtractState_NewSslErrorHandlerEnabled() {
+        val fragment = WebViewAuthorizationFragment()
+
+        val bundle = Bundle().apply {
+            putBoolean(WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED, true)
+        }
+
+        fragment.extractState(bundle)
+        assertTrue(fragment.shouldUseWebViewNewSslErrorHandler())
+    }
+
+    @Test
+    fun testExtractState_NewSslErrorHandlerDisabled() {
+        val fragment = WebViewAuthorizationFragment()
+
+        val bundle = Bundle().apply {
+            putBoolean(WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED, false)
+        }
+
+        fragment.extractState(bundle)
+        assertFalse(fragment.shouldUseWebViewNewSslErrorHandler())
+    }
+
+    @Test
+    fun testExtractState_NewSslErrorHandlerNotSet() {
+        val fragment = WebViewAuthorizationFragment()
+
+        val bundle = Bundle()
+
+        fragment.extractState(bundle)
+
+        // default value from flight
+        assertTrue(fragment.shouldUseWebViewNewSslErrorHandler())
+    }
+
+    @Test
+    fun testExtractState_NewSslErrorHandlerNotSet_FlightProvider_Enabled() {
+        val fragment = WebViewAuthorizationFragment()
+        val flightsManger : IFlightsManager = mock()
+        val flightsProvider: IFlightsProvider = mock()
+        whenever(flightsProvider.isFlightEnabled(eq(CommonFlight.ENABLE_WEB_VIEW_NEW_SSL_HANDLER))).thenReturn(true)
+        whenever(flightsManger.getFlightsProvider()).thenReturn(flightsProvider)
+
+
+        val bundle = Bundle()
+
+        fragment.extractState(bundle)
+
+        // default value from flight
+        assertTrue(fragment.shouldUseWebViewNewSslErrorHandler())
+    }
+
+    @Test
+    fun testExtractState_NewSslErrorHandlerNotSet_FlightProvider_Disabled() {
+        val fragment = WebViewAuthorizationFragment()
+        val flightsManger : IFlightsManager = mock()
+        val flightsProvider: IFlightsProvider = mock()
+        whenever(flightsProvider.isFlightEnabled(eq(CommonFlight.ENABLE_WEB_VIEW_NEW_SSL_HANDLER))).thenReturn(false)
+        whenever(flightsManger.getFlightsProvider()).thenReturn(flightsProvider)
+
+        val bundle = Bundle()
+
+        fragment.extractState(bundle)
+
+        // default value from flight
+        assertTrue(fragment.shouldUseWebViewNewSslErrorHandler())
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -22,8 +22,12 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview;
 
+import static android.webkit.WebViewClient.ERROR_FAILED_SSL_HANDSHAKE;
+
 import android.app.Activity;
 import android.content.Context;
+import android.net.http.SslError;
+import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -51,8 +55,12 @@ import org.robolectric.RobolectricTestRunner;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 
@@ -61,7 +69,7 @@ import io.opentelemetry.api.trace.Span;
 
 @RunWith(RobolectricTestRunner.class)
 public class AzureActiveDirectoryWebViewClientTest {
-    private WebView mMockWebView;
+    private AzureActiveDirectoryWebView mMockWebView;
     private AzureActiveDirectoryWebViewClient mWebViewClient;
     private Context mContext;
     private Activity mActivity;
@@ -101,7 +109,7 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Before
     public void setup() throws ClientException {
         mContext = ApplicationProvider.getApplicationContext();
-        mMockWebView = new WebView(mContext);
+        mMockWebView = new AzureActiveDirectoryWebView(mContext);
         mActivity = Robolectric.buildActivity(Activity.class).get();
         mWebViewClient = new AzureActiveDirectoryWebViewClient(
                 mActivity,
@@ -200,6 +208,7 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testUrlOverrideHandlesInvalidUrl() {
         assertFalse(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INVALID_URL));
+        assertEquals(TEST_INVALID_URL, mWebViewClient.getActiveLoadUrl());
     }
 
     @Test
@@ -302,5 +311,81 @@ public class AzureActiveDirectoryWebViewClientTest {
         } catch (Exception e) {
             Assert.fail("Failure is not expected." + e);
         }
+    }
+
+    @Test
+    public void testOnReceivedSslError_Legacy() {
+        final String mockActiveUrl = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize";
+        final SslErrorHandler mockHandler = Mockito.mock(android.webkit.SslErrorHandler.class);
+        final SslError mockError = Mockito.mock(android.net.http.SslError.class);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        when(mockError.getUrl()).thenReturn("https://example.com");
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class));
+        final AzureActiveDirectoryWebView mockWebView = new AzureActiveDirectoryWebView(mContext);
+        mockWebView.setWebViewClient(mockWebViewClient);
+        mockWebViewClient.setActiveLoadUrl(mockActiveUrl);
+
+        // act
+        mockWebViewClient.onReceivedSslError(mockWebView, mockHandler, mockError);
+
+        Mockito.verify(mockHandler, Mockito.times(1)).cancel();
+        Mockito.verify(mockCallback, Mockito.times(1)).onChallengeResponseReceived(any());
+    }
+
+    @Test
+    public void testOnReceivedSslError_NotMainFrame() {
+        final String mockActiveUrl = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize";
+        final SslErrorHandler mockHandler = Mockito.mock(android.webkit.SslErrorHandler.class);
+        final SslError mockError = Mockito.mock(android.net.http.SslError.class);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        when(mockError.getUrl()).thenReturn("https://example.com");
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                true
+        );
+        final AzureActiveDirectoryWebView mockWebView = new AzureActiveDirectoryWebView(mContext);
+        mockWebView.setWebViewClient(mockWebViewClient);
+        mockWebViewClient.setActiveLoadUrl(mockActiveUrl);
+
+        // act
+        mockWebViewClient.onReceivedSslError(mockWebView, mockHandler, mockError);
+
+        Mockito.verify(mockHandler, Mockito.times(1)).cancel();
+        Mockito.verify(mockCallback, never()).onChallengeResponseReceived(any());
+    }
+
+    @Test
+    public void testOnReceivedSslError_MainFrame() {
+        final String mockActiveUrl = "https://login.microsoftonline.com/organizations/oAuth2/v2.0/authorize";
+        final SslErrorHandler mockHandler = Mockito.mock(android.webkit.SslErrorHandler.class);
+        final SslError mockError = Mockito.mock(android.net.http.SslError.class);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        when(mockError.getUrl()).thenReturn("https://login.microsoftonline.com/organizations");
+        final AzureActiveDirectoryWebViewClient mockWebViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                true
+        );
+        final AzureActiveDirectoryWebView mockWebView = new AzureActiveDirectoryWebView(mContext);
+        mockWebView.setWebViewClient(mockWebViewClient);
+        mockWebViewClient.setActiveLoadUrl(mockActiveUrl);
+
+        // act
+        mockWebViewClient.onReceivedSslError(mockWebView, mockHandler, mockError);
+
+        Mockito.verify(mockHandler, Mockito.times(1)).cancel();
+        Mockito.verify(mockCallback, Mockito.times(1)).onChallengeResponseReceived(any());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewTest.kt
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+
+/**
+ * Test class for [AzureActiveDirectoryWebView].
+ */
+@RunWith(RobolectricTestRunner::class)
+class AzureActiveDirectoryWebViewTest {
+
+    private lateinit var context: Context
+    private lateinit var webView: AzureActiveDirectoryWebView
+    private lateinit var mockWebViewClient: AzureActiveDirectoryWebViewClient
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        webView = AzureActiveDirectoryWebView(context)
+        mockWebViewClient = mock()
+    }
+
+    @Test
+    fun testLoadUrl() {
+        // Given
+        val testUrl = "https://login.microsoftonline.com"
+        webView.setWebViewClient(mockWebViewClient)
+
+        // When
+        webView.loadUrl(testUrl)
+
+        // Then
+        verify(mockWebViewClient).activeLoadUrl = testUrl
+    }
+
+    @Test
+    fun testLoadUrlWithHeaders() {
+        // Given
+        val testUrl = "https://login.microsoftonline.com"
+        val headers = mapOf("header1" to "value1", "header2" to "value2")
+        webView.setWebViewClient(mockWebViewClient)
+
+        // When
+        webView.loadUrl(testUrl, headers)
+
+        // Then
+        verify(mockWebViewClient).activeLoadUrl = testUrl
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -129,7 +129,9 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Web CP in WebView.
      */
-    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false);
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false),
+
+    ENABLE_WEB_VIEW_NEW_SSL_HANDLER("EnableWebViewNewSslHandler", true);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION


**Summary:**  
This PR updates the handling of SSL errors in the Android WebView used for authentication. The change is in response to an incident where the MSA sign-up flow failed due to an expired certificate on an MSA UX web page. The expired certificate was associated with a resource loaded by the page; however, the existing SSL error handling in Common’s WebView would cancel the loading of that resource and subsequently terminate the entire authentication flow. (See PBI for details.)

**Solution**
**Option 1**
We simply log and stop loading the resource that caused the error by calling `SssHandler.cancel()` but not stop the flow by erroring out. This is a simple change. The only thing is the main URL (the url loading in the WebView) itself has SSL error then the flow would end up in *blank page*. This is as bad as finishing the flow but does not inform calling app of the error via exception.

But if sub-resource has the error, then the flow continues.

This is a low cost solution and easy to implement with slightly poorer UX.

**Option 2** (Changes in this PR)
The objective of this update is to improve SSL error handling so that the flow is only cancelled if an SSL error occurs on the main frame resource (the primary page being loaded). If an SSL error affects a sub-resource, only the loading of that specific resource is cancelled, and the overall authentication flow continues. This approach helps prevent unnecessary failures caused by SSL errors on secondary or non-critical resources.

Changes introduced:

1. **WebView and WebViewClient Update**:
   - Introduces a new `AzureActiveDirectoryWebView` class, which extends Android's `WebView` and tracks the active URL being loaded, along with `AzureActiveDirectoryWebViewClient`
   - Tracking is done by maintaining the next URL (called active url) that's going to be loaded in WebView.  We cannot fully rely on `WebViewClient`'s callbacks like `onPageStarted` because webpage can run into error even before `onPageStarted` is called. So, we track the URL ourselves by
     1) Setting active Url to be loaded in `shouldOverrideUrlLoading(..)` callback. This is called before URL is about to get loaded
     2) When WebView's `loadUrl` is called explicitly. This is case where `shouldOverrideUrlLoading()` is not called. Since there are multiple places webView.loadUrl is called, added `AzureActiveDirectoryWebView` which keeps track of the URL being loaded in loadUrl and then continues with webView.loadUrl

2. **Handling error in onReceivedSslError**
-  `onReceivedSslError` checks if the SSL error is for the main frame (i.e., the main page being loaded). It does so by comparing the active url against the error url on host/domain. If error is for main frame, it cancels the flow and calls the completion callback with an error; otherwise, it just cancels the faulty resource, and let the flow continue.
- For purpose of enabling/disabling new flow, a boolean is added. This should be temporary till changes are stable.

**Flighting**

3. **New SSL Error Handler Toggle**: 
   - Adds a new intent key (`WEB_VIEW_NEW_SSL_ERROR_HANDLER_ENABLED`) in `AuthenticationConstants.java` to control whether the new SSL error handler logic is enabled. This can be used by OneAuth to opt-in or opt-out.
   - Adds a new flight value is well defaulting to `true`. If the key is not passed. If the key passed, that will be used (primarily meant for OneAuth/MSALCPP). If not, flight would be used (meant for Broker). MSAL would also use default flight value, as there's no remote flighting there.

