### PR TITLE
 Fix for SDL violation in device pop scenarios, Fixes AB#3284510

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [MINOR] Enable Broker Discovery by default in MSAL/Broker API (#2818)
 - [MINOR] Share SharedPreferencesInMemoryCache across instances of BrokerOAuth2TokenCache
 - [MINOR] Use SharedPreferencesInMemoryCache implementation in Broker (#2802)
+- [MINOR] Fix for SDL violation in device pop scenarios, Fixes AB#3284510 (#2744)
 
 Version 23.1.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/AndroidDevicePoPManagerEncryptionTests.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/internal/platform/AndroidDevicePoPManagerEncryptionTests.java
@@ -24,19 +24,27 @@ package com.microsoft.identity.common.internal.platform;
 
 import android.os.Build;
 
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.java.crypto.IDevicePopManager;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -92,6 +100,7 @@ public class AndroidDevicePoPManagerEncryptionTests {
     @After
     public void tearDown() {
         devicePopManager.clearAsymmetricKey();
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test
@@ -101,5 +110,47 @@ public class AndroidDevicePoPManagerEncryptionTests {
 
         Assert.assertEquals(DATA_TO_ENCRYPT, decryptedValue);
         Assert.assertNotEquals(DATA_TO_ENCRYPT, cipherText);
+    }
+
+    @Test
+    public void testEncryption_Disabled() throws ClientException, CertificateException, KeyStoreException, NoSuchAlgorithmException, IOException {
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        Mockito.when(mockFlightsProvider.isFlightEnabled(CommonFlight.DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER))
+                .thenReturn(true);
+        // Create anonymous IFlightsManager
+        IFlightsManager anonymousFlightsManager = new IFlightsManager() {
+            @Override
+            public @NotNull IFlightsProvider getFlightsProvider(long waitForConfigsWithTimeoutInMs) {
+                return mockFlightsProvider;
+            }
+            @Override
+            public @NotNull IFlightsProvider getFlightsProviderForTenant(@NotNull String tenantId, long waitForConfigsWithTimeoutInMs) {
+                return mockFlightsProvider;
+            }
+            @Override
+            public @NotNull IFlightsProvider getFlightsProviderForTenant(@NotNull String tenantId) {
+                return mockFlightsProvider;
+            }
+            @NonNull
+            @Override
+            public IFlightsProvider getFlightsProvider() {
+                return mockFlightsProvider;
+            }
+        };
+
+        // Initialize CommonFlightsManager with the anonymous implementation
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(anonymousFlightsManager);
+        IDevicePopManager devicePopManager = new AndroidDevicePopManager(ApplicationProvider.getApplicationContext());
+        devicePopManager.generateAsymmetricKey();
+        try {
+            final String cipherText = devicePopManager.encrypt(cipher, DATA_TO_ENCRYPT);
+            devicePopManager.decrypt(cipher, cipherText);
+        } catch (Exception exception) {
+            Assert.assertTrue(exception instanceof ClientException);
+            Assert.assertTrue(exception.getCause().getCause().getMessage().contains("Incompatible purpose"));
+            return;
+        }
+        Assert.fail();
+
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -357,7 +357,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                             final boolean enableImport,
                             final boolean trySetAttestationChallenge) throws InvalidAlgorithmParameterException {
         final boolean unnecessaryCryptoPurposesDisabled =
-                CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_UNNECESSARY_CRYPTO_PURPOSES);
+                CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER);
 
         int purposes = KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY;
         if (!unnecessaryCryptoPurposesDisabled) {
@@ -383,7 +383,8 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                               final int keySize,
                               final boolean useStrongbox,
                               final boolean trySetAttestationChallenge,
-                              final int purposes) throws InvalidAlgorithmParameterException {
+                              final int purposes,
+                              final boolean unnecessaryCryptoPurposesDisabled) throws InvalidAlgorithmParameterException {
         KeyGenParameterSpec.Builder builder;
 
         builder = new KeyGenParameterSpec.Builder(
@@ -398,6 +399,13 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
                 );
+
+        if (!unnecessaryCryptoPurposesDisabled) {
+            builder.setEncryptionPaddings(
+                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
+                    KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
+            );
+        }
 
         if (trySetAttestationChallenge && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             builder = setAttestationChallenge(builder);

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -40,6 +40,8 @@ import androidx.annotation.RequiresApi;
 
 import com.microsoft.identity.common.java.crypto.IKeyStoreKeyManager;
 import com.microsoft.identity.common.java.crypto.SecureHardwareState;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.platform.AbstractDevicePopManager;
 import com.microsoft.identity.common.logging.Logger;
 import com.nimbusds.jose.crypto.impl.RSAKeyUtils;
@@ -348,19 +350,35 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
      * @param trySetAttestationChallenge True if we should attempt to generate an attestation challenge cert.
      * @throws InvalidAlgorithmParameterException
      */
-    private void initialize(@androidx.annotation.NonNull final Context context,
-                            @androidx.annotation.NonNull final KeyPairGenerator keyPairGenerator,
+    private void initialize(@NonNull final Context context,
+                            @NonNull final KeyPairGenerator keyPairGenerator,
                             final int keySize,
                             final boolean useStrongbox,
                             final boolean enableImport,
                             final boolean trySetAttestationChallenge) throws InvalidAlgorithmParameterException {
+        final boolean unnecessaryCryptoPurposesDisabled =
+                CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.DISABLE_UNNECESSARY_CRYPTO_PURPOSES);
+
+        int purposes = KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY;
+        if (!unnecessaryCryptoPurposesDisabled) {
+            // If the flight is not enabled, we can use the key for encryption and decryption.
+            purposes |= KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT;
+        }
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             initializePre23(context, keyPairGenerator, keySize);
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge);
-        } else {
-            initialize28(keyPairGenerator, keySize, useStrongbox, enableImport, trySetAttestationChallenge);
+            return;
         }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
+            return;
+        }
+
+        if (!unnecessaryCryptoPurposesDisabled && enableImport) {
+            purposes |= KeyProperties.PURPOSE_WRAP_KEY;
+        }
+        initialize28(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
     }
 
     @SuppressLint("InlinedApi")
@@ -368,14 +386,12 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
     private void initialize23(@androidx.annotation.NonNull final KeyPairGenerator keyPairGenerator,
                               final int keySize,
                               final boolean useStrongbox,
-                              final boolean trySetAttestationChallenge) throws InvalidAlgorithmParameterException {
+                              final boolean trySetAttestationChallenge,
+                              final int purposes) throws InvalidAlgorithmParameterException {
         KeyGenParameterSpec.Builder builder;
+
         builder = new KeyGenParameterSpec.Builder(
-                mKeyManager.getKeyAlias(),
-                KeyProperties.PURPOSE_SIGN
-                        | KeyProperties.PURPOSE_VERIFY
-                        | KeyProperties.PURPOSE_ENCRYPT
-                        | KeyProperties.PURPOSE_DECRYPT
+                mKeyManager.getKeyAlias(), purposes
         )
                 .setKeySize(keySize)
                 .setSignaturePaddings(
@@ -385,9 +401,6 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                         KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-                ).setEncryptionPaddings(
-                        KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
-                        KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
                 );
 
         if (trySetAttestationChallenge && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -444,15 +457,8 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
     private void initialize28(@androidx.annotation.NonNull final KeyPairGenerator keyPairGenerator,
                               final int keySize,
                               final boolean useStrongbox,
-                              final boolean enableImport,
-                              final boolean trySetAttestationChallenge) throws InvalidAlgorithmParameterException {
-        int purposes = KeyProperties.PURPOSE_SIGN
-                | KeyProperties.PURPOSE_VERIFY
-                | KeyProperties.PURPOSE_ENCRYPT
-                | KeyProperties.PURPOSE_DECRYPT;
-        if (enableImport) {
-            purposes |= KeyProperties.PURPOSE_WRAP_KEY;
-        }
+                              final boolean trySetAttestationChallenge,
+                              final int purposes) throws InvalidAlgorithmParameterException {
         KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
                 mKeyManager.getKeyAlias(), purposes)
                 .setKeySize(keySize)

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -385,28 +385,9 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                               final boolean trySetAttestationChallenge,
                               final int purposes,
                               final boolean unnecessaryCryptoPurposesDisabled) throws InvalidAlgorithmParameterException {
-        KeyGenParameterSpec.Builder builder;
+        KeyGenParameterSpec.Builder builder = buildCommonKeyGenSpec(keySize, purposes, unnecessaryCryptoPurposesDisabled);
 
-        builder = new KeyGenParameterSpec.Builder(
-                mKeyManager.getKeyAlias(), purposes
-        )
-                .setKeySize(keySize)
-                .setSignaturePaddings(
-                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
-                )
-                .setDigests(
-                        KeyProperties.DIGEST_NONE,
-                        KeyProperties.DIGEST_SHA1,
-                        KeyProperties.DIGEST_SHA256
-                );
-
-        if (!unnecessaryCryptoPurposesDisabled) {
-            builder.setEncryptionPaddings(
-                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
-                    KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
-            );
-        }
-
+        // API 23-specific conditions: attestation requires API 24+, StrongBox requires API 28+
         if (trySetAttestationChallenge && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             builder = setAttestationChallenge(builder);
         }
@@ -464,24 +445,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                               final boolean trySetAttestationChallenge,
                               final int purposes,
                               final boolean unnecessaryCryptoPurposesDisabled) throws InvalidAlgorithmParameterException {
-        KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
-                mKeyManager.getKeyAlias(), purposes)
-                .setKeySize(keySize)
-                .setSignaturePaddings(
-                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
-                )
-                .setDigests(
-                        KeyProperties.DIGEST_NONE,
-                        KeyProperties.DIGEST_SHA1,
-                        KeyProperties.DIGEST_SHA256
-                );
-
-        if (!unnecessaryCryptoPurposesDisabled) {
-            builder.setEncryptionPaddings(
-                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
-                    KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
-            );
-        }
+        KeyGenParameterSpec.Builder builder = buildCommonKeyGenSpec(keySize, purposes, unnecessaryCryptoPurposesDisabled);
 
         if (trySetAttestationChallenge) {
             builder = setAttestationChallenge(builder);
@@ -499,6 +463,55 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
         keyPairGenerator.initialize(spec);
     }
 
+    /**
+     * Sets encryption paddings on the KeyGenParameterSpec.Builder if encryption purposes are enabled.
+     *
+     * @param builder The KeyGenParameterSpec.Builder to configure
+     * @param unnecessaryCryptoPurposesDisabled When true, encryption paddings are not set to address
+     *                                          SDL security requirements by limiting key usage to signing operations only
+     */
+    private void setEncryptionPaddingsIfNeeded(@NonNull final KeyGenParameterSpec.Builder builder,
+                                              final boolean unnecessaryCryptoPurposesDisabled) {
+        final String methodTag = TAG + ":setEncryptionPaddingsIfNeeded";
+        if (!unnecessaryCryptoPurposesDisabled) {
+            Logger.verbose(methodTag, "Adding encryption paddings (RSA_OAEP, RSA_PKCS1) to key specification");
+            builder.setEncryptionPaddings(
+                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
+                    KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
+            );
+        } else {
+            Logger.verbose(methodTag, "Skipping encryption paddings due to SDL security restrictions");
+        }
+    }
+
+    /**
+     * Builds the common KeyGenParameterSpec configuration shared between API 23+ and 28+ initialization methods.
+     * Setting core configuration : Key alias, purposes, size, signature paddings, digests, and encryption paddings.
+     *
+     * @param keySize The RSA key size
+     * @param purposes The key purposes (signing, encryption, etc.)
+     * @param unnecessaryCryptoPurposesDisabled Whether to skip encryption paddings for SDL compliance
+     * @return Configured KeyGenParameterSpec.Builder ready for API-specific configuration
+     */
+    private KeyGenParameterSpec.Builder buildCommonKeyGenSpec(final int keySize,
+                                                             final int purposes,
+                                                             final boolean unnecessaryCryptoPurposesDisabled) {
+        KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
+                mKeyManager.getKeyAlias(), purposes)
+                .setKeySize(keySize)
+                .setSignaturePaddings(
+                        KeyProperties.SIGNATURE_PADDING_RSA_PKCS1
+                )
+                .setDigests(
+                        KeyProperties.DIGEST_NONE,
+                        KeyProperties.DIGEST_SHA1,
+                        KeyProperties.DIGEST_SHA256
+                );
+
+        setEncryptionPaddingsIfNeeded(builder, unnecessaryCryptoPurposesDisabled);
+        
+        return builder;
+    }
 
     @SuppressLint(NewApi)
     @SuppressWarnings("deprecation")

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -368,7 +368,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             initializePre23(context, keyPairGenerator, keySize);
         } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
+            initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes, unnecessaryCryptoPurposesDisabled);
         } else {
             if (!unnecessaryCryptoPurposesDisabled && enableImport) {
                 purposes |= KeyProperties.PURPOSE_WRAP_KEY;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -373,7 +373,7 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
             if (!unnecessaryCryptoPurposesDisabled && enableImport) {
                 purposes |= KeyProperties.PURPOSE_WRAP_KEY;
             }
-            initialize28(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
+            initialize28(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes, unnecessaryCryptoPurposesDisabled);
         }
     }
 
@@ -454,7 +454,8 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                               final int keySize,
                               final boolean useStrongbox,
                               final boolean trySetAttestationChallenge,
-                              final int purposes) throws InvalidAlgorithmParameterException {
+                              final int purposes,
+                              final boolean unnecessaryCryptoPurposesDisabled) throws InvalidAlgorithmParameterException {
         KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
                 mKeyManager.getKeyAlias(), purposes)
                 .setKeySize(keySize)
@@ -465,10 +466,14 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
                         KeyProperties.DIGEST_NONE,
                         KeyProperties.DIGEST_SHA1,
                         KeyProperties.DIGEST_SHA256
-                ).setEncryptionPaddings(
-                        KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
-                        KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
                 );
+
+        if (!unnecessaryCryptoPurposesDisabled) {
+            builder.setEncryptionPaddings(
+                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP,
+                    KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1
+            );
+        }
 
         if (trySetAttestationChallenge) {
             builder = setAttestationChallenge(builder);

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDevicePopManager.java
@@ -367,18 +367,14 @@ public class AndroidDevicePopManager extends AbstractDevicePopManager {
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             initializePre23(context, keyPairGenerator, keySize);
-            return;
-        }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             initialize23(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
-            return;
+        } else {
+            if (!unnecessaryCryptoPurposesDisabled && enableImport) {
+                purposes |= KeyProperties.PURPOSE_WRAP_KEY;
+            }
+            initialize28(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
         }
-
-        if (!unnecessaryCryptoPurposesDisabled && enableImport) {
-            purposes |= KeyProperties.PURPOSE_WRAP_KEY;
-        }
-        initialize28(keyPairGenerator, keySize, useStrongbox, trySetAttestationChallenge, purposes);
     }
 
     @SuppressLint("InlinedApi")

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
@@ -285,6 +285,7 @@ public interface IDevicePopManager {
      * @return The decrypted text.
      * @throws ClientException If decryption fails.
      */
+    @Deprecated
     String decrypt(Cipher cipher, String ciphertext) throws ClientException;
 
     /**
@@ -295,6 +296,7 @@ public interface IDevicePopManager {
      * @return The decrypted text.
      * @throws ClientException If decryption fails.
      */
+    @Deprecated
     byte[] decrypt(@NonNull Cipher cipher, byte[] ciphertext) throws ClientException;
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/crypto/IDevicePopManager.java
@@ -265,6 +265,7 @@ public interface IDevicePopManager {
      * @return The encrypted plaintext.
      * @throws ClientException If encryption fails.
      */
+    @Deprecated
     String encrypt(Cipher cipher, String plaintext) throws ClientException;
 
     /**
@@ -275,6 +276,7 @@ public interface IDevicePopManager {
      * @return The encrypted plaintext.
      * @throws ClientException If encryption fails.
      */
+    @Deprecated
     byte[] encrypt(@NonNull final Cipher cipher, @NonNull final byte[] plaintext) throws ClientException;
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -185,7 +185,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to control whether or not to use in memory cache for accounts and credentials.
      */
-    USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS("UseInMemoryCacheForAccountsAndCredentials", false);
+    USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS("UseInMemoryCacheForAccountsAndCredentials", false),
+
+    /**
+     * Flight to disable the unnecessary crypto operation purposes in device pop manager like encrypt, decrypt and wrap.
+     */
+    DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER ("DisableUnnecessaryCryptoPurposes", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -190,7 +190,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to disable the unnecessary crypto operation purposes in device pop manager like encrypt, decrypt and wrap.
      */
-    DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER ("DisableUnnecessaryCryptoPurposes", false);
+    DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER ("DisableUnnecessaryCryptoPurposesFromDevicePopManager", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -75,9 +75,9 @@ public enum SpanName {
     PasskeyWebListener,
     PersistToStorageAsync,
     InstallCertOnWpj,
-
     /**
      * Span name for fetching initial ECS flight configurations.
      */
-    EcsFlightsFetchConfigs
+    EcsFlightsFetchConfigs,
+    DevicePopMintSignedAccessToken
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -58,6 +58,9 @@ import com.microsoft.identity.common.java.crypto.SigningAlgorithm;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.marker.CodeMarkerManager;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.TaskCompletedCallbackWithError;
 import com.nimbusds.jose.JOSEException;
@@ -103,6 +106,9 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import lombok.NonNull;
 
 public abstract class AbstractDevicePopManager implements IDevicePopManager {
@@ -877,14 +883,23 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                                         @NonNull final String accessToken,
                                         @Nullable final String nonce,
                                         @Nullable final String clientClaims) throws ClientException {
-        return mintSignedHttpRequestInternal(
-                httpMethod,
-                timestamp,
-                requestUrl,
-                accessToken,
-                nonce,
-                clientClaims
-        );
+        final Span span = OTelUtility.createSpan(SpanName.DevicePopMintSignedAccessToken.name());
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            return mintSignedHttpRequestInternal(
+                    httpMethod,
+                    timestamp,
+                    requestUrl,
+                    accessToken,
+                    nonce,
+                    clientClaims
+            );
+        } catch (final Exception exception) {
+            span.recordException(exception);
+            span.setStatus(StatusCode.ERROR);
+            throw exception;
+        } finally {
+            span.end();
+        }
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -885,7 +885,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                                         @Nullable final String clientClaims) throws ClientException {
         final Span span = OTelUtility.createSpan(SpanName.DevicePopMintSignedAccessToken.name());
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
-            return mintSignedHttpRequestInternal(
+            final String signedAccessToken = mintSignedHttpRequestInternal(
                     httpMethod,
                     timestamp,
                     requestUrl,
@@ -893,6 +893,8 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                     nonce,
                     clientClaims
             );
+            span.setStatus(StatusCode.OK);
+            return signedAccessToken;
         } catch (final Exception exception) {
             span.recordException(exception);
             span.setStatus(StatusCode.ERROR);


### PR DESCRIPTION
- 1 of the SDL assessments has a requirement that we should avoid using multiple crypto purposes with the same key.
- There are multiple places where we are using multiple purposes and device pop scenario is one of them.
- In Device pop scenario, we do not use encrypt/decrypt methods anywhere in our code. Only signing is used. Hence removing the ununsed purposes encrypt, decrypt from the key gen spec. 
- Also, encrypt and decrypt methods added in [IDevicePopManager.java](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/compare/somalaya/devicePopSdlFix?expand=1#diff-2ca2fe49df086f6ee051aeeedcc5bf3bfd53b1b3390e2a8d1143af2cfc74da7e) are probably for maintaining all the crypto operations but I have deprecated them as they are not getting used.
- Added telemetry in mintSignedHttpRequest method. 

Note : The flight to remove encryption paddings in initialize method of AndroidDevicePopManager is not going to be enabled until we observe telemetry added in this PR first. Idea is that the telemetry should prove that encrypt/decrypt methods are not getting used. Only then, we can enable the flight! So, this is going to be enabled in Jan/Feb next year.


Fixes [AB#3284510](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3284510)

