### PR TITLE
Fix test_2798415_SDM_MAM, Fixes AB#3414752

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerCompanyPortal.java
@@ -394,6 +394,14 @@ public class BrokerCompanyPortal extends AbstractTestBroker implements ITestBrok
                 getAccessScreen.waitForExists(TimeUnit.MINUTES.toMillis(2))
         );
 
+        // Adding small sleep before continuing, as Teams can trigger MAM PIN flow twice
+        // With delay we'd only interact with 2nd instance of the flow.
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         // get access screen - continue
         UiAutomatorUtils.handleButtonClick("com.microsoft.windowsintune.companyportal:id/positive_button");
 


### PR DESCRIPTION
Fixes [AB#3414752](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3414752)
- Add delay before interactive with MAM screen "Get access" as it can trigger twice by Teams. 

Have already contact with Teams OCE on this.