### PR TITLE
Reset flights between tests, Fixes AB#3413737

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -62,6 +62,7 @@ import com.microsoft.identity.common.java.providers.microsoft.azureactivedirecto
 import com.microsoft.identity.common.java.ui.webview.authorization.IAuthorizationCompletionCallback;
 import com.microsoft.identity.common.shadows.ShadowProcessUtil;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -157,6 +158,11 @@ public class AzureActiveDirectoryWebViewClientTest {
         if (!AzureActiveDirectory.isInitialized()) {
             AzureActiveDirectory.performCloudDiscovery();
         }
+    }
+
+    @After
+    public void cleanUp(){
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -412,7 +418,6 @@ public class AzureActiveDirectoryWebViewClientTest {
         // Verify
         Mockito.verify(mockFlightsProvider, Mockito.never()).isFlightEnabled(Mockito.any());
         Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
-        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test
@@ -490,6 +495,11 @@ public class AzureActiveDirectoryWebViewClientTest {
         final SslError mockError = Mockito.mock(android.net.http.SslError.class);
         final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
         when(mockError.getUrl()).thenReturn("https://example.com");
+        final IFlightsManager mockFlightsManager = Mockito.mock(IFlightsManager.class);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(eq(CommonFlight.SHOULD_PRESERVE_WEBVIEW_FLOW_ON_SSL_ERROR))).thenReturn(false);
+        when(mockFlightsManager.getFlightsProvider(anyLong())).thenReturn(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);
         final AzureActiveDirectoryWebViewClient mockWebViewClient = new AzureActiveDirectoryWebViewClient(
                 mActivity,
                 mockCallback,

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -412,6 +412,7 @@ public class AzureActiveDirectoryWebViewClientTest {
         // Verify
         Mockito.verify(mockFlightsProvider, Mockito.never()).isFlightEnabled(Mockito.any());
         Mockito.verify(mockWebview).loadUrl(Mockito.anyString(), Mockito.any());
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     @Test


### PR DESCRIPTION
The testcase testUrlOverrideHandlesNonceRedirectUrl was failing because there was a new testcase introduced in the class where we were setting flights but we missed resetting them before the next testcase runs.
Fix : Resetting flights between the UTs
Additional fix : There was a change that was relying on the state of flights set in previous tests which was incorrect. Correcting this as well.
Fixes [AB#3413737](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3413737)
