### PR TITLE
set background color to 255

### DIFF
--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -11,4 +11,5 @@
     <color name="dialogProgress">#616161</color>
     <color name="certIssuerTitle">#212121</color>
     <color name="dialogErrorText">#D92C2C</color>
+    <color name="white">#FFFFFF</color>
 </resources>

--- a/common/src/main/res/values/styles.xml
+++ b/common/src/main/res/values/styles.xml
@@ -60,6 +60,6 @@
     <!-- Theme for DualScreenActivity.
         Force set to a light theme (to status and navigation bars) since broker/common activities always have white background. -->
     <style name="DualScreenActivityTheme" parent="Base.Theme.AppCompat.Light">
-        <item name="android:background">#FFFFFF</item>
+        <item name="android:background">@color/white</item>
     </style>
 </resources>

--- a/common/src/main/res/values/styles.xml
+++ b/common/src/main/res/values/styles.xml
@@ -50,6 +50,8 @@
 
     <!-- Theme for DualScreenActivity.
         Force set to a light theme (to status and navigation bars) since broker/common activities always have white background. -->
-    <style name="DualScreenActivityTheme" parent="Base.Theme.AppCompat.Light"/>
+    <style name="DualScreenActivityTheme" parent="Base.Theme.AppCompat.Light">
+        <item name="android:background">#FFFFFF</item>
+    </style>
 
 </resources>


### PR DESCRIPTION
The default value in light theme is R250 G250 B250,
while webview is pure white (255 255 255)

before
<img width="555" height="886" alt="image" src="https://github.com/user-attachments/assets/f8de9ba7-2b56-4ec4-8603-fda0c067e5e6" />

after
<img width="557" height="540" alt="image" src="https://github.com/user-attachments/assets/14ef9053-ae5a-4023-8e82-735924f889d7" />
