### PR TITLE
[October release cherry-pick] Don't set browser pkg name in CustomTabIntent, Fixes AB#3391792

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Version 23.0.0-RC2
 - [MINOR] SDK now handles SMS as strong authentication method #2766
 - [MINOR] Added error handling when webcp redirects have browser protocol #2767
 - [PATCH] Fix for app link redirect from CCT due to forced browser preference (#2775)
+- [PATCH] Don't set browser pkg name in CustomTabIntent (#2778)
 
 Version 22.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/browser/BrowserAuthorizationStrategy.java
@@ -99,6 +99,7 @@ public abstract class BrowserAuthorizationStrategy<
             if (!mCustomTabManager.bind(context, mBrowser.getPackageName())) {
                 //create browser auth intent
                 authIntent = new Intent(Intent.ACTION_VIEW);
+                authIntent.setPackage(mBrowser.getPackageName());
             } else {
                 authIntent = mCustomTabManager.getCustomTabsIntent().intent;
             }
@@ -109,9 +110,9 @@ public abstract class BrowserAuthorizationStrategy<
             );
             //create browser auth intent
             authIntent = new Intent(Intent.ACTION_VIEW);
+            authIntent.setPackage(mBrowser.getPackageName());
         }
 
-        authIntent.setPackage(mBrowser.getPackageName());
         final URI requestUrl = authorizationRequest.getAuthorizationRequestAsHttpRequest();
 
         authIntent.setData(Uri.parse(requestUrl.toString()));


### PR DESCRIPTION
Fixes [AB#3391792](https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3391792)

Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2775