### PR TITLE
Fix for enrollment id not sent to /token from local controller

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ vNext
 - [PATCH] Fix a few small switch browser bugs (#2710)
 - [MINOR] Update Nimbus version (#2724)
 - [MINOR] Using tenant based flighting for webcp (#2723)
+- [PATCH] Fix for enrollment id not sent to /token from local controller (#2726)
 
 Version 21.4.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -872,6 +872,14 @@ public abstract class BaseController {
                 ((MicrosoftTokenRequest) refreshTokenRequest).setPKeyAuthHeaderAllowed(
                         ((BrokerSilentTokenCommandParameters) parameters).isPKeyAuthHeaderAllowed()
                 );
+
+                // set enrollment id if available
+                // This is used to support MAM scenarios where the broker needs to send the enrollment id to the service
+                // For BrokerLocalController, PRT is not used but RT may have device claim so MAM enrollment is still possible
+                // as long as the broker sends the enrollment id.
+                if (!StringUtil.isNullOrEmpty(parameters.getMamEnrollmentId())) {
+                    ((MicrosoftTokenRequest) refreshTokenRequest).setMicrosoftEnrollmentId(parameters.getMamEnrollmentId());
+                }
             }
         }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -875,7 +875,7 @@ public abstract class BaseController {
 
                 // set enrollment id if available
                 // This is used to support MAM scenarios where the broker needs to send the enrollment id to the service
-                // For BrokerLocalController, PRT is not used but RT may have device claim so MAM enrollment is still possible
+                // For BrokerLocalController, PRT is not used but RT may have device claim so satisfying MAM-CA is still possible
                 // as long as the broker sends the enrollment id.
                 if (!StringUtil.isNullOrEmpty(parameters.getMamEnrollmentId())) {
                     ((MicrosoftTokenRequest) refreshTokenRequest).setMicrosoftEnrollmentId(parameters.getMamEnrollmentId());


### PR DESCRIPTION
Fix for ICM: https://portal.microsofticm.com/imp/v5/incidents/details/663024585/summary

What happens is follows:

- MAM compliant app makes ATS call to Broker
- Broker doesn't have PRT for account so fallbacks to local RT (BrokerLocalController)
- Broker correctly queries MAM enrollment id from CP content providers and populates it on CommandParameters
- Now request goes through BrokerLocalController which apparently uses BaseController (as opposed to AbstractBrokerController) for creating token request to renew AT with RT.
- BaseController ignores the MAM enrollment id from CommandParameters and doesn't attach it to the request.
- ESTS throws IntuneAppProtectionPolicyRequired error because it doesn't see enrollment ID in request

Had BrokerLocalController actually relied on its immediate parent class i.e. AbstractBrokerLocalController this would've worked but that's not the case.

Changing the above is a big refactor.

To fix the issue, I'm just attaching MAM enrollment ID (if present on CommandParameters) to the request in BaseController.