### PR TITLE
[SDL Assessment task] Secure webview settings, Fixes AB#3288572

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 vNext
 ----------
+- [MINOR] [SDL Assessment task] Secure webview settings (#2715)
+
 
 Version 22.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -300,11 +300,20 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
         // Create the Web View to show the page
         mWebView = view.findViewById(R.id.common_auth_webview);
-        WebSettings userAgentSetting = mWebView.getSettings();
-        final String userAgent = userAgentSetting.getUserAgentString();
-        mWebView.getSettings().setUserAgentString(
+        final WebSettings webSettings = mWebView.getSettings();
+        final String userAgent = webSettings.getUserAgentString();
+        webSettings.setUserAgentString(
                 userAgent + AuthenticationConstants.Broker.CLIENT_TLS_NOT_SUPPORTED);
-        mWebView.getSettings().setJavaScriptEnabled(true);
+        webSettings.setJavaScriptEnabled(true);
+
+        // Security settings to prevent unauthorized access - controlled by flight
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_SECURITY_SETTINGS)) {
+            webSettings.setAllowFileAccess(false);
+            webSettings.setAllowContentAccess(false);
+            webSettings.setAllowFileAccessFromFileURLs(false);
+            webSettings.setAllowUniversalAccessFromFileURLs(false);
+        }
+
         mWebView.requestFocus(View.FOCUS_DOWN);
 
         // Set focus to the view for touch event

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -312,6 +312,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             webSettings.setAllowContentAccess(false);
             webSettings.setAllowFileAccessFromFileURLs(false);
             webSettings.setAllowUniversalAccessFromFileURLs(false);
+            webSettings.setGeolocationEnabled(false);
         }
 
         mWebView.requestFocus(View.FOCUS_DOWN);

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -150,7 +150,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to control the timeout to wait for tenant based flight in WebCP.
      */
-    WEB_CP_WAIT_TIMEOUT_FOR_FLIGHTS("WebCpWaitTimeoutForFlights", 3000);
+    WEB_CP_WAIT_TIMEOUT_FOR_FLIGHTS("WebCpWaitTimeoutForFlights", 3000),
+
+    /**
+     * Flight to enable WebView security settings to prevent unauthorized access.
+     */
+    ENABLE_WEBVIEW_SECURITY_SETTINGS("EnableWebViewSecuritySettings", false);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
SDL assessment task : https://securityassurance.visualstudio.com/Threat%20Modeling/_workitems/edit/80425

As per above SDL assessment task, we have secure some input settings in webview

WebSettings settings = webView.getSettings();
settings.setAllowFileAccess(false);
settings.setAllowContentAccess(false);
settings.setAllowFileAccessFromFileURLs(false); // Requires API 16+
settings.setAllowUniversalAccessFromFileURLs(false); // Requires API 16+

Keeping the changes behind a flight which will be true only in brokered flow for now https://github.com/AzureAD/ad-accounts-for-android/pull/3168

Fixes [AB#3288572](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3288572)