### PR TITLE
Native auth: update auth method blocked error handling, Fixes AB#3395876

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ vNext
 - [MINOR] WebApps AccountId Registry (#2787)
 - [MINOR] Expose WebApps APIs (#2793)
 - [MINOR] Add domainHint support to authorization request (#2792)
+- [PATCH] Fix auth method blocked error handling (#2804)
 
 Version 23.0.2
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandler.kt
@@ -730,6 +730,7 @@ class NativeAuthResponseHandler {
                 codeLength = null,
                 interval = null,
                 errorCodes = null,
+                subError = null,
                 correlationId = correlationId
             )
         } else {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/jit/JITChallengeApiResponse.kt
@@ -26,11 +26,12 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.INativeAuthApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
-import com.microsoft.identity.common.java.nativeauth.util.isBlockedChallengeTarget
+import com.microsoft.identity.common.java.nativeauth.util.isAccessDenied
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidChallengeTarget
 import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
 import com.microsoft.identity.common.java.nativeauth.util.isOOB
 import com.microsoft.identity.common.java.nativeauth.util.isPreverified
+import com.microsoft.identity.common.java.nativeauth.util.isProviderBlocked
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
 import java.net.HttpURLConnection
 
@@ -51,6 +52,7 @@ class JITChallengeApiResponse(
     @SerializedName("error_description") override val errorDescription: String?,
     @SerializedName("error_uri") val errorUri: String?,
     @SerializedName("error_codes") val errorCodes: List<Int>?,
+    @SerializedName("suberror") val subError: String?,
     @Expose @SerializedName("challenge_type") override val challengeType: String?,
     @SerializedName("redirect_reason") override val redirectReason: String?,
 ) : INativeAuthApiResponse(statusCode, correlationId, continuationToken, challengeType, redirectReason, error, errorDescription) {
@@ -79,7 +81,7 @@ class JITChallengeApiResponse(
                             correlationId = correlationId
                         )
                     }
-                    error.isInvalidRequest() && errorCodes?.first().isBlockedChallengeTarget() -> {
+                    error.isAccessDenied() && subError.isProviderBlocked() -> {
                         JITChallengeApiResult.BlockedVerificationContact(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/signin/SignInChallengeApiResponse.kt
@@ -26,10 +26,10 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.microsoft.identity.common.java.nativeauth.providers.INativeAuthApiResponse
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
-import com.microsoft.identity.common.java.nativeauth.util.isBlockedChallengeTarget
-import com.microsoft.identity.common.java.nativeauth.util.isInvalidRequest
+import com.microsoft.identity.common.java.nativeauth.util.isAccessDenied
 import com.microsoft.identity.common.java.nativeauth.util.isOOB
 import com.microsoft.identity.common.java.nativeauth.util.isPassword
+import com.microsoft.identity.common.java.nativeauth.util.isProviderBlocked
 import com.microsoft.identity.common.java.nativeauth.util.isRedirect
 import java.net.HttpURLConnection
 
@@ -78,7 +78,7 @@ class SignInChallengeApiResponse(
             // Handle 400 errors
             HttpURLConnection.HTTP_BAD_REQUEST -> {
                 return when {
-                    error.isInvalidRequest() && errorCodes?.first().isBlockedChallengeTarget() -> {
+                    error.isAccessDenied() && subError.isProviderBlocked() -> {
                         SignInChallengeApiResult.BlockedAuthMethod(
                             error = error.orEmpty(),
                             errorDescription = errorDescription.orEmpty(),

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/util/ApiErrorResponseUtil.kt
@@ -50,6 +50,10 @@ internal fun String?.isInvalidRequest(): Boolean {
     return this.contentEquals(other = "invalid_request", ignoreCase = true)
 }
 
+internal fun String?.isAccessDenied(): Boolean {
+    return this.contentEquals(other = "access_denied", ignoreCase = true)
+}
+
 internal fun String?.isPasswordTooWeak(): Boolean {
     return this.contentEquals(other = "password_too_weak", ignoreCase = true)
 }
@@ -117,8 +121,8 @@ internal fun Int?.isInvalidChallengeTarget(): Boolean {
     return this == 901001
 }
 
-internal fun Int?.isBlockedChallengeTarget(): Boolean {
-    return this == 550024
+fun String?.isProviderBlocked(): Boolean {
+    return this.contentEquals(other = "provider_blocked_by_rep", ignoreCase = true)
 }
 
 fun String?.isMFARequired(): Boolean {

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/NativeAuthResponseHandlerTest.kt
@@ -3793,6 +3793,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = null,
             codeLength = null,
             interval = null,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()
@@ -3820,6 +3821,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = null,
             codeLength = null,
             interval = null,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()
@@ -3844,6 +3846,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = null,
             codeLength = null,
             interval = null,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()
@@ -3872,6 +3875,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = null,
             codeLength = null,
             interval = null,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()
@@ -3902,6 +3906,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = null,
             codeLength = null,
             interval = null,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()
@@ -3931,6 +3936,7 @@ class NativeAuthResponseHandlerTest {
             challengeTarget = challengeTargetLabel,
             codeLength = codeLength,
             interval = interval,
+            subError = null,
             correlationId = correlationId
         )
         val apiResult = jitChallengeApiResponse.toResult()


### PR DESCRIPTION
Update auth method blocked error handling. Use suberror instead of error codes

[AB#3395876](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3395876)