### PR TITLE
Fix true positives in policheck results, Fixes AB#3288598

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapper.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/PowerManagerWrapper.java
@@ -128,7 +128,7 @@ public class PowerManagerWrapper {
      * Wrap the calling to method isIgnoringBatteryOptimizations() of final class PowerManager.
      *
      * @param connectionContext Context used to query if app is ignoring battery optimizations.
-     * @return true if the given application package name is on the device's power whitelist.
+     * @return true if the given application package name is on the device's power allow list.
      */
     @TargetApi(Build.VERSION_CODES.M)
     public boolean isIgnoringBatteryOptimizations(final Context connectionContext) {


### PR DESCRIPTION
PoliCheck scans files and directories for sensitive geopolitical terms, profanity, and other sensitive terms.
Policheck overview : https://eng.ms/docs/experiences-devices/customer-success-engineering/global/language-as-a-service/validationservices/policheck-for-microsoft/policheckclient/overview
SDL assessment task : https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3279420

In this PR, I have fixed some true positives found in common lib's SDL results and there will be a separate PR in which we file for exclusions for all false positives

Fixes [AB#3288598](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3288598)