### PR TITLE
Use ContentProvider instead of hashmap for numberMatch data, AB#3308440, Fixes AB#3308440

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker
 
+import android.content.Context
 import android.webkit.JavascriptInterface
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
@@ -37,7 +38,7 @@ import java.net.URL
  * JavaScript API to receive JSON string payloads from AuthUX in order to facilitate calling various
  * broker methods.
  */
-class AuthUxJavaScriptInterface {
+class AuthUxJavaScriptInterface(private val context: Context) {
 
     // Store number matches in a static hash map
     // No need to persist this storage beyond the current broker process, but we need to keep them
@@ -133,6 +134,7 @@ class AuthUxJavaScriptInterface {
             when (operation) {
                 OperationNames.NUMBER_MATCHING ->
                     NumberMatchHelper.storeNumberMatch(
+                        context,
                         parameters.sessionId,
                         parameters.codeMatch
                     )

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchContentProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchContentProvider.kt
@@ -1,0 +1,130 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.numberMatch
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.UriMatcher
+import android.database.Cursor
+import android.net.Uri
+import com.microsoft.identity.common.logging.Logger
+
+class NumberMatchContentProvider : ContentProvider() {
+    companion object {
+        const val AUTHORITY = "com.microsoft.identity.common.internal.numberMatch.provider"
+        const val TABLE_NAME = "number_match"
+        const val SESSION_ID = "sessionId"
+        const val NUMBER_MATCH_DATA = "numberMatchData"
+        const val CODE_NUMBER_MATCH = 1
+        val TAG = NumberMatchContentProvider::class.java.simpleName
+        val CONTENT_URI: Uri = Uri.parse("content://$AUTHORITY/$TABLE_NAME")
+        private val uriMatcher = UriMatcher(UriMatcher.NO_MATCH).apply {
+            addURI(AUTHORITY, TABLE_NAME, CODE_NUMBER_MATCH)
+        }
+    }
+
+    private lateinit var dbHelper: NumberMatchDbHelper
+
+    override fun onCreate(): Boolean {
+        dbHelper = NumberMatchDbHelper(context!!)
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? {
+        Logger.info(TAG, "Query called: uri=$uri, selection=$selection, selectionArgs=${selectionArgs?.joinToString()}")
+
+        // Validate URI
+        validateURI(uri)
+
+        val db = dbHelper.readableDatabase
+        return db.query(
+            TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs,
+            null,
+            null,
+            sortOrder
+        )
+    }
+
+    override fun getType(uri: Uri): String? {
+        return when (uriMatcher.match(uri)) {
+            CODE_NUMBER_MATCH -> "vnd.android.cursor.dir/vnd.$AUTHORITY.$TABLE_NAME"
+            else -> null
+        }
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? {
+        Logger.info(TAG, "Insert called: uri=$uri, values=$values")
+
+        // Validate URI
+        validateURI(uri)
+
+        val db = dbHelper.writableDatabase
+        val id = db.insert(TABLE_NAME, null, values)
+        if (id > 0) {
+            Logger.info(TAG, "Insert successful: id=$id")
+            return Uri.withAppendedPath(CONTENT_URI, id.toString())
+        } else {
+            Logger.warn(TAG, "Insert failed")
+            return null
+        }
+    }
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int {
+        Logger.info(TAG, "Delete called: uri=$uri, selection=$selection, selectionArgs=${selectionArgs?.joinToString()}")
+        validateURI(uri)
+        val db = dbHelper.writableDatabase
+        val rows = db.delete(TABLE_NAME, selection, selectionArgs)
+        Logger.info(TAG, "Rows deleted: $rows")
+        return rows
+    }
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int {
+        Logger.info(TAG, "Update called: uri=$uri, values=$values, selection=$selection, selectionArgs=${selectionArgs?.joinToString()}")
+        val db = dbHelper.writableDatabase
+        val rows = db.update(TABLE_NAME, values, selection, selectionArgs)
+        Logger.info(TAG, "Rows updated: $rows")
+        return rows
+    }
+
+    private fun validateURI(uri: Uri) {
+        if (uriMatcher.match(uri) != CODE_NUMBER_MATCH) {
+            Logger.warn(TAG, "Unknown URI: $uri")
+            throw IllegalArgumentException("Unknown URI: $uri")
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchContentProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchContentProvider.kt
@@ -30,6 +30,13 @@ import android.database.Cursor
 import android.net.Uri
 import com.microsoft.identity.common.logging.Logger
 
+/**
+ * ContentProvider implementation for the Number Match feature.
+ * This provider exposes CRUD operations for number match data, allowing secure storage and retrieval
+ * of session IDs and number match values for authentication flows.
+ *
+ * The provider uses NumberMatchDbHelper for database management and exposes its data via a content URI.
+ */
 class NumberMatchContentProvider : ContentProvider() {
     companion object {
         const val AUTHORITY = "com.microsoft.identity.common.internal.numberMatch.provider"

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchDbHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchDbHelper.kt
@@ -28,6 +28,12 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.provider.BaseColumns
 
+/**
+ * Helper class to manage database creation and version management for Number Match feature.
+ * This class creates and upgrades the SQLite database used by NumberMatchContentProvider.
+ *
+ * @param context The context to use for locating paths to the the database
+ */
 class NumberMatchDbHelper(context: Context) : SQLiteOpenHelper(context, "number_match.db", null, 1) {
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL(
@@ -43,4 +49,3 @@ class NumberMatchDbHelper(context: Context) : SQLiteOpenHelper(context, "number_
         onCreate(db)
     }
 }
-

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchDbHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchDbHelper.kt
@@ -1,0 +1,46 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.common.internal.numberMatch
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import android.provider.BaseColumns
+
+class NumberMatchDbHelper(context: Context) : SQLiteOpenHelper(context, "number_match.db", null, 1) {
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE ${NumberMatchContentProvider.TABLE_NAME} (" +
+                    "${BaseColumns._ID} INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                    "${NumberMatchContentProvider.SESSION_ID} TEXT UNIQUE, " +
+                    "${NumberMatchContentProvider.NUMBER_MATCH_DATA} TEXT)"
+        )
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        db.execSQL("DROP TABLE IF EXISTS ${NumberMatchContentProvider.TABLE_NAME}")
+        onCreate(db)
+    }
+}
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
@@ -22,6 +22,9 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.numberMatch
 
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -35,9 +38,7 @@ import com.microsoft.identity.common.logging.Logger
  */
 class NumberMatchHelper {
 
-    // Store number matches in a static hash map
-    // No need to persist this storage beyond the current broker process, but we need to keep them
-    // long enough for AuthApp to call the broker api to fetch the number match
+    // Store number matches in a Content Provider
     companion object {
         val TAG = NumberMatchHelper::class.java.simpleName
         val numberMatchMap: HashMap<String, String> = HashMap()
@@ -45,20 +46,22 @@ class NumberMatchHelper {
         const val NUMBER_MATCH_ATTRIBUTE_NAME = "numberMatch"
 
         /**
-         * Method to add a key:value pair of sessionID:numberMatch to static hashmap. This hashmap will be accessed
-         * by broker api to get the number match for a particular sessionID.
+         * Method to add a key:value pair of sessionID:numberMatch to Content Provider.
          */
-        fun storeNumberMatch(sessionId: String?, numberMatch: String?) {
+        fun storeNumberMatch(context: Context, sessionId: String?, numberMatch: String?) {
             val methodTag = "$TAG:storeNumberMatch"
             Logger.info(methodTag,
-                "Adding entry in NumberMatch hashmap for session ID: $sessionId")
+                "Adding entry in NumberMatch Content Provider for session ID: $sessionId")
 
             // If both parameters are non-null, add a new entry to the hashmap
             if (sessionId != null && numberMatch != null) {
-                numberMatchMap[sessionId] = numberMatch
-            }
-            // If either parameter is null, do nothing
-            else {
+                val values = ContentValues().apply {
+                    put(NumberMatchContentProvider.SESSION_ID, sessionId)
+                    put(NumberMatchContentProvider.NUMBER_MATCH_DATA, numberMatch)
+                }
+                val uri = NumberMatchContentProvider.CONTENT_URI
+                context.contentResolver.insert(uri, values)
+            } else {
                 Logger.warn(methodTag,
                     "Either session ID or number match is null. Nothing to add for number match."
                 )
@@ -66,10 +69,32 @@ class NumberMatchHelper {
         }
 
         /**
-         * Clear existing number match key:value pairs
+         * Retrieve numberMatch for a session using ContentProvider.
          */
-        fun clearNumberMatchMap() {
-            numberMatchMap.clear()
+        fun getNumberMatch(context: Context, sessionId: String?): String? {
+            if (sessionId == null) return null
+            val uri = NumberMatchContentProvider.CONTENT_URI
+            val cursor: Cursor? = context.contentResolver.query(
+                uri,
+                arrayOf(NumberMatchContentProvider.NUMBER_MATCH_DATA),
+                "${NumberMatchContentProvider.SESSION_ID} = ?",
+                arrayOf(sessionId),
+                null
+            )
+            cursor?.use {
+                if (it.moveToFirst()) {
+                    return it.getString(it.getColumnIndexOrThrow(NumberMatchContentProvider.NUMBER_MATCH_DATA))
+                }
+            }
+            return null
+        }
+
+        /**
+         * Clear all number match data from ContentProvider.
+         */
+        fun clearNumberMatchMap(context: Context) {
+            val uri = NumberMatchContentProvider.CONTENT_URI
+            context.contentResolver.delete(uri, null, null)
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
@@ -91,7 +91,7 @@ class NumberMatchHelper {
         /**
          * Clear all number match data from ContentProvider.
          */
-        fun clearNumberMatchMap(context: Context) {
+        fun clearNumberMatchData(context: Context) {
             val uri = NumberMatchContentProvider.CONTENT_URI
             context.contentResolver.delete(uri, null, null)
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
@@ -41,7 +41,6 @@ class NumberMatchHelper {
     // Store number matches in a Content Provider
     companion object {
         val TAG = NumberMatchHelper::class.java.simpleName
-        val numberMatchMap: HashMap<String, String> = HashMap()
         const val SESSION_ID_ATTRIBUTE_NAME = "sessionID"
         const val NUMBER_MATCH_ATTRIBUTE_NAME = "numberMatch"
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
@@ -91,7 +91,7 @@ class NumberMatchHelper {
         /**
          * Clear all number match data from ContentProvider.
          */
-        fun clearNumberMatchData(context: Context) {
+        fun clearNumberMatch(context: Context) {
             val uri = NumberMatchContentProvider.CONTENT_URI
             context.contentResolver.delete(uri, null, null)
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -147,7 +147,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (shouldExposeJavaScriptInterface(url)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(TAG, "Adding AuthUx JavaScript Interface");
-            view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
+            view.addJavascriptInterface(new AuthUxJavaScriptInterface(getActivity().getApplicationContext()),
+                    AuthUxJavaScriptInterface.Companion.getInterfaceName());
             mAuthUxJavaScriptInterfaceAdded = true;
         }
     }
@@ -241,7 +242,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (shouldExposeJavaScriptInterface(url)) {
             // If broker request, and a valid url, expose JavaScript API
             Logger.info(methodTag, "Adding AuthUx JavaScript Interface");
-            view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
+            view.addJavascriptInterface(new AuthUxJavaScriptInterface(getActivity().getApplicationContext()),
+                    AuthUxJavaScriptInterface.Companion.getInterfaceName());
             mAuthUxJavaScriptInterfaceAdded = true;
         } else if (mAuthUxJavaScriptInterfaceAdded) {
             // Remove AuthUx JavaScript Interface

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -63,7 +63,7 @@ class AuthUxJavaScriptInterfaceTest {
     @After
     fun tearDown() {
         // Clear the static map after each test
-        NumberMatchHelper.numberMatchMap.clear()
+        NumberMatchHelper.clearNumberMatchData(context)
     }
 
     @Test
@@ -72,7 +72,7 @@ class AuthUxJavaScriptInterfaceTest {
         authUxJavaScriptInterface.receiveAuthUxMessage(numberMatchTestPayload)
 
         // Verify that the data was stored in NumberMatchHelper
-        val storedValue = NumberMatchHelper.numberMatchMap[mockSessionId]
+        val storedValue = NumberMatchHelper.getNumberMatch(context, mockSessionId)
         Assert.assertTrue(storedValue == mockNumberMatchValue)
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -22,15 +22,21 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker
 
+import android.content.Context
 import com.microsoft.identity.common.internal.numberMatch.NumberMatchHelper
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
 
 class AuthUxJavaScriptInterfaceTest {
 
     private lateinit var authUxJavaScriptInterface: AuthUxJavaScriptInterface
+
+    @Mock
+    private lateinit var context: Context
 
     private val mockSessionId = "1234"
     private val mockNumberMatchValue = "00"
@@ -50,7 +56,8 @@ class AuthUxJavaScriptInterfaceTest {
 
     @Before
     fun setUp() {
-        authUxJavaScriptInterface = AuthUxJavaScriptInterface()
+        MockitoAnnotations.openMocks(this)
+        authUxJavaScriptInterface = AuthUxJavaScriptInterface(context)
     }
 
     @After

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -22,21 +22,33 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.broker
 
+import android.content.ContentResolver
 import android.content.Context
+import android.database.Cursor
+import android.net.Uri
 import com.microsoft.identity.common.internal.numberMatch.NumberMatchHelper
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
 
+@RunWith(RobolectricTestRunner::class)
 class AuthUxJavaScriptInterfaceTest {
 
     private lateinit var authUxJavaScriptInterface: AuthUxJavaScriptInterface
 
     @Mock
     private lateinit var context: Context
+    @Mock
+    private lateinit var contentResolver: ContentResolver
+    @Mock
+    private lateinit var cursor: Cursor
 
     private val mockSessionId = "1234"
     private val mockNumberMatchValue = "00"
@@ -57,13 +69,24 @@ class AuthUxJavaScriptInterfaceTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
+        Mockito.reset(context, contentResolver, cursor)
+        // Mock contentResolver on context
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        // Mock insert, delete, and query for contentResolver
+        `when`(contentResolver.insert(Mockito.any(Uri::class.java), Mockito.any())).thenReturn(null)
+        `when`(contentResolver.delete(Mockito.any(Uri::class.java), Mockito.any(), Mockito.any())).thenReturn(1)
+        // Mock query for getNumberMatch
+        `when`(contentResolver.query(Mockito.any(Uri::class.java), Mockito.any(), Mockito.anyString(), Mockito.any(), Mockito.isNull())).thenReturn(cursor)
+        // Mock cursor for getNumberMatch
+        `when`(cursor.moveToFirst()).thenReturn(true)
+        `when`(cursor.getColumnIndexOrThrow(Mockito.anyString())).thenReturn(0)
+        `when`(cursor.getString(0)).thenReturn(mockNumberMatchValue)
         authUxJavaScriptInterface = AuthUxJavaScriptInterface(context)
     }
 
     @After
     fun tearDown() {
-        // Clear the static map after each test
-        NumberMatchHelper.clearNumberMatchData(context)
+//        NumberMatchHelper.clearNumberMatchData(context)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterfaceTest.kt
@@ -86,7 +86,7 @@ class AuthUxJavaScriptInterfaceTest {
 
     @After
     fun tearDown() {
-//        NumberMatchHelper.clearNumberMatchData(context)
+        NumberMatchHelper.clearNumberMatch(context)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
@@ -22,63 +22,104 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.numberMatch
 
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
 
 class NumberMatchHelperTest {
 
     private val mockSessionId = "1234"
     private val mockNumberMatchValue = "00"
+    @Mock
+    private lateinit var context: Context
+    @Mock
+    private lateinit var contentResolver: ContentResolver
+    @Mock
+    private lateinit var cursor: Cursor
 
     @Before
     fun setUp() {
-        // Clear the map before each test to ensure a clean state
-        NumberMatchHelper.clearNumberMatchMap()
+        MockitoAnnotations.openMocks(this)
+        Mockito.`when`(context.contentResolver).thenReturn(contentResolver)
     }
 
     @Test
     fun `test storeNumberMatch with valid inputs`() {
-        // Store a valid session ID and number match
-        val sessionId = mockSessionId
-        val numberMatch = mockNumberMatchValue
-        NumberMatchHelper.storeNumberMatch(sessionId, numberMatch)
+        Mockito.`when`(contentResolver.insert(Mockito.any(), Mockito.any(ContentValues::class.java))).thenReturn(null)
+        Mockito.`when`(contentResolver.query(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.isNull()
+        )).thenReturn(cursor)
+        Mockito.`when`(cursor.moveToFirst()).thenReturn(true)
+        Mockito.`when`(cursor.getColumnIndexOrThrow(Mockito.anyString())).thenReturn(0)
+        Mockito.`when`(cursor.getString(0)).thenReturn(mockNumberMatchValue)
 
-        // Verify that the map contains the correct value
-        assertEquals(mockNumberMatchValue, NumberMatchHelper.numberMatchMap[sessionId])
+        NumberMatchHelper.storeNumberMatch(context, mockSessionId, mockNumberMatchValue)
+        val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
+        assertEquals(mockNumberMatchValue, result)
     }
 
     @Test
     fun `test storeNumberMatch with null sessionId`() {
-        // Attempt to store a null session ID
-        val numberMatch = mockNumberMatchValue
-        NumberMatchHelper.storeNumberMatch(null, numberMatch)
-
-        // Verify that the map is still empty
-        assertTrue(NumberMatchHelper.numberMatchMap.isEmpty())
+        NumberMatchHelper.storeNumberMatch(context, null, mockNumberMatchValue)
+        val result = NumberMatchHelper.getNumberMatch(context, null)
+        assertNull(result)
     }
 
     @Test
     fun `test storeNumberMatch with null numberMatch`() {
-        // Attempt to store a null number match
-        val sessionId = mockSessionId
-        NumberMatchHelper.storeNumberMatch(sessionId, null)
-
-        // Verify that the map is still empty
-        assertTrue(NumberMatchHelper.numberMatchMap.isEmpty())
+        NumberMatchHelper.storeNumberMatch(context, mockSessionId, null)
+        // Should not call insert, so query returns null
+        Mockito.`when`(contentResolver.query(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.isNull()
+        )).thenReturn(null)
+        val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
+        assertNull(result)
     }
 
     @Test
-    fun `test clearNumberMatchMap`() {
-        // Add an entry to the map
-        val sessionId = mockSessionId
-        val numberMatch = mockNumberMatchValue
-        NumberMatchHelper.storeNumberMatch(sessionId, numberMatch)
+    fun `test getNumberMatch with non-existent sessionId`() {
+        Mockito.`when`(contentResolver.query(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.isNull()
+        )).thenReturn(cursor)
+        Mockito.`when`(cursor.moveToFirst()).thenReturn(false)
+        val result = NumberMatchHelper.getNumberMatch(context, "nonexistent")
+        assertNull(result)
+    }
 
-        // Clear the map
-        NumberMatchHelper.clearNumberMatchMap()
-
-        // Verify that the map is empty
-        assertTrue(NumberMatchHelper.numberMatchMap.isEmpty())
+    @Test
+    fun `test getNumberMatch after storing and clearing`() {
+        // Simulate storing
+        Mockito.`when`(contentResolver.insert(Mockito.any(), Mockito.any(ContentValues::class.java))).thenReturn(null)
+        // Simulate clearing by returning a cursor that returns false for moveToFirst
+        Mockito.`when`(contentResolver.query(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.anyString(),
+            Mockito.any(),
+            Mockito.isNull()
+        )).thenReturn(cursor)
+        Mockito.`when`(cursor.moveToFirst()).thenReturn(false)
+        NumberMatchHelper.storeNumberMatch(context, mockSessionId, mockNumberMatchValue)
+        val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
+        assertNull(result)
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
@@ -130,7 +130,7 @@ class NumberMatchHelperTest {
 
     @Test
     fun `clearNumberMatchData should call delete on contentResolver`() {
-        NumberMatchHelper.clearNumberMatchData(context)
+        NumberMatchHelper.clearNumberMatch(context)
         verify(contentResolver, times(1)).delete(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelperTest.kt
@@ -27,12 +27,20 @@ import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
 import org.junit.Assert.*
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
 
+@RunWith(RobolectricTestRunner::class)
 class NumberMatchHelperTest {
 
     private val mockSessionId = "1234"
@@ -47,79 +55,82 @@ class NumberMatchHelperTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        Mockito.`when`(context.contentResolver).thenReturn(contentResolver)
+        Mockito.reset(context, contentResolver, cursor)
+        `when`(context.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.insert(ArgumentMatchers.any(), ArgumentMatchers.any(ContentValues::class.java))).thenReturn(null)
+        `when`(contentResolver.delete(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(1)
+        `when`(contentResolver.query(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.isNull()
+        )).thenReturn(cursor)
+        `when`(cursor.moveToFirst()).thenReturn(true)
+        `when`(cursor.getColumnIndexOrThrow(ArgumentMatchers.anyString())).thenReturn(0)
+        `when`(cursor.getString(0)).thenReturn(mockNumberMatchValue)
+    }
+
+    @After
+    fun tearDown() {
+        Mockito.reset(context, contentResolver, cursor)
     }
 
     @Test
-    fun `test storeNumberMatch with valid inputs`() {
-        Mockito.`when`(contentResolver.insert(Mockito.any(), Mockito.any(ContentValues::class.java))).thenReturn(null)
-        Mockito.`when`(contentResolver.query(
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.anyString(),
-            Mockito.any(),
-            Mockito.isNull()
-        )).thenReturn(cursor)
-        Mockito.`when`(cursor.moveToFirst()).thenReturn(true)
-        Mockito.`when`(cursor.getColumnIndexOrThrow(Mockito.anyString())).thenReturn(0)
-        Mockito.`when`(cursor.getString(0)).thenReturn(mockNumberMatchValue)
-
+    fun `storeNumberMatch should insert when sessionId and numberMatch are not null`() {
         NumberMatchHelper.storeNumberMatch(context, mockSessionId, mockNumberMatchValue)
+        verify(contentResolver, times(1)).insert(ArgumentMatchers.any(), ArgumentMatchers.any(ContentValues::class.java))
+    }
+
+    @Test
+    fun `storeNumberMatch should not insert when sessionId is null`() {
+        NumberMatchHelper.storeNumberMatch(context, null, mockNumberMatchValue)
+        verify(contentResolver, times(0)).insert(ArgumentMatchers.any(), ArgumentMatchers.any(ContentValues::class.java))
+    }
+
+    @Test
+    fun `storeNumberMatch should not insert when numberMatch is null`() {
+        NumberMatchHelper.storeNumberMatch(context, mockSessionId, null)
+        verify(contentResolver, times(0)).insert(ArgumentMatchers.any(), ArgumentMatchers.any(ContentValues::class.java))
+    }
+
+    @Test
+    fun `getNumberMatch should return value when sessionId exists`() {
+        `when`(cursor.moveToFirst()).thenReturn(true)
+        `when`(cursor.getString(0)).thenReturn(mockNumberMatchValue)
         val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
         assertEquals(mockNumberMatchValue, result)
     }
 
     @Test
-    fun `test storeNumberMatch with null sessionId`() {
-        NumberMatchHelper.storeNumberMatch(context, null, mockNumberMatchValue)
+    fun `getNumberMatch should return null when sessionId is null`() {
         val result = NumberMatchHelper.getNumberMatch(context, null)
         assertNull(result)
     }
 
     @Test
-    fun `test storeNumberMatch with null numberMatch`() {
-        NumberMatchHelper.storeNumberMatch(context, mockSessionId, null)
-        // Should not call insert, so query returns null
-        Mockito.`when`(contentResolver.query(
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.anyString(),
-            Mockito.any(),
-            Mockito.isNull()
+    fun `getNumberMatch should return null when cursor is null`() {
+        `when`(contentResolver.query(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.isNull()
         )).thenReturn(null)
         val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
         assertNull(result)
     }
 
     @Test
-    fun `test getNumberMatch with non-existent sessionId`() {
-        Mockito.`when`(contentResolver.query(
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.anyString(),
-            Mockito.any(),
-            Mockito.isNull()
-        )).thenReturn(cursor)
-        Mockito.`when`(cursor.moveToFirst()).thenReturn(false)
-        val result = NumberMatchHelper.getNumberMatch(context, "nonexistent")
+    fun `getNumberMatch should return null when cursor is empty`() {
+        `when`(cursor.moveToFirst()).thenReturn(false)
+        val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
         assertNull(result)
     }
 
     @Test
-    fun `test getNumberMatch after storing and clearing`() {
-        // Simulate storing
-        Mockito.`when`(contentResolver.insert(Mockito.any(), Mockito.any(ContentValues::class.java))).thenReturn(null)
-        // Simulate clearing by returning a cursor that returns false for moveToFirst
-        Mockito.`when`(contentResolver.query(
-            Mockito.any(),
-            Mockito.any(),
-            Mockito.anyString(),
-            Mockito.any(),
-            Mockito.isNull()
-        )).thenReturn(cursor)
-        Mockito.`when`(cursor.moveToFirst()).thenReturn(false)
-        NumberMatchHelper.storeNumberMatch(context, mockSessionId, mockNumberMatchValue)
-        val result = NumberMatchHelper.getNumberMatch(context, mockSessionId)
-        assertNull(result)
+    fun `clearNumberMatchData should call delete on contentResolver`() {
+        NumberMatchHelper.clearNumberMatchData(context)
+        verify(contentResolver, times(1)).delete(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())
     }
 }


### PR DESCRIPTION
[AB#3308440](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3308440)
In the current implementation for number matching feature, the data is stored in the hashmap. On testing, I found out that the data in the hashmap was not accessible since this is an interprocess communication. This PR uses ContentProvider to enable interprocess communication.