### PR TITLE
Add callback for OneAuth for measuring Broker Discovery Client Perf, Fixes AB#3416279

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add callback for OneAuth for measuring Broker Discovery Client Perf (#2796)
 - [MINOR] Add new span name for DELEGATION_CERT_INSTALL's telemetry (#2790)
 - [MINOR] Refactor getAccountByLocalAccountId (#2781)
 - [MINOR] Add OTel Benchmarker (#2786)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
+import IBrokerDiscoveryClientTelemetryCallback
 import android.content.Context
 import android.os.Bundle
 import com.microsoft.identity.common.exception.BrokerCommunicationException
@@ -66,15 +67,6 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                             private val isPackageInstalled: (BrokerData) -> Boolean,
                             private val isValidBroker: (BrokerData) -> Boolean) : IBrokerDiscoveryClient {
 
-    interface IBrokerDiscoveryClientTelemetryCallback {
-        fun onReadFromCache()
-        fun onShouldUseAccountManager()
-        fun onFinishCheckingIfPackageIsInstalled(timeSpent: Long)
-        fun onFinishCheckingIfSupportedByTargetedBroker(timeSpent: Long)
-        fun onFinishQueryingResultFromBroker(timeSpent: Long)
-        fun onFinishCheckingIfValidBroker(timeSpent: Long)
-    }
-
     companion object {
         val TAG = BrokerDiscoveryClient::class.simpleName
 
@@ -107,8 +99,6 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         const val FORCE_TRIGGER_BROKER_DISCOVERY_RESULT_UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
 
         const val ERROR_BUNDLE_KEY = "ERROR_BUNDLE_KEY"
-
-        public val sTelemetryCallback: IBrokerDiscoveryClientTelemetryCallback? = null
 
         /**
          * Per-process Thread-safe, coroutine-safe Mutex of this class.
@@ -286,24 +276,35 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
 
     override fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
         return runBlocking {
-            return@runBlocking getActiveBrokerAsync(shouldSkipCache)
+            return@runBlocking getActiveBrokerAsync(shouldSkipCache, null)
         }
     }
 
-    private suspend fun getActiveBrokerAsync(shouldSkipCache:Boolean): BrokerData?{
+    override fun getActiveBroker(
+        shouldSkipCache: Boolean,
+        telemetryCallback: IBrokerDiscoveryClientTelemetryCallback
+    ): BrokerData? {
+        return runBlocking {
+            return@runBlocking getActiveBrokerAsync(shouldSkipCache, telemetryCallback)
+        }
+    }
+
+    private suspend fun getActiveBrokerAsync(shouldSkipCache:Boolean,
+                                             telemetryCallback: IBrokerDiscoveryClientTelemetryCallback?): BrokerData?{
         val methodTag = "$TAG:getActiveBrokerAsync"
         classLevelLock.withLock {
             if (!shouldSkipCache) {
                 if (cache.shouldUseAccountManager()) {
-                    sTelemetryCallback?.onShouldUseAccountManager()
+                    telemetryCallback?.onUseAccountManager()
                     return getActiveBrokerFromAccountManager()
                 }
+                val timeStartReadingFromCache = System.nanoTime()
                 cache.getCachedActiveBroker()?.let {
-                    sTelemetryCallback?.onReadFromCache()
+                    telemetryCallback?.onReadFromCache(System.nanoTime() - timeStartReadingFromCache)
 
-                    val startTime1 = System.nanoTime()
+                    val timeStartIsPackageInstalled = System.nanoTime()
                     val isPackageInstalled= isPackageInstalled(it)
-                    sTelemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - startTime1)
+                    telemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - timeStartIsPackageInstalled)
                     if (!isPackageInstalled) {
                         Logger.info(
                             methodTag,
@@ -313,9 +314,9 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                         return@let
                     }
 
-                    val startTime2 = System.nanoTime()
+                    val timeStartIsValidBroker = System.nanoTime()
                     val isValidBroker= isValidBroker(it)
-                    sTelemetryCallback?.onFinishCheckingIfValidBroker(System.nanoTime() - startTime2)
+                    telemetryCallback?.onFinishCheckingIfValidBroker(System.nanoTime() - timeStartIsValidBroker)
                     if (!isValidBroker) {
                         Logger.info(
                             methodTag,
@@ -325,10 +326,10 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                         return@let
                     }
 
-                    val startTime3 = System.nanoTime()
+                    val timeStartIsSupportedByTargetedBroker = System.nanoTime()
                     val isSupportedByTargetedBroker =
                         ipcStrategy.isSupportedByTargetedBroker(it.packageName)
-                    sTelemetryCallback?.onFinishCheckingIfSupportedByTargetedBroker(System.nanoTime() - startTime3)
+                    telemetryCallback?.onFinishCheckingIfSupportedByTargetedBroker(System.nanoTime() - timeStartIsSupportedByTargetedBroker)
                     if(!isSupportedByTargetedBroker){
                         Logger.info(
                             methodTag,
@@ -343,14 +344,14 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                 }
             }
 
-            val startTime4 = System.nanoTime()
+            val timeStartQueryFromBroker = System.nanoTime()
             val brokerData = queryFromBroker(
                 brokerCandidates = brokerCandidates,
                 ipcStrategy = ipcStrategy,
                 isPackageInstalled = isPackageInstalled,
                 isValidBroker = isValidBroker
             )
-            sTelemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - startTime4)
+            telemetryCallback?.onFinishQueryingResultFromBroker(System.nanoTime() - timeStartQueryFromBroker)
 
             if (brokerData != null) {
                 cache.setCachedActiveBroker(brokerData)
@@ -369,6 +370,7 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                 )
             )
 
+            telemetryCallback?.onUseAccountManager()
             val accountManagerResult = getActiveBrokerFromAccountManager()
             Logger.info(
                 methodTag, "Tried getting active broker from account manager, " +

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
-import IBrokerDiscoveryClientTelemetryCallback
 import android.content.Context
 import android.os.Bundle
 import com.microsoft.identity.common.exception.BrokerCommunicationException
@@ -303,7 +302,7 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                     telemetryCallback?.onReadFromCache(System.nanoTime() - timeStartReadingFromCache)
 
                     val timeStartIsPackageInstalled = System.nanoTime()
-                    val isPackageInstalled= isPackageInstalled(it)
+                    val isPackageInstalled = isPackageInstalled(it)
                     telemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - timeStartIsPackageInstalled)
                     if (!isPackageInstalled) {
                         Logger.info(
@@ -315,7 +314,7 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                     }
 
                     val timeStartIsValidBroker = System.nanoTime()
-                    val isValidBroker= isValidBroker(it)
+                    val isValidBroker = isValidBroker(it)
                     telemetryCallback?.onFinishCheckingIfValidBroker(System.nanoTime() - timeStartIsValidBroker)
                     if (!isValidBroker) {
                         Logger.info(

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -291,7 +291,10 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
     private suspend fun getActiveBrokerAsync(shouldSkipCache:Boolean,
                                              telemetryCallback: IBrokerDiscoveryClientTelemetryCallback?): BrokerData?{
         val methodTag = "$TAG:getActiveBrokerAsync"
+
+        val timeStartAcquiringLock = System.nanoTime()
         classLevelLock.withLock {
+            telemetryCallback?.onLockAcquired(System.nanoTime() - timeStartAcquiringLock)
             if (!shouldSkipCache) {
                 if (cache.shouldUseAccountManager()) {
                     telemetryCallback?.onUseAccountManager()

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/BrokerDiscoveryClient.kt
@@ -66,6 +66,15 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                             private val isPackageInstalled: (BrokerData) -> Boolean,
                             private val isValidBroker: (BrokerData) -> Boolean) : IBrokerDiscoveryClient {
 
+    interface IBrokerDiscoveryClientTelemetryCallback {
+        fun onReadFromCache()
+        fun onShouldUseAccountManager()
+        fun onFinishCheckingIfPackageIsInstalled(timeSpent: Long)
+        fun onFinishCheckingIfSupportedByTargetedBroker(timeSpent: Long)
+        fun onFinishQueryingResultFromBroker(timeSpent: Long)
+        fun onFinishCheckingIfValidBroker(timeSpent: Long)
+    }
+
     companion object {
         val TAG = BrokerDiscoveryClient::class.simpleName
 
@@ -98,6 +107,8 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         const val FORCE_TRIGGER_BROKER_DISCOVERY_RESULT_UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
 
         const val ERROR_BUNDLE_KEY = "ERROR_BUNDLE_KEY"
+
+        public val sTelemetryCallback: IBrokerDiscoveryClientTelemetryCallback? = null
 
         /**
          * Per-process Thread-safe, coroutine-safe Mutex of this class.
@@ -284,10 +295,16 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
         classLevelLock.withLock {
             if (!shouldSkipCache) {
                 if (cache.shouldUseAccountManager()) {
+                    sTelemetryCallback?.onShouldUseAccountManager()
                     return getActiveBrokerFromAccountManager()
                 }
                 cache.getCachedActiveBroker()?.let {
-                    if (!isPackageInstalled(it)) {
+                    sTelemetryCallback?.onReadFromCache()
+
+                    val startTime1 = System.nanoTime()
+                    val isPackageInstalled= isPackageInstalled(it)
+                    sTelemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - startTime1)
+                    if (!isPackageInstalled) {
                         Logger.info(
                             methodTag,
                             "There is a cached broker: $it, but the app is no longer installed."
@@ -296,7 +313,10 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                         return@let
                     }
 
-                    if (!isValidBroker(it)) {
+                    val startTime2 = System.nanoTime()
+                    val isValidBroker= isValidBroker(it)
+                    sTelemetryCallback?.onFinishCheckingIfValidBroker(System.nanoTime() - startTime2)
+                    if (!isValidBroker) {
                         Logger.info(
                             methodTag,
                             "Clearing cache as the installed app does not have a matching signature hash."
@@ -305,7 +325,11 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                         return@let
                     }
 
-                    if(!ipcStrategy.isSupportedByTargetedBroker(it.packageName)){
+                    val startTime3 = System.nanoTime()
+                    val isSupportedByTargetedBroker =
+                        ipcStrategy.isSupportedByTargetedBroker(it.packageName)
+                    sTelemetryCallback?.onFinishCheckingIfSupportedByTargetedBroker(System.nanoTime() - startTime3)
+                    if(!isSupportedByTargetedBroker){
                         Logger.info(
                             methodTag,
                             "Clearing cache as the installed app does not provide any IPC mechanism to communicate to. (e.g. the broker code isn't shipped with this apk)"
@@ -319,12 +343,14 @@ class BrokerDiscoveryClient(private val brokerCandidates: Set<BrokerData>,
                 }
             }
 
+            val startTime4 = System.nanoTime()
             val brokerData = queryFromBroker(
                 brokerCandidates = brokerCandidates,
                 ipcStrategy = ipcStrategy,
                 isPackageInstalled = isPackageInstalled,
                 isValidBroker = isValidBroker
             )
+            sTelemetryCallback?.onFinishCheckingIfPackageIsInstalled(System.nanoTime() - startTime4)
 
             if (brokerData != null) {
                 cache.setCachedActiveBroker(brokerData)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClient.kt
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
-import IBrokerDiscoveryClientTelemetryCallback
 import com.microsoft.identity.common.internal.broker.BrokerData
 import com.microsoft.identity.common.java.exception.ClientException
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClient.kt
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
+import IBrokerDiscoveryClientTelemetryCallback
 import com.microsoft.identity.common.internal.broker.BrokerData
 import com.microsoft.identity.common.java.exception.ClientException
 
@@ -36,6 +37,20 @@ interface IBrokerDiscoveryClient {
      * @return BrokerData package name and signature hash of the targeted app.
      * **/
     fun getActiveBroker(shouldSkipCache: Boolean = false) : BrokerData?
+
+
+    /**
+     * Performs a discovery to figure out which broker app the SDK (MSAL/OneAuth)
+     * has to send its request to.
+     *
+     * @param shouldSkipCache       If true, this will skip cached value (if any)
+     *                              and always query the broker for the result.
+     * @param telemetryCallback     callback with telemetry data.
+     * @return BrokerData package name and signature hash of the targeted app.
+     * **/
+    fun getActiveBroker(shouldSkipCache: Boolean = false,
+                        telemetryCallback: IBrokerDiscoveryClientTelemetryCallback) : BrokerData?
+
 
     /**
      * Force a broker app to figure out which broker app the SDK (MSAL/OneAuth)

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
@@ -20,6 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
+package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 interface IBrokerDiscoveryClientTelemetryCallback {
     /**
@@ -31,28 +32,28 @@ interface IBrokerDiscoveryClientTelemetryCallback {
     /**
      * Triggered when BrokerDiscoveryClient finishes reading from its cache.
      *
-     * @return timeSpentInNanoSeconds Time spent reading the cache (in nanoseconds).
+     * @param timeSpentInNanoSeconds Time spent reading the cache (in nanoseconds).
      **/
     fun onReadFromCache(timeSpentInNanoSeconds: Long)
 
     /**
      * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package is installed.
      *
-     * @return timeSpentInNanoSeconds Time spent to validate if the package is installed (in nanoseconds).
+     * @param timeSpentInNanoSeconds Time spent to validate if the package is installed (in nanoseconds).
      **/
     fun onFinishCheckingIfPackageIsInstalled(timeSpentInNanoSeconds: Long)
 
     /**
      * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package supports the given IPC strategy.
      *
-     * @return timeSpentInNanoSeconds Time spent to validate if the package supports the IPC strategy (in nanoseconds).
+     * @param timeSpentInNanoSeconds Time spent to validate if the package supports the IPC strategy (in nanoseconds).
      **/
     fun onFinishCheckingIfSupportedByTargetedBroker(timeSpentInNanoSeconds: Long)
 
     /**
      * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package is a valid broker.
      *
-     * @return timeSpentInNanoSeconds Time spent to validate if the package is a valid broker (in nanoseconds).
+     * @param timeSpentInNanoSeconds Time spent to validate if the package is a valid broker (in nanoseconds).
      **/
     fun onFinishCheckingIfValidBroker(timeSpentInNanoSeconds: Long)
 
@@ -66,7 +67,7 @@ interface IBrokerDiscoveryClientTelemetryCallback {
      * 2. Broker has already done broker discovery before (e.g. by other MSAL/OneAuth app). Only this MSAL/OneAuth app is freshly installed.
      * When the request reaches the broker, the broker would just return the cached value, which will be faster.
      *
-     * @return timeSpentInNanoSeconds Time spent to query the active broker (in nanoseconds).
+     * @param timeSpentInNanoSeconds Time spent to query the active broker (in nanoseconds).
      **/
     fun onFinishQueryingResultFromBroker(timeSpentInNanoSeconds: Long)
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
@@ -1,0 +1,72 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+interface IBrokerDiscoveryClientTelemetryCallback {
+    /**
+     * If triggered, the broker discovery client is using Account Manager
+     * (e.g. one of the installed broker is too old and doesn't support this new mechanism).
+     **/
+    fun onUseAccountManager()
+
+    /**
+     * Triggered when BrokerDiscoveryClient finishes reading from its cache.
+     *
+     * @return timeSpentInNanoSeconds Time spent reading the cache (in nanoseconds).
+     **/
+    fun onReadFromCache(timeSpentInNanoSeconds: Long)
+
+    /**
+     * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package is installed.
+     *
+     * @return timeSpentInNanoSeconds Time spent to validate if the package is installed (in nanoseconds).
+     **/
+    fun onFinishCheckingIfPackageIsInstalled(timeSpentInNanoSeconds: Long)
+
+    /**
+     * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package supports the given IPC strategy.
+     *
+     * @return timeSpentInNanoSeconds Time spent to validate if the package supports the IPC strategy (in nanoseconds).
+     **/
+    fun onFinishCheckingIfSupportedByTargetedBroker(timeSpentInNanoSeconds: Long)
+
+    /**
+     * Triggered when BrokerDiscoveryClient finishes validating if the cached broker package is a valid broker.
+     *
+     * @return timeSpentInNanoSeconds Time spent to validate if the package is a valid broker (in nanoseconds).
+     **/
+    fun onFinishCheckingIfValidBroker(timeSpentInNanoSeconds: Long)
+
+    /**
+     * Triggered when BrokerDiscoveryClient finishes querying active broker from one of the broker apps.
+     *
+     * There are 2 possible cases when this is triggered.
+     * 1. Both Broker and this MSAL/OneAuth app are freshly installed.
+     * This will trigger the broker discovery in broker, and will take longer time.
+     *
+     * 2. Broker has already done broker discovery before (e.g. by other MSAL/OneAuth app). Only this MSAL/OneAuth app is freshly installed.
+     * When the request reaches the broker, the broker would just return the cached value, which will be faster.
+     *
+     * @return timeSpentInNanoSeconds Time spent to query the active broker (in nanoseconds).
+     **/
+    fun onFinishQueryingResultFromBroker(timeSpentInNanoSeconds: Long)
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/IBrokerDiscoveryClientTelemetryCallback.kt
@@ -24,6 +24,13 @@ package com.microsoft.identity.common.internal.activebrokerdiscovery
 
 interface IBrokerDiscoveryClientTelemetryCallback {
     /**
+     * Time spent acquiring the lock/mutex for broker discovery.
+     *
+     * @param timeSpentInNanoSeconds Time spent acquiring the lock/mutex (in nanoseconds).
+     **/
+    fun onLockAcquired(timeSpentInNanoSeconds: Long)
+
+    /**
      * If triggered, the broker discovery client is using Account Manager
      * (e.g. one of the installed broker is too old and doesn't support this new mechanism).
      **/

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
+import IBrokerDiscoveryClientTelemetryCallback
 import android.content.Context
 import com.microsoft.identity.common.internal.broker.BrokerData
 
@@ -31,6 +32,15 @@ import com.microsoft.identity.common.internal.broker.BrokerData
 class LegacyBrokerDiscoveryClient(val context: Context): IBrokerDiscoveryClient {
 
     override fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
+        return AccountManagerBrokerDiscoveryUtil(context)
+            .getActiveBrokerFromAccountManager()
+    }
+
+    override fun getActiveBroker(
+        shouldSkipCache: Boolean,
+        telemetryCallback: IBrokerDiscoveryClientTelemetryCallback
+    ): BrokerData? {
+        // LegacyBrokerDiscoveryClient does not support telemetry callback.
         return AccountManagerBrokerDiscoveryUtil(context)
             .getActiveBrokerFromAccountManager()
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/activebrokerdiscovery/LegacyBrokerDiscoveryClient.kt
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.activebrokerdiscovery
 
-import IBrokerDiscoveryClientTelemetryCallback
 import android.content.Context
 import com.microsoft.identity.common.internal.broker.BrokerData
 
@@ -40,7 +39,7 @@ class LegacyBrokerDiscoveryClient(val context: Context): IBrokerDiscoveryClient 
         shouldSkipCache: Boolean,
         telemetryCallback: IBrokerDiscoveryClientTelemetryCallback
     ): BrokerData? {
-        // LegacyBrokerDiscoveryClient does not support telemetry callback.
+        telemetryCallback.onUseAccountManager()
         return AccountManagerBrokerDiscoveryUtil(context)
             .getActiveBrokerFromAccountManager()
     }


### PR DESCRIPTION
[AB#3416279](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3416279)

This will allow OneAuth to wire telemetry into BrokerDiscoveryClient.getActiveBroker()