### PR TITLE
Add telemetry for Auth Ux Javascript and Number Match, Fixes AB#3308132

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -29,6 +29,8 @@ import com.google.gson.JsonSyntaxException
 import com.google.gson.stream.MalformedJsonException
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants
 import com.microsoft.identity.common.internal.numberMatch.NumberMatchHelper
+import com.microsoft.identity.common.java.opentelemetry.AttributeName
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.logging.Logger
 import java.net.MalformedURLException
 import java.net.URL
@@ -115,10 +117,11 @@ class AuthUxJavaScriptInterface {
                 "Correlation ID during JavaScript Call: [${payloadObject.correlationId}]"
             )
 
-
-            // TODO: Leaving these here, as these will be relevant for next WebCP feature
-            // val actionName = payloadObject.actionName
-            // val actionComponent = payloadObject.actionComponent
+            val span = SpanExtension.current()
+            val actionName = payloadObject.actionName
+            span.setAttribute(AttributeName.authux_js_action_name.name, actionName)
+            val actionComponent = payloadObject.actionComponent
+            span.setAttribute(AttributeName.authux_js_action_component.name, actionComponent)
 
             val parameters = payloadObject.params
             if (parameters == null) {
@@ -127,6 +130,9 @@ class AuthUxJavaScriptInterface {
             }
 
             val operation = parameters.operation
+            if (operation != null) {
+                span.setAttribute(AttributeName.authux_js_operation.name, operation)
+            }
 
             Logger.info(methodTag, "Function name: [$operation]")
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/numberMatch/NumberMatchHelper.kt
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.numberMatch
 
+import com.microsoft.identity.common.java.opentelemetry.AttributeName
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -56,6 +58,8 @@ class NumberMatchHelper {
             // If both parameters are non-null, add a new entry to the hashmap
             if (sessionId != null && numberMatch != null) {
                 numberMatchMap[sessionId] = numberMatch
+                val span = SpanExtension.current()
+                span.setAttribute(AttributeName.stored_number_match_entry.name, true)
             }
             // If either parameter is null, do nothing
             else {

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -378,5 +378,26 @@ public enum AttributeName {
     /**
      * Records if the webcp is enabled in webview.
      */
-    is_webcp_in_webview_enabled
+    is_webcp_in_webview_enabled,
+
+    /**
+     * Record action name from Webview JavaScript Payload
+     */
+    authux_js_action_name,
+
+    /**
+     * Record action component from Webview JavaScript Payload
+     */
+    authux_js_action_component,
+
+    /**
+     * Record operation name from Webview JavaScript Payload
+     */
+    authux_js_operation,
+
+    /**
+     * Record whether or not the request stored a number match entry.
+     */
+    stored_number_match_entry
+
 }


### PR DESCRIPTION
Add telemetry for Auth Ux Javascript and Number Match. Also have a broker PR where we copy the attribute name.

[AB#3308132](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3308132)