### PR TITLE
Adding NoSuchMethodError to catch blocks

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
@@ -55,7 +55,7 @@ public class BaggageExtension {
                 return SpanExtension.NoopScope.INSTANCE;
             }
             return baggage.storeInContext(Context.current()).makeCurrent();
-        } catch (final Exception e) {
+        } catch (final Exception | NoSuchMethodError e) {
             Logger.error(TAG + ":makeBaggageCurrent", "Failed to make baggage current", e);
             return SpanExtension.NoopScope.INSTANCE;
         }
@@ -69,7 +69,7 @@ public class BaggageExtension {
     public static Baggage fromContext(final Context context) {
         try {
             return Baggage.fromContext(context);
-        } catch (final Exception e) {
+        } catch (final Exception | NoSuchMethodError e) {
             Logger.error(TAG + ":fromContext", "Failed to get baggage from context", e);
             return new NoopBaggage();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
@@ -55,7 +55,7 @@ public class BaggageExtension {
                 return SpanExtension.NoopScope.INSTANCE;
             }
             return baggage.storeInContext(Context.current()).makeCurrent();
-        } catch (final Throwable e) {
+        } catch (final Exception | NoSuchMethodError e) {
             Logger.error(TAG + ":makeBaggageCurrent", "Failed to make baggage current", e);
             return SpanExtension.NoopScope.INSTANCE;
         }
@@ -69,7 +69,7 @@ public class BaggageExtension {
     public static Baggage fromContext(final Context context) {
         try {
             return Baggage.fromContext(context);
-        } catch (final Throwable e) {
+        } catch (final Exception | NoSuchMethodError e) {
             Logger.error(TAG + ":fromContext", "Failed to get baggage from context", e);
             return new NoopBaggage();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BaggageExtension.java
@@ -55,7 +55,7 @@ public class BaggageExtension {
                 return SpanExtension.NoopScope.INSTANCE;
             }
             return baggage.storeInContext(Context.current()).makeCurrent();
-        } catch (final Exception | NoSuchMethodError e) {
+        } catch (final Throwable e) {
             Logger.error(TAG + ":makeBaggageCurrent", "Failed to make baggage current", e);
             return SpanExtension.NoopScope.INSTANCE;
         }
@@ -69,7 +69,7 @@ public class BaggageExtension {
     public static Baggage fromContext(final Context context) {
         try {
             return Baggage.fromContext(context);
-        } catch (final Exception | NoSuchMethodError e) {
+        } catch (final Throwable e) {
             Logger.error(TAG + ":fromContext", "Failed to get baggage from context", e);
             return new NoopBaggage();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -85,7 +85,7 @@ public class SpanExtension {
     public static Scope makeCurrentSpan(@NonNull final Span span) {
         try {
             return span.makeCurrent();
-        } catch (final AbstractMethodError | Exception | NoSuchMethodError exception) {
+        } catch (final AbstractMethodError | Exception exception) {
             Logger.error(TAG + ":makeCurrentSpan", exception.getMessage(), exception);
             return NoopScope.INSTANCE;
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -100,7 +100,7 @@ public class SpanExtension {
     public static Span fromContext(@NonNull final Context context) {
         try {
             return Span.fromContext(context);
-        } catch (final Exception | NoSuchMethodError error) {
+        } catch (final Throwable error) {
             Logger.error(TAG + ":fromContext", error.getMessage(), error);
             return new NoopSpan(INVALID);
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -85,7 +85,7 @@ public class SpanExtension {
     public static Scope makeCurrentSpan(@NonNull final Span span) {
         try {
             return span.makeCurrent();
-        } catch (final AbstractMethodError | Exception exception) {
+        } catch (final AbstractMethodError | Exception | NoSuchMethodError exception) {
             Logger.error(TAG + ":makeCurrentSpan", exception.getMessage(), exception);
             return NoopScope.INSTANCE;
         }
@@ -100,7 +100,7 @@ public class SpanExtension {
     public static Span fromContext(@NonNull final Context context) {
         try {
             return Span.fromContext(context);
-        } catch (final Exception error) {
+        } catch (final Exception | NoSuchMethodError error) {
             Logger.error(TAG + ":fromContext", error.getMessage(), error);
             return new NoopSpan(INVALID);
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanExtension.java
@@ -100,7 +100,7 @@ public class SpanExtension {
     public static Span fromContext(@NonNull final Context context) {
         try {
             return Span.fromContext(context);
-        } catch (final Throwable error) {
+        } catch (final Exception | NoSuchMethodError error) {
             Logger.error(TAG + ":fromContext", error.getMessage(), error);
             return new NoopSpan(INVALID);
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
@@ -72,7 +72,7 @@ public final class TextMapPropagatorExtension {
             );
             propagator.inject(contextToInject, carrier, setter);
             return carrier;
-        } catch (final Exception | NoSuchMethodError e) {
+        } catch (final Throwable e) {
             // Log the error and return an empty map if injection fails
             Logger.error(TAG + ":inject", "Failed to inject context", e);
             return new HashMap<>();
@@ -109,7 +109,7 @@ public final class TextMapPropagatorExtension {
                     W3CBaggagePropagator.getInstance()
             );
             return propagator.extract(Context.current(), carrier, getter);
-        } catch (final Exception | NoSuchMethodError e) {
+        } catch (final Throwable e) {
             // Log the error and return null if extraction fails
             Logger.error(TAG + ":extract", "Failed to extract context", e);
             return null;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
@@ -72,7 +72,7 @@ public final class TextMapPropagatorExtension {
             );
             propagator.inject(contextToInject, carrier, setter);
             return carrier;
-        } catch (final Exception e) {
+        } catch (final Exception | NoSuchMethodError e) {
             // Log the error and return an empty map if injection fails
             Logger.error(TAG + ":inject", "Failed to inject context", e);
             return new HashMap<>();
@@ -109,7 +109,7 @@ public final class TextMapPropagatorExtension {
                     W3CBaggagePropagator.getInstance()
             );
             return propagator.extract(Context.current(), carrier, getter);
-        } catch (final Exception e) {
+        } catch (final Exception | NoSuchMethodError e) {
             // Log the error and return null if extraction fails
             Logger.error(TAG + ":extract", "Failed to extract context", e);
             return null;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
@@ -109,7 +109,7 @@ public final class TextMapPropagatorExtension {
                     W3CBaggagePropagator.getInstance()
             );
             return propagator.extract(Context.current(), carrier, getter);
-        } catch (final Throwable e) {
+        } catch (final Exception | NoSuchMethodError e) {
             // Log the error and return null if extraction fails
             Logger.error(TAG + ":extract", "Failed to extract context", e);
             return null;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/TextMapPropagatorExtension.java
@@ -72,7 +72,7 @@ public final class TextMapPropagatorExtension {
             );
             propagator.inject(contextToInject, carrier, setter);
             return carrier;
-        } catch (final Throwable e) {
+        } catch (final Exception | NoSuchMethodError e) {
             // Log the error and return an empty map if injection fails
             Logger.error(TAG + ":inject", "Failed to inject context", e);
             return new HashMap<>();


### PR DESCRIPTION
### Summary
The UIAutomation tests failed due to uncaught NoSuchMethodErrors. The methods I added as a part of my Baggage PRs do have catch blocks meant for this purpose, but they were catching a generic exception (which NoSuchMethodError does not fall into).