### PR TITLE
Print library variant being built in assemble task, Fixes AB#3412918

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -146,6 +146,7 @@ android {
     libraryVariants.all { variant ->
         variant.outputs.all {
             outputFileName = "${archivesBaseName}-${version}.aar"
+            println("Building variant: ${variant.name} for ${project.name}")
         }
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -146,7 +146,6 @@ android {
     libraryVariants.all { variant ->
         variant.outputs.all {
             outputFileName = "${archivesBaseName}-${version}.aar"
-            println("Building variant: ${variant.name} for ${project.name}")
         }
     }
 }
@@ -261,6 +260,14 @@ android.libraryVariants.all { variant ->
     task("${variant.name}JavadocJar", type: Jar, dependsOn: "${variant.name}Javadoc") {
         archiveClassifier.set('javadoc')
         from tasks["${variant.name}Javadoc"].destinationDir
+    }
+}
+
+android.libraryVariants.all { variant ->
+    tasks.named("assemble${variant.name.capitalize()}").configure {
+        doFirst {
+            println("Assembling variant: ${variant.name} for ${project.name}")
+        }
     }
 }
 


### PR DESCRIPTION
Print library variant being built in assemble task. This should help as a sanity check during pipeline runs

[AB#3412918](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3412918)