### PR TITLE
Using tenant based flighting for webcp, Fixes AB#3335954

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ vNext
 - [MINOR] Update IP phone app teams signature constants to use SHA-512 format (#2700)
 - [MINOR] Using Baggage to propagate attributes from parent Span (#2671)
 - [PATCH] Fix a few small switch browser bugs (#2710)
+- [MINOR] Using tenant based flighting for webcp (#2723)
 
 Version 21.4.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -662,7 +662,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             SpanExtension.current().setAttribute(AttributeName.web_cp_flight_get_time.name(), (System.currentTimeMillis() - webCpGetFlightStartTime));
             if (isWebCpFlightEnabled) {
                 // Directly enabled via flight rollout.
-                Logger.info(methodTag, "WebCP in WebView feature is enabled. "+ waitForFlightsTimeOut);
+                Logger.info(methodTag, "WebCP in WebView feature is enabled. ");
                 mIsWebCpInWebViewFeatureEnabled = true;
                 return true;
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -650,25 +650,24 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 return false;
             }
 
-            if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)) {
-                // Directly enabled via flight rollout.
-                Logger.info(methodTag, "WebCP in WebView feature is enabled.");
-                mIsWebCpInWebViewFeatureEnabled = true;
-                return true;
-            }
-
-            // Else, check if the home tenant is in the list of tenants that have this feature enabled.
             final String homeTenantId = !StringUtil.isNullOrEmpty(mUtid)? mUtid : getHomeTenantIdFromUrl(originalUrl);
             if (StringUtil.isNullOrEmpty(homeTenantId)) {
                 Logger.info(methodTag, "Home tenantId is empty");
                 return false;
             }
 
-            final String tenantIdList = CommonFlightsManager.INSTANCE.getFlightsProvider().getStringValue(CommonFlight.TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW);
-            final boolean isFlightEnabledForCurrentTenant = !StringUtil.isNullOrEmpty(tenantIdList) && tenantIdList.contains(homeTenantId);
-            Logger.info(methodTag, "TenantId list is empty? " + StringUtil.isNullOrEmpty(tenantIdList) + ", Is current tenantId in list? " + isFlightEnabledForCurrentTenant);
-            mIsWebCpInWebViewFeatureEnabled = isFlightEnabledForCurrentTenant;
-            return isFlightEnabledForCurrentTenant;
+            final long webCpGetFlightStartTime = System.currentTimeMillis();
+            final int waitForFlightsTimeOut = CommonFlightsManager.INSTANCE.getFlightsProvider().getIntValue(CommonFlight.WEB_CP_WAIT_TIMEOUT_FOR_FLIGHTS);
+            final boolean isWebCpFlightEnabled = CommonFlightsManager.INSTANCE.getFlightsProviderForTenant(homeTenantId, waitForFlightsTimeOut).isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW);
+            SpanExtension.current().setAttribute(AttributeName.web_cp_flight_get_time.name(), (System.currentTimeMillis() - webCpGetFlightStartTime));
+            if (isWebCpFlightEnabled) {
+                // Directly enabled via flight rollout.
+                Logger.info(methodTag, "WebCP in WebView feature is enabled. "+ waitForFlightsTimeOut);
+                mIsWebCpInWebViewFeatureEnabled = true;
+                return true;
+            }
+
+            return false;
         } catch (final Throwable throwable) {
             // Catching any unexpected exceptions to avoid breaking the flow. We will anyway remove this block once the feature is fully rolled out.
             Logger.error(methodTag, "Failed to check if WebCP in WebView feature is enabled.", throwable);

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -135,11 +135,6 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable the Playstore URL launch for broker apps.
      */
     ENABLE_PLAYSTORE_URL_LAUNCH("EnablePlaystoreUrlLaunch", false),
-    
-    /**
-     * Flight to enable the Web CP for a tenant list.
-     */
-    TENANT_LIST_TO_ENABLE_WEB_CP_IN_WEBVIEW("TenantListToEnableWebCpInWebView", ""),
 
     /**
      * Flight to enable the WebView flow to not cancel and preserve WebView flow on SSL errors.

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -150,7 +150,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable adding username field in broker request for UiRequiredException from broker.
      */
-    ADD_USERNAME_IN_UI_REQUIRED_EXCEPTION_BROKER_RESULT("AddUsernameInUiRequiredExceptionBrokerResult", true);
+    ADD_USERNAME_IN_UI_REQUIRED_EXCEPTION_BROKER_RESULT("AddUsernameInUiRequiredExceptionBrokerResult", true),
+
+    /**
+     * Flight to control the timeout to wait for tenant based flight in WebCP.
+     */
+    WEB_CP_WAIT_TIMEOUT_FOR_FLIGHTS("WebCpWaitTimeoutForFlights", 3000);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -427,5 +427,11 @@ public enum AttributeName {
     /**
      * Record whether or not the request stored a number match entry.
      */
-    stored_number_match_entry
+    stored_number_match_entry,
+
+    /**
+     * Records the time (in milliseconds) spent on flight check for webcp.
+     */
+    web_cp_flight_get_time
+
 }


### PR DESCRIPTION
- Removed the tenantId list and making use of tenant based flighting for webcp
- Added another flight to control the timeout value used for fetching the webcp flight. default value is 3secs.

Related broker PR : https://github.com/AzureAD/ad-accounts-for-android/pull/3175

Fixes [AB#3335954](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3335954)