### PR TITLE
Fix dualscreenactivity darkmode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Fix DualScreenActivity theme color constant (#2737)
 
 Version 22.0.1
 ----------

--- a/common/src/main/res/values-v29/styles.xml
+++ b/common/src/main/res/values-v29/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="DualScreenActivityTheme" parent="Theme.AppCompat.Light">
+        <item name="android:background">@color/white</item>
+        <item name="android:forceDarkAllowed">false</item>
+    </style>
+</resources>

--- a/common/src/main/res/values-v29/styles.xml
+++ b/common/src/main/res/values-v29/styles.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="DualScreenActivityTheme" parent="Theme.AppCompat.Light">
-        <item name="android:background">@color/white</item>
-        <item name="android:forceDarkAllowed">false</item>
-    </style>
-</resources>

--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -11,5 +11,5 @@
     <color name="dialogProgress">#616161</color>
     <color name="certIssuerTitle">#212121</color>
     <color name="dialogErrorText">#D92C2C</color>
-    <color name="white">#FFFFFF</color>
+    <color name="com_microsoft_identity_common_white">#FFFFFF</color>
 </resources>

--- a/common/src/main/res/values/styles.xml
+++ b/common/src/main/res/values/styles.xml
@@ -60,6 +60,6 @@
     <!-- Theme for DualScreenActivity.
         Force set to a light theme (to status and navigation bars) since broker/common activities always have white background. -->
     <style name="DualScreenActivityTheme" parent="Theme.AppCompat.Light">
-        <item name="android:background">@color/white</item>
+        <item name="android:background">@color/com_microsoft_identity_common_white</item>
     </style>
 </resources>

--- a/common/src/main/res/values/styles.xml
+++ b/common/src/main/res/values/styles.xml
@@ -59,7 +59,7 @@
 
     <!-- Theme for DualScreenActivity.
         Force set to a light theme (to status and navigation bars) since broker/common activities always have white background. -->
-    <style name="DualScreenActivityTheme" parent="Base.Theme.AppCompat.Light">
+    <style name="DualScreenActivityTheme" parent="Theme.AppCompat.Light">
         <item name="android:background">@color/white</item>
     </style>
 </resources>


### PR DESCRIPTION
Issue:
Color constant value "white" is defined in both Android Common and Auth App
In Common, this is defined as FFFFFF which is real white.

In Auth App, defined as [background_1](https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android?path=/PhoneFactor/CommonUiLibrary/src/main/res/values/colors.xml&version=GBworking&line=5&lineEnd=6&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents), which itself it defined as FFFFFF (white) in day mode - light and 000000 in night mode. 000000 is actually black.

Due to same names, the final APK uses the one from auth app, and effectively makes color of DualScreenActivity black (000000) in dark theme/night mode.


Fix
Change the constant name in Android common. Named it with prefix library package suffix com_microsoft_identity_common, to avoid any conflicts.
Going forward we should name resources with namespace prefix to avoid resource merging issues. (Perhaps rename existing ones)

Also change them for DualScreenActivity from Base.Theme.AppCompat.Light to Theme.AppCompat.Light (recommended)

Auth App should also address this: Using "white" to indirectly define both white and black, is misleading and causes confusion.