### PR TITLE
Web Apps account id registry, Fixes AB#3406762

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ vNext
 - [MINOR] Added error handling when webcp redirects have browser protocol #2767
 - [PATCH] Fix for app link redirect from CCT due to forced browser preference (#2775)
 - [MINOR] getAllSsoTokens method for Edge (#2774)
+- [MINOR] WebApps AccountId Registry (#2787)
 
 Version 22.1.3
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -27,6 +27,7 @@ import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage
 import com.microsoft.identity.common.java.interfaces.IStorageSupplier
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.logging.Logger
+import com.squareup.moshi.Json
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
@@ -43,7 +44,6 @@ class WebAppsAccountIdRegistry private constructor(
     companion object {
         private val TAG = WebAppsAccountIdRegistry::class.java.simpleName
         private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
-        private const val MAP_JSON_KEY = "MapJsonKey"
         private val rwLock = ReentrantReadWriteLock()
 
         /**
@@ -58,41 +58,64 @@ class WebAppsAccountIdRegistry private constructor(
         }
     }
 
-    // So we can more easily serialize/deserialize the entire map.
-    private data class Container(
-        val accounts: MutableMap<String, MutableSet<String>> = mutableMapOf()
-    )
-
     /**
-     * Load the registry from storage.
+     * Deserialize a JSON string into a set of client IDs.
      *
-     * @return The current mapping of account IDs to sets of client IDs.
+     * @param raw The JSON string to deserialize.
+     * @return A mutable set of client IDs.
      */
-    private fun load(): MutableMap<String, MutableSet<String>> {
-        val methodTag = "$TAG:load"
-        val raw = storage.getString(MAP_JSON_KEY)
-        val map = if (!raw.isNullOrBlank()) {
-            try {
-                ObjectMapper.deserializeJsonStringToObject(raw, Container::class.java).accounts
-            } catch (e: Exception) {
-                Logger.warn(methodTag, "Failed to deserialize existing registry: ${e.message}.")
-                mutableMapOf()
-            }
-        } else {
-            Logger.info(methodTag, "No existing registry, creating a new one.")
-            mutableMapOf()
+    private fun deserializeSet(raw: String?): MutableSet<String> {
+        if (raw.isNullOrBlank()) return mutableSetOf()
+        return try {
+            ObjectMapper.deserializeJsonStringToObject(raw, Array<String>::class.java).toMutableSet()
+        } catch (e: Exception) {
+            Logger.warn(TAG, "Failed to deserialize set: ${e.message}")
+            mutableSetOf()
         }
-        return map
     }
 
     /**
-     * Save the current registry state to storage.
+     * Serialize the set of client IDs to a JSON string.
      *
-     * @param current The mapping of account IDs to sets of client IDs to save.
+     * @param set The set of client IDs to serialize.
+     * @return The JSON string representation of the set.
      */
-    private fun save(current: Map<String, MutableSet<String>>) {
-        val json = ObjectMapper.serializeObjectToJsonString(Container(current.toMutableMap()))
-        storage.putString(MAP_JSON_KEY, json)
+    private fun serializeSet(set: Set<String>): String {
+        return ObjectMapper.serializeObjectToJsonString(set)
+    }
+
+    /**
+     * Load the account entry from storage.
+     *
+     * @param accountId The account ID to load.
+     * @return A set of client IDs associated with the given account ID. Or an empty set if none exist.
+     */
+    private fun loadAccount(accountId: String): MutableSet<String>{
+        return deserializeSet(storage.getString(accountId))
+    }
+
+    /**
+     * Save the account entry to storage.
+     *
+     * @param accountId The account ID.
+     * @param set The set of client IDs to associate with the account ID.
+     */
+    private fun saveAccount(accountId: String, set: Set<String>) {
+        storage.putString(accountId, serializeSet(set))
+    }
+
+
+    /**
+     * Remove the account entry from storage.
+     *
+     * @param accountId The account ID to remove.
+     */
+    private fun removeAccountStorage(accountId: String) {
+        try {
+            storage.remove(accountId)
+        } catch (e: Exception) {
+            storage.putString(accountId, null)
+        }
     }
 
     /**
@@ -103,12 +126,12 @@ class WebAppsAccountIdRegistry private constructor(
      */
     fun addClient(accountId: String, clientId: String) {
         rwLock.write {
-            val map = load()
-            val set = map.getOrPut(accountId) { mutableSetOf() }
-            if (set.add(clientId)) save(map)
+            val set = loadAccount(accountId)
+            if (set.add(clientId)) {
+                saveAccount(accountId, set)
+            }
         }
     }
-
     /**
      * Remove a client ID from the set associated with the given account ID.
      * If the set becomes empty after removal, the account ID is also removed from the registry.
@@ -118,11 +141,12 @@ class WebAppsAccountIdRegistry private constructor(
      */
     fun removeClient(accountId: String, clientId: String) {
         rwLock.write {
-            val map = load()
-            val set = map[accountId] ?: return
-            if (set.remove(clientId)) {
-                if (set.isEmpty()) map.remove(accountId)
-                save(map)
+            val set = loadAccount(accountId)
+            if (!set.remove(clientId)) return
+            if (set.isEmpty()) {
+                removeAccountStorage(accountId)
+            } else {
+                saveAccount(accountId, set)
             }
         }
     }
@@ -134,8 +158,7 @@ class WebAppsAccountIdRegistry private constructor(
      */
     fun getClients(accountId: String): Set<String> {
         return rwLock.read {
-            val map = load()
-            map[accountId]?.toSet() ?: emptySet()
+            loadAccount(accountId).toSet()
         }
     }
 
@@ -147,25 +170,20 @@ class WebAppsAccountIdRegistry private constructor(
      */
     fun contains(accountId: String, clientId: String): Boolean {
         return rwLock.read {
-            val map = load()
-            map[accountId]?.contains(clientId) == true
+            loadAccount(accountId).contains(clientId)
         }
     }
 
     /**
      * Remove the given account ID and all its associated client IDs from the registry.
+     *
+     * @param accountId The account ID to remove.
      */
     fun removeAccount(accountId: String) {
         rwLock.write {
-            val map = load()
-            if (map.remove(accountId) != null) save(map)
-        }
-    }
-
-    @VisibleForTesting
-    fun getAll(): Map<String, Set<String>> {
-        rwLock.read {
-            return load().mapValues { it.value.toSet() }
+            val set = loadAccount(accountId)
+            if (set.isEmpty()) return
+            removeAccountStorage(accountId)
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -22,12 +22,10 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.cache
 
-import androidx.annotation.VisibleForTesting
 import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage
 import com.microsoft.identity.common.java.interfaces.IStorageSupplier
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.logging.Logger
-import com.squareup.moshi.Json
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache
+
+import androidx.annotation.VisibleForTesting
+import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage
+import com.microsoft.identity.common.java.interfaces.IStorageSupplier
+import com.microsoft.identity.common.java.util.ObjectMapper
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * A registry that maps account IDs to sets of web app client IDs.
+ *
+ * This is used to track which web applications are associated with which accounts,
+ * enabling coordinated sign-out and management of web app sessions.
+ */
+class WebAppsAccountIdRegistry private constructor(
+    private val storage: IMultiTypeNameValueStorage
+){
+    private val TAG = WebAppsAccountIdRegistry::class.java.simpleName
+    private val MAP_JSON_KEY = "MapJsonKey"
+    private val lock = Any()
+
+    @Volatile
+    private var cache: MutableMap<String, MutableSet<String>>? = null
+
+    // So we can more easily serialize/deserialize the entire map.
+    private data class Container(
+        val accounts: MutableMap<String, MutableSet<String>> = mutableMapOf()
+    )
+
+    /**
+     * Load the registry from storage, or return the cached version if already loaded.
+     *
+     * @return The current mapping of account IDs to sets of client IDs.
+     */
+    private fun load(): MutableMap<String, MutableSet<String>> {
+        val methodTag = "$TAG:load"
+        cache?.let { return it }
+        val raw = storage.getString(MAP_JSON_KEY)
+        val map = if (!raw.isNullOrBlank()) {
+            try {
+                ObjectMapper.deserializeJsonStringToObject(raw, Container::class.java).accounts
+            } catch (e: Exception) {
+                Logger.warn(methodTag, "Failed to deserialize existing registry: ${e.message}.")
+                mutableMapOf()
+            }
+        } else {
+            Logger.info(methodTag, "No existing registry, creating a new one.")
+            mutableMapOf()
+        }
+        cache = map
+        return map
+    }
+
+    /**
+     * Save the current registry state to storage.
+     *
+     * @param current The mapping of account IDs to sets of client IDs to save.
+     */
+    private fun save(current: Map<String, MutableSet<String>>) {
+        val json = ObjectMapper.serializeObjectToJsonString(Container(current.toMutableMap()))
+        storage.putString(MAP_JSON_KEY, json)
+    }
+
+    /**
+     * Add a client ID to the set associated with the given account ID.
+     *
+     * @param accountId The account ID.
+     * @param clientId The client ID to add.
+     */
+    fun addClient(accountId: String, clientId: String) {
+        synchronized(lock) {
+            val map = load()
+            val set = map.getOrPut(accountId) { mutableSetOf() }
+            if (set.add(clientId)) save(map)
+        }
+    }
+
+    /**
+     * Remove a client ID from the set associated with the given account ID.
+     * If the set becomes empty after removal, the account ID is also removed from the registry.
+     *
+     * @param accountId The account ID.
+     * @param clientId The client ID to remove.
+     */
+    fun removeClient(accountId: String, clientId: String) {
+        synchronized(lock) {
+            val map = load()
+            val set = map[accountId] ?: return
+            if (set.remove(clientId)) {
+                if (set.isEmpty()) map.remove(accountId)
+                save(map)
+            }
+        }
+    }
+
+    /** Get the set of client IDs associated with the given account ID.
+     *
+     * @param accountId The account ID.
+     * @return A set of client IDs associated with the account ID, or an empty set if none exist.
+     */
+    fun getClients(accountId: String): Set<String> {
+        synchronized(lock) {
+            val map = load()
+            return map[accountId]?.toSet() ?: emptySet()
+        }
+    }
+
+    /** Check if the registry contains the given client ID for the specified account ID.
+     *
+     * @param accountId The account ID.
+     * @param clientId The client ID to check for.
+     * @return True if the client ID is associated with the account ID, false otherwise.
+     */
+    fun contains(accountId: String, clientId: String): Boolean {
+        synchronized(lock) {
+            val map = load()
+            return map[accountId]?.contains(clientId) == true
+        }
+    }
+
+    /**
+     * Remove the given account ID and all its associated client IDs from the registry.
+     */
+    fun removeAccount(accountId: String) {
+        synchronized(lock) {
+            val map = load()
+            if (map.remove(accountId) != null) save(map)
+        }
+    }
+
+    /**
+     * Clear the in-memory cache and reload the registry from storage.
+     * This is useful for testing or if the underlying storage may have changed externally.
+     */
+    fun refresh() {
+        synchronized(lock) {
+            cache = null
+            load()
+        }
+    }
+
+    @VisibleForTesting
+    fun getAll(): Map<String, Set<String>> =
+        synchronized(lock) { load().mapValues { it.value.toSet() } }
+
+    companion object {
+        private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
+
+        /**
+         * Factory method to create an instance of [WebAppsAccountIdRegistry].
+         *
+         * @param supplier The storage supplier.
+         * @return A new instance of [WebAppsAccountIdRegistry].
+         */
+        fun create(supplier: IStorageSupplier): WebAppsAccountIdRegistry {
+            val store = supplier.getEncryptedFileStore(WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY)
+            return WebAppsAccountIdRegistry(store)
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -31,7 +31,7 @@ import kotlin.concurrent.read
 import kotlin.concurrent.write
 
 /**
- * A registry that maps account IDs to sets of web app client IDs.
+ * A registry that maps home account IDs to sets of web app client IDs.
  *
  * This is used to track which web applications are associated with which accounts,
  * enabling coordinated sign-out and management of web app sessions.
@@ -85,48 +85,48 @@ class WebAppsAccountIdRegistry private constructor(
     /**
      * Load the account entry from storage.
      *
-     * @param accountId The account ID to load.
+     * @param homeAccountId The home account ID to load.
      * @return A set of client IDs associated with the given account ID. Or an empty set if none exist.
      */
-    private fun loadAccount(accountId: String): MutableSet<String>{
-        return deserializeSet(storage.getString(accountId))
+    private fun loadClientIdsForAccount(homeAccountId: String): MutableSet<String>{
+        return deserializeSet(storage.getString(homeAccountId))
     }
 
     /**
      * Save the account entry to storage.
      *
-     * @param accountId The account ID.
+     * @param homeAccountId The home account ID.
      * @param set The set of client IDs to associate with the account ID.
      */
-    private fun saveAccount(accountId: String, set: Set<String>) {
-        storage.putString(accountId, serializeSet(set))
+    private fun saveAccount(homeAccountId: String, set: Set<String>) {
+        storage.putString(homeAccountId, serializeSet(set))
     }
 
 
     /**
      * Remove the account entry from storage.
      *
-     * @param accountId The account ID to remove.
+     * @param homeAccountId The account ID to remove.
      */
-    private fun removeAccountStorage(accountId: String) {
+    private fun removeAccountStorage(homeAccountId: String) {
         try {
-            storage.remove(accountId)
+            storage.remove(homeAccountId)
         } catch (e: Exception) {
-            storage.putString(accountId, null)
+            storage.putString(homeAccountId, null)
         }
     }
 
     /**
      * Add a client ID to the set associated with the given account ID.
      *
-     * @param accountId The account ID.
+     * @param homeAccountId The account ID.
      * @param clientId The client ID to add.
      */
-    fun addClient(accountId: String, clientId: String) {
+    fun addClient(homeAccountId: String, clientId: String) {
         rwLock.write {
-            val set = loadAccount(accountId)
+            val set = loadClientIdsForAccount(homeAccountId)
             if (set.add(clientId)) {
-                saveAccount(accountId, set)
+                saveAccount(homeAccountId, set)
             }
         }
     }
@@ -134,54 +134,54 @@ class WebAppsAccountIdRegistry private constructor(
      * Remove a client ID from the set associated with the given account ID.
      * If the set becomes empty after removal, the account ID is also removed from the registry.
      *
-     * @param accountId The account ID.
+     * @param homeAccountId The account ID.
      * @param clientId The client ID to remove.
      */
-    fun removeClient(accountId: String, clientId: String) {
+    fun removeClient(homeAccountId: String, clientId: String) {
         rwLock.write {
-            val set = loadAccount(accountId)
+            val set = loadClientIdsForAccount(homeAccountId)
             if (!set.remove(clientId)) return
             if (set.isEmpty()) {
-                removeAccountStorage(accountId)
+                removeAccountStorage(homeAccountId)
             } else {
-                saveAccount(accountId, set)
+                saveAccount(homeAccountId, set)
             }
         }
     }
 
     /** Get the set of client IDs associated with the given account ID.
      *
-     * @param accountId The account ID.
+     * @param homeAccountId The account ID.
      * @return A set of client IDs associated with the account ID, or an empty set if none exist.
      */
-    fun getClients(accountId: String): Set<String> {
+    fun getClients(homeAccountId: String): Set<String> {
         return rwLock.read {
-            loadAccount(accountId).toSet()
+            loadClientIdsForAccount(homeAccountId).toSet()
         }
     }
 
     /** Check if the registry contains the given client ID for the specified account ID.
      *
-     * @param accountId The account ID.
+     * @param homeAccountId The account ID.
      * @param clientId The client ID to check for.
      * @return True if the client ID is associated with the account ID, false otherwise.
      */
-    fun contains(accountId: String, clientId: String): Boolean {
+    fun contains(homeAccountId: String, clientId: String): Boolean {
         return rwLock.read {
-            loadAccount(accountId).contains(clientId)
+            loadClientIdsForAccount(homeAccountId).contains(clientId)
         }
     }
 
     /**
      * Remove the given account ID and all its associated client IDs from the registry.
      *
-     * @param accountId The account ID to remove.
+     * @param homeAccountId The account ID to remove.
      */
-    fun removeAccount(accountId: String) {
+    fun removeAccount(homeAccountId: String) {
         rwLock.write {
-            val set = loadAccount(accountId)
+            val set = loadClientIdsForAccount(homeAccountId)
             if (set.isEmpty()) return
-            removeAccountStorage(accountId)
+            removeAccountStorage(homeAccountId)
         }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -45,8 +45,6 @@ class WebAppsAccountIdRegistry private constructor(
         private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
         private const val MAP_JSON_KEY = "MapJsonKey"
         private val rwLock = ReentrantReadWriteLock()
-        @Volatile
-        private var cache: MutableMap<String, MutableSet<String>>? = null
 
         /**
          * Factory method to create an instance of [WebAppsAccountIdRegistry].
@@ -66,13 +64,12 @@ class WebAppsAccountIdRegistry private constructor(
     )
 
     /**
-     * Load the registry from storage, or return the cached version if already loaded.
+     * Load the registry from storage.
      *
      * @return The current mapping of account IDs to sets of client IDs.
      */
     private fun load(): MutableMap<String, MutableSet<String>> {
         val methodTag = "$TAG:load"
-        cache?.let { return it }
         val raw = storage.getString(MAP_JSON_KEY)
         val map = if (!raw.isNullOrBlank()) {
             try {
@@ -85,7 +82,6 @@ class WebAppsAccountIdRegistry private constructor(
             Logger.info(methodTag, "No existing registry, creating a new one.")
             mutableMapOf()
         }
-        cache = map
         return map
     }
 
@@ -163,17 +159,6 @@ class WebAppsAccountIdRegistry private constructor(
         rwLock.write {
             val map = load()
             if (map.remove(accountId) != null) save(map)
-        }
-    }
-
-    /**
-     * Clear the in-memory cache and reload the registry from storage.
-     * This is useful for testing or if the underlying storage may have changed externally.
-     */
-    fun refresh() {
-        rwLock.write {
-            cache = null
-            load()
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -162,8 +162,11 @@ class WebAppsAccountIdRegistry private constructor(
     }
 
     @VisibleForTesting
-    fun getAll(): Map<String, Set<String>> =
-        synchronized(lock) { load().mapValues { it.value.toSet() } }
+    fun getAll(): Map<String, Set<String>> {
+        synchronized(lock) {
+            return load().mapValues { it.value.toSet() }
+        }
+    }
 
     companion object {
         private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -27,6 +27,9 @@ import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage
 import com.microsoft.identity.common.java.interfaces.IStorageSupplier
 import com.microsoft.identity.common.java.util.ObjectMapper
 import com.microsoft.identity.common.logging.Logger
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 /**
  * A registry that maps account IDs to sets of web app client IDs.
@@ -37,12 +40,13 @@ import com.microsoft.identity.common.logging.Logger
 class WebAppsAccountIdRegistry private constructor(
     private val storage: IMultiTypeNameValueStorage
 ){
-    private val lock = Any()
-
     companion object {
         private val TAG = WebAppsAccountIdRegistry::class.java.simpleName
         private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
         private const val MAP_JSON_KEY = "MapJsonKey"
+        private val rwLock = ReentrantReadWriteLock()
+        @Volatile
+        private var cache: MutableMap<String, MutableSet<String>>? = null
 
         /**
          * Factory method to create an instance of [WebAppsAccountIdRegistry].
@@ -55,9 +59,6 @@ class WebAppsAccountIdRegistry private constructor(
             return WebAppsAccountIdRegistry(store)
         }
     }
-
-    @Volatile
-    private var cache: MutableMap<String, MutableSet<String>>? = null
 
     // So we can more easily serialize/deserialize the entire map.
     private data class Container(
@@ -105,7 +106,7 @@ class WebAppsAccountIdRegistry private constructor(
      * @param clientId The client ID to add.
      */
     fun addClient(accountId: String, clientId: String) {
-        synchronized(lock) {
+        rwLock.write {
             val map = load()
             val set = map.getOrPut(accountId) { mutableSetOf() }
             if (set.add(clientId)) save(map)
@@ -120,7 +121,7 @@ class WebAppsAccountIdRegistry private constructor(
      * @param clientId The client ID to remove.
      */
     fun removeClient(accountId: String, clientId: String) {
-        synchronized(lock) {
+        rwLock.write {
             val map = load()
             val set = map[accountId] ?: return
             if (set.remove(clientId)) {
@@ -136,9 +137,9 @@ class WebAppsAccountIdRegistry private constructor(
      * @return A set of client IDs associated with the account ID, or an empty set if none exist.
      */
     fun getClients(accountId: String): Set<String> {
-        synchronized(lock) {
+        return rwLock.read {
             val map = load()
-            return map[accountId]?.toSet() ?: emptySet()
+            map[accountId]?.toSet() ?: emptySet()
         }
     }
 
@@ -149,9 +150,9 @@ class WebAppsAccountIdRegistry private constructor(
      * @return True if the client ID is associated with the account ID, false otherwise.
      */
     fun contains(accountId: String, clientId: String): Boolean {
-        synchronized(lock) {
+        return rwLock.read {
             val map = load()
-            return map[accountId]?.contains(clientId) == true
+            map[accountId]?.contains(clientId) == true
         }
     }
 
@@ -159,7 +160,7 @@ class WebAppsAccountIdRegistry private constructor(
      * Remove the given account ID and all its associated client IDs from the registry.
      */
     fun removeAccount(accountId: String) {
-        synchronized(lock) {
+        rwLock.write {
             val map = load()
             if (map.remove(accountId) != null) save(map)
         }
@@ -170,7 +171,7 @@ class WebAppsAccountIdRegistry private constructor(
      * This is useful for testing or if the underlying storage may have changed externally.
      */
     fun refresh() {
-        synchronized(lock) {
+        rwLock.write {
             cache = null
             load()
         }
@@ -178,7 +179,7 @@ class WebAppsAccountIdRegistry private constructor(
 
     @VisibleForTesting
     fun getAll(): Map<String, Set<String>> {
-        synchronized(lock) {
+        rwLock.read {
             return load().mapValues { it.value.toSet() }
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistry.kt
@@ -37,9 +37,24 @@ import com.microsoft.identity.common.logging.Logger
 class WebAppsAccountIdRegistry private constructor(
     private val storage: IMultiTypeNameValueStorage
 ){
-    private val TAG = WebAppsAccountIdRegistry::class.java.simpleName
-    private val MAP_JSON_KEY = "MapJsonKey"
     private val lock = Any()
+
+    companion object {
+        private val TAG = WebAppsAccountIdRegistry::class.java.simpleName
+        private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
+        private const val MAP_JSON_KEY = "MapJsonKey"
+
+        /**
+         * Factory method to create an instance of [WebAppsAccountIdRegistry].
+         *
+         * @param supplier The storage supplier.
+         * @return A new instance of [WebAppsAccountIdRegistry].
+         */
+        fun create(supplier: IStorageSupplier): WebAppsAccountIdRegistry {
+            val store = supplier.getEncryptedFileStore(WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY)
+            return WebAppsAccountIdRegistry(store)
+        }
+    }
 
     @Volatile
     private var cache: MutableMap<String, MutableSet<String>>? = null
@@ -165,21 +180,6 @@ class WebAppsAccountIdRegistry private constructor(
     fun getAll(): Map<String, Set<String>> {
         synchronized(lock) {
             return load().mapValues { it.value.toSet() }
-        }
-    }
-
-    companion object {
-        private const val WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY = "WebAppsAccountIdRegistryStorageKey"
-
-        /**
-         * Factory method to create an instance of [WebAppsAccountIdRegistry].
-         *
-         * @param supplier The storage supplier.
-         * @return A new instance of [WebAppsAccountIdRegistry].
-         */
-        fun create(supplier: IStorageSupplier): WebAppsAccountIdRegistry {
-            val store = supplier.getEncryptedFileStore(WEBAPPS_ACCOUNT_ID_REGISTRY_STORAGE_KEY)
-            return WebAppsAccountIdRegistry(store)
         }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistryTest.kt
@@ -39,7 +39,6 @@ class WebAppsAccountIdRegistryTest {
     fun testAddClient_veryBasicTest() {
         val registry = createRegistry()
         registry.addClient(accountId1, clientId1)
-        Assert.assertEquals(1, registry.getAll().size)
         Assert.assertEquals(1, registry.getClients(accountId1).size)
     }
 
@@ -48,10 +47,8 @@ class WebAppsAccountIdRegistryTest {
         val registry = createRegistry()
         registry.addClient(accountId1, clientId1)
         registry.addClient(accountId1, clientId2)
-        Assert.assertEquals(1, registry.getAll().size)
         Assert.assertEquals(2, registry.getClients(accountId1).size)
         registry.removeClient(accountId1, clientId1)
-        Assert.assertEquals(1, registry.getAll().size)
         Assert.assertEquals(1, registry.getClients(accountId1).size)
     }
 
@@ -60,7 +57,7 @@ class WebAppsAccountIdRegistryTest {
         val registry = createRegistry()
         registry.addClient(accountId1, clientId1)
         registry.removeClient(accountId1, clientId1)
-        Assert.assertEquals(0, registry.getAll().size)
+        Assert.assertEquals(0, registry.getClients(accountId1).size)
     }
 
     @Test
@@ -71,29 +68,23 @@ class WebAppsAccountIdRegistryTest {
         registry.addClient(accountId2, clientId1)
         registry.addClient(accountId2, clientId3)
         registry.addClient(accountId3, clientId1)
-        Assert.assertEquals(3, registry.getAll().size)
         Assert.assertEquals(2, registry.getClients(accountId1).size)
         Assert.assertEquals(2, registry.getClients(accountId2).size)
         Assert.assertEquals(1, registry.getClients(accountId3).size)
 
         registry.removeClient(accountId1, clientId1)
-        Assert.assertEquals(3, registry.getAll().size)
         Assert.assertEquals(1, registry.getClients(accountId1).size)
 
         registry.removeClient(accountId1, clientId2)
-        Assert.assertEquals(2, registry.getAll().size)
         Assert.assertEquals(0, registry.getClients(accountId1).size)
 
         registry.removeClient(accountId2, clientId3)
-        Assert.assertEquals(2, registry.getAll().size)
         Assert.assertEquals(1, registry.getClients(accountId2).size)
 
         registry.removeClient(accountId2, clientId1)
-        Assert.assertEquals(1, registry.getAll().size)
         Assert.assertEquals(0, registry.getClients(accountId2).size)
 
         registry.removeClient(accountId3, clientId1)
-        Assert.assertEquals(0, registry.getAll().size)
         Assert.assertEquals(0, registry.getClients(accountId3).size)
     }
 
@@ -111,9 +102,7 @@ class WebAppsAccountIdRegistryTest {
         registry.addClient(accountId1, clientId1)
         registry.addClient(accountId1, clientId2)
         registry.addClient(accountId2, clientId1)
-        Assert.assertEquals(2, registry.getAll().size)
         registry.removeAccount(accountId1)
-        Assert.assertEquals(1, registry.getAll().size)
         Assert.assertEquals(0, registry.getClients(accountId1).size)
         Assert.assertEquals(1, registry.getClients(accountId2).size)
     }
@@ -134,24 +123,19 @@ class WebAppsAccountIdRegistryTest {
         registry1.addClient(accountId1, clientId1)
         registry1.addClient(accountId1, clientId2)
         registry1.addClient(accountId2, clientId1)
-        Assert.assertEquals(2, registry1.getAll().size)
 
         val registry2 = WebAppsAccountIdRegistry.create(storageSupplier)
-        Assert.assertEquals(2, registry2.getAll().size)
         Assert.assertEquals(2, registry2.getClients(accountId1).size)
         Assert.assertEquals(1, registry2.getClients(accountId2).size)
 
         registry2.removeClient(accountId1, clientId1)
-        Assert.assertEquals(2, registry2.getAll().size)
         Assert.assertEquals(1, registry2.getClients(accountId1).size)
 
         val registry3 = WebAppsAccountIdRegistry.create(storageSupplier)
-        Assert.assertEquals(2, registry3.getAll().size)
         Assert.assertEquals(1, registry3.getClients(accountId1).size)
         Assert.assertEquals(1, registry3.getClients(accountId2).size)
 
         registry3.removeAccount(accountId2)
-        Assert.assertEquals(1, registry3.getAll().size)
         Assert.assertEquals(0, registry3.getClients(accountId2).size)
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/WebAppsAccountIdRegistryTest.kt
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.cache
+
+import com.microsoft.identity.common.components.InMemoryStorageSupplier
+import org.junit.Assert
+import org.junit.Test
+
+class WebAppsAccountIdRegistryTest {
+    private val accountId1 = "11111111-1111-1111-1111-111111111111.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    private val accountId2 = "22222222-2222-2222-2222-222222222222.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    private val accountId3 = "33333333-3333-3333-3333-333333333333.cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+    private val clientId1 = "99999999-1111-4444-8888-121212121212"
+    private val clientId2 = "aaaaaaaa-2222-5555-9999-131313131313"
+    private val clientId3 = "bbbbbbbb-3333-6666-aaaa-141414141414"
+
+    @Test
+    fun testAddClient_veryBasicTest() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        Assert.assertEquals(1, registry.getAll().size)
+        Assert.assertEquals(1, registry.getClients(accountId1).size)
+    }
+
+    @Test
+    fun testRemoveClient_veryBasicTest() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        registry.addClient(accountId1, clientId2)
+        Assert.assertEquals(1, registry.getAll().size)
+        Assert.assertEquals(2, registry.getClients(accountId1).size)
+        registry.removeClient(accountId1, clientId1)
+        Assert.assertEquals(1, registry.getAll().size)
+        Assert.assertEquals(1, registry.getClients(accountId1).size)
+    }
+
+    @Test
+    fun testRemoveClient_accountEntryCleanedUp() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        registry.removeClient(accountId1, clientId1)
+        Assert.assertEquals(0, registry.getAll().size)
+    }
+
+    @Test
+    fun testManyCombinedAddAndRemove() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        registry.addClient(accountId1, clientId2)
+        registry.addClient(accountId2, clientId1)
+        registry.addClient(accountId2, clientId3)
+        registry.addClient(accountId3, clientId1)
+        Assert.assertEquals(3, registry.getAll().size)
+        Assert.assertEquals(2, registry.getClients(accountId1).size)
+        Assert.assertEquals(2, registry.getClients(accountId2).size)
+        Assert.assertEquals(1, registry.getClients(accountId3).size)
+
+        registry.removeClient(accountId1, clientId1)
+        Assert.assertEquals(3, registry.getAll().size)
+        Assert.assertEquals(1, registry.getClients(accountId1).size)
+
+        registry.removeClient(accountId1, clientId2)
+        Assert.assertEquals(2, registry.getAll().size)
+        Assert.assertEquals(0, registry.getClients(accountId1).size)
+
+        registry.removeClient(accountId2, clientId3)
+        Assert.assertEquals(2, registry.getAll().size)
+        Assert.assertEquals(1, registry.getClients(accountId2).size)
+
+        registry.removeClient(accountId2, clientId1)
+        Assert.assertEquals(1, registry.getAll().size)
+        Assert.assertEquals(0, registry.getClients(accountId2).size)
+
+        registry.removeClient(accountId3, clientId1)
+        Assert.assertEquals(0, registry.getAll().size)
+        Assert.assertEquals(0, registry.getClients(accountId3).size)
+    }
+
+    @Test
+    fun testAddClient_addSameClient() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        registry.addClient(accountId1, clientId1)
+        Assert.assertEquals(1, registry.getClients(accountId1).size)
+    }
+
+    @Test
+    fun testRemoveAccount_removeAccount() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        registry.addClient(accountId1, clientId2)
+        registry.addClient(accountId2, clientId1)
+        Assert.assertEquals(2, registry.getAll().size)
+        registry.removeAccount(accountId1)
+        Assert.assertEquals(1, registry.getAll().size)
+        Assert.assertEquals(0, registry.getClients(accountId1).size)
+        Assert.assertEquals(1, registry.getClients(accountId2).size)
+    }
+
+    @Test
+    fun testContains_containsClientId() {
+        val registry = createRegistry()
+        registry.addClient(accountId1, clientId1)
+        Assert.assertTrue(registry.contains(accountId1, clientId1))
+        Assert.assertFalse(registry.contains(accountId1, clientId2))
+        Assert.assertFalse(registry.contains(accountId2, clientId1))
+    }
+
+    @Test
+    fun testPersistenceAcrossInstances() {
+        val storageSupplier = InMemoryStorageSupplier()
+        val registry1 = WebAppsAccountIdRegistry.create(storageSupplier)
+        registry1.addClient(accountId1, clientId1)
+        registry1.addClient(accountId1, clientId2)
+        registry1.addClient(accountId2, clientId1)
+        Assert.assertEquals(2, registry1.getAll().size)
+
+        val registry2 = WebAppsAccountIdRegistry.create(storageSupplier)
+        Assert.assertEquals(2, registry2.getAll().size)
+        Assert.assertEquals(2, registry2.getClients(accountId1).size)
+        Assert.assertEquals(1, registry2.getClients(accountId2).size)
+
+        registry2.removeClient(accountId1, clientId1)
+        Assert.assertEquals(2, registry2.getAll().size)
+        Assert.assertEquals(1, registry2.getClients(accountId1).size)
+
+        val registry3 = WebAppsAccountIdRegistry.create(storageSupplier)
+        Assert.assertEquals(2, registry3.getAll().size)
+        Assert.assertEquals(1, registry3.getClients(accountId1).size)
+        Assert.assertEquals(1, registry3.getClients(accountId2).size)
+
+        registry3.removeAccount(accountId2)
+        Assert.assertEquals(1, registry3.getAll().size)
+        Assert.assertEquals(0, registry3.getClients(accountId2).size)
+    }
+
+    private fun createRegistry(): WebAppsAccountIdRegistry {
+        return WebAppsAccountIdRegistry.create(InMemoryStorageSupplier())
+    }
+}


### PR DESCRIPTION
[AB#3406762](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3406762)
### Summary
The WebAppsAccountIdRegistry maps account ids to sets of client ids. This class is created for the purpose of the Edge TB APIs work, where it will be used for the getToken operation (silent case where we want to check that the user has signed into this webapp before) and the SignOut operation (to remember which web apps we need to sign out of).

Broker PR for the SignOut operation using this registry will follow.