### PR TITLE
Refactored code to iterate over SharedPreferences once Fixes AB#3417272

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Refactor getAccountByLocalAccountId to iterate over SharedPreferences only once (#2799)
 - [MINOR] Add new span name for DELEGATION_CERT_INSTALL's telemetry (#2790)
 - [MINOR] Refactor getAccountByLocalAccountId (#2781)
 - [MINOR] Add OTel Benchmarker (#2786)

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -40,6 +40,8 @@ import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.PrimaryRefreshTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.shadows.ShadowAndroidSdkStorageEncryptionManager;
 
@@ -47,6 +49,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -69,7 +72,6 @@ public class SharedPreferencesAccountCredentialCacheTest {
     static final String HOME_ACCOUNT_ID = "29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
     static final String ENVIRONMENT = "login.microsoftonline.com";
     static final String CLIENT_ID = "0287f963-2d72-4363-9e3a-5705c5b0f031";
-    static final String APPLICATION_IDENTIFIER_SHA1 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/=";
     static final String APPLICATION_IDENTIFIER_SHA512 = "some.package/AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIjKlMnOpQrStUvWxYz/+0123456789AbCdEfGhIj==";
     static final String MAM_ENROLLMENT_IDENTIFIER = "UNSET";
     static final String TARGET = "user.read user.write https://graph.windows.net";
@@ -430,6 +432,51 @@ public class SharedPreferencesAccountCredentialCacheTest {
         refreshToken.setSecret(SECRET);
         refreshToken.setTarget(TARGET);
         mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        // Verify getAccountsFilteredBy() returns one matching element
+        final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertTrue(accounts.size() == 1);
+        assertEquals(account, accounts.get(0));
+    }
+
+    @Test
+    public void getAccountsWithFlight() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        Mockito.when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH))
+                .thenReturn(true);
 
         // Verify getAccountsFilteredBy() returns one matching element
         final List<AccountRecord> accounts = mSharedPreferencesAccountCredentialCache.getAccounts();

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheTest.java
@@ -734,6 +734,52 @@ public class SharedPreferencesAccountCredentialCacheTest {
     }
 
     @Test
+    public void getCredentialsWithFlight() {
+        // Save an Account into the cache
+        final AccountRecord account = new AccountRecord();
+        account.setHomeAccountId(HOME_ACCOUNT_ID);
+        account.setEnvironment(ENVIRONMENT);
+        account.setRealm(REALM);
+        account.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        account.setUsername(USERNAME);
+        account.setAuthorityType(AUTHORITY_TYPE);
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        // Save an AccessToken into the cache
+        final AccessTokenRecord accessToken = new AccessTokenRecord();
+        accessToken.setCredentialType(CredentialType.AccessToken.name());
+        accessToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        accessToken.setRealm("Foo");
+        accessToken.setEnvironment(ENVIRONMENT);
+        accessToken.setClientId(CLIENT_ID);
+        accessToken.setApplicationIdentifier(APPLICATION_IDENTIFIER_SHA512);
+        accessToken.setMamEnrollmentIdentifier(MAM_ENROLLMENT_IDENTIFIER);
+        accessToken.setTarget(TARGET);
+        accessToken.setCachedAt(CACHED_AT);
+        accessToken.setExpiresOn(EXPIRES_ON);
+        accessToken.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(accessToken);
+
+        // Save a RefreshToken into the cache
+        final RefreshTokenRecord refreshToken = new RefreshTokenRecord();
+        refreshToken.setCredentialType(CredentialType.RefreshToken.name());
+        refreshToken.setEnvironment(ENVIRONMENT);
+        refreshToken.setHomeAccountId(HOME_ACCOUNT_ID);
+        refreshToken.setClientId(CLIENT_ID);
+        refreshToken.setSecret(SECRET);
+        refreshToken.setTarget(TARGET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(refreshToken);
+
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        Mockito.when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH))
+                .thenReturn(true);
+
+        // Verify getCredentials() returns two matching elements
+        final List<Credential> credentials = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertTrue(credentials.size() == 2);
+    }
+
+    @Test
     public void getCredentialsNoEnvironment() {
         final RefreshTokenRecord refreshToken1 = new RefreshTokenRecord();
         refreshToken1.setCredentialType(CredentialType.RefreshToken.name());

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -28,8 +28,12 @@ import com.microsoft.identity.common.java.dto.Credential;
 import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
@@ -49,6 +53,9 @@ import lombok.NonNull;
 public class SharedPreferencesAccountCredentialCache extends AbstractAccountCredentialCache {
 
     private static final String TAG = SharedPreferencesAccountCredentialCache.class.getSimpleName();
+    // Lists to maintain accounts and credentials
+    private final List<AccountRecord> mAccountList = new ArrayList<>();
+    private final List<Credential> mCredentialList = new ArrayList<>();
 
     /**
      * The name of the SharedPreferences file on disk.
@@ -96,6 +103,26 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
         mCacheValueDelegate = accountCacheValueDelegate;
+    }
+
+    /**
+     * Returns the list of all AccountRecords.
+     */
+    public List<AccountRecord> getAllAccountRecords() {
+        if (mAccountList.isEmpty()) {
+            fetchAndPopulateAllAccountsAndCredentials();
+        }
+        return mAccountList;
+    }
+
+    /**
+     * Returns the list of all Credentials.
+     */
+    public List<Credential> getAllCredentials() {
+        if (mCredentialList.isEmpty()) {
+            fetchAndPopulateAllAccountsAndCredentials();
+        }
+        return mCredentialList;
     }
 
     @Override
@@ -203,6 +230,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     @NonNull
     private Map<String, AccountRecord> getAccountsWithKeys() {
         Logger.verbose(TAG, "Loading Accounts + keys...");
+        SpanExtension.current().setAttribute(AttributeName.num_account_credential_cache_records.name(), mSharedPreferencesFileManager.keySet().size());
         final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
             @Override
             public boolean test(String value) {
@@ -237,10 +265,17 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public List<AccountRecord> getAccounts() {
         final String methodTag = TAG + ":getAccounts";
         Logger.verbose(methodTag, "Loading Accounts...(no arg)");
-        final Map<String, AccountRecord> allAccounts = getAccountsWithKeys();
-        final List<AccountRecord> accounts = new ArrayList<>(allAccounts.values());
-        Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
-        return accounts;
+        if (CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH)) {
+               return getAllAccountRecords();
+        } else {
+            final Map<String, AccountRecord> allAccounts = getAccountsWithKeys();
+            final List<AccountRecord> accounts = new ArrayList<>(allAccounts.values());
+            Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
+            return accounts;
+        }
+
     }
 
     @Override
@@ -298,11 +333,54 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         return credentials;
     }
 
+    /**
+     * Loads all Account and Credential objects from SharedPreferences.
+     * Iterates over all entries, determines if each is an Account or Credential,
+     * deserializes to the appropriate object, and adds to the corresponding list.
+     *
+     * @return void. Populates mAccountList and mCredentialList with all found records.
+     */
+    private void fetchAndPopulateAllAccountsAndCredentials() {
+        List<AccountRecord> accounts = new ArrayList<>();
+        List<Credential> credentials = new ArrayList<>();
+        SpanExtension.current().setAttribute(AttributeName.refactored_account_credential_cache_path_triggered.name(),
+                true);
+
+        Map<String, String> cacheKeysWithValues = mSharedPreferencesFileManager.getAll();
+        for (Map.Entry<String, ?> cacheValue : cacheKeysWithValues.entrySet()) {
+            String cacheKey = cacheValue.getKey();
+            String cacheValueStr = cacheValue.getValue().toString();
+
+            if (isAccount(cacheKey)) {
+                AccountRecord account = mCacheValueDelegate.fromCacheValue(cacheValueStr, AccountRecord.class);
+                if (account != null) {
+                    accounts.add(account);
+                } else {
+                    Logger.warn(TAG, ACCOUNT_RECORD_DESERIALIZATION_FAILED);
+                }
+            } else { // since it's not an account, it must be a credential
+                Credential credential = mCacheValueDelegate.fromCacheValue(cacheValueStr, credentialClassForType(cacheKey));
+                if (credential != null) {
+                    credentials.add(credential);
+                } else {
+                    Logger.warn(TAG, CREDENTIAL_DESERIALIZATION_FAILED);
+                }
+            }
+        }
+        mAccountList.addAll(accounts);
+        mCredentialList.addAll(credentials);
+    }
+
     @Override
     @NonNull
     public List<Credential> getCredentials() {
         final String methodTag = TAG + ":getCredentials";
         Logger.verbose(methodTag, "Loading Credentials...");
+        if (CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH)) {
+            return getAllCredentials();
+        }
         final Map<String, Credential> allCredentials = getCredentialsWithKeys();
         final List<Credential> creds = new ArrayList<>(allCredentials.values());
         return creds;

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -108,21 +109,21 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     /**
      * Returns the list of all AccountRecords.
      */
-    public List<AccountRecord> getAllAccountRecords() {
+    private List<AccountRecord> getAllAccountRecords() {
         if (mAccountList.isEmpty()) {
             fetchAndPopulateAllAccountsAndCredentials();
         }
-        return mAccountList;
+        return Collections.unmodifiableList(mAccountList);
     }
 
     /**
      * Returns the list of all Credentials.
      */
-    public List<Credential> getAllCredentials() {
+    private List<Credential> getAllCredentials() {
         if (mCredentialList.isEmpty()) {
             fetchAndPopulateAllAccountsAndCredentials();
         }
-        return mCredentialList;
+        return Collections.unmodifiableList(mCredentialList);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.NonNull;
@@ -57,6 +58,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     // Lists to maintain accounts and credentials
     private final List<AccountRecord> mAccountList = new ArrayList<>();
     private final List<Credential> mCredentialList = new ArrayList<>();
+    ReentrantReadWriteLock mLock = new ReentrantReadWriteLock();
 
     /**
      * The name of the SharedPreferences file on disk.
@@ -110,20 +112,30 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
      * Returns the list of all AccountRecords.
      */
     private List<AccountRecord> getAllAccountRecords() {
-        if (mAccountList.isEmpty()) {
-            fetchAndPopulateAllAccountsAndCredentials();
+        mLock.readLock().lock();
+        try {
+            if (mAccountList.isEmpty()) {
+                fetchAndPopulateAllAccountsAndCredentials();
+            }
+            return Collections.unmodifiableList(mAccountList);
+        } finally {
+            mLock.readLock().unlock();
         }
-        return Collections.unmodifiableList(mAccountList);
     }
 
     /**
      * Returns the list of all Credentials.
      */
     private List<Credential> getAllCredentials() {
-        if (mCredentialList.isEmpty()) {
-            fetchAndPopulateAllAccountsAndCredentials();
+        mLock.readLock().lock();
+        try {
+            if (mCredentialList.isEmpty()) {
+                fetchAndPopulateAllAccountsAndCredentials();
+            }
+            return Collections.unmodifiableList(mCredentialList);
+        } finally {
+            mLock.readLock().unlock();
         }
-        return Collections.unmodifiableList(mCredentialList);
     }
 
     @Override
@@ -132,7 +144,6 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Account type: [" + accountToSave.getClass().getSimpleName() + "]");
         final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToSave);
         Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
-
         // Perform any necessary field merging on the Account to save...
         final AccountRecord existingAccount = getAccount(cacheKey);
 
@@ -141,7 +152,18 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         }
 
         final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
-        mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+        mLock.writeLock().lock();
+        try {
+            clearAccountAndCredentialsList();
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+        } finally {
+            mLock.writeLock().unlock();
+        }
+    }
+
+    private  void clearAccountAndCredentialsList() {
+        mAccountList.clear();
+        mCredentialList.clear();
     }
 
     @Override
@@ -149,7 +171,6 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Logger.verbose(TAG, "Saving credential...");
         final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToSave);
         Logger.verbosePII(TAG, "Generated cache key: [" + cacheKey + "]");
-
         // Perform any necessary field merging on the Credential to save...
         final Credential existingCredential = getCredential(cacheKey);
 
@@ -158,17 +179,30 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         }
 
         final String cacheValue = mCacheValueDelegate.generateCacheValue(credentialToSave);
-        mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+        mLock.writeLock().lock();
+        try {
+            clearAccountAndCredentialsList();
+            mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+
+        } finally {
+            mLock.writeLock().unlock();
+        }
     }
 
     @Override
     public AccountRecord getAccount(@NonNull final String cacheKey) {
         Logger.verbose(TAG, "Loading Account by key...");
-        AccountRecord account = mCacheValueDelegate.fromCacheValue(
-                mSharedPreferencesFileManager.get(cacheKey),
-                AccountRecord.class
-        );
-
+        AccountRecord account;
+        mLock.readLock().lock();
+        try {
+             account = mCacheValueDelegate.fromCacheValue(
+                    mSharedPreferencesFileManager.get(cacheKey),
+                    AccountRecord.class
+            );
+        }
+        finally {
+            mLock.readLock().unlock();
+        }
         if (null == account) {
             // We could not deserialize the target AccountRecord...
             // Maybe it was encrypted for another application?
@@ -178,7 +212,12 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             );
         } else if (EMPTY_ACCOUNT.equals(account)) {
             Logger.warn(TAG, "The returned Account was uninitialized. Removing...");
-            mSharedPreferencesFileManager.remove(cacheKey);
+            mLock.writeLock().lock();
+            try {
+                mSharedPreferencesFileManager.remove(cacheKey);
+            } finally {
+                mLock.writeLock().unlock();
+            }
             account = null;
         }
 
@@ -202,10 +241,15 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         Credential credential = null;
 
         if (null != clazz) {
-            credential = mCacheValueDelegate.fromCacheValue(
-                    mSharedPreferencesFileManager.get(cacheKey),
-                    clazz
-            );
+            mLock.readLock().lock();
+            try {
+                credential = mCacheValueDelegate.fromCacheValue(
+                        mSharedPreferencesFileManager.get(cacheKey),
+                        clazz
+                );
+            } finally {
+                mLock.readLock().unlock();
+            }
         }
 
         if (null == credential) {
@@ -221,7 +265,12 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             // The returned credential came back uninitialized...
             // Remove the entry and return null...
             Logger.warn(TAG, "The returned Credential was uninitialized. Removing...");
-            mSharedPreferencesFileManager.remove(cacheKey);
+            mLock.writeLock().lock();
+            try {
+                mSharedPreferencesFileManager.remove(cacheKey);
+            } finally {
+                mLock.writeLock().unlock();
+            }
             credential = null;
         }
 
@@ -232,12 +281,14 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     private Map<String, AccountRecord> getAccountsWithKeys() {
         Logger.verbose(TAG, "Loading Accounts + keys...");
         SpanExtension.current().setAttribute(AttributeName.num_account_credential_cache_records.name(), mSharedPreferencesFileManager.keySet().size());
-        final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
-            @Override
-            public boolean test(String value) {
-                return isAccount(value);
-            }
-        });
+        final Iterator<Map.Entry<String, String>> cacheValues;
+        mLock.readLock().lock();
+        try {
+            cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(SharedPreferencesAccountCredentialCache::isAccount);
+        } finally {
+            mLock.readLock().unlock();
+        }
+
         final Map<String, AccountRecord> accounts = new HashMap<>();
         if (cacheValues != null) {
             while (cacheValues.hasNext()) {
@@ -307,12 +358,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         final String methodTag = TAG + ":getCredentialsWithKeys";
         Logger.verbose(methodTag, "Loading Credentials with keys...");
         final Map<String, Credential> credentials = new HashMap<>();
-        final Iterator<Map.Entry<String, String>> cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(new Predicate<String>() {
-            @Override
-            public boolean test(String value) {
-                return isCredential(value);
-            }
-        });
+        final Iterator<Map.Entry<String, String>> cacheValues;
+        mLock.readLock().lock();
+        try {
+            cacheValues = mSharedPreferencesFileManager.getAllFilteredByKey(SharedPreferencesAccountCredentialCache::isCredential);
+        } finally {
+            mLock.readLock().unlock();
+        }
 
         while (cacheValues.hasNext()) {
             Map.Entry<String, ?> cacheValue = cacheValues.next();
@@ -346,8 +398,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         List<Credential> credentials = new ArrayList<>();
         SpanExtension.current().setAttribute(AttributeName.refactored_account_credential_cache_path_triggered.name(),
                 true);
-
-        Map<String, String> cacheKeysWithValues = mSharedPreferencesFileManager.getAll();
+        Map<String, String> cacheKeysWithValues;
+        mLock.readLock().lock();
+        try {
+             cacheKeysWithValues = mSharedPreferencesFileManager.getAll();
+        } finally {
+            mLock.readLock().unlock();
+        }
         for (Map.Entry<String, ?> cacheValue : cacheKeysWithValues.entrySet()) {
             String cacheKey = cacheValue.getKey();
             String cacheValueStr = cacheValue.getValue().toString();
@@ -368,8 +425,15 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                 }
             }
         }
-        mAccountList.addAll(accounts);
-        mCredentialList.addAll(credentials);
+        mLock.writeLock().lock();
+        try {
+            clearAccountAndCredentialsList(); // clear the existing lists to avoid creating duplicates
+            mAccountList.addAll(accounts);
+            mCredentialList.addAll(credentials);
+        } finally {
+            mLock.writeLock().unlock();
+        }
+
     }
 
     @Override
@@ -402,27 +466,32 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy()");
 
-        final List<Credential> allCredentials = getCredentials();
+        mLock.readLock().lock();
+        try {
+            final List<Credential> allCredentials = getCredentials();
 
-        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
-                allCredentials,
-                homeAccountId,
-                environment,
-                credentialType,
-                clientId,
-                applicationIdentifier,
-                mamEnrollmentIdentifier,
-                realm,
-                target,
-                authScheme,
-                null,
-                null,
-                false
-        );
+            final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                    allCredentials,
+                    homeAccountId,
+                    environment,
+                    credentialType,
+                    clientId,
+                    applicationIdentifier,
+                    mamEnrollmentIdentifier,
+                    realm,
+                    target,
+                    authScheme,
+                    null,
+                    null,
+                    false
+            );
 
-        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+            Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
 
-        return matchingCredentials;
+            return matchingCredentials;
+        } finally {
+            mLock.readLock().unlock();
+        }
     }
 
     @Override
@@ -662,8 +731,14 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
         boolean accountRemoved = false;
         if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
         {
-            mSharedPreferencesFileManager.remove(cacheKey);
-            accountRemoved = true;
+            mLock.writeLock().lock();
+            try {
+                clearAccountAndCredentialsList();
+                mSharedPreferencesFileManager.remove(cacheKey);
+                accountRemoved = true;
+            } finally {
+                mLock.writeLock().unlock();
+            }
         }
 
         Logger.info(methodTag, "Account was removed? [" + accountRemoved + "]");
@@ -680,13 +755,21 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             throw new IllegalArgumentException("Param [credentialToRemove] cannot be null.");
         }
 
+
         final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToRemove);
 
         boolean credentialRemoved = false;
         if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
         {
-            mSharedPreferencesFileManager.remove(cacheKey);
-            credentialRemoved = true;
+            mLock.writeLock().lock();
+            try {
+                clearAccountAndCredentialsList();
+                mSharedPreferencesFileManager.remove(cacheKey);
+                credentialRemoved = true;
+            } finally {
+                mLock.writeLock().unlock();
+            }
+
         }
 
         Logger.info(methodTag, "Credential was removed? [" + credentialRemoved + "]");
@@ -698,7 +781,13 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     public void clearAll() {
         final String methodTag = TAG + ":clearAll";
         Logger.info(methodTag, "Clearing all SharedPreferences entries...");
-        mSharedPreferencesFileManager.clear();
+        mLock.writeLock().lock();
+        try {
+            mSharedPreferencesFileManager.clear();
+            clearAccountAndCredentialsList();
+        } finally {
+            mLock.writeLock().unlock();
+        }
         Logger.info(methodTag, "SharedPreferences cleared.");
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -175,13 +175,18 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to skip ests telemetry.
      */
-    SKIP_ESTS_TELEMETRY("SkipEstsTelemetry", false),
+    SKIP_ESTS_TELEMETRY("SkipEstsTelemetry", true),
 
     /**
      * Flight to enable OpenID issuer validation code which validates issuer against the open id well known
      * config endpoint and only reports the failure result.
      */
-    ENABLE_OPENID_ISSUER_VALIDATION_REPORTING("EnableOpenIdIssuerValidationReporting", true);
+    ENABLE_OPENID_ISSUER_VALIDATION_REPORTING("EnableOpenIdIssuerValidationReporting", true),
+
+    /**
+     * Flight to enable refactored getAccountByLocalAccountId path.
+     */
+    ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH("EnableRefactoredGetAccountByLocalAccountIdPath", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -186,7 +186,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable refactored getAccountByLocalAccountId path.
      */
-    ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH("EnableRefactoredGetAccountByLocalAccountIdPath", true);
+    ENABLE_REFACTORED_GET_ACCOUNT_BY_LOCAL_ACCOUNT_ID_PATH("EnableRefactoredGetAccountByLocalAccountIdPath", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -151,6 +151,11 @@ public enum AttributeName {
     num_concurrent_silent_requests,
 
     /**
+     * The number of account and credential records in the cache.
+     */
+    num_account_credential_cache_records,
+
+    /**
      * The time (in milliseconds) spent in executing the save method in OAuth2TokenCache.
      */
     elapsed_time_cache_save,
@@ -487,5 +492,10 @@ public enum AttributeName {
     /**
      * Records if current flow is in webcp flow.
      */
-    is_in_web_cp_flow
+    is_in_web_cp_flow,
+
+    /**
+     * Indicates if the refactored account credential cache path was triggered.
+     */
+    refactored_account_credential_cache_path_triggered
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -151,7 +151,7 @@ public enum AttributeName {
     num_concurrent_silent_requests,
 
     /**
-     * The number of account and credential records in the cache.
+     * The number of account and credential records in the SharedPreferences.
      */
     num_account_credential_cache_records,
 


### PR DESCRIPTION
Fixes [AB#3417272](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3417272)

## PR Summary: Refactored code to iterate over SharedPreferences once

This pull request refactors the existing implementation to optimize how SharedPreferences are accessed. Previously, the code may have iterated over SharedPreferences multiple times, which could lead to inefficiencies. The changes introduced ensure that SharedPreferences are only iterated over once during relevant operations.
Also set the flight SkipEstsTelemetry to true by default since it is 100% rolled out in the production.

### Key Changes:
- Consolidated loops and logic to perform a single iteration over SharedPreferences data.
- Reduced redundant accesses, improving performance and maintainability.
- Enhanced code readability and simplified logic flow.

### Impact:
- More efficient handling of SharedPreferences, especially in scenarios with large data sets.
- Reduced computational overhead and potential performance bottlenecks.