### PR TITLE
[Common] Update proguard rules, Fixes AB#3340920

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MAJOR] Update proguard rules in common (#2756)
 - [PATCH] Fix Switch browser back stack (#2750)
 - [MINOR] Move ests telemetry behind feature flag (#2742)
 - [MINOR] Update Broker ATS flow for Resource Account (#2704)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     implementation "androidx.credentials:credentials-play-services-auth:$rootProject.ext.AndroidCredentialsVersion"
     implementation "com.google.android.gms:play-services-fido:$rootProject.ext.LegacyFidoApiVersion"
     implementation "com.google.android.libraries.identity.googleid:googleid:$rootProject.ext.GoogleIdVersion"
+    implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
 
     constraints {
         implementation ("com.squareup.okio:okio:3.4.0") {

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -50,7 +50,7 @@
 # keep everything in this package from being removed or renamed
 -keep class io.opentelemetry.** { *; }
 
-# keep names
+# keep names only to allow keeping them logs and exceptions
 -keepnames class com.microsoft.identity.** { *; }
 
 # Prevent R8 from leaving Data object members always null
@@ -65,6 +65,7 @@
   *;
 }
 
+# Runtime annotations
 -keep class net.jcip.annotations.GuardedBy
 -keep class net.jcip.annotations.Immutable
 -keep class net.jcip.annotations.ThreadSafe
@@ -77,4 +78,3 @@
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.extension.memoized.Memoized
-

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -50,9 +50,13 @@
 # keep everything in this package from being removed or renamed
 -keep class io.opentelemetry.** { *; }
 
+# keep names
+-keepnames class com.microsoft.identity.** { *; }
+
 # Prevent R8 from leaving Data object members always null
--keepclassmembers,allowobfuscation class * {
+-keepclassmembers class * {
   @com.google.gson.annotations.SerializedName <fields>;
+  @com.squareup.moshi.Json <fields>;
 }
 
 #For Android Credential Manager: https://developer.android.com/training/sign-in/passkeys#proguard
@@ -60,3 +64,17 @@
 -keep class androidx.credentials.playservices.** {
   *;
 }
+
+-keep class net.jcip.annotations.GuardedBy
+-keep class net.jcip.annotations.Immutable
+-keep class net.jcip.annotations.ThreadSafe
+
+# Compile time annotations
+-dontwarn edu.umd.cs.findbugs.annotations.NonNull
+-dontwarn edu.umd.cs.findbugs.annotations.Nullable
+-dontwarn edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.extension.memoized.Memoized
+

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -46,6 +46,8 @@
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken { *; }
 
 # keep everything in this package from being removed or renamed
 -keep class io.opentelemetry.** { *; }

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -17,7 +17,6 @@
 #}
 
 ##---------------Begin: proguard configuration for Common  --------
-# Intentionally blank, left to consumers of common to implement.
 # keep with optmizations and shrinking, but do not obfuscate
 -keep,allowoptimization,allowshrinking class !com.microsoft.identity.common.java.nativeauth.**, !com.microsoft.identity.common.nativeauth.**, com.microsoft.identity.** { *; }
 -keep class * extends com.microsoft.identity.common.java.authorities.Authority { *; }

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -56,10 +56,18 @@
 -keepnames class com.microsoft.identity.** { *; }
 
 # Prevent R8 from leaving Data object members always null
--keepclassmembers class * {
+-keepclassmembers class com.microsoft.identity.** {
   @com.google.gson.annotations.SerializedName <fields>;
   @com.squareup.moshi.Json <fields>;
 }
+
+-keep class * extends com.microsoft.identity.common.java.authorities.Authority { *; }
+-keep class * extends com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience { *; }
+-keep class * extends com.microsoft.identity.common.java.cache.ICacheRecord { *; }
+-keep class * extends com.microsoft.identity.common.java.cache.ITokenCacheItem { *; }
+-keep class * extends com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme { *; }
+-keep class com.microsoft.identity.common.internal.broker.AuthUxJsonPayload { *;}
+
 
 #For Android Credential Manager: https://developer.android.com/training/sign-in/passkeys#proguard
 -if class androidx.credentials.CredentialManager

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -18,55 +18,14 @@
 
 ##---------------Begin: proguard configuration for Common  --------
 # Intentionally blank, left to consumers of common to implement.
-
-##---------------Begin: proguard configuration for Nimbus  ----------
-# Intentionally blank, left to consumers of common to implement.
-
-##---------------Begin: proguard configuration for Lombok  ----------
--dontwarn lombok.**
-
-##---------------Begin: proguard configuration for Gson  --------
-# Gson uses generic type information stored in a class file when working with fields. Proguard
-# removes such information by default, so configure it to keep all of it.
--keepattributes Signature
-
-# For using GSON @Expose annotation
--keepattributes *Annotation*
-
-# Gson specific classes
--dontwarn sun.misc.**
-#-keep class com.google.gson.stream.** { *; }
-
-# Application classes that will be serialized/deserialized over Gson
--keep class com.google.gson.examples.android.model.** { <fields>; }
-
-# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
-# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * extends com.google.gson.TypeAdapter
--keep class * implements com.google.gson.TypeAdapterFactory
--keep class * implements com.google.gson.JsonSerializer
--keep class * implements com.google.gson.JsonDeserializer
--keep class com.google.gson.reflect.TypeToken { *; }
--keep class * extends com.google.gson.reflect.TypeToken { *; }
-
-# keep everything in this package from being removed or renamed
--keep class io.opentelemetry.** { *; }
-
-# keep names only to allow keeping them logs and exceptions
--keepnames class com.microsoft.identity.** { *; }
-
-# Prevent R8 from leaving Data object members always null
--keepclassmembers class com.microsoft.identity.** {
-  @com.google.gson.annotations.SerializedName <fields>;
-  @com.squareup.moshi.Json <fields>;
-}
-
+# keep with optmizations and shrinking, but do not obfuscate
+-keep,allowoptimization,allowshrinking class !com.microsoft.identity.common.java.nativeauth.**, !com.microsoft.identity.common.nativeauth.**, com.microsoft.identity.** { *; }
 -keep class * extends com.microsoft.identity.common.java.authorities.Authority { *; }
 -keep class * extends com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience { *; }
 -keep class * extends com.microsoft.identity.common.java.cache.ICacheRecord { *; }
 -keep class * extends com.microsoft.identity.common.java.cache.ITokenCacheItem { *; }
 -keep class * extends com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme { *; }
--keep class com.microsoft.identity.common.internal.broker.AuthUxJsonPayload { *;}
+-keep class com.microsoft.identity.common.internal.broker.AuthUxJsonPayload { *; }
 
 
 #For Android Credential Manager: https://developer.android.com/training/sign-in/passkeys#proguard
@@ -85,6 +44,47 @@
 -dontwarn edu.umd.cs.findbugs.annotations.Nullable
 -dontwarn edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
+-keepattributes SourceFile,LineNumberTable
+
+##---------------Begin: proguard configuration for Nimbus  ----------
+# Intentionally blank, left to consumers of common to implement.
+
+##---------------Begin: proguard configuration for Lombok  ----------
+-dontwarn lombok.**
+
+##---------------Begin: proguard configuration for Gson  --------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature,SourceFile,LineNumberTable
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken { *; }
+
+##---------------Begin: proguard configuration for OpenTelemetry  --------
+# keep everything in this package from being removed or renamed
+-keep class io.opentelemetry.** { *; }
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers class com.microsoft.identity.** {
+  @com.google.gson.annotations.SerializedName <fields>;
+  @com.squareup.moshi.Json <fields>;
+}
+
+## Other
+# Compile time annotation
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.extension.memoized.Memoized

--- a/common/src/main/java/com/microsoft/identity/common/base64/AndroidBase64.kt
+++ b/common/src/main/java/com/microsoft/identity/common/base64/AndroidBase64.kt
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.base64
 
+import androidx.annotation.Keep
 import com.microsoft.identity.common.java.base64.Base64Flags
 import com.microsoft.identity.common.java.base64.Base64Util
 import com.microsoft.identity.common.java.base64.IBase64
@@ -34,7 +35,7 @@ import com.microsoft.identity.common.java.base64.IBase64
  *
  * see [Base64Util] for more info.
  **/
-
+@Keep
 class AndroidBase64 : IBase64 {
 
     override fun encode(input: ByteArray, vararg flags: Base64Flags): ByteArray {

--- a/common/src/main/java/com/microsoft/identity/common/base64/AndroidBase64.kt
+++ b/common/src/main/java/com/microsoft/identity/common/base64/AndroidBase64.kt
@@ -34,6 +34,7 @@ import com.microsoft.identity.common.java.base64.IBase64
  * you'll need to make change in [Base64Util] too.
  *
  * see [Base64Util] for more info.
+ * This is called using reflection from [Base64Util], hence the @Keep annotation.
  **/
 @Keep
 class AndroidBase64 : IBase64 {


### PR DESCRIPTION
Updated proguard rules
1. Keep annotation at AndroidBase64, since it is used by reflection
2. removed com.microsoft.identity* from keeps but keeping names to help with logging and exception. So, names are not obfuscated.
3. Updated build.gradle for jcipAnnotationVersion dependency as it provides runtime objects, to avoid any issues.
4. Added donotwarn for compile time classes (annotations)
5. Major version bump as it can require consumers to adjust their code to avoid build time/runtime issues.

Fixes [AB#3340920](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3340920)

Run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1532428&view=results