### PR TITLE
Adjust Ui Automation to handle both old and new Authenticator Settings Ui, Fixes AB#3330305

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
@@ -66,11 +66,11 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
             );
         }
         else {
-            performDeviceRegistrationHelperWithButtonText(
+            performDeviceRegistrationHelperWithRegexText(
                     username,
                     password,
                     "Register a new organization",
-                    "Register device",
+                    "Register(?: device)?",
                     isFederatedUser,
                     AUTHENTICATOR_IS_REGISTER_EXPECTED
             );
@@ -91,11 +91,11 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
     public void performSharedDeviceRegistration(@NonNull final String username,
                                                 @NonNull final String password) {
         Logger.i(TAG, "Performing Shared Device Registration for the given account..");
-        performDeviceRegistrationHelperWithButtonText(
+        performDeviceRegistrationHelperWithRegexText(
                 username,
                 password,
-                "Register a shared device",
-                "Register device",
+                "Register (a|as) shared device",
+                "Register(?: device)?",
                 false,
                 AUTHENTICATOR_IS_REGISTER_EXPECTED_SHARED
         );
@@ -121,10 +121,10 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
     public void performSharedDeviceRegistrationDontValidate(@NonNull final String username,
                                                 @NonNull final String password) {
         Logger.i(TAG, "Performing Shared Device Registration for the given account without validating we are in shared device mode.");
-        performDeviceRegistrationHelperWithButtonText(
+        performDeviceRegistrationHelperWithRegexText(
                 username,
                 password,
-                "Register a shared device",
+                "Register (a|as) shared device",
                 "Register device",
                 false,
                 AUTHENTICATOR_IS_REGISTER_EXPECTED_SHARED

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerAuthenticatorUpdatedVersionImpl.java
@@ -34,6 +34,7 @@ import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -93,8 +94,8 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
         performDeviceRegistrationHelperWithButtonText(
                 username,
                 password,
-                "Register as shared device",
-                "Register",
+                "Register a shared device",
+                "Register device",
                 false,
                 AUTHENTICATOR_IS_REGISTER_EXPECTED_SHARED
         );
@@ -123,8 +124,8 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
         performDeviceRegistrationHelperWithButtonText(
                 username,
                 password,
-                "Register as shared device",
-                "Register",
+                "Register a shared device",
+                "Register device",
                 false,
                 AUTHENTICATOR_IS_REGISTER_EXPECTED_SHARED
         );
@@ -142,7 +143,6 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
             settings.click();
 
             final UiObject deviceRegistration = UiAutomatorUtils.obtainChildInScrollable(
-                    "settingsScrollView",
                     "Device Registration"
             );
 
@@ -161,18 +161,35 @@ public class BrokerAuthenticatorUpdatedVersionImpl extends BrokerMicrosoftAuthen
         // open device registration page
         openDeviceRegistrationPage();
 
-        // Click the registered account domain
-        UiAutomatorUtils.handleButtonClickForObjectWithText(
-                username.split("@")[1]
-        );
+        // Have to have a try-catch here until the React Native rollout is complete, must handle old and new UI
+        try {
+            // Click the registered account domain
+            UiAutomatorUtils.handleButtonClickForObjectWithDescription(
+                    username.split("@")[1],
+                    CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT
+            );
 
-        // Click enable browser access
-        UiAutomatorUtils.handleButtonClickForObjectWithText(
-                "Enable browser access"
-        );
+            // Click enable browser access
+            UiAutomatorUtils.handleButtonClickForObjectWithDescription(
+                    "Enable browser access"
+            );
 
-        // click continue in Dialog
-        UiAutomatorUtils.handleButtonClick("android:id/button1");
+            // click continue in Dialog
+            UiAutomatorUtils.handleButtonClickForObjectWithExactText("Continue");
+        } catch (AssertionError e) {
+            // Click the registered account domain
+            UiAutomatorUtils.handleButtonClickForObjectWithText(
+                    username.split("@")[1]
+            );
+
+            // Click enable browser access
+            UiAutomatorUtils.handleButtonClickForObjectWithText(
+                    "Enable browser access"
+            );
+
+            // click continue in Dialog
+            UiAutomatorUtils.handleButtonClick("android:id/button1");
+        }
 
         final UiDevice device =
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -49,6 +49,7 @@ import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerPara
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 
 import org.junit.Assert;
@@ -211,23 +212,20 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
 
             UiAutomatorUtils.handleButtonClickForObjectWithText("Other");
 
-            final UiObject describeIssueBox = UiAutomatorUtils.obtainUiObjectWithDescription(
-                    "Describe the issue you are facing"
-            );
-
-            describeIssueBox.setText(INCIDENT_MSG);
+            // Fetch the first edit text and enter the incident message
+            UiAutomatorUtils.obtainAllEditTextObjects(CommonUtils.FIND_UI_ELEMENT_TIMEOUT).get(1).setText(INCIDENT_MSG);
 
             // Send incident button also has send feedback description
             final UiObject sendIncident = UiAutomatorUtils.obtainUiObjectWithDescription("Send feedback");
             sendIncident.click();
 
-            final UiObject postLogSubmissionMsg = UiAutomatorUtils.obtainUiObjectWithResourceId(
-                    "android:id/parentPanel"
+            final UiObject postLogSubmissionMsg = UiAutomatorUtils.obtainUiObjectWithText(
+                    "Thank you for your feedback!"
             );
 
             Assert.assertTrue(postLogSubmissionMsg.exists());
 
-            final UiObject incidentDetails = UiAutomatorUtils.obtainUiObjectWithResourceId("android:id/message");
+            final UiObject incidentDetails = UiAutomatorUtils.obtainUiObjectWithText("Incident ID");
             Assert.assertTrue(incidentDetails.exists());
 
             final String incidentIdText = incidentDetails.getText();

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -30,8 +30,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -338,18 +336,18 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
             aadPromptHandler.handlePrompt(username, password);
         }
     }
-    protected void performDeviceRegistrationHelperWithButtonText(@NonNull final String username,
-                                                   @NonNull final String password,
-                                                   @NonNull final String firstRegisterBtnText,
-                                                   @NonNull final String secondRegisterBtnText,
-                                                   final boolean isFederatedUser,
-                                                   final boolean isRegistrationPageExpected) {
+    protected void performDeviceRegistrationHelperWithRegexText(@NonNull final String username,
+                                                                         @NonNull final String password,
+                                                                         @NonNull final String firstRegisterBtnRegex,
+                                                                         @NonNull final String secondRegisterBtnRegex,
+                                                                         final boolean isFederatedUser,
+                                                                         final boolean isRegistrationPageExpected) {
         Logger.i(TAG, "Execution of Helper for Device Registration..");
         // open device registration page
         openDeviceRegistrationPage();
 
         // click register button
-        UiAutomatorUtils.handleButtonClickForObjectWithText(firstRegisterBtnText);
+        UiAutomatorUtils.handleButtonClickForObjectWithRegexMatch(firstRegisterBtnRegex);
 
         // enter email
         UiAutomatorUtils.handleInputByClass(
@@ -357,7 +355,7 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
                 username
         );
 
-        UiAutomatorUtils.handleButtonClickForObjectWithExactText(secondRegisterBtnText);
+        UiAutomatorUtils.handleButtonClickForObjectWithRegexMatch(secondRegisterBtnRegex);
 
         final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                 .prompt(PromptParameter.LOGIN)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -152,7 +152,7 @@ public class UiAutomatorUtils {
     }
 
     /**
-     * Obtain an instance of the UiObject for the given text.
+     * Obtain an instance of the UiObject for the given description.
      *
      * @param description the description of the element to obtain
      * @return the UiObject associated to the supplied text
@@ -161,6 +161,19 @@ public class UiAutomatorUtils {
         Logger.i(TAG, "Obtain an instance of the UiObject with description:" + description);
         return obtainUiObjectWithUiSelector(new UiSelector().description(description),
                 FIND_UI_ELEMENT_TIMEOUT);
+    }
+
+    /**
+     * Obtain an instance of the UiObject for the given description.
+     *
+     * @param description the description of the element to obtain
+     * @param existsTimeout time to wait until ui object with description exists.
+     * @return the UiObject associated to the supplied text
+     */
+    public static UiObject obtainUiObjectWithDescription(@NonNull final String description, final long existsTimeout) {
+        Logger.i(TAG, "Obtain an instance of the UiObject with description:" + description);
+        return obtainUiObjectWithUiSelector(new UiSelector().description(description),
+                existsTimeout);
     }
 
     /**
@@ -443,6 +456,31 @@ public class UiAutomatorUtils {
     public static void handleButtonClick(@NonNull final String resourceId, final long existsTimeout) {
         Logger.i(TAG, "Clicks the button element associated to the resource id (custom timeout):" + resourceId);
         final UiObject button = obtainUiObjectWithResourceId(resourceId, existsTimeout);
+
+        try {
+            button.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Clicks the button element that contains the supplied description.
+     *
+     * @param desc the description of the button to click
+     */
+    public static void handleButtonClickForObjectWithDescription(@NonNull final String desc) {
+        final UiObject button = obtainUiObjectWithDescription(desc);
+
+        try {
+            button.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public static void handleButtonClickForObjectWithDescription(@NonNull final String desc, final long existsTimeout) {
+        final UiObject button = obtainUiObjectWithDescription(desc, existsTimeout);
 
         try {
             button.click();


### PR DESCRIPTION
Authenticator is rolling out React Native settings page. This PR is to update our E2E Ui Automation validation to handle both the old Ui and the new to maintain success rate as the feature rolls out.

Using regex is a more efficient way to handle multiple possible text fields rather than a typical try-catch, we don't need to wait and see which one is available, the regex can select either one consistently.

Validation:
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1526083&view=results

[AB#3330305](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3330305)