### PR TITLE
Update keyword to suppress camera consent , Fixes AB#3307418

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Update keyword to suppress camera consent (#2694)
 
 Version 21.3.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
@@ -37,7 +37,11 @@ interface IRestrictionsManager {
         // String keys
         const val PREFERRED_AUTH_CONFIG = "preferred_auth_config"
         // Boolean keys
-        const val SUPPRESS_CAMERA_CONSENT = "sdm_suppress_camera_consent"
+        // SDM_SUPPRESS_CAMERA_CONSENT key was used in the past to suppress camera consent for the SDM QR PIN mode.
+        // It is now deprecated and replaced with the new key SUPPRESS_CAMERA_CONSENT.
+        // This key is kept for backward compatibility.
+        const val SDM_SUPPRESS_CAMERA_CONSENT = "sdm_suppress_camera_consent"
+        const val SUPPRESS_CAMERA_CONSENT = "suppress_camera_consent"
 
         /**
          * Creates a request bundle with the keys to be requested from the app restrictions manager.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IRestrictionsManager.kt
@@ -40,6 +40,7 @@ interface IRestrictionsManager {
         // SDM_SUPPRESS_CAMERA_CONSENT key was used in the past to suppress camera consent for the SDM QR PIN mode.
         // It is now deprecated and replaced with the new key SUPPRESS_CAMERA_CONSENT.
         // This key is kept for backward compatibility.
+        @Deprecated("Use SUPPRESS_CAMERA_CONSENT instead")
         const val SDM_SUPPRESS_CAMERA_CONSENT = "sdm_suppress_camera_consent"
         const val SUPPRESS_CAMERA_CONSENT = "suppress_camera_consent"
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/SdmQrPinManager.kt
@@ -23,7 +23,9 @@
 package com.microsoft.identity.common.internal.broker
 
 import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.PREFERRED_AUTH_CONFIG
+import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.SDM_SUPPRESS_CAMERA_CONSENT
 import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.SUPPRESS_CAMERA_CONSENT
+import com.microsoft.identity.common.internal.broker.IRestrictionsManager.BrokerRestrictionsManagerKeys.buildMultiValueRequest
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -80,11 +82,15 @@ object SdmQrPinManager {
         val methodTag = "$TAG:isCameraConsentSuppressed"
         val defaultValue = false
         restrictionsManager?.let { manager ->
-            return manager.getBoolean(
-                key = SUPPRESS_CAMERA_CONSENT,
-                brokerAppPackageName = authenticatorPackageName,
-                defaultValue = defaultValue
+            val multiValueRequest = buildMultiValueRequest(
+                booleanKeys = setOf(SUPPRESS_CAMERA_CONSENT, SDM_SUPPRESS_CAMERA_CONSENT)
             )
+            val values = manager.getMultiValues(
+                brokerAppPackageName = authenticatorPackageName,
+                bundleOfKeys = multiValueRequest
+            )
+            return values.getBoolean(SUPPRESS_CAMERA_CONSENT, defaultValue) ||
+                    values.getBoolean(SDM_SUPPRESS_CAMERA_CONSENT, defaultValue)
         } ?: run {
             Logger.warn(methodTag, "Broker restrictions manager is not initialized.")
             return defaultValue


### PR DESCRIPTION
[AB#3307418](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3307418)

Related PR: https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android/pullrequest/12799812

keep all key to support backward compatibility with deprecated camera consent key