### PR TITLE
Added error handling when webcp redirects have browser protocol, Fixes AB#3385536

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ vNext
 - [MINOR] Add client scenario to JwtRequestBody (#2755)
 - [MINOR] Awaiting MFA Delegate now automatically returns the AuthMethods to be used when calling MFA Challenge (#2764)
 - [MINOR] SDK now handles SMS as strong authentication method #2766
+- [MINOR] Added error handling when webcp redirects have browser protocol #2767
 
 Version 22.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -131,7 +131,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private HashMap<String, String> mRequestHeaders;
     private String mRequestUrl;
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
-    private boolean mIsWebCpInWebViewFeatureEnabled = false;
+    private boolean mInWebCpFlow = false;
 
     private final String mUtid;
 
@@ -339,10 +339,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_PRT_HEADER_WHEN_CROSS_CLOUD) && isCrossCloudRedirect(formattedURL)) {
                 Logger.info(methodTag,"Navigation contains cross cloud redirect.");
                 processCrossCloudRedirect(view, url);
-            } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpEnrollmentUrl(url)) {
+            } else if (mInWebCpFlow && isWebCpEnrollmentUrl(url)) {
                 Logger.info(methodTag,"Navigation contains web cp enrollment url.");
                 processWebCpEnrollmentUrl(view, url);
-            } else if (mIsWebCpInWebViewFeatureEnabled && isWebCpAuthorizeUrl(url)) {
+            } else if (mInWebCpFlow && isWebCpAuthorizeUrl(url)) {
                 processWebCpAuthorize(view, url);
             }  else if (isDeviceCaRequest(url) && isHttpsScheme(url) && isWebCpInWebviewFeatureEnabled(url)) {
                 // Special handling for device CA requests due to a corner case in eSTS for webapps/confidential clients, which should be handled by the WebView.
@@ -582,7 +582,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebsiteRequest.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebsiteRequest.name());
-        span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), mIsWebCpInWebViewFeatureEnabled);
+        span.setAttribute(AttributeName.is_in_web_cp_flow.name(), mInWebCpFlow);
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             if (isDeviceCaRequest(url)) {
                 processDeviceCaRequest(view, url);
@@ -590,7 +590,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 return;
             }
 
-            if (isRedirectToPlaystoreToInstallCp(url) && mIsWebCpInWebViewFeatureEnabled) {
+            if (isRedirectToPlaystoreToInstallCp(url) && mInWebCpFlow) {
                 handlePlaystoreLaunchUrlFromWebCp(url);
                 span.setStatus(StatusCode.OK);
                 return;
@@ -617,7 +617,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private void handleBrowserRedirect(@NonNull final String methodTag, @NonNull final String url) {
         Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
         openLinkInBrowser(url);
-        final RawAuthorizationResult.ResultCode resultCode = mIsWebCpInWebViewFeatureEnabled
+        final RawAuthorizationResult.ResultCode resultCode = mInWebCpFlow
                 ? RawAuthorizationResult.ResultCode.MDM_FLOW
                 : RawAuthorizationResult.ResultCode.CANCELLED;
 
@@ -742,7 +742,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             if (isWebCpFlightEnabled) {
                 // Directly enabled via flight rollout.
                 Logger.info(methodTag, "WebCP in WebView feature is enabled.");
-                mIsWebCpInWebViewFeatureEnabled = true;
+                mInWebCpFlow = true;
                 return true;
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -579,7 +579,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     protected void processWebsiteRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processWebsiteRequest";
         view.stopLoading();
-        // Create a span for this browser redirect operation
         final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         final Span span = spanContext != null ?
                 OTelUtility.createSpanFromParent(SpanName.ProcessWebsiteRequest.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebsiteRequest.name());

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -92,6 +92,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AMAZON_APP_REDIRECT_PREFIX;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.IPPHONE_APP_SHA512_RELEASE_SIGNATURE;
@@ -132,7 +133,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
     private boolean mIsWebCpInWebViewFeatureEnabled = false;
 
-    private String mUtid;
+    private final String mUtid;
 
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
@@ -574,17 +575,77 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
-    private void processWebsiteRequest(@NonNull final WebView view, @NonNull final String url) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    protected void processWebsiteRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processWebsiteRequest";
         view.stopLoading();
+        // Create a span for this browser redirect operation
+        final SpanContext spanContext = getActivity() instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
+        final Span span = spanContext != null ?
+                OTelUtility.createSpanFromParent(SpanName.ProcessWebsiteRequest.name(), spanContext) : OTelUtility.createSpan(SpanName.ProcessWebsiteRequest.name());
+        span.setAttribute(AttributeName.is_webcp_in_webview_enabled.name(), mIsWebCpInWebViewFeatureEnabled);
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            if (isDeviceCaRequest(url)) {
+                processDeviceCaRequest(view, url);
+                span.setStatus(StatusCode.OK);
+                return;
+            }
 
-        if (isDeviceCaRequest(url)) {
-           processDeviceCaRequest(view, url);
-        } else {
-            Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
-            openLinkInBrowser(url);
-            returnResult(RawAuthorizationResult.ResultCode.CANCELLED);
+            if (isRedirectToPlaystoreToInstallCp(url) && mIsWebCpInWebViewFeatureEnabled) {
+                handlePlaystoreLaunchUrlFromWebCp(url);
+                span.setStatus(StatusCode.OK);
+                return;
+            }
+
+            // Default case: redirect to browser
+            handleBrowserRedirect(methodTag, url);
+            span.setStatus(StatusCode.OK);
+        } catch (final Throwable throwable) {
+            Logger.error(methodTag, "Failed to open link in browser.", throwable);
+            span.recordException(throwable);
+            span.setStatus(StatusCode.ERROR);
+            returnError(ErrorStrings.UNEXPECTED_ERROR, "No browser found to open the link.");
+        } finally {
+            span.end();
         }
+    }
+
+    /**
+     * Handles the default browser redirect case for website requests.
+     * @param methodTag The method tag for logging
+     * @param url The URL to open in browser
+     */
+    private void handleBrowserRedirect(@NonNull final String methodTag, @NonNull final String url) {
+        Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
+        openLinkInBrowser(url);
+        final RawAuthorizationResult.ResultCode resultCode = mIsWebCpInWebViewFeatureEnabled
+                ? RawAuthorizationResult.ResultCode.MDM_FLOW
+                : RawAuthorizationResult.ResultCode.CANCELLED;
+
+        Logger.info(methodTag, "Returning result code: " + resultCode);
+        returnResult(resultCode);
+    }
+
+    // Handles Playstore launch URLs originating from WebCP, specifically for installing the Company Portal app.
+    private void handlePlaystoreLaunchUrlFromWebCp(@NonNull final String url) {
+        final String methodTag = TAG + ":handlePlaystoreLaunchUrlFromWebCp";
+        Logger.info(methodTag, "Redirect to Playstore to install Company Portal app from WebCP flow.");
+        SpanExtension.current().setAttribute(AttributeName.isRedirectToPlaystoreLaunchFromWebCp.name(), true);
+        openLinkInBrowser(url);
+        returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
+    }
+
+    /**
+     * Checks if it is a redirect to Playstore to install Company Portal app.
+     * @param url The URL to check.
+     * @return true if it is a redirect to Playstore to install Company Portal app.
+     */
+    private boolean isRedirectToPlaystoreToInstallCp(@NonNull final String url) {
+       if (url.contains(PLAY_STORE_INSTALL_APP_PREFIX) && url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME)) {
+           Logger.info(TAG, "Redirect to Playstore to install Company Portal app.");
+           return true;
+       }
+       return false;
     }
 
     /**
@@ -679,6 +740,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             final int waitForFlightsTimeOut = CommonFlightsManager.INSTANCE.getFlightsProvider().getIntValue(CommonFlight.WEB_CP_WAIT_TIMEOUT_FOR_FLIGHTS);
             final boolean isWebCpFlightEnabled = CommonFlightsManager.INSTANCE.getFlightsProviderForTenant(homeTenantId, waitForFlightsTimeOut).isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW);
             SpanExtension.current().setAttribute(AttributeName.web_cp_flight_get_time.name(), (System.currentTimeMillis() - webCpGetFlightStartTime));
+
             if (isWebCpFlightEnabled) {
                 // Directly enabled via flight rollout.
                 Logger.info(methodTag, "WebCP in WebView feature is enabled.");
@@ -755,12 +817,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
         view.stopLoading();
         if (!(url.startsWith(PLAY_STORE_INSTALL_PREFIX + COMPANY_PORTAL_APP_PACKAGE_NAME))
-                && !(url.startsWith(PLAY_STORE_INSTALL_PREFIX + AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))) {
+                && !(url.startsWith(PLAY_STORE_INSTALL_PREFIX + AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))) {
             Logger.info(methodTag, "The URI is either trying to open an unknown application or contains unknown query parameters");
             return false;
         }
-        final String appPackageName = (url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME) ?
-                COMPANY_PORTAL_APP_PACKAGE_NAME : AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME);
+        final String appPackageName = getBrokerAppPackageNameFromUrl(url);
         Logger.info(methodTag, "Request to open PlayStore to install package : '" + appPackageName + "'");
 
         try {
@@ -779,21 +840,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean processPlayStoreURLForBrokerApps(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processPlayStoreURL";
 
-        final String appPackageName = (url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME) ?
-                COMPANY_PORTAL_APP_PACKAGE_NAME : AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME);
+        final String appPackageName = getBrokerAppPackageNameFromUrl(url);
         Logger.info(methodTag, "Request to open PlayStore to install package : '" + appPackageName + "'");
 
         try {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_INSTALL_APP_PREFIX + appPackageName));
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             getActivity().startActivity(intent);
             view.stopLoading();
-            if (appPackageName.equalsIgnoreCase(COMPANY_PORTAL_APP_PACKAGE_NAME) && (mIsWebCpInWebViewFeatureEnabled)) {
-                // If the flight for webcp is enabled, we will return the result code to the activity to indicate that the MDM flow has started.
-                // Note that this is only for CP app as we are not aware of any other flows (other than webcp) reaching this code path.
-                returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
-            }
-
             return true;
         } catch (final ActivityNotFoundException e) {
             //if GooglePlay is not present on the device.
@@ -839,7 +892,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.info(methodTag, "Sent Intent to launch Amazon app");
     }
 
-    private void openLinkInBrowser(final String url) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    protected void openLinkInBrowser(final String url) {
         final String methodTag = TAG + ":openLinkInBrowser";
         Logger.info(methodTag, "Try to open url link in browser");
         final String link = url
@@ -910,7 +964,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodTag = TAG + ":processInvalidRedirectUri";
 
         Logger.error(methodTag, "The RedirectUri is not as expected.", null);
-        Logger.errorPII(methodTag,String.format("Received %s and expected %s", url, mRedirectUrl), null);
+        Logger.errorPII(methodTag, String.format("Received %s and expected %s", url, mRedirectUrl), null);
         returnError(ErrorStrings.DEVELOPER_REDIRECTURI_INVALID,
                 String.format("The RedirectUri is not as expected. Received %s and expected %s", url,
                         mRedirectUrl));
@@ -1136,6 +1190,24 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
         //The challenge handler will make sure no smartcard is connected before result is sent.
         ((AbstractSmartcardCertBasedAuthChallengeHandler<?>)mCertBasedAuthChallengeHandler).promptSmartcardRemovalForResult(callback);
+    }
+
+    /**
+     * Extracts the broker app package name from the given URL.
+     * Supports all known broker apps. Returns the first match found.
+     * If no known broker app is found, logs a warning and returns an empty string.
+     *
+     * @param url The URL to inspect.
+     * @return The broker app package name, or empty string if not found.
+     */
+    private String getBrokerAppPackageNameFromUrl(@NonNull final String url) {
+        for (final BrokerData brokerData : BrokerData.getAllBrokers()) {
+            if (url.contains(brokerData.getPackageName())) {
+                return brokerData.getPackageName();
+            }
+        }
+        Logger.warn(TAG + ":getBrokerAppPackageNameFromUrl", "No known broker app package name found in URL: " + url);
+        return "";
     }
 
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -628,6 +628,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     // Handles Playstore launch URLs originating from WebCP, specifically for installing the Company Portal app.
     private void handlePlaystoreLaunchUrlFromWebCp(@NonNull final String url) {
         final String methodTag = TAG + ":handlePlaystoreLaunchUrlFromWebCp";
+        Logger.info(methodTag, "Handling playstore launch URL from WebCP.");
         SpanExtension.current().setAttribute(AttributeName.is_redirect_to_playstore_launch_from_webcp.name(), true);
         openLinkInBrowser(url);
         returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -628,8 +628,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     // Handles Playstore launch URLs originating from WebCP, specifically for installing the Company Portal app.
     private void handlePlaystoreLaunchUrlFromWebCp(@NonNull final String url) {
         final String methodTag = TAG + ":handlePlaystoreLaunchUrlFromWebCp";
-        Logger.info(methodTag, "Redirect to Playstore to install Company Portal app from WebCP flow.");
-        SpanExtension.current().setAttribute(AttributeName.isRedirectToPlaystoreLaunchFromWebCp.name(), true);
+        SpanExtension.current().setAttribute(AttributeName.is_redirect_to_playstore_launch_from_webcp.name(), true);
         openLinkInBrowser(url);
         returnResult(RawAuthorizationResult.ResultCode.MDM_FLOW);
     }
@@ -640,7 +639,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      * @return true if it is a redirect to Playstore to install Company Portal app.
      */
     private boolean isRedirectToPlaystoreToInstallCp(@NonNull final String url) {
-       if (url.contains(PLAY_STORE_INSTALL_APP_PREFIX) && url.contains(COMPANY_PORTAL_APP_PACKAGE_NAME)) {
+       if (url.contains(PLAY_STORE_INSTALL_APP_PREFIX + COMPANY_PORTAL_APP_PACKAGE_NAME)) {
            Logger.info(TAG, "Redirect to Playstore to install Company Portal app.");
            return true;
        }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -25,8 +25,11 @@ package com.microsoft.identity.common.internal.ui.webview;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
+import static com.microsoft.identity.common.java.providers.RawAuthorizationResult.ResultCode.CANCELLED;
+import static com.microsoft.identity.common.java.providers.RawAuthorizationResult.ResultCode.MDM_FLOW;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,6 +37,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.net.http.SslError;
 import android.webkit.SslErrorHandler;
@@ -48,6 +52,7 @@ import com.microsoft.identity.common.internal.ui.DualScreenActivity;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.ReAttachPrtHeaderHandler;
 import com.microsoft.identity.common.internal.ui.webview.challengehandlers.SwitchBrowserRequestHandler;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.flighting.CommonFlight;
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.flighting.IFlightsManager;
@@ -61,6 +66,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -115,6 +121,7 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     private static final String TEST_WEB_CP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
+    private static final String TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL = "browser://play.app.goo.gl/?link=https://play.google.com/store/apps/details?id=com.microsoft.windowsintune.companyportal";
     @Before
     public void setup() throws ClientException {
         mContext = ApplicationProvider.getApplicationContext();
@@ -170,6 +177,7 @@ public class AzureActiveDirectoryWebViewClientTest {
     public void testUrlOverrideHandlesWebsiteRequestUrl() {
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEBSITE_REQUEST_URL));
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER));
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL));
     }
 
     @Test
@@ -486,5 +494,156 @@ public class AzureActiveDirectoryWebViewClientTest {
         Mockito.verify(mockCallback, never()).onChallengeResponseReceived(any());
 
         CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    @Config(shadows = {ShadowProcessUtil.class})
+    public void testProcessWebsiteRequest() {
+        // Test case 1: General browser redirect (default case)
+        testProcessWebsiteRequest_BrowserRedirect();
+
+        // Test case 2: Device CA request
+        testProcessWebsiteRequest_DeviceCaRequest();
+
+        // Test case 3: WebCP playstore redirect when feature is enabled
+        testProcessWebsiteRequest_WebCpPlaystoreRedirect();
+
+        // Test case 4: Exception handling
+        testProcessWebsiteRequest_ExceptionHandling();
+    }
+
+    private void testProcessWebsiteRequest_BrowserRedirect() {
+        // Arrange
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = Mockito.spy(new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId"
+        ));
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Mock openLinkInBrowser to simulate successful browser launch
+        Mockito.doNothing().when(webViewClient).openLinkInBrowser(any());
+
+        // Act
+        webViewClient.processWebsiteRequest(mockWebView, TEST_WEBSITE_REQUEST_URL);
+
+        // Verify
+        Mockito.verify(webViewClient).openLinkInBrowser(TEST_WEBSITE_REQUEST_URL);
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        assertEquals(CANCELLED, capturedResult.getResultCode());
+    }
+
+    private void testProcessWebsiteRequest_DeviceCaRequest() {
+        // Arrange
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = Mockito.spy(new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId"
+        ));
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+
+        // Mock openLinkInBrowser to simulate successful browser launch
+        Mockito.doNothing().when(webViewClient).openLinkInBrowser(any());
+
+        // Act
+        webViewClient.processWebsiteRequest(mockWebView, TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
+
+        // Assert
+        Mockito.verify(mockWebView).stopLoading();
+        Mockito.verify(webViewClient).openLinkInBrowser(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER);
+
+        // Capture and verify the specific result received in the callback
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        assertEquals(MDM_FLOW, capturedResult.getResultCode());
+    }
+
+    private void testProcessWebsiteRequest_WebCpPlaystoreRedirect() {
+        // Arrange
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId"
+        );
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Mock flight manager to enable WebCP in WebView feature
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(eq(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW))).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+
+        // Mock the isWebCpInWebviewFeatureEnabled method to return true
+        webViewClient.isWebCpInWebviewFeatureEnabled(TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL);
+
+        // Act
+        webViewClient.processWebsiteRequest(mockWebView, TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL);
+
+        // Capture and verify that the callback is invoked with success result
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        // For WebCP playstore redirects, we expect MDM_FLOW result code when successful
+        assertEquals(MDM_FLOW, capturedResult.getResultCode());
+
+        // Cleanup
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    private void testProcessWebsiteRequest_ExceptionHandling() {
+        // Arrange
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = Mockito.spy(new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId"
+        ));
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Mock openLinkInBrowser to throw ActivityNotFoundException to simulate failure
+        Mockito.doThrow(new ActivityNotFoundException("Test: No browser found")).when(webViewClient).openLinkInBrowser(any());
+
+        // Act
+        webViewClient.processWebsiteRequest(mockWebView, TEST_WEBSITE_REQUEST_URL);
+
+        // Verify that openLinkInBrowser was called
+        Mockito.verify(webViewClient).openLinkInBrowser(TEST_WEBSITE_REQUEST_URL);
+
+        // Capture and verify the specific error received in the callback
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        // Verify that the error contains the expected error code when browser launch fails
+        assertEquals("Expected UNEXPECTED_ERROR error code",
+                ErrorStrings.UNEXPECTED_ERROR,
+                ((ClientException) capturedResult.getException()).getErrorCode());
+
+        // Verify that the error message is about browser not found
+        assertTrue("Expected error message about browser not found",
+                capturedResult.getException().getMessage().contains("No browser found to open the link"));
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -489,5 +489,8 @@ public enum AttributeName {
      */
     secret_key_wrapping_operation,
 
-
+    /**
+     * Indicates if the request is a redirect to playstore launch from webcp.
+     */
+    isRedirectToPlaystoreLaunchFromWebCp
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -492,5 +492,5 @@ public enum AttributeName {
     /**
      * Indicates if the request is a redirect to playstore launch from webcp.
      */
-    isRedirectToPlaystoreLaunchFromWebCp
+    is_redirect_to_playstore_launch_from_webcp
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -492,5 +492,10 @@ public enum AttributeName {
     /**
      * Indicates if the request is a redirect to playstore launch from webcp.
      */
-    is_redirect_to_playstore_launch_from_webcp
+    is_redirect_to_playstore_launch_from_webcp,
+
+    /**
+     * Records if current flow is in webcp flow.
+     */
+    is_in_web_cp_flow
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -68,5 +68,6 @@ public enum SpanName {
     WrappedKeyAlgorithmIdentifier,
     ProcessWebCpRedirects,
 
-    ProvisionResourceAccount
+    ProvisionResourceAccount,
+    ProcessWebsiteRequest
 }


### PR DESCRIPTION
Issue : There is a recent change made in WebCP side to pass browser protocol redirects for China market urls, 3rd part MDM urls and also the Url to playstore launch for installing CP. This is an unexpected change on their side and we did not have proper handling for these cases.

Fix : 
1. Added try/catch block around the operations in processWebsiteRequest method.
2. Returning MDM_FLOW as the result instead of CANCELLED result currently being returned when we open link in a browser for webcp urls.
3. Added telemetry for operations in processWebsiteRequest method.
4. Made some minor improvements in AzureActiveDirectoryWebViewClient class to avoid duplicate code for getting broker package name from url.

Related broker with just an attribute added : https://github.com/AzureAD/ad-accounts-for-android/pull/3228

Fixes [AB#3385536](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3385536)