### PR TITLE
partial revert to fix failing tests in broker FixesAB#3397557, Fixes AB#3397557

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -1124,7 +1124,6 @@ public class MsalOAuth2TokenCache
 
         for (final AccountRecord accountRecord: accountRecordList) {
             if (accountRecord.getLocalAccountId().equals(localAccountId)
-                    && accountRecord.getEnvironment().equals(environment)
                         && accountHasCredential(accountRecord, appCredentials)) {
                 return accountRecord;
             }
@@ -1373,9 +1372,8 @@ public class MsalOAuth2TokenCache
     }
 
     /**
-     * Evaluates the supplied list of Credentials. Returns true if the provided Account's
-     * homeAccountId matches with any of the credentials' homeAccountId.
-     * This does not filter on environment, as that is expected to be pre-filtered.
+     * Evaluates the supplied list of Credentials. Returns true if the provided Account
+     * 'owns' any one of these tokens.
      *
      * @param account        The Account whose credential ownership should be evaluated.
      * @param appCredentials The Credentials to evaluate.
@@ -1384,17 +1382,20 @@ public class MsalOAuth2TokenCache
     private boolean accountHasCredential(@NonNull final AccountRecord account,
                                          @NonNull final List<Credential> appCredentials) {
         final String methodName = ":accountHasCredential";
+
         final String accountHomeId = account.getHomeAccountId();
+        final String accountEnvironment = account.getEnvironment();
 
         Logger.verbosePII(
                 TAG + methodName,
                 "HomeAccountId: [" + accountHomeId + "]"
+                        + "\n"
+                        + "Environment: [" + accountEnvironment + "]"
         );
 
-        // Since we already filtered accounts and credentials by environment, there is no need to check
-        // environment again
         for (final Credential credential : appCredentials) {
-            if (accountHomeId.equals(credential.getHomeAccountId())) {
+            if (accountHomeId.equals(credential.getHomeAccountId())
+                    && accountEnvironment.equals(credential.getEnvironment())) {
                 Logger.verbose(
                         TAG + methodName,
                         "Credentials located for account."


### PR DESCRIPTION
Fixes[AB#3397557](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3397557)

Recently refactored getAccountByLocalAccountId method to first filter both accounts and credentials on environment and then, check their homeAccountId to match the accounts with credentials. However, that refactoring does not work when environment passed is **null**. This resulted in test failures in the broker repo. https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2781
 
This PR is to revert some of the changes made as part of that commit and fix the failing tests.

