### PR TITLE
Using utid for webcp flow whenever, Fixes AB#3311720

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [MINOR] Flighting webcp in webview (#2686)
 - [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 - [MINOR] Update keyword to suppress camera consent (#2694)
+- [MINOR] Using utid for webcp flow whenever (#2695)
 
 Version 21.3.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -33,7 +33,7 @@ import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoo
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.internal.util.ProcessUtil
-import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.HOME_TENANT_ID
+import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID
 import com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT
 import com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION
 import com.microsoft.identity.common.java.configuration.LibraryConfiguration
@@ -125,8 +125,8 @@ object AuthorizationActivityFactory {
             if (parameters.sourceLibraryVersion != null) {
                 putExtra(VERSION, parameters.sourceLibraryVersion)
             }
-            if (parameters.homeTenantId != null) {
-                putExtra(HOME_TENANT_ID, parameters.homeTenantId)
+            if (parameters.utid != null) {
+                putExtra(UTID, parameters.utid)
             }
         }
         return intent

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoo
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.internal.util.ProcessUtil
+import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.HOME_TENANT_ID
 import com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT
 import com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION
 import com.microsoft.identity.common.java.configuration.LibraryConfiguration
@@ -123,6 +124,9 @@ object AuthorizationActivityFactory {
             }
             if (parameters.sourceLibraryVersion != null) {
                 putExtra(VERSION, parameters.sourceLibraryVersion)
+            }
+            if (parameters.homeTenantId != null) {
+                putExtra(HOME_TENANT_ID, parameters.homeTenantId)
             }
         }
         return intent

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -51,5 +51,8 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
     val webViewZoomControlsEnabled: Boolean = true,
     val sourceLibraryName: String? = null,
     val sourceLibraryVersion: String? = null,
+    /**
+     * The tenant unique id
+     */
     val utid: String? = null
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -51,5 +51,5 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
     val webViewZoomControlsEnabled: Boolean = true,
     val sourceLibraryName: String? = null,
     val sourceLibraryVersion: String? = null,
-    val homeTenantId: String? = null
+    val utid: String? = null
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -50,5 +50,6 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
     val webViewZoomEnabled: Boolean = true,
     val webViewZoomControlsEnabled: Boolean = true,
     val sourceLibraryName: String? = null,
-    val sourceLibraryVersion: String? = null
+    val sourceLibraryVersion: String? = null,
+    val homeTenantId: String? = null
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -267,7 +267,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 },
                 mRedirectUri,
                 getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
-                utid
+                mUtid
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -81,6 +81,9 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.HOME_TENANT_ID;
+
+
 import io.opentelemetry.api.trace.SpanContext;
 
 /**
@@ -115,6 +118,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
     private boolean webViewZoomControlsEnabled;
 
     private boolean webViewZoomEnabled;
+
+    private String mHomeTenantId;
 
     private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
 
@@ -223,6 +228,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
+        mHomeTenantId = state.getString(HOME_TENANT_ID);
     }
 
     @Nullable
@@ -260,7 +266,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     }
                 },
                 mRedirectUri,
-                getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler()
+                getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
+                mHomeTenantId
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -81,8 +81,7 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.HOME_TENANT_ID;
-
+import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID;
 
 import io.opentelemetry.api.trace.SpanContext;
 
@@ -119,7 +118,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private boolean webViewZoomEnabled;
 
-    private String mHomeTenantId;
+    private String mUtid;
 
     private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
 
@@ -211,6 +210,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
+        outState.putString(UTID, mUtid);
     }
 
     @Override
@@ -228,7 +228,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
-        mHomeTenantId = state.getString(HOME_TENANT_ID);
+        mUtid = state.getString(UTID);
     }
 
     @Nullable
@@ -267,7 +267,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 },
                 mRedirectUri,
                 getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
-                mHomeTenantId
+                utid
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -677,6 +677,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(username)) {
             return null;
         }
+
         return CommonTenantInfoProvider.INSTANCE.getHomeTenantId(username);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -595,6 +595,48 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
+    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
+    @VisibleForTesting
+    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
+        final String methodTag = TAG + ":loadDeviceCaUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
+            Logger.info(methodTag, "Loading device CA request in WebView.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
+            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
+            view.loadUrl(httpsUrl, mRequestHeaders);
+        } else {
+            Logger.info(methodTag, "Loading device CA request in browser.");
+            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
+            openLinkInBrowser(originalUrl);
+            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+        }
+    }
+
+    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
+    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
+    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
+        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
+        view.stopLoading();
+        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
+        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
+        openLinkInBrowser(url);
+        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
+        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+            }
+        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
+    }
+
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -131,15 +131,19 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
     private boolean mIsWebCpInWebViewFeatureEnabled = false;
 
+    private String mHomeTenantId;
+
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
                                              @NonNull final OnPageLoadedCallback pageLoadedCallback,
                                              @NonNull final String redirectUrl,
-                                             @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler) {
+                                             @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
+                                             @Nullable final String homeTenantId) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
+        mHomeTenantId = homeTenantId;
     }
 
     /**
@@ -655,13 +659,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             // Else, check if the home tenant is in the list of tenants that have this feature enabled.
-            final String tenantId = getHomeTenantIdFromUrl(originalUrl);
-            if (StringUtil.isNullOrEmpty(tenantId)) {
+            final String homeTenantId = mHomeTenantId != null? mHomeTenantId : getHomeTenantIdFromUrl(originalUrl);
+            if (StringUtil.isNullOrEmpty(homeTenantId)) {
+                Logger.info(methodTag, "Home tenantId is empty");
                 return false;
             }
 
             final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
-            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(tenantId);
+            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(homeTenantId);
             Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
             mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
             return isFlightEnabledForCurrentTenant;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -131,19 +131,19 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
     private boolean mIsWebCpInWebViewFeatureEnabled = false;
 
-    private String mHomeTenantId;
+    private String mUtid;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
                                              @NonNull final OnPageLoadedCallback pageLoadedCallback,
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
-                                             @Nullable final String homeTenantId) {
+                                             @Nullable final String utid) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
-        mHomeTenantId = homeTenantId;
+        mUtid = utid;
     }
 
     /**
@@ -659,7 +659,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             // Else, check if the home tenant is in the list of tenants that have this feature enabled.
-            final String homeTenantId = mHomeTenantId != null? mHomeTenantId : getHomeTenantIdFromUrl(originalUrl);
+            final String homeTenantId = mUtid != null? mUtid : getHomeTenantIdFromUrl(originalUrl);
             if (StringUtil.isNullOrEmpty(homeTenantId)) {
                 Logger.info(methodTag, "Home tenantId is empty");
                 return false;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -659,7 +659,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
 
             // Else, check if the home tenant is in the list of tenants that have this feature enabled.
-            final String homeTenantId = mUtid != null? mUtid : getHomeTenantIdFromUrl(originalUrl);
+            final String homeTenantId = !StringUtil.isNullOrEmpty(mUtid)? mUtid : getHomeTenantIdFromUrl(originalUrl);
             if (StringUtil.isNullOrEmpty(homeTenantId)) {
                 Logger.info(methodTag, "Home tenantId is empty");
                 return false;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -596,48 +596,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
-    // Loads the device CA URL in the WebView if the flight is enabled, otherwise opens it in the browser.
-    @VisibleForTesting
-    protected void loadDeviceCaUrl(@NonNull final String originalUrl, @NonNull final WebView view) {
-        final String methodTag = TAG + ":loadDeviceCaUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-            Logger.info(methodTag, "Loading device CA request in WebView.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), true);
-            String httpsUrl = originalUrl.replace(AuthenticationConstants.Broker.BROWSER_EXT_PREFIX, "https://");
-            view.loadUrl(httpsUrl, mRequestHeaders);
-        } else {
-            Logger.info(methodTag, "Loading device CA request in browser.");
-            span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), false);
-            openLinkInBrowser(originalUrl);
-            returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-        }
-    }
-
-    // WebCP enrollment URL is a guided enrollment page showing instructions on how to enroll within the productivity app.
-    // This is a special case where the enrollment is not done in the WebView, but rather in the browser.
-    private void processWebCpEnrollmentUrl(@NonNull final WebView view, @NonNull final String url) {
-        final String methodTag = TAG + ":processWebCpEnrollmentUrl";
-        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
-        final Span span = spanContext != null ?
-                OTelUtility.createSpanFromParent(SpanName.ProcessWebCpRedirects.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebCpRedirects.name());
-        span.setAttribute(AttributeName.is_webcp_enrollment_request.name(), true);
-        view.stopLoading();
-        Logger.info(methodTag, "Loading WebCP enrollment url in browser.");
-        // This is a WebCP enrollment URL, so we need to open it in the browser (it does not work in WebView as google enrollment is enforced to be done in browser).
-        openLinkInBrowser(url);
-        // We need to return MDM_FLOW result code as the enrollment is done in browser. But this may sometimes take a few seconds to launch the intent.
-        // So we will wait for a few seconds before returning the result so that the current page in webview does not get closed immediately.
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            }
-        }, TimeUnit.SECONDS.toMillis(THREAD_SLEEP_FOR_INTENT_LAUNCH_MS));
-    }
-
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -677,7 +677,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (StringUtil.isNullOrEmpty(username)) {
             return null;
         }
-
         return CommonTenantInfoProvider.INSTANCE.getHomeTenantId(username);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.ui.webview;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.admin.DevicePolicyManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Intent;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationRequest;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
@@ -89,6 +90,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
 
         String sourceLibraryName = null;
         String sourceLibraryVersion = null;
+        String homeTenantId = null;
 
         // TODO: Pretty sure this type check wouldn't be necessary, since all authorization requests that go through this path will
         //  extend MicrosoftAuthorizationRequest. Perhaps we can change the Generic type to extend MicrosoftAuthorizationRequest rather than just AuthorizationRequest.
@@ -96,8 +98,11 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
             sourceLibraryName = ((MicrosoftAuthorizationRequest) mAuthorizationRequest).getLibraryName();
             sourceLibraryVersion = ((MicrosoftAuthorizationRequest) mAuthorizationRequest).getLibraryVersion();
         }
+        if (mAuthorizationRequest instanceof MicrosoftStsAuthorizationRequest) {
+            homeTenantId = ((MicrosoftStsAuthorizationRequest) mAuthorizationRequest).getUtid();
+        }
 
-        final Intent authIntent = buildAuthorizationActivityStartIntent(requestUrl, sourceLibraryName, sourceLibraryVersion);
+        final Intent authIntent = buildAuthorizationActivityStartIntent(requestUrl, sourceLibraryName, sourceLibraryVersion, homeTenantId);
 
         launchIntent(authIntent);
         return mAuthorizationResultFuture;
@@ -115,7 +120,8 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
     private Intent buildAuthorizationActivityStartIntent(
             URI requestUrl,
             @Nullable final String sourceLibraryName,
-            @Nullable final String sourceLibraryVersion) {
+            @Nullable final String sourceLibraryVersion,
+            @Nullable final String homeTenantId) {
         // RedirectURI used to get the auth code in nested app auth is that of a hub app (brkRedirectURI)       
         final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         final AuthorizationActivityParameters authorizationActivityParameters = new AuthorizationActivityParameters(
@@ -128,7 +134,8 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
                 mAuthorizationRequest.isWebViewZoomEnabled(),
                 mAuthorizationRequest.isWebViewZoomControlsEnabled(),
                 sourceLibraryName,
-                sourceLibraryVersion
+                sourceLibraryVersion,
+                homeTenantId
         );
         return AuthorizationActivityFactory.getAuthorizationActivityIntent(authorizationActivityParameters);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/EmbeddedWebViewAuthorizationStrategy.java
@@ -90,7 +90,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
 
         String sourceLibraryName = null;
         String sourceLibraryVersion = null;
-        String homeTenantId = null;
+        String utid = null;
 
         // TODO: Pretty sure this type check wouldn't be necessary, since all authorization requests that go through this path will
         //  extend MicrosoftAuthorizationRequest. Perhaps we can change the Generic type to extend MicrosoftAuthorizationRequest rather than just AuthorizationRequest.
@@ -99,10 +99,10 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
             sourceLibraryVersion = ((MicrosoftAuthorizationRequest) mAuthorizationRequest).getLibraryVersion();
         }
         if (mAuthorizationRequest instanceof MicrosoftStsAuthorizationRequest) {
-            homeTenantId = ((MicrosoftStsAuthorizationRequest) mAuthorizationRequest).getUtid();
+            utid = ((MicrosoftStsAuthorizationRequest) mAuthorizationRequest).getUtid();
         }
 
-        final Intent authIntent = buildAuthorizationActivityStartIntent(requestUrl, sourceLibraryName, sourceLibraryVersion, homeTenantId);
+        final Intent authIntent = buildAuthorizationActivityStartIntent(requestUrl, sourceLibraryName, sourceLibraryVersion, utid);
 
         launchIntent(authIntent);
         return mAuthorizationResultFuture;
@@ -121,7 +121,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
             URI requestUrl,
             @Nullable final String sourceLibraryName,
             @Nullable final String sourceLibraryVersion,
-            @Nullable final String homeTenantId) {
+            @Nullable final String utid) {
         // RedirectURI used to get the auth code in nested app auth is that of a hub app (brkRedirectURI)       
         final String redirectUri = mAuthorizationRequest.getBrkRedirectUri() != null ? mAuthorizationRequest.getBrkRedirectUri() : mAuthorizationRequest.getRedirectUri();
         final AuthorizationActivityParameters authorizationActivityParameters = new AuthorizationActivityParameters(
@@ -135,7 +135,7 @@ public class EmbeddedWebViewAuthorizationStrategy<GenericOAuth2Strategy extends 
                 mAuthorizationRequest.isWebViewZoomControlsEnabled(),
                 sourceLibraryName,
                 sourceLibraryVersion,
-                homeTenantId
+                utid
         );
         return AuthorizationActivityFactory.getAuthorizationActivityIntent(authorizationActivityParameters);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -39,6 +39,7 @@ class ReAttachPrtHeaderHandler(
     private val span : Span
 ) : IChallengeHandler<String, Void> {
     private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
+
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/challengehandlers/ReAttachPrtHeaderHandler.kt
@@ -39,7 +39,6 @@ class ReAttachPrtHeaderHandler(
     private val span : Span
 ) : IChallengeHandler<String, Void> {
     private val TAG = ReAttachPrtHeaderHandler::class.java.simpleName
-
     override fun processChallenge(inputUrl: String): Void? {
         Logger.info(TAG, "Processing challenge to attach prt header.")
         modifyHeadersWithRefreshTokenCredential(inputUrl)

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -137,8 +137,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                     }
                 },
                 TEST_REDIRECT_URI,
-                Mockito.mock(SwitchBrowserRequestHandler.class)
-        );
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId");
         HashMap<String, String> dummyHeaders = new HashMap<>();
         dummyHeaders.put("key", "value");
         mWebViewClient.setRequestHeaders(dummyHeaders);
@@ -383,8 +383,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                         }
                     },
                     TEST_REDIRECT_URI,
-                    Mockito.mock(SwitchBrowserRequestHandler.class)
-            );
+                    Mockito.mock(SwitchBrowserRequestHandler.class),
+                    "homeTenantId");
             mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL);
         } catch (ClassCastException e) {
             Assert.fail("Failure is not expected. The class checks should have prevented this." + e);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -413,7 +413,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 mockCallback,
                 url -> {},
                 TEST_REDIRECT_URI,
-                Mockito.mock(SwitchBrowserRequestHandler.class));
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId");
         final WebView mockWebView = new WebView(mContext);
         mockWebView.setWebViewClient(mockWebViewClient);
 
@@ -440,7 +441,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 mockCallback,
                 url -> {},
                 TEST_REDIRECT_URI,
-                Mockito.mock(SwitchBrowserRequestHandler.class)
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId"
         );
         final WebView mockWebView = new WebView(mContext);
         mockWebView.setWebViewClient(mockWebViewClient);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -176,7 +176,14 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Test
     public void testUrlOverrideHandlesPlayStoreRequest() {
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_PLAYSTORE_URL_LAUNCH)).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAYSTORE_FOR_BROKER_APP_URL));
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test
@@ -252,6 +259,7 @@ public class AzureActiveDirectoryWebViewClientTest {
 
         assertTrue(mockWebViewClient.isWebCpInWebviewFeatureEnabled(TEST_WEB_CP_ENROLLMENT_URL));
         assertTrue(mockWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEB_CP_ENROLLMENT_URL));
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -400,6 +400,9 @@ public class AuthenticationConstants {
          */
         public static final String IT_VER_PARAM = "itver";
 
+        /**
+         * String for the tenant unique id
+         */
         public static final String UTID = "utid";
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -400,7 +400,7 @@ public class AuthenticationConstants {
          */
         public static final String IT_VER_PARAM = "itver";
 
-        public static final String HOME_TENANT_ID = "home_tenant_id";
+        public static final String UTID = "utid";
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -399,6 +399,8 @@ public class AuthenticationConstants {
          * String as Query parameter key to send a V1 request to V2 endpoint
          */
         public static final String IT_VER_PARAM = "itver";
+
+        public static final String HOME_TENANT_ID = "home_tenant_id";
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -134,7 +134,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Playstore URL launch for broker apps.
      */
-    ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", true),
+    ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", false),
     
     /**
      * Flight to enable the Web CP for a tenant list.


### PR DESCRIPTION
In webcp flow, we rely on the login hint passed in the URL for querying the broker account storage to get the tenantId.
Based on the code in eSTS, they always pass the login hint for the redirect when user clicks on the continue page on CA block page. However, to handle any corner case involving the login hint being missing in the URL, I made the changes to leverage the utid parameter passed using authorization request.

Related broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/3145

Fixes [AB#3311720](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3311720)