### PR TITLE
Fix playstore url launch for broker apps, Fixes AB#3307594

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1387,6 +1387,11 @@ public final class AuthenticationConstants {
         public static final String PLAY_STORE_INSTALL_PREFIX = "market://details?id=";
 
         /**
+         * Another prefix in the redirect for PlayStore.
+         */
+        public static final String PLAY_STORE_INSTALL_APP_PREFIX = "https://play.google.com/store/apps/details?id=";
+
+        /**
          * String for expiration buffer.
          * Integer for token expiration buffer. see {@link AuthenticationSettings#mExpirationBuffer}
          */

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -677,12 +677,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean processPlayStoreURLForBrokerApps(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processPlayStoreURL";
 
-        if (!(url.startsWith(PLAY_STORE_INSTALL_APP_PREFIX + COMPANY_PORTAL_APP_PACKAGE_NAME))
-                && !(url.startsWith(PLAY_STORE_INSTALL_APP_PREFIX + AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))) {
-            Logger.info(methodTag, "The URI is either trying to open an unknown application or contains unknown query parameters");
-            return false;
-        }
-
         final String appPackageName = (url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME) ?
                 COMPANY_PORTAL_APP_PACKAGE_NAME : AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME);
         Logger.info(methodTag, "Request to open PlayStore to install package : '" + appPackageName + "'");
@@ -693,8 +687,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             getActivity().startActivity(intent);
             view.stopLoading();
             if (appPackageName.equalsIgnoreCase(COMPANY_PORTAL_APP_PACKAGE_NAME) && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-                // If the flight is enabled, we will return the result code to the activity to indicate that the MDM flow has started.
-                // Note that this is only for CP app as we are not aware of any other flows reaching this code path.
+                // If the flight for webcp is enabled, we will return the result code to the activity to indicate that the MDM flow has started.
+                // Note that this is only for CP app as we are not aware of any other flows (other than webcp) reaching this code path.
                 returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
             }
             return true;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -94,9 +94,11 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_SIGNATURE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_APP_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
 import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP_LINK_KEY;
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_ERROR;
+import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_PLAYSTORE_URL_LAUNCH;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
@@ -305,6 +307,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (isPlayStoreUrl(formattedURL)) {
                 Logger.info(methodTag,"Request to open PlayStore.");
                 return processPlayStoreURL(view, url);
+            } else if(CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(ENABLE_PLAYSTORE_URL_LAUNCH) && isPlaystoreUrlToInstallBrokerApp(formattedURL)) {
+                Logger.info(methodTag,"Request to open PlayStore for broker app install.");
+                return processPlayStoreURLForBrokerApps(view, url);
             } else if (isAuthAppMFAUrl(formattedURL)) {
                 Logger.info(methodTag,"Request to link account with Authenticator.");
                 processAuthAppMFAUrl(url);
@@ -366,6 +371,18 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isPlayStoreUrl(@NonNull final String url) {
         return url.startsWith(PLAY_STORE_INSTALL_PREFIX);
+    }
+
+    private boolean isPlaystoreUrlToInstallBrokerApp(@NonNull final String url) {
+        if (url.startsWith(PLAY_STORE_INSTALL_APP_PREFIX)) {
+            // Check if the url query parameter is for a broker app.
+            for (final BrokerData brokerData : BrokerData.getAllBrokers()) {
+                if (url.contains("id=" + brokerData.getPackageName())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private boolean isPkeyAuthUrl(@NonNull final String url) {
@@ -466,7 +483,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             final String path = uri.getPath();
 
             if (host == null || path == null) {
-                Logger.info(methodTag, "URL missing host or path");
+                Logger.verbose(methodTag, "URL missing host or path");
                 return false;
             }
 
@@ -654,6 +671,39 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
 
         return true;
+    }
+
+    // This method processes the Play Store URL for broker apps. We check if the URL is for installing the Company Portal app or the Azure Authenticator app.
+    private boolean processPlayStoreURLForBrokerApps(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processPlayStoreURL";
+
+        if (!(url.startsWith(PLAY_STORE_INSTALL_APP_PREFIX + COMPANY_PORTAL_APP_PACKAGE_NAME))
+                && !(url.startsWith(PLAY_STORE_INSTALL_APP_PREFIX + AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))) {
+            Logger.info(methodTag, "The URI is either trying to open an unknown application or contains unknown query parameters");
+            return false;
+        }
+
+        final String appPackageName = (url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME) ?
+                COMPANY_PORTAL_APP_PACKAGE_NAME : AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME);
+        Logger.info(methodTag, "Request to open PlayStore to install package : '" + appPackageName + "'");
+
+        try {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_INSTALL_APP_PREFIX + appPackageName));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            getActivity().startActivity(intent);
+            view.stopLoading();
+            if (appPackageName.equalsIgnoreCase(COMPANY_PORTAL_APP_PACKAGE_NAME) && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+                // If the flight is enabled, we will return the result code to the activity to indicate that the MDM flow has started.
+                // Note that this is only for CP app as we are not aware of any other flows reaching this code path.
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+            return true;
+        } catch (android.content.ActivityNotFoundException e) {
+            //if GooglePlay is not present on the device.
+            Logger.error(methodTag, "PlayStore is not present on the device", e);
+        }
+
+        return false;
     }
 
     private void processAuthAppMFAUrl(String url) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -86,7 +86,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_BLANK_PAGE_REQUEST_URL = "about:blank";
     private static final String TEST_PKEY_AUTH_URL = "urn:http-auth:PKeyAuth/xyz";
     private static final String TEST_WEB_CP_URL = "companyportal://abc/123";
-    private static final String TEST_INVALID_URL = "https://play.google.com/store/apps/details?id=com.azure.authenticator";
+    private static final String TEST_PLAYSTORE_FOR_BROKER_APP_URL = "https://play.google.com/store/apps/details?id=com.azure.authenticator";
+    private static final String TEST_INVALID_URL = "https://some.invalid.url";
     private static final String TEST_MSA_HEADER_FORWARDING_POSITIVE_URL = "https://login.live.com/oauth20_authorize.srf";
     private static final String TEST_MSA_HEADER_FORWARDING_NEGATIVE_URL = "https://login.blah.com/oauth20_authorize.srf";
 
@@ -157,6 +158,11 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testUrlOverrideHandlesInstallRequest() {
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_INSTALL_REQUEST_URL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesPlayStoreRequest() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAYSTORE_FOR_BROKER_APP_URL));
     }
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -131,6 +131,9 @@ public enum CommonFlight implements IFlightConfig {
      */
     ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false),
 
+    /**
+     * Flight to enable the Playstore URL launch for broker apps.
+     */
     ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true);
 
     private String key;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -129,7 +129,9 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Web CP in WebView.
      */
-    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false);
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false),
+
+    ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
Issue : When there is an intent to launch to playstore URL for broker apps, webview loads the page https://play.google.com/store/apps/details?id=com.microsoft.windowsintune.companyportal for a brief second and then redirects to the intent:// which gets launched using https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/e5b119cb218560210befbf570b89b3f4271def9c/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java#L778
In this PR, I am fixing the momentary load of the URL and directly launching the intent for a smooth experience.

- I put the change behind a flight which is ON by default.
- If for some reason this fails by throwing an exception, I am returning false so that webview loads the URL and follows the existing path instead of completely breaking.

Fixes [AB#3307594](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3307594)