### PR TITLE
Enable ShouldPreserveWebViewFlowOnSslError in Common for OneAuth and MSAL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Enable ShouldPreserveWebViewFlowOnSslError in Common
 - [PATCH] Fix DualScreenActivity theme color constant (#2737)
 - [MINOR] [SDL Assessment task] Secure webview settings (#2715)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Enable ShouldPreserveWebViewFlowOnSslError in Common
+- [MINOR] Enable ShouldPreserveWebViewFlowOnSslError in Common (#2741)
 - [PATCH] Fix DualScreenActivity theme color constant (#2737)
 - [MINOR] [SDL Assessment task] Secure webview settings (#2715)
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -140,7 +140,7 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable the WebView flow to not cancel and preserve WebView flow on SSL errors.
      * The web resource running into SSL will itself not be loaded.
      */
-    SHOULD_PRESERVE_WEBVIEW_FLOW_ON_SSL_ERROR("ShouldPreserveWebViewFlowOnSslError", false),
+    SHOULD_PRESERVE_WEBVIEW_FLOW_ON_SSL_ERROR("ShouldPreserveWebViewFlowOnSslError", true),
 
     /**
      * Flight to enable adding username field in broker request for UiRequiredException from broker.


### PR DESCRIPTION
The feature flag has been true in broker for last month. We don't see any negative impact on Acquire Token interactive. And overall, there's an improvement ATI success. To compare

Previously, SSL error rate was around  in range of 400-600 devices per day. This is when request failed with SSL Error during.
<img width="1146" height="269" alt="image" src="https://github.com/user-attachments/assets/380580eb-2466-4812-ab12-b688161a0ae8" />
 
 
In comparison,  UserCancelException on device where SSL error was hit (we have separate metric point to track this, I joined them) is ranging between 200 and 300. 
<img width="1151" height="221" alt="image" src="https://github.com/user-attachments/assets/8918f3cc-3033-47cf-8d39-29b987c8c52a" />

 
Both results have same sampling rates.
 
There's net improvement in in success rate.

In this, enabling this by default for OneAuth and MSAL.

Next: In next sprint, delete the feature flag.
