### PR TITLE
Edge to edge fix limited to brokered only scenarios, Fixes AB#3293334

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
@@ -43,6 +43,7 @@ import androidx.fragment.app.FragmentTransaction;
 
 import com.microsoft.device.display.DisplayMask;
 import com.microsoft.identity.common.R;
+import com.microsoft.identity.common.internal.util.ProcessUtil;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.logging.Logger;
@@ -62,7 +63,7 @@ public class DualScreenActivity extends FragmentActivity {
 
     private void initializeContentView(){
         super.setContentView(R.layout.dual_screen_layout);
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
+        if (ProcessUtil.isBrokerProcess(getApplicationContext()) && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
             try {
                 ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (view, insets) -> {
                     int topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/DualScreenActivity.java
@@ -43,7 +43,6 @@ import androidx.fragment.app.FragmentTransaction;
 
 import com.microsoft.device.display.DisplayMask;
 import com.microsoft.identity.common.R;
-import com.microsoft.identity.common.internal.util.ProcessUtil;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.logging.Logger;
@@ -63,7 +62,7 @@ public class DualScreenActivity extends FragmentActivity {
 
     private void initializeContentView(){
         super.setContentView(R.layout.dual_screen_layout);
-        if (ProcessUtil.isBrokerProcess(getApplicationContext()) && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_HANDLING_FOR_EDGE_TO_EDGE)) {
             try {
                 ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (view, insets) -> {
                     int topInset = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -124,7 +124,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable handling the UI in edge to edge mode
      */
-    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true),
+    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", false),
 
     /**
      * Flight to enable the Web CP in WebView.


### PR DESCRIPTION
The fix I did in this PR is flighted https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2665
But we cannot control flighting when no broker is installed. I have checked with OneAuth team and they are ok with just turning this fix ON for brokered flow since that is the majority case.

Fix : Simply limit the fix to brokered flow by setting the default flight value in common to false and in broker to true. See broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/3130

Fixes [AB#3293334](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3293334)
