### PR TITLE
Native auth: add new SDK error when auth method is blocked, Fixes AB#3313635

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthMsalController.kt
@@ -482,7 +482,7 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                         correlationId = result.correlationId
                     )
                 }
-                is SignInChallengeApiResult.PasswordRequired -> {
+                is SignInChallengeApiResult.PasswordRequired, is SignInChallengeApiResult.BlockedAuthMethod -> {
                     Logger.warnWithObject(
                         TAG,
                         result.correlationId,
@@ -624,6 +624,16 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                     INativeAuthCommandResult.APIError(
                         error = result.error,
                         errorDescription = result.errorDescription,
+                        errorCodes = result.errorCodes,
+                        correlationId = result.correlationId
+                    )
+                }
+                is SignInChallengeApiResult.BlockedAuthMethod -> {
+                    val customDescription = "Strong authentication method blocked. " +
+                            "Reach out to customer support to seek assistance."
+                    MFACommandResult.BlockedAuthMethod(
+                        error = result.error,
+                        errorDescription = customDescription + result.errorDescription,
                         errorCodes = result.errorCodes,
                         correlationId = result.correlationId
                     )
@@ -1684,9 +1694,6 @@ class NativeAuthMsalController : BaseNativeAuthController() {
         )
     }
 
-
-
-
     private fun performSignInChallengeCall(
         oAuth2Strategy: NativeAuthOAuth2Strategy,
         continuationToken: String,
@@ -2667,6 +2674,21 @@ class NativeAuthMsalController : BaseNativeAuthController() {
                 )
             }
             is SignInChallengeApiResult.UnknownError -> {
+                Logger.warnWithObject(
+                    TAG,
+                    result.correlationId,
+                    "Unexpected result: ",
+                    result
+                )
+                INativeAuthCommandResult.APIError(
+                    error = result.error,
+                    errorDescription = result.errorDescription,
+                    errorCodes = result.errorCodes,
+                    correlationId = result.correlationId
+                )
+            }
+
+            is SignInChallengeApiResult.BlockedAuthMethod -> {
                 Logger.warnWithObject(
                     TAG,
                     result.correlationId,

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -538,7 +538,7 @@ class NativeAuthControllerTest {
 
     // region sign in MFA
     @Test
-    fun `testsignInWithPasswordReturnMFARequired`() {
+    fun testSignInWithPasswordReturnMFARequired() {
         val correlationId = UUID.randomUUID().toString()
         MockApiUtils.configureMockApi(
             endpointType = MockApiEndpoint.SignInChallenge,
@@ -549,6 +549,20 @@ class NativeAuthControllerTest {
         val parameters = createMFAChallengeCommandParameters(correlationId, authMethodId)
         val result = controller.signInChallenge(parameters)
         assert(result is INativeAuthCommandResult.Redirect)
+    }
+
+    @Test
+    fun testTriggerMFAAuthMethodReturnsBlockedResponse() {
+        val correlationId = UUID.randomUUID().toString()
+        MockApiUtils.configureMockApi(
+            endpointType = MockApiEndpoint.SignInChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.AUTH_METHOD_BLOCKED
+        )
+
+        val parameters = createMFAChallengeCommandParameters(correlationId, authMethodId)
+        val result = controller.signInChallenge(parameters)
+        assert(result is MFACommandResult.BlockedAuthMethod)
     }
 
     @Test
@@ -1525,6 +1539,25 @@ class NativeAuthControllerTest {
         )
         val result = controller.jitChallengeAuthMethod(parameters)
         assert(result is JITCommandResult.IncorrectVerificationContact)
+    }
+
+    @Test
+    fun testChallengeJITAuthMethodBlockedVerificationContact() {
+        val correlationId = UUID.randomUUID().toString()
+        MockApiUtils.configureMockApi(
+            endpointType = MockApiEndpoint.JITChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.AUTH_METHOD_BLOCKED
+        )
+
+        val parameters = createJITChallengeAuthMethodCommandParametersCommandParameters(
+            verificationContact = "+353 658894628",
+            authMethodChallengeType = "oob",
+            challengeChannel = "sms",
+            correlationId = correlationId
+        )
+        val result = controller.jitChallengeAuthMethod(parameters)
+        assert(result is JITCommandResult.BlockedVerificationContact)
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -98,7 +98,6 @@ class NativeAuthControllerTest {
     private val defaultScopes: List<String> = AuthenticationConstants.DEFAULT_SCOPES.toList()
     private val scopes: List<String> = listOf("scope1", "scope2", "scope3")
     private val invalidGrantError = "invalid_grant"
-    private val credentialRequiredError = "credential_required"
     private val userNotFoundError = "user_not_found"
     private val continuationToken = "1234"
     private val newPassword = "newPassword".toCharArray()

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/NativeAuthControllerTest.kt
@@ -705,8 +705,7 @@ class NativeAuthControllerTest {
         val result = controller.signInChallenge(parameters)
         assert(result is INativeAuthCommandResult.APIError)
     }
-
-
+    
     @Test
     fun testMFAChallengeExpiredTokenShouldReturnAPIError() {
         val correlationId = UUID.randomUUID().toString()

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/MFACommandResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/MFACommandResult.kt
@@ -42,4 +42,15 @@ interface MFACommandResult {
 
         override fun toString(): String = "VerificationRequired(correlationId=$correlationId, codeLength=$codeLength, challengeChannel=$challengeChannel)"
     }
+
+    data class BlockedAuthMethod(
+        override val correlationId: String,
+        val error: String,
+        val errorDescription: String,
+        val errorCodes: List<Int>
+    ) : MFAChallengeCommandResult {
+        override fun toUnsanitizedString(): String = "BlockedAuthMethod(correlationId=$correlationId, error=$error, errorDescription=$errorDescription, errorCodes=$errorCodes)"
+
+        override fun toString(): String = "BlockedAuthMethod(correlationId=$correlationId)"
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
@@ -26,6 +26,8 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.INativeAuthApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
+import com.microsoft.identity.common.java.nativeauth.util.isBlockedChallengeTarget
+import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
 import com.microsoft.identity.common.java.nativeauth.util.isOOB
 import com.microsoft.identity.common.java.nativeauth.util.isPassword
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
@@ -75,13 +77,24 @@ class SignInChallengeApiResponse(
 
             // Handle 400 errors
             HttpURLConnection.HTTP_BAD_REQUEST -> {
-                SignInChallengeApiResult.UnknownError(
-                    error = error.orEmpty(),
-                    subError = subError.orEmpty(),
-                    errorDescription = errorDescription.orEmpty(),
-                    errorCodes = errorCodes.orEmpty(),
-                    correlationId = correlationId
-                )
+                return when {
+                    error.isInvalidRequest() && errorCodes?.first().isBlockedChallengeTarget() -> {
+                        SignInChallengeApiResult.BlockedAuthMethod(
+                            error = error.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    } else -> {
+                        SignInChallengeApiResult.UnknownError(
+                            error = error.orEmpty(),
+                            subError = subError.orEmpty(),
+                            errorDescription = errorDescription.orEmpty(),
+                            errorCodes = errorCodes.orEmpty(),
+                            correlationId = correlationId
+                        )
+                    }
+                }
             }
             // Handle success and redirect
             HttpURLConnection.HTTP_OK -> {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResult.kt
@@ -56,6 +56,23 @@ sealed interface SignInChallengeApiResult: ApiResult {
                 "challengeChannel=$challengeChannel, codeLength=$codeLength)"
     }
 
+    data class BlockedAuthMethod(
+        override val correlationId: String,
+        override val error: String,
+        override val errorDescription: String,
+        override val errorCodes: List<Int>
+    ) : ApiErrorResult(
+        error = error,
+        errorDescription = errorDescription,
+        errorCodes = errorCodes,
+        correlationId = correlationId
+    ), SignInChallengeApiResult {
+        override fun toUnsanitizedString() = "BlockedAuthMethod(correlationId=$correlationId, " +
+                "error=$error, errorDescription=$errorDescription, subError=$subError)"
+
+        override fun toString(): String = "BlockedAuthMethod(correlationId=$correlationId)"
+    }
+
     data class PasswordRequired(
         override val correlationId: String,
         val continuationToken: String

--- a/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/MockApiResponseType.kt
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/MockApiResponseType.kt
@@ -80,5 +80,6 @@ enum class MockApiResponseType(val stringValue: String) {
     // Typo below on Registraion is expected, on par with Mock API
     REGISTRATION_INTROSPECT_SUCCESS("RegistraionIntrospectSuccess"),
     REGISTRATION_CHALLENGE_SUCCESS("RegistraionChallengeSuccess"),
-    REGISTRATION_INVALID_CHALLENGE_TARGET("RegistraionInvalidChallengeTarget")
+    REGISTRATION_INVALID_CHALLENGE_TARGET("RegistraionInvalidChallengeTarget"),
+    AUTH_METHOD_BLOCKED("AuthMethodBlocked")
 }


### PR DESCRIPTION
This PR adds a new SDK error with instructions when the auth method is blocked during MFA flow.

MSAL PR: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2384

Fixes [AB#3313635](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3313635)