### PR TITLE
[Android SDK] Change Native Auth E2E tests variables, Fixes AB#3320709

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -131,7 +131,7 @@ stages:
     - task: Gradle@3
       displayName: Run msal Unit tests
       inputs:
-        tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL)
+        tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)
         jdkArchitecture: x64
         jdkVersionOption: "1.17"
   # broker

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -1,5 +1,6 @@
 # File: azure-pipelines\pull-request-validation\common.yml
 # Variable: 'MOCK_API_URL' was defined in the Variables tab
+# Variable: 'NATIVE_AUTH_CONFIG_STRING' was defined in the Variables tab
 # Description: Assemble and run unit test
 name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
@@ -49,7 +50,7 @@ jobs:
     inputs:
       javaHomeSelection: JDKVersion
       jdkVersionOption: "1.17"
-      tasks: common:testLocalDebugUnitTest -PlabSecret=$(LabVaultAppCert) -PmockApiUrl=$(MOCK_API_URL) 
+      tasks: common:testLocalDebugUnitTest -PlabSecret=$(LabVaultAppCert) -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)
   - task: Gradle@3
     displayName: Check Dependencies size
     condition: eq(variables['system.pullRequest.targetBranch'], 'dev')

--- a/azure-pipelines/pull-request-validation/common4j.yml
+++ b/azure-pipelines/pull-request-validation/common4j.yml
@@ -1,6 +1,7 @@
 # File: azure-pipelines\pull-request-validation\common4j.yml
 # Description: Run test in common4j
 # Variable: 'MOCK_API_URL' was defined in the Variables tab
+# Variable: 'NATIVE_AUTH_CONFIG_STRING' was defined in the Variables tab
 # Uses Java 11
 name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
@@ -42,7 +43,7 @@ jobs:
     displayName: Run the unit tests.
     inputs:
       cwd: $(Build.SourcesDirectory)/common-java-root
-      tasks: common4j:test -Psugar=true -PmockApiUrl=$(MOCK_API_URL)
+      tasks: common4j:test -Psugar=true -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)
       javaHomeOption: JDKVersion
       jdkVersionOption: 1.17
 ...

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -151,6 +151,8 @@ def sliceParameter = "" // will be blank unless specified by developer
 def dcParameter = "" // will be blank unless specified by developer
 def useMockApiForNativeAuthParameter = false // will be false unless specified by developer
 def mockApiUrlParameter = "" // will be blank unless specified by developer
+def nativeAuthConfigFilePathParameter = "" // will be blank unless specified by developer, used to run e2e tests locally
+def nativeAuthConfigStringParameter = "" // will be blank unless specified by developer, used to run e2e tests in CI
 def disableAcquireTokenSilentTimeoutParameter = false // will be false unless specified by developer
 def allowOneboxAuthorities = false // will be false unless specified by developer
 
@@ -172,6 +174,16 @@ if (project.hasProperty("mockApiUrl")) {
     mockApiUrlParameter = mockApiUrl
 }
 
+// Locally we run e2e tests using a local config file and we supply the path to that file
+if (project.hasProperty("nativeAuthConfigFilePath")) {
+    nativeAuthConfigFilePathParameter = nativeAuthConfigFilePath
+}
+
+// In CI we run e2e tests using a config string which we read from the Variables tab
+if (project.hasProperty("nativeAuthConfigString")) {
+    nativeAuthConfigStringParameter = nativeAuthConfigString
+}
+
 // By adding -PdisableAcquireTokenSilentTimeout in your dev environment, you will no longer subject to the ATS timeout,
 // and your life will be much happier during debugging.
 if (project.hasProperty("disableAcquireTokenSilentTimeout")) {
@@ -189,6 +201,8 @@ sourceSets {
         buildConfigField("String", "DC", "\"$dcParameter\"")
         buildConfigField("boolean", "USE_MOCK_API_FOR_NATIVE_AUTH_AUTHORITY", "${useMockApiForNativeAuthParameter}")
         buildConfigField("String", "MOCK_API_URL", "\"$mockApiUrlParameter\"")
+        buildConfigField("String", "NATIVE_AUTH_CONFIG_FILE_PATH", "\"$nativeAuthConfigFilePathParameter\"")
+        buildConfigField("String", "NATIVE_AUTH_CONFIG_STRING", "\"$nativeAuthConfigStringParameter\"")
         buildConfigField("boolean", "DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT", "${disableAcquireTokenSilentTimeoutParameter}")
         buildConfigField("boolean", "ALLOW_ONEBOX_AUTHORITIES", "${allowOneboxAuthorities}")
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/BuildValues.java
@@ -49,6 +49,10 @@ public class BuildValues {
 
     private static String MOCK_API_URL = BuildConfig.MOCK_API_URL;
 
+    private static String NATIVE_AUTH_CONFIG_STRING = BuildConfig.NATIVE_AUTH_CONFIG_STRING;
+
+    private static String NATIVE_AUTH_CONFIG_FILE_PATH = BuildConfig.NATIVE_AUTH_CONFIG_FILE_PATH;
+
     public static Boolean shouldUseMockApiForNativeAuth()
     {
         return USE_MOCK_API_FOR_NATIVE_AUTH_AUTHORITY;
@@ -60,5 +64,13 @@ public class BuildValues {
 
     public static String getMockApiUrl() {
         return MOCK_API_URL;
+    }
+
+    public static String getNativeAuthConfigString() {
+        return NATIVE_AUTH_CONFIG_STRING;
+    }
+
+    public static String getNativeAuthConfigFilePath() {
+        return NATIVE_AUTH_CONFIG_FILE_PATH;
     }
 }


### PR DESCRIPTION
This PR introduces the following:
-Add NATIVE_AUTH_CONFIG_STRING to Pipeline variables and use it in scripts to run E2E tests instead of the KeyVault
-Add NATIVE_AUTH_CONFIG_FILE_PATH to be used locally from build settings and use it in scripts to run E2E tests
This PR is connected to the MSAL Android PR[[Android SDK] Change Native Auth E2E tests variables, Fixes AB#3320709](https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2331)