### PR TITLE
Add aea app to DUNA browser safelist

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [MINOR] Add AAD authority validation for DUNA flow (#2740)
 - [PATCH] Fix DualScreenActivity theme color constant (#2737)
 - [MINOR] [SDL Assessment task] Secure webview settings (#2715)
+- [MINOR] Add aea app to DUNA browser safelist (#2747)
 
 Version 22.0.3
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/ui/BrowserDescriptor.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/ui/BrowserDescriptor.java
@@ -97,6 +97,17 @@ public class BrowserDescriptor implements Serializable {
         );
     }
 
+    static private BrowserDescriptor getBrowserDescriptorForAea() {
+        final HashSet<String> signatureHashes = new HashSet<>();
+        signatureHashes.add("Nd3EDftVD0lR3Lz0Odq8NMkWWyM5CT8lahePkMtzvS6YkVYne_Hn5jaDSxrdXkN1s4AywAnav2RnarZvcqVFJQ==");
+        return new BrowserDescriptor(
+                "com.amazon.enterprise.access.android",
+                signatureHashes,
+                null,
+                null
+        );
+    }
+
     /**
      * Return a list of BrowserDescriptors that are considered safe for the Switch to browser flow.
      */
@@ -104,6 +115,7 @@ public class BrowserDescriptor implements Serializable {
         final List<BrowserDescriptor> browserDescriptors = new ArrayList<>();
         browserDescriptors.add(getBrowserDescriptorForChrome());
         browserDescriptors.add(getBrowserDescriptorForEdge());
+        browserDescriptors.add(getBrowserDescriptorForAea());
         return browserDescriptors;
     }
 


### PR DESCRIPTION
Amazon wants to use their own browser as CCT provider so adding this to browser safelist for DUNA.