### PR TITLE
Pass webcp flight inlocal flight build

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -33,6 +33,7 @@ if (project.hasProperty("distCommon4jVersion") && project.distCommon4jVersion !=
 boolean newBrokerDiscoveryEnabledFlag = project.hasProperty("newBrokerDiscoveryEnabledFlag")
 boolean trustDebugBrokerFlag = project.hasProperty("trustDebugBrokerFlag")
 boolean bypassRedirectUriCheck = project.hasProperty("bypassRedirectUriCheck")
+boolean enableWebCpForDebugBuild = project.hasProperty("enableWebCpForDebugBuild")
 
 android {
     compileSdk rootProject.ext.compileSdkVersion
@@ -54,6 +55,7 @@ android {
         buildConfigField("boolean", "newBrokerDiscoveryEnabledFlag", "$newBrokerDiscoveryEnabledFlag")
         buildConfigField("boolean", "trustDebugBrokerFlag", "$trustDebugBrokerFlag")
         buildConfigField("boolean", "bypassRedirectUriCheck", "$bypassRedirectUriCheck")
+        buildConfigField("boolean", "enableWebCpForDebugBuild", "$enableWebCpForDebugBuild")
     }
     //aidl is being set to true since aidl only generated with this set
     buildFeatures {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -40,6 +40,7 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.ViewTreeLifecycleOwner;
 
+import com.microsoft.identity.common.BuildConfig;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.internal.broker.BrokerData;
@@ -649,7 +650,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             }
             span.setStatus(StatusCode.OK);
         } catch (final Throwable throwable) {
-            Logger.error(methodTag, "Failed to load device CA URL in WebView.", throwable);
+            Logger.error(methodTag, "Failed to load device CA URL", throwable);
             span.recordException(throwable);
             span.setStatus(StatusCode.ERROR);
             returnError(UNKNOWN_ERROR, throwable.getMessage());
@@ -682,6 +683,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             if (isWebCpFlightEnabled) {
                 // Directly enabled via flight rollout.
                 Logger.info(methodTag, "WebCP in WebView feature is enabled.");
+                mIsWebCpInWebViewFeatureEnabled = true;
+                return true;
+            } else if (BuildConfig.DEBUG && BuildConfig.enableWebCpForDebugBuild) {
+                Logger.info(methodTag, "WebCP in WebView feature is enabled in debug build.");
                 mIsWebCpInWebViewFeatureEnabled = true;
                 return true;
             }


### PR DESCRIPTION
- It seems local flights set in the pipeline do not work well when we use tenant based flighting provider. As a quick fix, in this PR, we use the traditional way of passing flags and checking that flag if it is a debug build for webcp feature as we want to enable this feature in September