### PR TITLE
Fix a few small switch browser bugs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Version 21.4.0
 - [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 - [MINOR] Update keyword to suppress camera consent (#2694)
 - [MINOR] Using utid for webcp flow whenever (#2695)
+- [PATCH] Fix a few small switch browser bugs (#2710)
 
 Version 21.3.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Fix caching of secret key and add retries for InvalidKeyException during unwrap (#2659)
 - [MINOR] Replace AbstractSecretKeyLoader with ISecretKeyProvider (#2666)
 - [MINOR] Update IP phone app teams signature constants to use SHA-512 format (#2700)
+- [PATCH] Fix a few small switch browser bugs (#2710)
 
 Version 21.4.0
 ----------
@@ -14,7 +15,6 @@ Version 21.4.0
 - [MINOR] Construct broker app link redirect based on broker pkg name (#2682)
 - [MINOR] Update keyword to suppress camera consent (#2694)
 - [MINOR] Using utid for webcp flow whenever (#2695)
-- [PATCH] Fix a few small switch browser bugs (#2710)
 
 Version 21.3.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -296,7 +296,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 Logger.info(methodTag,"Navigation starts with the redirect uri.");
                 if (mSwitchBrowserRequestHandler.isSwitchBrowserRequest(formattedURL, mRedirectUrl)) {
                     Logger.info(methodTag,"Request to switch browser.");
-                    processSwitchBrowserRequest(formattedURL);
+                    processSwitchBrowserRequest(url);
                 } else {
                     Logger.info(methodTag,"It is a redirect request.");
                     processRedirectUrl(view, url);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinator.kt
@@ -134,7 +134,8 @@ class SwitchBrowserProtocolCoordinator(
             SwitchBrowserUriHelper.statesMatch(authorizationRequest, state)
             // Validate the state from auth request and redirect URL is the same
             val resumeUri = SwitchBrowserUriHelper.buildResumeUri(actionUri, state)
-            val headers = hashMapOf(AUTHORIZATION to code)
+            val authorizationHeaderValue = "Bearer $code"
+            val headers = hashMapOf(AUTHORIZATION to authorizationHeaderValue)
             onSuccessAction(resumeUri, headers)
             // Reset the challenge state after processing the resume action
             switchBrowserRequestHandler.resetChallengeState()

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelper.kt
@@ -203,14 +203,10 @@ object SwitchBrowserUriHelper {
         actionUri: String,
         queryParams: HashMap<String, String> = hashMapOf()
     ): Uri {
-        val paths = actionUri.split("/")
-        val authority = paths[0]
-        val uriBuilder = Uri.Builder()
-            .scheme("https")
-            .encodedAuthority(authority)
-        for (i in 1 until paths.size) {
-            uriBuilder.appendPath(paths[i])
-        }
+        val uri = Uri.parse(actionUri)
+
+        val uriBuilder = uri.buildUpon()
+
         for ((key, value) in queryParams.entries) {
             uriBuilder.appendQueryParameter(key, value)
         }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
@@ -52,7 +52,7 @@ class SwitchBrowserProtocolCoordinatorTest {
         val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
         doNothing().`when`(mockSwitchBrowserRequestHandler).resetChallengeState()
         val code = "switch_browser_code"
-        val actionUrl = "test.example.com/switchbrowser/path"
+        val actionUrl = "https://test.example.com/switchbrowser/path"
         val state = "123"
         val extras = Bundle().apply {
             putString(SWITCH_BROWSER.CODE, code)
@@ -77,7 +77,7 @@ class SwitchBrowserProtocolCoordinatorTest {
         val mockSwitchBrowserRequestHandler = mock(SwitchBrowserRequestHandler::class.java)
         doNothing().`when`(mockSwitchBrowserRequestHandler).resetChallengeState()
         val code = "switch_browser_code"
-        val actionUrl = "test.example.com/switchbrowser/path"
+        val actionUrl = "https://test.example.com/switchbrowser/path"
         val extras = Bundle().apply {
             putString(SWITCH_BROWSER.CODE, code)
             putString(SWITCH_BROWSER.ACTION_URI, actionUrl)

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserProtocolCoordinatorTest.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.ui.webview.switchbrowser
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.AUTHORIZATION_AGENT
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker
@@ -65,8 +66,11 @@ class SwitchBrowserProtocolCoordinatorTest {
         // Call the method to be tested
         coordinator.processSwitchBrowserResume("https://auth.com?state=$state",extras) { uri, headers ->
             // Verify the resume URI
-            Assert.assertEquals(actionUrl, uri.host + uri.path)
-            Assert.assertEquals(code, headers[AUTHORIZATION])
+            val actionUri = Uri.parse(actionUrl)
+            Assert.assertEquals(actionUri.scheme, uri.scheme)
+            Assert.assertEquals(actionUri.host, uri.host)
+            Assert.assertEquals(actionUri.path, uri.path)
+            Assert.assertEquals("Bearer $code", headers[AUTHORIZATION])
         }
     }
 
@@ -88,8 +92,11 @@ class SwitchBrowserProtocolCoordinatorTest {
         // Call the method to be tested
         coordinator.processSwitchBrowserResume("https://auth.com",extras) { uri, headers ->
             // Verify the resume URI
-            Assert.assertEquals(actionUrl, uri.host + uri.path)
-            Assert.assertEquals(code, headers[AUTHORIZATION])
+            val actionUri = Uri.parse(actionUrl)
+            Assert.assertEquals(actionUri.scheme, uri.scheme)
+            Assert.assertEquals(actionUri.host, uri.host)
+            Assert.assertEquals(actionUri.path, uri.path)
+            Assert.assertEquals("Bearer $code", headers[AUTHORIZATION])
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUriHelperTest.kt
@@ -38,7 +38,7 @@ class SwitchBrowserUriHelperTest {
 
     companion object {
         private const val CODE = "your-switch-browser-code"
-        private const val ACTION_URI = "login.microsoftonline.com/switchbrowser/process"
+        private const val ACTION_URI = "https://login.microsoftonline.com/switchbrowser/process"
         private const val STATE = "123"
     }
 
@@ -57,10 +57,10 @@ class SwitchBrowserUriHelperTest {
             CODE,
             switchBrowserProcessUri.getQueryParameter(SWITCH_BROWSER.CODE)
         )
-        Assert.assertEquals(
-            ACTION_URI,
-            switchBrowserProcessUri.host + switchBrowserProcessUri.path
-        )
+        val actionUri = Uri.parse(ACTION_URI)
+        Assert.assertEquals(actionUri.scheme, switchBrowserProcessUri.scheme)
+        Assert.assertEquals(actionUri.host, switchBrowserProcessUri.host)
+        Assert.assertEquals(actionUri.path, switchBrowserProcessUri.path)
         Assert.assertEquals(
             STATE,
             switchBrowserProcessUri.getQueryParameter(SWITCH_BROWSER.STATE)
@@ -81,10 +81,10 @@ class SwitchBrowserUriHelperTest {
             CODE,
             switchBrowserProcessUri.getQueryParameter(SWITCH_BROWSER.CODE)
         )
-        Assert.assertEquals(
-            ACTION_URI,
-            switchBrowserProcessUri.host + switchBrowserProcessUri.path
-        )
+        val actionUri = Uri.parse(ACTION_URI)
+        Assert.assertEquals(actionUri.scheme, switchBrowserProcessUri.scheme)
+        Assert.assertEquals(actionUri.host, switchBrowserProcessUri.host)
+        Assert.assertEquals(actionUri.path, switchBrowserProcessUri.path)
     }
 
     @Test
@@ -142,10 +142,10 @@ class SwitchBrowserUriHelperTest {
             ACTION_URI, null
         )
         Assert.assertNotNull(uri)
-        Assert.assertEquals(
-            ACTION_URI,
-            uri.host + uri.path
-        )
+        val actionUri = Uri.parse(ACTION_URI)
+        Assert.assertEquals(actionUri.scheme, uri.scheme)
+        Assert.assertEquals(actionUri.host, uri.host)
+        Assert.assertEquals(actionUri.path, uri.path)
         Assert.assertNull(uri.getQueryParameter(SWITCH_BROWSER.STATE))
     }
 
@@ -155,10 +155,10 @@ class SwitchBrowserUriHelperTest {
             ACTION_URI, STATE
         )
         Assert.assertNotNull(uri)
-        Assert.assertEquals(
-            ACTION_URI,
-            uri.host + uri.path
-        )
+        val actionUri = Uri.parse(ACTION_URI)
+        Assert.assertEquals(actionUri.scheme, uri.scheme)
+        Assert.assertEquals(actionUri.host, uri.host)
+        Assert.assertEquals(actionUri.path, uri.path)
         Assert.assertEquals(
             STATE,
             uri.getQueryParameter(SWITCH_BROWSER.STATE)


### PR DESCRIPTION
- URL was being loweredcased which caused the purpose token to get lowercased and become invalid
- At resume the authorization header value needs to have Bearer prefix
- The Switch Browser URL were having double scheme (https) in them due to how they were being formed. Example https/https://www.myurl.com

This PR fixes the above mentioned issues.