### PR TITLE
add correlation_id to AcquireTokenResult FixesAB#3389047, Fixes AB#3389047

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 vNext
 ----------
+- [MINOR] Add correlation_id to AcquireTokenResult (#2779)
+
+vNext
+----------
 - [MAJOR] Add KeyStoreBackedSecretKeyProvider (#2674)
 - [MINOR] Add Open Id configuration issuer validation reporting in OpenIdProviderConfigurationClient (#2751)
 - [MINOR] Add helper method to record elapsed time (#2768)

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -253,6 +253,7 @@ public abstract class BaseController {
 
             // Set the AuthenticationResult on the final result object
             acquireTokenResult.setLocalAuthenticationResult(authenticationResult);
+            acquireTokenResult.setCorrelationId(parameters.getCorrelationId());
         }
 
         return acquireTokenResult;

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -32,6 +32,8 @@ public class AcquireTokenResult {
     private ILocalAuthenticationResult mLocalAuthenticationResult;
     private TokenResult mTokenResult;
 
+    private String mCorrelationId;
+
     @SuppressWarnings(WarningType.rawtype_warning)
     private AuthorizationResult mAuthorizationResult;
 
@@ -66,6 +68,14 @@ public class AcquireTokenResult {
 
     public Boolean getSucceeded() {
         return mSucceeded;
+    }
+
+    public String getCorrelationId() {
+        return mCorrelationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.mCorrelationId = correlationId;
     }
 
 }


### PR DESCRIPTION
This PR adds a parameter correlation_id to the AcquireTokenResult so MATS telemetry can be joined with Broker telemetry. Fixes [AB#3389047](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3389047)