### PR TITLE
Fix for app link redirect from CCT due to forced browser preference, Fixes AB#3387976

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ vNext
 - [MINOR] Awaiting MFA Delegate now automatically returns the AuthMethods to be used when calling MFA Challenge (#2764)
 - [MINOR] SDK now handles SMS as strong authentication method #2766
 - [MINOR] Added error handling when webcp redirects have browser protocol #2767
+- [PATCH] Fix for app link redirect from CCT due to forced browser preference (#2775)
 
 Version 22.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
@@ -147,7 +147,6 @@ class SwitchBrowserActivity : FragmentActivity() {
             Logger.warn(methodTag, "CustomTabsService is NOT supported")
             browserIntent = Intent(Intent.ACTION_VIEW)
         }
-        browserIntent.setPackage(browserPackageName)
         browserIntent.setData(processUri.toUri())
         startActivity(browserIntent)
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
@@ -146,6 +146,7 @@ class SwitchBrowserActivity : FragmentActivity() {
         } else {
             Logger.warn(methodTag, "CustomTabsService is NOT supported")
             browserIntent = Intent(Intent.ACTION_VIEW)
+            browserIntent.setPackage(browserPackageName)
         }
         browserIntent.setData(processUri.toUri())
         startActivity(browserIntent)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/CustomTabsManager.java
@@ -134,7 +134,6 @@ public class CustomTabsManager {
         final CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder(createSession(null));
         builder.setSendToExternalDefaultHandlerEnabled(true);
         mCustomTabsIntent = builder.setShowTitle(true).build();
-        mCustomTabsIntent.intent.setPackage(browserPackage);
         return true;
     }
 


### PR DESCRIPTION
Fixes [AB#3387976](https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3387976)

The previous fix seems to have addressed the issue only partially. 
Previous fix: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2745

Basically what's happening is that even with that flag CCT will sometimes still launch the URL in browser and this is happening because we're setting the browser's pkg name explicitly on the intent which tells the OS that this MUST be opened in the browser.

Checked CCT logs and they print something like:

`Launching in browser as Browser pkg was explicitly set on the Intent`

Once we remove the explicit pkg name then OS finds the best possible app on the device to handle the intent. For an app link that's the the broker hosting app. 