### PR TITLE
Handle BadTokenException gracefully in CBA dialogs, Fixes AB#3346402

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ vNext
 - [MINOR] Update Nimbus version (#2724)
 - [MINOR] Using tenant based flighting for webcp (#2723)
 - [PATCH] Fix for enrollment id not sent to /token from local controller (#2726)
+- [PATCH] Handle BadTokenException gracefully in CBA dialogs (#2731)
 
 Version 21.4.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Handle BadTokenException gracefully in CBA dialogs (#2731)
 
 Version 22.0.0
 ----------
@@ -16,7 +17,6 @@ Version 22.0.0
 - [MINOR] Update Nimbus version (#2724)
 - [MINOR] Using tenant based flighting for webcp (#2723)
 - [PATCH] Fix for enrollment id not sent to /token from local controller (#2726)
-- [PATCH] Handle BadTokenException gracefully in CBA dialogs (#2731)
 
 Version 21.4.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -23,11 +23,13 @@
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
 import android.app.Activity;
+import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.R;
+import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;
 
@@ -38,6 +40,9 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class DialogHolder implements IDialogHolder {
+
+    private final String TAG = DialogHolder.class.getSimpleName();
+
     //Current host activity.
     private final Activity mActivity;
     //The current dialog that is showing, if any.
@@ -61,12 +66,22 @@ public class DialogHolder implements IDialogHolder {
     public synchronized void showCertPickerDialog(@NonNull final List<ICertDetails> certList,
                                                   @NonNull final SmartcardCertPickerDialog.PositiveButtonListener positiveButtonListener,
                                                   @NonNull final ICancelCbaCallback cancelCbaCallback) {
-        final SmartcardCertPickerDialog certPickerDialog = new SmartcardCertPickerDialog(
-                certList,
-                positiveButtonListener,
-                cancelCbaCallback,
-                mActivity);
-        showDialog(certPickerDialog);
+        try {
+            final SmartcardCertPickerDialog certPickerDialog = new SmartcardCertPickerDialog(
+                    certList,
+                    positiveButtonListener,
+                    cancelCbaCallback,
+                    mActivity);
+            showDialog(certPickerDialog);
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            // In this case, we simply do not show the dialog and will call the cancel callback.
+            Logger.error(TAG + ":showCertPickerDialog",
+                    "Failed to show CertPickerDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            cancelCbaCallback.onCancel();
+        }
     }
 
     /**
@@ -76,12 +91,22 @@ public class DialogHolder implements IDialogHolder {
      */
     public synchronized void showPinDialog(@NonNull final SmartcardPinDialog.PositiveButtonListener positiveButtonListener,
                                            @NonNull final ICancelCbaCallback cancelCbaCallback) {
-        final SmartcardPinDialog pinDialog = new SmartcardPinDialog(
-                positiveButtonListener,
-                cancelCbaCallback,
-                mActivity);
-        //PinDialog should always be called after a positive button press.
-        showDialog(pinDialog);
+        try {
+            final SmartcardPinDialog pinDialog = new SmartcardPinDialog(
+                    positiveButtonListener,
+                    cancelCbaCallback,
+                    mActivity);
+            //PinDialog should always be called after a positive button press.
+            showDialog(pinDialog);
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            // In this case, we simply do not show the dialog and will call the cancel callback.
+            Logger.error(TAG + ":showPinDialog",
+                    "Failed to show PinDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            cancelCbaCallback.onCancel();
+        }
     }
 
     /**
@@ -91,18 +116,26 @@ public class DialogHolder implements IDialogHolder {
      */
     public synchronized void showErrorDialog(final int titleStringResourceId,
                                              final int messageStringResourceId) {
-        showDialog(new SmartcardErrorDialog(
-                titleStringResourceId,
-                messageStringResourceId,
-                R.string.smartcard_error_dialog_positive_button, //Default dismiss text.
-                new IDismissCallback() {
-                    @Override
-                    public void onDismiss() {
-                        //Call dismissDialog
-                        dismissDialog();
-                    }
-                },
-                mActivity));
+        try {
+            showDialog(new SmartcardErrorDialog(
+                    titleStringResourceId,
+                    messageStringResourceId,
+                    R.string.smartcard_error_dialog_positive_button, //Default dismiss text.
+                    new IDismissCallback() {
+                        @Override
+                        public void onDismiss() {
+                            //Call dismissDialog
+                            dismissDialog();
+                        }
+                    },
+                    mActivity));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showErrorDialog",
+                    "Failed to show ErrorDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+        }
     }
 
     /**
@@ -114,18 +147,26 @@ public class DialogHolder implements IDialogHolder {
     public synchronized void showErrorDialog(final int titleStringResourceId,
                                              final int messageStringResourceId,
                                              final int dismissButtonStringResourceId) {
-        showDialog(new SmartcardErrorDialog(
-                titleStringResourceId,
-                messageStringResourceId,
-                dismissButtonStringResourceId,
-                new IDismissCallback() {
-                    @Override
-                    public void onDismiss() {
-                        //Call dismissDialog
-                        dismissDialog();
-                    }
-                },
-                mActivity));
+        try {
+            showDialog(new SmartcardErrorDialog(
+                    titleStringResourceId,
+                    messageStringResourceId,
+                    dismissButtonStringResourceId,
+                    new IDismissCallback() {
+                        @Override
+                        public void onDismiss() {
+                            //Call dismissDialog
+                            dismissDialog();
+                        }
+                    },
+                    mActivity));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showErrorDialog",
+                    "Failed to show ErrorDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+        }
     }
 
     /**
@@ -136,11 +177,22 @@ public class DialogHolder implements IDialogHolder {
      */
     public synchronized void showUserChoiceDialog(@NonNull final UserChoiceDialog.PositiveButtonListener positiveButtonListener,
                                                   @NonNull final ICancelCbaCallback cancelCbaCallback) {
-        showDialog(new UserChoiceDialog(
-                positiveButtonListener,
-                 cancelCbaCallback,
-                mActivity
-        ));
+        try {
+            showDialog(new UserChoiceDialog(
+                    positiveButtonListener,
+                    cancelCbaCallback,
+                    mActivity
+            ));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            // In this case, we simply do not show the dialog and will call the cancel callback.
+            // We log the exception but do not crash the app.
+            Logger.error(TAG + ":showUserChoiceDialog",
+                    "Failed to show UserChoiceDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            cancelCbaCallback.onCancel();
+        }
     }
 
     /**
@@ -149,17 +201,34 @@ public class DialogHolder implements IDialogHolder {
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
     public synchronized void showSmartcardPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
-        showDialog(new SmartcardPromptDialog(
-                cancelCbaCallback,
-                mActivity
-        ));
+        try {
+            showDialog(new SmartcardPromptDialog(
+                    cancelCbaCallback,
+                    mActivity
+            ));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showSmartcardPromptDialog",
+                    "Failed to show SmartcardPromptDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            cancelCbaCallback.onCancel();
+        }
     }
 
     /**
      * Builds and shows a SmartcardDialog that reminds the user to remain holding their smartcard device to their phone.
      */
     public synchronized void showSmartcardNfcLoadingDialog() {
-        showDialog(new SmartcardNfcLoadingDialog(mActivity));
+        try {
+            showDialog(new SmartcardNfcLoadingDialog(mActivity));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showSmartcardNfcLoadingDialog",
+                    "Failed to show SmartcardNfcLoadingDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+        }
     }
 
     /**
@@ -167,9 +236,18 @@ public class DialogHolder implements IDialogHolder {
      * @param cancelCbaCallback A Callback that holds code to be run when CBA is being cancelled.
      */
     public synchronized void showSmartcardNfcPromptDialog(@NonNull final ICancelCbaCallback cancelCbaCallback) {
-        showDialog(new SmartcardNfcPromptDialog(
-                cancelCbaCallback,
-                mActivity));
+        try {
+            showDialog(new SmartcardNfcPromptDialog(
+                    cancelCbaCallback,
+                    mActivity));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showSmartcardNfcPromptDialog",
+                    "Failed to show SmartcardNfcPromptDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            cancelCbaCallback.onCancel();
+        }
     }
 
     /**
@@ -177,10 +255,20 @@ public class DialogHolder implements IDialogHolder {
      * @param dismissCallback a callback that holds logic to be run upon dismissal of the dialog.
      */
     public synchronized void showSmartcardNfcReminderDialog(@NonNull final IDismissCallback dismissCallback) {
-        showDialog(new SmartcardNfcReminderDialog(
-                dismissCallback,
-                mActivity
-        ));
+        try {
+            showDialog(new SmartcardNfcReminderDialog(
+                    dismissCallback,
+                    mActivity
+            ));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showSmartcardNfcReminderDialog",
+                    "Failed to show SmartcardNfcReminderDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+            // Call the dismissCallback since we couldn't show the dialog
+            dismissCallback.onDismiss();
+        }
     }
 
     /**
@@ -189,15 +277,23 @@ public class DialogHolder implements IDialogHolder {
      */
     @Override
     public synchronized void showSmartcardRemovalPromptDialog(@Nullable final IDismissCallback dismissCallback) {
-        showDialog(new SmartcardRemovalPromptDialog(new IDismissCallback() {
-            @Override
-            public void onDismiss() {
-                dismissDialog();
-                if (dismissCallback != null) {
-                    dismissCallback.onDismiss();
+        try {
+            showDialog(new SmartcardRemovalPromptDialog(new IDismissCallback() {
+                @Override
+                public void onDismiss() {
+                    dismissDialog();
+                    if (dismissCallback != null) {
+                        dismissCallback.onDismiss();
+                    }
                 }
-            }
-        }, mActivity));
+            }, mActivity));
+        } catch (final WindowManager.BadTokenException e) {
+            // This can happen if the activity is finishing or has been destroyed,
+            // or when the user navigates away from the app while a dialog is being shown.
+            Logger.error(TAG + ":showSmartcardRemovalPromptDialog",
+                    "Failed to show SmartcardRemovalPromptDialog due to BadTokenException. Activity may be finishing or destroyed.",
+                    e);
+        }
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolder.java
@@ -293,6 +293,9 @@ public class DialogHolder implements IDialogHolder {
             Logger.error(TAG + ":showSmartcardRemovalPromptDialog",
                     "Failed to show SmartcardRemovalPromptDialog due to BadTokenException. Activity may be finishing or destroyed.",
                     e);
+            if (dismissCallback != null) {
+                dismissCallback.onDismiss();
+            }
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolderTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolderTest.java
@@ -34,7 +34,10 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import androidx.annotation.NonNull;
@@ -57,7 +60,8 @@ public class DialogHolderTest {
 
     @Test
     @Config(shadows={ShadowUserChoiceDialog.class})
-    public void testExceptionThrownFromUserChoiceDialog() {
+    public void testExceptionThrownFromUserChoiceDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showUserChoiceDialog(
                 new UserChoiceDialog.PositiveButtonListener() {
                     @Override
@@ -70,14 +74,17 @@ public class DialogHolderTest {
                     @Override
                     public void onCancel() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Cancel callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Config(shadows={ShadowSmartcardCertPickerDialog.class})
-    public void testExceptionThrownFromCertPickerDialog() {
+    public void testExceptionThrownFromCertPickerDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         final List<ICertDetails> certList = new ArrayList<>();
         mDialogHolder.showCertPickerDialog(
                 certList,
@@ -92,14 +99,17 @@ public class DialogHolderTest {
                     @Override
                     public void onCancel() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Cancel callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Config(shadows={ShadowSmartcardPinDialog.class})
-    public void testExceptionThrownFromPinDialog() {
+    public void testExceptionThrownFromPinDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showPinDialog(
                 new SmartcardPinDialog.PositiveButtonListener() {
                     @Override
@@ -112,9 +122,11 @@ public class DialogHolderTest {
                     @Override
                     public void onCancel() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Cancel callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -142,15 +154,18 @@ public class DialogHolderTest {
 
     @Test
     @Config(shadows={ShadowSmartcardPromptDialog.class})
-    public void testExceptionThrownFromSmartcardPromptDialog() {
+    public void testExceptionThrownFromSmartcardPromptDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showSmartcardPromptDialog(
                 new ICancelCbaCallback() {
                     @Override
                     public void onCancel() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Cancel callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
@@ -162,40 +177,49 @@ public class DialogHolderTest {
 
     @Test
     @Config(shadows={ShadowSmartcardNfcPromptDialog.class})
-    public void testExceptionThrownFromSmartcardNfcPromptDialog() {
+    public void testExceptionThrownFromSmartcardNfcPromptDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showSmartcardNfcPromptDialog(
                 new ICancelCbaCallback() {
                     @Override
                     public void onCancel() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Cancel callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Config(shadows={ShadowSmartcardNfcReminderDialog.class})
-    public void testExceptionThrownFromSmartcardNfcReminderDialog() {
+    public void testExceptionThrownFromSmartcardNfcReminderDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showSmartcardNfcReminderDialog(
                 new IDismissCallback() {
                     @Override
                     public void onDismiss() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Dismiss callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 
     @Test
     @Config(shadows={ShadowSmartcardRemovalPromptDialog.class})
-    public void testExceptionThrownFromSmartcardRemovalPromptDialog() {
+    public void testExceptionThrownFromSmartcardRemovalPromptDialog() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
         mDialogHolder.showSmartcardRemovalPromptDialog(
                 new IDismissCallback() {
                     @Override
                     public void onDismiss() {
                         // If we get here, the test has passed.
+                        latch.countDown();
                     }
                 }
         );
+        assertTrue("Dismiss callback was not called", latch.await(500, TimeUnit.MILLISECONDS));
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolderTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/DialogHolderTest.java
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.app.Activity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Unit tests for {@link DialogHolder} class with focus on exception scenarios.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows={ShadowExceptionSmartcardDialog.class})
+public class DialogHolderTest {
+
+    private DialogHolder mDialogHolder;
+
+    @Before
+    public void setUp() {
+        ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class);
+        Activity activity = activityController.get();
+        mDialogHolder = new DialogHolder(activity);
+    }
+
+    @Test
+    @Config(shadows={ShadowUserChoiceDialog.class})
+    public void testExceptionThrownFromUserChoiceDialog() {
+        mDialogHolder.showUserChoiceDialog(
+                new UserChoiceDialog.PositiveButtonListener() {
+                    @Override
+                    public void onClick(int checkedPosition) {
+                        // This shouldn't be used.
+                        fail("Should not be here");
+                    }
+                },
+                new ICancelCbaCallback() {
+                    @Override
+                    public void onCancel() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardCertPickerDialog.class})
+    public void testExceptionThrownFromCertPickerDialog() {
+        final List<ICertDetails> certList = new ArrayList<>();
+        mDialogHolder.showCertPickerDialog(
+                certList,
+                new SmartcardCertPickerDialog.PositiveButtonListener() {
+                    @Override
+                    public void onClick(@NonNull ICertDetails selectedCertDetails) {
+                        // This shouldn't be used.
+                        fail("Should not be here");
+                    }
+                },
+                new ICancelCbaCallback() {
+                    @Override
+                    public void onCancel() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardPinDialog.class})
+    public void testExceptionThrownFromPinDialog() {
+        mDialogHolder.showPinDialog(
+                new SmartcardPinDialog.PositiveButtonListener() {
+                    @Override
+                    public void onClick(final char[] pin) {
+                        // This shouldn't be used.
+                        fail("Should not be here");
+                    }
+                },
+                new ICancelCbaCallback() {
+                    @Override
+                    public void onCancel() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardErrorDialog.class})
+    public void testExceptionThrownFromErrorDialog() {
+        // We can't easily verify the callback is called since it's an anonymous inner class
+        // in the implementation, but we can verify no exceptions are thrown
+        mDialogHolder.showErrorDialog(
+                1,
+                1
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardErrorDialog.class})
+    public void testExceptionThrownFromErrorDialogWithCustomButton() {
+        // We can't easily verify the callback is called since it's an anonymous inner class
+        // in the implementation, but we can verify no exceptions are thrown
+        mDialogHolder.showErrorDialog(
+                1,
+                1,
+                1
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardPromptDialog.class})
+    public void testExceptionThrownFromSmartcardPromptDialog() {
+        mDialogHolder.showSmartcardPromptDialog(
+                new ICancelCbaCallback() {
+                    @Override
+                    public void onCancel() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardNfcLoadingDialog.class})
+    public void testExceptionThrownFromSmartcardNfcLoadingDialog() {
+        // No callback to verify, but we can verify no exceptions are thrown
+        mDialogHolder.showSmartcardNfcLoadingDialog();
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardNfcPromptDialog.class})
+    public void testExceptionThrownFromSmartcardNfcPromptDialog() {
+        mDialogHolder.showSmartcardNfcPromptDialog(
+                new ICancelCbaCallback() {
+                    @Override
+                    public void onCancel() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardNfcReminderDialog.class})
+    public void testExceptionThrownFromSmartcardNfcReminderDialog() {
+        mDialogHolder.showSmartcardNfcReminderDialog(
+                new IDismissCallback() {
+                    @Override
+                    public void onDismiss() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+
+    @Test
+    @Config(shadows={ShadowSmartcardRemovalPromptDialog.class})
+    public void testExceptionThrownFromSmartcardRemovalPromptDialog() {
+        mDialogHolder.showSmartcardRemovalPromptDialog(
+                new IDismissCallback() {
+                    @Override
+                    public void onDismiss() {
+                        // If we get here, the test has passed.
+                    }
+                }
+        );
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowExceptionSmartcardDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowExceptionSmartcardDialog.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.view.WindowManager;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Doesn't rely on resources to create a dialog and throws exception upon Show.
+ */
+@Implements(SmartcardDialog.class)
+public class ShadowExceptionSmartcardDialog {
+    @Implementation
+    public void show() {
+        throw new WindowManager.BadTokenException("Thrown from show. Better handle this gracefully!");
+    }
+
+    @Implementation
+    public void dismiss() {
+        throw new WindowManager.BadTokenException("Thrown from dismiss. Better handle this gracefully!");
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardCertPickerDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardCertPickerDialog.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardCertPickerDialog} for use in unit tests.
+ */
+@Implements(SmartcardCertPickerDialog.class)
+public class ShadowSmartcardCertPickerDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardErrorDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardErrorDialog.java
@@ -22,9 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
 
-import android.app.Activity;
-import android.app.Dialog;
-
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardErrorDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardErrorDialog.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.app.Activity;
+import android.app.Dialog;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardErrorDialog} for use in unit tests.
+ */
+@Implements(SmartcardErrorDialog.class)
+public class ShadowSmartcardErrorDialog extends ShadowExceptionSmartcardDialog {
+
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcLoadingDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcLoadingDialog.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardNfcLoadingDialog} for use in unit tests.
+ */
+@Implements(SmartcardNfcLoadingDialog.class)
+public class ShadowSmartcardNfcLoadingDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcPromptDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcPromptDialog.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardNfcPromptDialog} for use in unit tests.
+ */
+@Implements(SmartcardNfcPromptDialog.class)
+public class ShadowSmartcardNfcPromptDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcReminderDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardNfcReminderDialog.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardNfcReminderDialog} for use in unit tests.
+ */
+@Implements(SmartcardNfcReminderDialog.class)
+public class ShadowSmartcardNfcReminderDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardPinDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardPinDialog.java
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import android.view.WindowManager;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardPinDialog} for use in unit tests.
+ */
+@Implements(SmartcardPinDialog.class)
+public class ShadowSmartcardPinDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+
+    @Implementation
+    public void show() {
+        throw new WindowManager.BadTokenException("Thrown from show. Better handle this gracefully!");
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardPromptDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardPromptDialog.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardPromptDialog} for use in unit tests.
+ */
+@Implements(SmartcardPromptDialog.class)
+public class ShadowSmartcardPromptDialog extends ShadowExceptionSmartcardDialog {
+
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardRemovalPromptDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowSmartcardRemovalPromptDialog.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link SmartcardRemovalPromptDialog} for use in unit tests.
+ */
+@Implements(SmartcardRemovalPromptDialog.class)
+public class ShadowSmartcardRemovalPromptDialog extends ShadowExceptionSmartcardDialog {
+
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowUserChoiceDialog.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/certbasedauth/ShadowUserChoiceDialog.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.certbasedauth;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/**
+ * Shadow implementation of {@link UserChoiceDialog} for use in unit tests.
+ */
+@Implements(UserChoiceDialog.class)
+public class ShadowUserChoiceDialog extends ShadowExceptionSmartcardDialog {
+    /**
+     * Shadow implementation for createDialog().
+     * This is intentionally left empty to avoid actual UI operations during tests.
+     */
+    @Implementation
+    protected void createDialog() {
+        // Intentionally empty implementation for testing
+    }
+}


### PR DESCRIPTION
### Summary
Fixes [AB#3346402](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3346402)

If activities are destroyed or in the process of being destroyed while a CBA dialog is going to pop up, a BadTokenException will get thrown, and this is currently not being handled by the CBA logic. This PR adds try/catch clauses to the "show" methods of the DialogHolder, which log the exception and call the appropriate callback methods to finish out the CBA flow as a cancellation.