### PR TITLE
Handling https scheme for device enrollment link, Fixes AB#3344894

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1283,6 +1283,11 @@ public final class AuthenticationConstants {
         public static final String BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "&ismdmurl=1";
 
         /**
+         * The scheme for HTTPS URLs.
+         */
+        public static final String HTTPS_SCHEME = "https://";
+
+        /**
          * Activity name to launch company portal.
          */
         public static final String COMPANY_PORTAL_APP_LAUNCH_ACTIVITY_NAME = Broker.COMPANY_PORTAL_APP_PACKAGE_NAME + ".views.SplashActivity";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1285,7 +1285,7 @@ public final class AuthenticationConstants {
         /**
          * The scheme for HTTPS URLs.
          */
-        public static final String HTTPS_SCHEME = "https://";
+        public static final String HTTPS_SCHEME = "https";
 
         /**
          * Activity name to launch company portal.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -586,6 +586,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
+    /**
+     * Processed device CA requests detected in the web flow.
+     * @param view The {@link WebView} instance in which the request originated.
+     * @param url  The URL representing the device CA request.
+     */
     private void processDeviceCaRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":handleDeviceCaRequest";
         Logger.info(methodTag, "This is a device CA request.");

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -343,6 +343,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 processWebCpEnrollmentUrl(view, url);
             } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpAuthorizeUrl(url)) {
                 processWebCpAuthorize(view, url);
+            } else if (isDeviceCaRequest(url)) {
+                 // Exception for device CA requests due to a corner case in eSTS for webapps/confidential clients, which should be handled by the WebView.
+                processDeviceCaRequest(view, url);
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");
                 processInvalidUrl(url);
@@ -575,27 +578,32 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         view.stopLoading();
 
         if (isDeviceCaRequest(url)) {
-            Logger.info(methodTag, "This is a device CA request.");
-
-            if (shouldLaunchCompanyPortal()) {
-                // If CP is installed, redirect to CP.
-                // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
-                //       CP is currently working on this.
-                //       Until that comes, we'll only handle this in ipphone.
-                try {
-                    launchCompanyPortal();
-                    return;
-                } catch (final Exception ex) {
-                    Logger.warn(methodTag, "Failed to launch Company Portal, falling back to browser.");
-                }
-            }
-
-            loadDeviceCaUrl(url, view);
+           processDeviceCaRequest(view, url);
         } else {
             Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
             openLinkInBrowser(url);
             returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
         }
+    }
+
+    private void processDeviceCaRequest(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":handleDeviceCaRequest";
+        Logger.info(methodTag, "This is a device CA request.");
+
+        if (shouldLaunchCompanyPortal()) {
+            // If CP is installed, redirect to CP.
+            // TODO: Until we get a signal from eSTS that CP is the MDM app, we cannot assume that.
+            //       CP is currently working on this.
+            //       Until that comes, we'll only handle this in ipphone.
+            try {
+                launchCompanyPortal();
+                return;
+            } catch (final Exception ex) {
+                Logger.warn(methodTag, "Failed to launch Company Portal, falling back to browser.");
+            }
+        }
+
+        loadDeviceCaUrl(url, view);
     }
 
     private boolean isDeviceCaRequest(@NonNull final String url) {
@@ -647,6 +655,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         try {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
                 // Enabling webcp in webview feature for brokered flows only for now.
+                Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
                 return false;
             }
 
@@ -662,7 +671,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             SpanExtension.current().setAttribute(AttributeName.web_cp_flight_get_time.name(), (System.currentTimeMillis() - webCpGetFlightStartTime));
             if (isWebCpFlightEnabled) {
                 // Directly enabled via flight rollout.
-                Logger.info(methodTag, "WebCP in WebView feature is enabled. ");
+                Logger.info(methodTag, "WebCP in WebView feature is enabled.");
                 mIsWebCpInWebViewFeatureEnabled = true;
                 return true;
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -587,7 +587,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     private void processDeviceCaRequest(@NonNull final WebView view, @NonNull final String url) {
-        final String methodTag = TAG + ":handleDeviceCaRequest";
+        final String methodTag = TAG + ":processDeviceCaRequest";
         Logger.info(methodTag, "This is a device CA request.");
 
         if (shouldLaunchCompanyPortal()) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -343,7 +343,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 processWebCpEnrollmentUrl(view, url);
             } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpAuthorizeUrl(url)) {
                 processWebCpAuthorize(view, url);
-            } else if (isDeviceCaRequest(url)) {
+            } else if (isDeviceCaRequest(url) && isHttpsScheme(url)) {
                  // Special handling for device CA requests due to a corner case in eSTS for webapps/confidential clients, which should be handled by the WebView.
                 processDeviceCaRequest(view, url);
             } else {
@@ -613,6 +613,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isDeviceCaRequest(@NonNull final String url) {
         return url.contains(AuthenticationConstants.Broker.BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
+    }
+
+    private boolean isHttpsScheme(@NonNull final String url) {
+        return url.startsWith(AuthenticationConstants.Broker.HTTPS_SCHEME);
     }
 
     // Decides whether to launch the Company Portal app based on the presence of the IPPhone app and its signature.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -344,7 +344,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpAuthorizeUrl(url)) {
                 processWebCpAuthorize(view, url);
             } else if (isDeviceCaRequest(url)) {
-                 // Exception for device CA requests due to a corner case in eSTS for webapps/confidential clients, which should be handled by the WebView.
+                 // Special handling for device CA requests due to a corner case in eSTS for webapps/confidential clients, which should be handled by the WebView.
                 processDeviceCaRequest(view, url);
             } else {
                 Logger.info(methodTag,"This maybe a valid URI, but no special handling for this mentioned URI, hence deferring to WebView for loading.");

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -95,6 +95,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_REDIRECT_URL = "ABC12/xyz";
     private static final String TEST_WEBSITE_REQUEST_URL = "browser://abcxyz/a";
     private static final String TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "browser://abcxyz/xyz&ismdmurl=1";
+
+    private static final String TEST_HTTPS_DEVICE_CA_URL_QUERY_STRING_PARAMETER = "https://abcxyz/xyz&ismdmurl=1";
     private static final String TEST_INSTALL_REQUEST_URL = "msauth://wpj/?username=someusername%somedomain.onmicrosoft.com&app_link=https%3a%2f%2fplay.google.com%2fstore%2fapps%2fdetails%3fid%3dcom.azure.authenticator%26referrer%3dcom.msft.identity.client.sample.local";
     private static final String TEST_DEVICE_REGISTRATION_URL = "msauth://wpj/?username=someusername%somedomain.onmicrosoft.com";
     private static final String TEST_BLANK_PAGE_REQUEST_URL = "about:blank";
@@ -168,6 +170,11 @@ public class AzureActiveDirectoryWebViewClientTest {
     public void testUrlOverrideHandlesWebsiteRequestUrl() {
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEBSITE_REQUEST_URL));
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesHttpsDeviceCARequestUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_HTTPS_DEVICE_CA_URL_QUERY_STRING_PARAMETER));
     }
 
     @Test


### PR DESCRIPTION
Issue : In my testing, I noticed that OneAuth team started sending a config for a confidential client and that there is a corner case for device enrollment url's scheme on eSTS side. Our contract with eSTS has been to send "browser://" scheme for device enrollment url redirect and we enable webcp flow once we notice the url is of browser scheme and has device enrollment parameters.
 
But eSTS's corner case is that when the calling app is a web app, they pass https:// scheme instead. My logic to handle webcp flow is not triggered in this case and breaks the user's sign in.
Although this is a corner case scenario, we may start seeing issues if consumers of OneAuth or MSAL register themselves as webapp/confidential clients unknowingly. 

Link to ests code where they replace browser scheme with https in specific cases : https://msazure.visualstudio.com/One/_git/ESTS-Main?path=/src/Product/Microsoft.AzureAD.ESTS/Sts/ConditionalAccess/DevicePolicyError.cs&version=GBmaster&_a=contents&line=497&lineStyle=plain&lineEnd=503&lineStartColumn=1&lineEndColumn=10
 
My fix : Is a small change to start supporting webcp flow with https:// scheme as well. 


Fixes [AB#3344894](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3344894)