### PR TITLE
Take flight value for whether to show webcp flow in weview or not in brokerless scenarios. Fixes AB#3407952

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ vNext
 - [PATCH] Fix for app link redirect from CCT due to forced browser preference (#2775)
 - [MINOR] getAllSsoTokens method for Edge (#2774)
 - [MINOR] WebApps AccountId Registry (#2787)
+- [MINOR] Take flight value for whether to show webcp flow in weview or not in brokerless scenarios. (#2784)
 
 Version 22.1.3
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -2054,6 +2054,8 @@ public final class AuthenticationConstants {
 
         public static final String WEB_VIEW_ZOOM_ENABLED = "com.microsoft.identity.web.view.zoom.enabled";
 
+        public static final String WEB_VIEW_WEBCP_ENABLED = "com.microsoft.identity.web.view.webcp.enabled";
+
         public static final String OTEL_CONTEXT_CARRIER = "otel_context_carrier";
 
         public static final String WEB_VIEW_SILENT_AUTHORIZATION_FLOW_TIMEOUT = "com.microsoft.identity.web.view.silent.authorization.flow.timeout";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -2054,7 +2054,7 @@ public final class AuthenticationConstants {
 
         public static final String WEB_VIEW_ZOOM_ENABLED = "com.microsoft.identity.web.view.zoom.enabled";
 
-        public static final String WEB_VIEW_WEBCP_ENABLED = "com.microsoft.identity.web.view.webcp.enabled";
+        public static final String WEB_VIEW_WEB_CP_ENABLED = "com.microsoft.identity.web.view.web.cp.enabled";
 
         public static final String OTEL_CONTEXT_CARRIER = "otel_context_carrier";
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -111,6 +111,10 @@ object AuthorizationActivityFactory {
                 parameters.webViewZoomEnabled
             )
             putExtra(
+                AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEBCP_ENABLED,
+                parameters.webViewWebcpEnabled
+            )
+            putExtra(
                 DiagnosticContext.CORRELATION_ID,
                 DiagnosticContext.INSTANCE.requestContext[DiagnosticContext.CORRELATION_ID]
             )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -111,8 +111,8 @@ object AuthorizationActivityFactory {
                 parameters.webViewZoomEnabled
             )
             putExtra(
-                AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEBCP_ENABLED,
-                parameters.isWebViewWebcpEnabledInBrokerlessCase
+                AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEB_CP_ENABLED,
+                parameters.isWebViewWebCpEnabled
             )
             putExtra(
                 DiagnosticContext.CORRELATION_ID,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -112,7 +112,7 @@ object AuthorizationActivityFactory {
             )
             putExtra(
                 AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEBCP_ENABLED,
-                parameters.webViewWebcpEnabled
+                parameters.isWebViewWebcpEnabledInBrokerlessCase
             )
             putExtra(
                 DiagnosticContext.CORRELATION_ID,

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -41,7 +41,7 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent
  * @param sourceLibraryVersion       Product version to be of library making the request
  * @param utid                       The tenant unique id, if applicable
  * @param webViewEnableSilentAuthorizationFlowTimeOutMs                 If set to a non-null value, this indicates that the flow is silent and specifies the timeout for the silent authorization flow in milliseconds.
- * @param webViewWebcpEnabled        This parameter controls whether webcp URLs should be handled within the WebView or redirected to external browser
+ * @param isWebViewWebCpEnabled        This parameter controls whether webcp URLs should be handled within the WebView or redirected to external browser
  */
 data class AuthorizationActivityParameters @JvmOverloads constructor(
     val context: Context,
@@ -59,5 +59,5 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
      */
     val utid: String? = null,
     val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null,
-    val isWebViewWebcpEnabledInBrokerlessCase: Boolean = false,
+    val isWebViewWebCpEnabled: Boolean = false,
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -41,6 +41,7 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent
  * @param sourceLibraryVersion       Product version to be of library making the request
  * @param utid                       The tenant unique id, if applicable
  * @param webViewEnableSilentAuthorizationFlowTimeOutMs                 If set to a non-null value, this indicates that the flow is silent and specifies the timeout for the silent authorization flow in milliseconds.
+ * @param webViewWebcpEnabled        This parameter controls whether webcp URLs should be handled within the WebView or redirected to external browser
  */
 data class AuthorizationActivityParameters @JvmOverloads constructor(
     val context: Context,
@@ -57,5 +58,6 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
      * The tenant unique id
      */
     val utid: String? = null,
-    val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null
+    val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null,
+    val webViewWebcpEnabled: Boolean = true,
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -59,5 +59,5 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
      */
     val utid: String? = null,
     val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null,
-    val webViewWebcpEnabled: Boolean = true,
+    val webViewWebcpEnabled: Boolean = false,
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -59,5 +59,5 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
      */
     val utid: String? = null,
     val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null,
-    val webViewWebcpEnabled: Boolean = false,
+    val isWebViewWebcpEnabledInBrokerlessCase: Boolean = false,
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -223,7 +223,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
-        webViewWebcpEnabled = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, true);
+        webViewWebcpEnabled = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, false);
         mUtid = state.getString(UTID);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -29,6 +29,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEBCP_ENABLED;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
 
@@ -117,6 +118,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private boolean webViewZoomEnabled;
 
+    private boolean webViewWebcpEnabled;
+
     private String mUtid;
 
     private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
@@ -201,6 +204,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
+        outState.putBoolean(WEB_VIEW_WEBCP_ENABLED, webViewWebcpEnabled);
         outState.putString(UTID, mUtid);
     }
 
@@ -219,6 +223,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
+        webViewWebcpEnabled = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, true);
         mUtid = state.getString(UTID);
     }
 
@@ -258,7 +263,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 },
                 mRedirectUri,
                 getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
-                mUtid
+                mUtid,
+                webViewWebcpEnabled
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -118,7 +118,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private boolean webViewZoomEnabled;
 
-    private boolean webViewWebcpEnabled;
+    private boolean isWebViewWebcpEnabledInBrokerlessCase;
 
     private String mUtid;
 
@@ -204,7 +204,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
-        outState.putBoolean(WEB_VIEW_WEBCP_ENABLED, webViewWebcpEnabled);
+        outState.putBoolean(WEB_VIEW_WEBCP_ENABLED, isWebViewWebcpEnabledInBrokerlessCase);
         outState.putString(UTID, mUtid);
     }
 
@@ -223,7 +223,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
-        webViewWebcpEnabled = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, false);
+        isWebViewWebcpEnabledInBrokerlessCase = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, false);
         mUtid = state.getString(UTID);
     }
 
@@ -264,7 +264,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 mRedirectUri,
                 getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
                 mUtid,
-                webViewWebcpEnabled
+                isWebViewWebcpEnabledInBrokerlessCase
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -29,7 +29,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_ZOOM_ENABLED;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEBCP_ENABLED;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.WEB_VIEW_WEB_CP_ENABLED;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.PRODUCT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlatformFields.VERSION;
 
@@ -204,7 +204,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         outState.putSerializable(POST_PAGE_LOADED_URL, mPostPageLoadedJavascript);
         outState.putBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, webViewZoomControlsEnabled);
         outState.putBoolean(WEB_VIEW_ZOOM_ENABLED, webViewZoomEnabled);
-        outState.putBoolean(WEB_VIEW_WEBCP_ENABLED, isWebViewWebcpEnabledInBrokerlessCase);
+        outState.putBoolean(WEB_VIEW_WEB_CP_ENABLED, isWebViewWebcpEnabledInBrokerlessCase);
         outState.putString(UTID, mUtid);
     }
 
@@ -223,7 +223,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mPostPageLoadedJavascript = state.getString(POST_PAGE_LOADED_URL);
         webViewZoomEnabled = state.getBoolean(WEB_VIEW_ZOOM_ENABLED, true);
         webViewZoomControlsEnabled = state.getBoolean(WEB_VIEW_ZOOM_CONTROLS_ENABLED, true);
-        isWebViewWebcpEnabledInBrokerlessCase = state.getBoolean(WEB_VIEW_WEBCP_ENABLED, false);
+        isWebViewWebcpEnabledInBrokerlessCase = state.getBoolean(WEB_VIEW_WEB_CP_ENABLED, false);
         mUtid = state.getString(UTID);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -710,12 +710,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
         try {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
-                if (mIsWebViewWebCpEnabledInBrokerlessCase) {
-                    mInWebCpFlow = true;
-                } else {
-                    // Disabled webcp in webview feature for brokerless flows for now.
-                    Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
-                }
+                mInWebCpFlow = mIsWebViewWebCpEnabledInBrokerlessCase;
+                Logger.info(methodTag, "Not running on AuthService, WebCP in WebView feature enabled? "+ mIsWebViewWebCpEnabledInBrokerlessCase);
                 return mInWebCpFlow;
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -711,8 +711,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
                 // Enabling webcp in webview feature for brokered flows only for now.
                 Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
-                if (mShouldHandleWebCpInWebView)
+                if (mShouldHandleWebCpInWebView) {
                     mInWebCpFlow = true;
+                }
                 return mShouldHandleWebCpInWebView;
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -136,7 +136,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private String mRequestUrl;
     private boolean mInWebCpFlow = false;
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
-    private final boolean mShouldHandleWebCpInWebView;
+    // Determines whether to handle WebCP requests in the WebView in brokerless scenarios.
+    private final boolean mIsWebViewWebcpEnabledInBrokerlessCase;
 
 
     private final String mUtid;
@@ -147,13 +148,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
                                              @Nullable final String utid,
-                                             final boolean webViewWebcpEnabled) {
+                                             final boolean isWebViewWebcpEnabledInBrokerlessCase) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
         mUtid = utid;
-        mShouldHandleWebCpInWebView = webViewWebcpEnabled;
+        mIsWebViewWebcpEnabledInBrokerlessCase = isWebViewWebcpEnabledInBrokerlessCase;
     }
 
     /**
@@ -709,12 +710,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
         try {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
-                // Enabling webcp in webview feature for brokered flows only for now.
-                Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
-                if (mShouldHandleWebCpInWebView) {
+                if (mIsWebViewWebcpEnabledInBrokerlessCase) {
                     mInWebCpFlow = true;
+                } else {
+                    // Enabling webcp in webview feature for brokered flows only for now.
+                    Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
                 }
-                return mShouldHandleWebCpInWebView;
+                return mInWebCpFlow;
             }
 
             final String homeTenantId = !StringUtil.isNullOrEmpty(mUtid)? mUtid : getHomeTenantIdFromUrl(originalUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -137,7 +137,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private boolean mInWebCpFlow = false;
     private boolean mAuthUxJavaScriptInterfaceAdded = false;
     // Determines whether to handle WebCP requests in the WebView in brokerless scenarios.
-    private final boolean mIsWebViewWebcpEnabledInBrokerlessCase;
+    private final boolean mIsWebViewWebCpEnabledInBrokerlessCase;
 
 
     private final String mUtid;
@@ -148,13 +148,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
                                              @Nullable final String utid,
-                                             final boolean isWebViewWebcpEnabledInBrokerlessCase) {
+                                             final boolean isWebViewWebCpEnabledInBrokerlessCase) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
         mUtid = utid;
-        mIsWebViewWebcpEnabledInBrokerlessCase = isWebViewWebcpEnabledInBrokerlessCase;
+        mIsWebViewWebCpEnabledInBrokerlessCase = isWebViewWebCpEnabledInBrokerlessCase;
     }
 
     /**
@@ -710,10 +710,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String methodTag = TAG + ":isWebCpInWebviewFeatureEnabled";
         try {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
-                if (mIsWebViewWebcpEnabledInBrokerlessCase) {
+                if (mIsWebViewWebCpEnabledInBrokerlessCase) {
                     mInWebCpFlow = true;
                 } else {
-                    // Enabling webcp in webview feature for brokered flows only for now.
+                    // Disabled webcp in webview feature for brokerless flows for now.
                     Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
                 }
                 return mInWebCpFlow;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -135,6 +135,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private HashMap<String, String> mRequestHeaders;
     private String mRequestUrl;
     private boolean mInWebCpFlow = false;
+    private boolean mAuthUxJavaScriptInterfaceAdded = false;
+    private final boolean mShouldHandleWebCpInWebView;
+
 
     private final String mUtid;
 
@@ -143,12 +146,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @NonNull final OnPageLoadedCallback pageLoadedCallback,
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
-                                             @Nullable final String utid) {
+                                             @Nullable final String utid,
+                                             final boolean webViewWebcpEnabled) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserRequestHandler = switchBrowserRequestHandler;
         mUtid = utid;
+        mShouldHandleWebCpInWebView = webViewWebcpEnabled;
     }
 
     /**
@@ -706,7 +711,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             if (!ProcessUtil.isRunningOnAuthService(getActivity().getApplicationContext())) {
                 // Enabling webcp in webview feature for brokered flows only for now.
                 Logger.info(methodTag, "Not running on AuthService, skipping WebCP in WebView feature check.");
-                return false;
+                if (mShouldHandleWebCpInWebView)
+                    mInWebCpFlow = true;
+                return mShouldHandleWebCpInWebView;
             }
 
             final String homeTenantId = !StringUtil.isNullOrEmpty(mUtid)? mUtid : getHomeTenantIdFromUrl(originalUrl);

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -148,7 +148,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 },
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId");
+                "homeTenantId",
+                false);
         HashMap<String, String> dummyHeaders = new HashMap<>();
         dummyHeaders.put("key", "value");
         mWebViewClient.setRequestHeaders(dummyHeaders);
@@ -374,6 +375,46 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     @Test
+    public void testLoadDeviceCaUrlInWebviewInBrokelessFlow() {
+        // Mocks
+        final WebView mockWebview = Mockito.mock(WebView.class);
+        final AzureActiveDirectoryWebViewClient mockWebViewClient  = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                new IAuthorizationCompletionCallback() {
+                    @Override
+                    public void onChallengeResponseReceived(@NonNull RawAuthorizationResult response) {
+
+                    }
+
+                    @Override
+                    public void setPKeyAuthStatus(boolean status) {
+                        return;
+                    }
+                },
+                new OnPageLoadedCallback() {
+                    @Override
+                    public void onPageLoaded(final String url) {
+                        return;
+                    }
+                },
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                true);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEB_CP_IN_WEBVIEW)).thenReturn(true);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+        // Actual call
+        mockWebViewClient.loadDeviceCaUrl(TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER, mockWebview);
+        // Verify
+        Mockito.verify(mockFlightsProvider, Mockito.never()).isFlightEnabled(Mockito.any());
+        Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
+    }
+
+    @Test
     public void testProcessCloudRedirectAndPrtHeaderInternalSuccess() {
         ReAttachPrtHeaderHandler mockCrossCloudChallengeHandler = Mockito.mock(ReAttachPrtHeaderHandler.class);
         try {
@@ -431,7 +472,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                     },
                     TEST_REDIRECT_URI,
                     Mockito.mock(SwitchBrowserRequestHandler.class),
-                    "homeTenantId");
+                    "homeTenantId",
+                    false);
             mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL);
         } catch (ClassCastException e) {
             Assert.fail("Failure is not expected. The class checks should have prevented this." + e);
@@ -453,7 +495,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId");
+                "homeTenantId",
+                false);
         final WebView mockWebView = new WebView(mContext);
         mockWebView.setWebViewClient(mockWebViewClient);
 
@@ -481,7 +524,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId"
+                "homeTenantId",
+                false
         );
         final WebView mockWebView = new WebView(mContext);
         mockWebView.setWebViewClient(mockWebViewClient);
@@ -522,7 +566,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId"
+                "homeTenantId",
+                false
         ));
         final WebView mockWebView = Mockito.mock(WebView.class);
 
@@ -549,7 +594,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId"
+                "homeTenantId",
+                false
         ));
         final WebView mockWebView = Mockito.mock(WebView.class);
 
@@ -581,7 +627,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId"
+                "homeTenantId",
+                false
         );
         final WebView mockWebView = Mockito.mock(WebView.class);
 
@@ -620,7 +667,8 @@ public class AzureActiveDirectoryWebViewClientTest {
                 url -> {},
                 TEST_REDIRECT_URI,
                 Mockito.mock(SwitchBrowserRequestHandler.class),
-                "homeTenantId"
+                "homeTenantId",
+                false
         ));
         final WebView mockWebView = Mockito.mock(WebView.class);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -144,7 +144,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Web CP in WebView.
      */
-    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", true),
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false),
 
     /**
      * Flight to enable the Playstore URL launch for broker apps.

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -144,7 +144,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the Web CP in WebView.
      */
-    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", false),
+    ENABLE_WEB_CP_IN_WEBVIEW("EnableWebCpInWebView", true),
 
     /**
      * Flight to enable the Playstore URL launch for broker apps.


### PR DESCRIPTION
1. In brokerless scenarios, we cannot control flighting the features.
2. WebCp in webview feature is planned to be first rolled out in brokered scenarios using flighting (slowing going from 25 to 100% in 4 weeks)
3. Once we complete step 2 above, we want to enable the feature by default in brokerless scenarios as well.
4. But in case there are any issues found, we also want to be able to provide a kill switch to calling apps to turn the feature off.
5. This PR takes a boolean value from OneAuth to decide whether to show webcp in webview or not.
6. Changes are made in OneAuth side as well for passing the value.

Fixes [AB#3407952](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3407952)