### PR TITLE
Add query parameter for Android Release OS Version, Fixes AB#3351713

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add query parameter for Android Release OS Version (#2754)
 - [PATCH] Fix Switch browser back stack (#2750)
 - [MINOR] Move ests telemetry behind feature flag (#2742)
 - [MINOR] Update Broker ATS flow for Resource Account (#2704)

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -82,6 +82,11 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
     }
 
     @Override
+    public @NonNull String getAndroidReleaseOs() {
+        return android.os.Build.VERSION.RELEASE;
+    }
+
+    @Override
     @NonNull
     public String getDeviceModel() {
         return Build.MODEL;

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -73,12 +73,12 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
 
     @Override
     public @NonNull String getOsForMats() {
-        return android.os.Build.VERSION.RELEASE;
+        return getAndroidReleaseOs();
     }
 
     @Override
     public @NonNull String getOsForDrs() {
-        return android.os.Build.VERSION.RELEASE;
+        return getAndroidReleaseOs();
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -474,11 +474,11 @@ public class AndroidKeyStoreUtil {
     }
 
 
-    private static @Nullable KeyStoreException findKeyStoreException(@NonNull Throwable throwable) {
+    private static @Nullable android.security.KeyStoreException findKeyStoreException(@NonNull Throwable throwable) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             while (throwable != null) {
                 if (throwable instanceof android.security.KeyStoreException) {
-                    return (KeyStoreException) throwable;
+                    return (android.security.KeyStoreException) throwable;
                 }
                 throwable = throwable.getCause();
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -89,7 +89,7 @@ public class AndroidKeyStoreUtil {
     private AndroidKeyStoreUtil() {
     }
 
-    public static final LongCounter sFailedAndroidKeyStoreUnwrapOperationCount = OTelUtility.createLongCounter(
+    private static final LongCounter sFailedAndroidKeyStoreUnwrapOperationCount = OTelUtility.createLongCounter(
             "failed_keystore_key_unwrap_operation_count",
             "Number of failed Android KeyStore unwrap operations"
     );

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -450,7 +450,7 @@ public class AndroidKeyStoreUtil {
         );
         if (exception instanceof InvalidKeyException) {
             final KeyStoreException keyStoreException = findKeyStoreException(exception);
-            String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Excerption Found";
+            String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Exception Found";
             if (ksMessage == null) {
                 ksMessage = "";
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -463,4 +463,5 @@ public class AndroidKeyStoreUtil {
 
         throw clientException;
     }
+    
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -47,8 +47,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -449,18 +447,11 @@ public class AndroidKeyStoreUtil {
                 exception
         );
         if (exception instanceof InvalidKeyException) {
-            final android.security.KeyStoreException keyStoreException = findKeyStoreException(exception);
-            String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Exception Found";
-            if (ksMessage == null) {
-                ksMessage = "";
-            }
             final Attributes attributes = Attributes.builder()
                     .put(AttributeName.keystore_operation.name(), "unwrap")
                     .put(AttributeName.error_code.name(), errCode)
                     .put(AttributeName.error_type.name(), clientException.getClass().getSimpleName())
                     .put(AttributeName.keystore_exception_stack_trace.name(), ThrowableUtil.getStackTraceAsString(clientException))
-                    .put(AttributeName.keystore_exception_message.name(), ksMessage)
-                    .put(AttributeName.keystore_internal_error_code.name(), extractInternalKeystoreCode(ksMessage))
                     .build();
             sFailedAndroidKeyStoreUnwrapOperationCount.add(1, attributes);
         }
@@ -471,32 +462,5 @@ public class AndroidKeyStoreUtil {
         );
 
         throw clientException;
-    }
-
-
-    private static @Nullable android.security.KeyStoreException findKeyStoreException(@NonNull Throwable throwable) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            while (throwable != null) {
-                if (throwable instanceof android.security.KeyStoreException) {
-                    return (android.security.KeyStoreException) throwable;
-                }
-                throwable = throwable.getCause();
-            }
-            return null;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Use Regex to pull out the internal error code from the key store exception message
-     * @param message the exception message
-     * @return the internal error code, or "N/A" if it can't be found
-     */
-    private static String extractInternalKeystoreCode(final String message) {
-        if (message == null) return "";
-        Pattern pattern = Pattern.compile("internal Keystore code:\\s*(-?\\d+)");
-        Matcher matcher = pattern.matcher(message);
-        return matcher.find() ? matcher.group(1) : "";
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -449,7 +449,7 @@ public class AndroidKeyStoreUtil {
                 exception
         );
         if (exception instanceof InvalidKeyException) {
-            final KeyStoreException keyStoreException = findKeyStoreException(exception);
+            final android.security.KeyStoreException keyStoreException = findKeyStoreException(exception);
             String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Exception Found";
             if (ksMessage == null) {
                 ksMessage = "";

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -463,5 +463,5 @@ public class AndroidKeyStoreUtil {
 
         throw clientException;
     }
-    
+ 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -87,7 +87,7 @@ public class AndroidKeyStoreUtil {
     private AndroidKeyStoreUtil() {
     }
 
-    private static final LongCounter sFailedAndroidKeyStoreUnwrapOperationCount = OTelUtility.createLongCounter(
+    public static final LongCounter sFailedAndroidKeyStoreUnwrapOperationCount = OTelUtility.createLongCounter(
             "failed_keystore_key_unwrap_operation_count",
             "Number of failed Android KeyStore unwrap operations"
     );
@@ -447,11 +447,17 @@ public class AndroidKeyStoreUtil {
                 exception
         );
         if (exception instanceof InvalidKeyException) {
+            final KeyStoreException keyStoreException = findKeyStoreException(exception);
+            String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Excerption Found";
+            if (ksMessage == null) {
+                ksMessage = "null";
+            }
             final Attributes attributes = Attributes.builder()
                     .put(AttributeName.keystore_operation.name(), "unwrap")
                     .put(AttributeName.error_code.name(), errCode)
                     .put(AttributeName.error_type.name(), clientException.getClass().getSimpleName())
                     .put(AttributeName.keystore_exception_stack_trace.name(), ThrowableUtil.getStackTraceAsString(clientException))
+                    .put(AttributeName.keystore_exception_message.name(), ksMessage)
                     .build();
             sFailedAndroidKeyStoreUnwrapOperationCount.add(1, attributes);
         }
@@ -464,4 +470,18 @@ public class AndroidKeyStoreUtil {
         throw clientException;
     }
 
+
+    private static @Nullable KeyStoreException findKeyStoreException(@NonNull Throwable throwable) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            while (throwable != null) {
+                if (throwable instanceof android.security.KeyStoreException) {
+                    return (KeyStoreException) throwable;
+                }
+                throwable = throwable.getCause();
+            }
+            return null;
+        } else {
+            return null;
+        }
+    }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -47,6 +47,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -450,7 +452,7 @@ public class AndroidKeyStoreUtil {
             final KeyStoreException keyStoreException = findKeyStoreException(exception);
             String ksMessage = keyStoreException != null ? keyStoreException.getMessage() : "No Keystore Excerption Found";
             if (ksMessage == null) {
-                ksMessage = "null";
+                ksMessage = "";
             }
             final Attributes attributes = Attributes.builder()
                     .put(AttributeName.keystore_operation.name(), "unwrap")
@@ -458,6 +460,7 @@ public class AndroidKeyStoreUtil {
                     .put(AttributeName.error_type.name(), clientException.getClass().getSimpleName())
                     .put(AttributeName.keystore_exception_stack_trace.name(), ThrowableUtil.getStackTraceAsString(clientException))
                     .put(AttributeName.keystore_exception_message.name(), ksMessage)
+                    .put(AttributeName.keystore_internal_error_code.name(), extractInternalKeystoreCode(ksMessage))
                     .build();
             sFailedAndroidKeyStoreUnwrapOperationCount.add(1, attributes);
         }
@@ -483,5 +486,17 @@ public class AndroidKeyStoreUtil {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Use Regex to pull out the internal error code from the key store exception message
+     * @param message the exception message
+     * @return the internal error code, or "N/A" if it can't be found
+     */
+    private static String extractInternalKeystoreCode(final String message) {
+        if (message == null) return "";
+        Pattern pattern = Pattern.compile("internal Keystore code:\\s*(-?\\d+)");
+        Matcher matcher = pattern.matcher(message);
+        return matcher.find() ? matcher.group(1) : "";
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -463,5 +463,5 @@ public class AndroidKeyStoreUtil {
 
         throw clientException;
     }
- 
+
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -306,16 +306,6 @@ public enum AttributeName {
     keystore_exception_stack_trace,
 
     /**
-     * Indicates the exception message from a Android KeyStore operation exception.
-     */
-    keystore_exception_message,
-
-    /**
-     * Indicates the error code from a Android KeyStore operation exception.
-     */
-    keystore_internal_error_code,
-
-    /**
      * Indicates the new nonce found in the eSTS request.
      */
     is_sso_nonce_found_in_ests_request,

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -311,6 +311,11 @@ public enum AttributeName {
     keystore_exception_message,
 
     /**
+     * Indicates the error code from a Android KeyStore operation exception.
+     */
+    keystore_internal_error_code,
+
+    /**
      * Indicates the new nonce found in the eSTS request.
      */
     is_sso_nonce_found_in_ests_request,

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -306,6 +306,11 @@ public enum AttributeName {
     keystore_exception_stack_trace,
 
     /**
+     * Indicates the exception message from a Android KeyStore operation exception.
+     */
+    keystore_exception_message,
+
+    /**
      * Indicates the new nonce found in the eSTS request.
      */
     is_sso_nonce_found_in_ests_request,

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/Device.java
@@ -215,6 +215,25 @@ public class Device {
     }
 
     /**
+     * Get the Android Release OS of this device
+     *
+     * @return a String representing the Android Release OS information
+     */
+    @NonNull
+    @GuardedBy("sLock")
+    public static String getAndroidReleaseOs() {
+        sLock.readLock().lock();
+        try {
+            if (sDeviceMetadata != null) {
+                return sDeviceMetadata.getAndroidReleaseOs();
+            }
+            return NOT_SET;
+        } finally {
+            sLock.readLock().unlock();
+        }
+    }
+
+    /**
      * Gets the manufacturer of the current device.
      *
      * @return The name of the device manufacturer.

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/IDeviceMetadata.java
@@ -67,6 +67,14 @@ public interface IDeviceMetadata {
     String getOsForMats();
 
     /**
+     * Get the Android Release OS of this device (i.e 14, 15, 16).
+     *
+     * @return a String representing the Release OS information
+     */
+    @NonNull
+    String getAndroidReleaseOs();
+
+    /**
      * Get the model name of this device.
      *
      * @return a String representing the device's model

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/MicrosoftAuthorizationRequest.java
@@ -122,6 +122,12 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
     @Expose()
     @Getter
     @Accessors(prefix = "m")
+    @SerializedName("x-client-ReleaseOS")
+    private final String mDiagnosticReleaseOS;
+
+    @Expose()
+    @Getter
+    @Accessors(prefix = "m")
     @SerializedName("x-client-CPU")
     private final String mDiagnosticCPU;
 
@@ -186,9 +192,11 @@ public abstract class MicrosoftAuthorizationRequest<T extends MicrosoftAuthoriza
         // If the flight is enabled, set the fields
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_AM_API_WORKPROFILE_EXTRA_QUERY_PARAMETERS)) {
             mDiagnosticMN = Device.getManufacturer();
+            mDiagnosticReleaseOS = Device.getAndroidReleaseOs();
             mWorkProfileAvailable = Device.isInPersonalProfileButClouddpcWorkProfileAvailable();
         } else {
             mDiagnosticMN = null;
+            mDiagnosticReleaseOS = null;
             mWorkProfileAvailable = null;
         }
     }

--- a/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/platform/MockDeviceMetadata.java
@@ -31,6 +31,7 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
     public static final String TEST_OS_ESTS = "TestOSEsts";
     public static final String TEST_OS_MATS = "TestOSMats";
     public static final String TEST_OS_DRS = "TestOSDrs";
+    public static final String TEST_RELEASE_OS = "TestReleaseOS";
     public static final String TEST_DEVICE_MODEL = "TestDeviceModel";
     public static final String TEST_MANUFACTURER = "TestManufacturer";
 
@@ -55,6 +56,11 @@ public class MockDeviceMetadata extends AbstractDeviceMetadata {
     @Override
     public @NonNull String getOsForDrs() {
         return TEST_OS_DRS;
+    }
+
+    @Override
+    public @NonNull String getAndroidReleaseOs() {
+        return TEST_RELEASE_OS;
     }
 
     @Override


### PR DESCRIPTION
This is needed for WebCP work. Intune Portal uses android release os versions, not api level versions. Need this additional query parameter to facilitate flow.

[AB#3351713](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3351713)