### PR TITLE
Fix for App Link Usage in DUNA / SSO scenarios

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ vNext
 - [MINOR] Add AAD authority validation for DUNA flow (#2740)
 - [PATCH] Fix DualScreenActivity theme color constant (#2737)
 - [MINOR] [SDL Assessment task] Secure webview settings (#2715)
+- [MINOR] Fix for App Link Usage in DUNA / SSO scenarios (#2745)
 
 Version 22.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
@@ -119,7 +119,6 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
                 // Use RECEIVER_NOT_EXPORTED for Android 13+ to prevent external apps from sending broadcasts
                 registerReceiver(redirectReceiver, filter, Context.RECEIVER_NOT_EXPORTED); // 0x4 = RECEIVER_NOT_EXPORTED
             } else {
-                // For older versions, use RECEIVER_NOT_EXPORTED flag as well to satisfy build requirements
                 registerReceiver(redirectReceiver, filter);
             }
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/CurrentTaskAuthorizationActivity.java
@@ -22,15 +22,16 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.providers.oauth2;
 
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 import com.microsoft.identity.common.logging.Logger;
@@ -56,6 +57,7 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
     private boolean mCloseCustomTabs = true;
     private BroadcastReceiver redirectReceiver;
 
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -109,9 +111,17 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
                     startActivity(newIntent);
                 }
             };
-            LocalBroadcastManager.getInstance(this).registerReceiver(redirectReceiver,
-                    new IntentFilter(REDIRECT_RETURNED_ACTION)
-            );
+
+
+            IntentFilter filter = new IntentFilter(REDIRECT_RETURNED_ACTION);
+            // Use backward-compatible receiver registration
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) { // API 33 = TIRAMISU
+                // Use RECEIVER_NOT_EXPORTED for Android 13+ to prevent external apps from sending broadcasts
+                registerReceiver(redirectReceiver, filter, Context.RECEIVER_NOT_EXPORTED); // 0x4 = RECEIVER_NOT_EXPORTED
+            } else {
+                // For older versions, use RECEIVER_NOT_EXPORTED flag as well to satisfy build requirements
+                registerReceiver(redirectReceiver, filter);
+            }
         }
     }
 
@@ -126,7 +136,8 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
         super.onNewIntent(intent);
         if (REFRESH_TO_CLOSE.equals(intent.getAction())) {
             final Intent broadcast = new Intent(DESTROY_REDIRECT_RECEIVING_ACTIVITY_ACTION);
-            LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+            broadcast.setPackage(getPackageName()); // Restrict to our app only
+            sendBroadcast(broadcast);
             unregisterAndFinish();
         }
         //IMPORTANT: If you don't call this...
@@ -158,7 +169,9 @@ public class CurrentTaskAuthorizationActivity extends DualScreenActivity {
     }
 
     private void unregisterAndFinish() {
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(redirectReceiver);
+        if (redirectReceiver != null) {
+            unregisterReceiver(redirectReceiver);
+        }
         finish();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
@@ -132,6 +132,7 @@ public class CustomTabsManager {
 
         // Create the Intent used to launch the Url
         final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(createSession(null));
+        builder.setSendToExternalDefaultHandlerEnabled(true);
         mCustomTabsIntent = builder.setShowTitle(true).build();
         mCustomTabsIntent.intent.setPackage(browserPackage);
         return true;

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,7 +25,7 @@ ext {
     androidxCoreVersion = "1.5.0"
     annotationVersion = "1.0.0"
     appCompatVersion = "1.1.0"
-    browserVersion = "1.0.0"
+    browserVersion = "1.7.0"
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"
     espressoCoreVersion = "3.1.0"


### PR DESCRIPTION
**Issue:** When app link redirect URI is used from within CCT then CCT may not redirect to the native app to handle the redirect and instead open it directly within the browser. From experience I've seen this happen there are existing cookies present at the IdP and there is no user interaction.

**Solution:**  Per [this chromium thread](https://issues.chromium.org/issues/40918490), the solution is set a flag when launching CCT called as [EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER](https://developer.android.com/reference/kotlin/androidx/browser/customtabs/CustomTabsIntent#EXTRA_SEND_TO_EXTERNAL_DEFAULT_HANDLER()). 

That flag was actually introduced in `androidx.browser` library version `1.7.0` and we were on a very ancient version (1.0.0). So this PR updates that library version to `1.7.0`

As a side effect of that upgrade we can no longer use LocalBroadcastManager API (it's deprecated). So I've updated that accordingly similar to what @p3dr0rv was doing earlier when he tried upgrading browser library to 1.9.0 (which we couldn't do due to requiring compile sdk 36)