### PR TITLE
revert function key append, update HTTP request methods, Fixes AB#3430779

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -229,10 +229,7 @@ public class LabClient implements ILabClient {
                 mLabApiAuthenticationClient.getAccessToken()
         );
 
-        final String createTempUserFunctionCode = getKeyVaultSecret(
-                CreateTempUserApi.AZURE_FUNCTION_CODE_SECRET_NAME
-        );
-        final CreateTempUserApi createTempUserApi = new CreateTempUserApi(createTempUserFunctionCode);
+        final CreateTempUserApi createTempUserApi = new CreateTempUserApi();
         createTempUserApi.getApiClient().setReadTimeout(TEMP_USER_API_READ_TIMEOUT);
         final TempUser tempUser;
 
@@ -329,11 +326,7 @@ public class LabClient implements ILabClient {
         Configuration.getDefaultApiClient().setAccessToken(
                 mLabApiAuthenticationClient.getAccessToken()
         );
-
-        final String deleteDeviceFunctionCode = getKeyVaultSecret(
-                DeleteDeviceApi.AZURE_FUNCTION_CODE_SECRET_NAME
-        );
-        final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi(deleteDeviceFunctionCode);
+        final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi();
 
         try {
             final CustomSuccessResponse successResponse = deleteDeviceApi.apiDeleteDeviceDelete(
@@ -435,10 +428,10 @@ public class LabClient implements ILabClient {
 
     @Override
     public boolean resetPassword(@NonNull final String upn) throws LabApiException {
-        final String resetApiFunctionCode = getKeyVaultSecret(
-                ResetApi.AZURE_FUNCTION_CODE_SECRET_NAME
+        Configuration.getDefaultApiClient().setAccessToken(
+                mLabApiAuthenticationClient.getAccessToken()
         );
-        final ResetApi resetApi = new ResetApi(resetApiFunctionCode);
+        final ResetApi resetApi = new ResetApi();
         try {
             final CustomSuccessResponse resetResponse = resetApi.apiResetPut(upn, ResetOperation.PASSWORD.toString());
             if (resetResponse == null) {
@@ -512,10 +505,7 @@ public class LabClient implements ILabClient {
         Configuration.getDefaultApiClient().setAccessToken(
                 mLabApiAuthenticationClient.getAccessToken()
         );
-        final String enablePolicyFunctionCode = getKeyVaultSecret(
-                EnablePolicyApi.AZURE_FUNCTION_CODE_SECRET_NAME
-        );
-        final EnablePolicyApi enablePolicyApi = new EnablePolicyApi(enablePolicyFunctionCode);
+        final EnablePolicyApi enablePolicyApi = new EnablePolicyApi();
         try {
             final CustomSuccessResponse enablePolicyResult = enablePolicyApi.apiEnablePolicyPut(upn, policy.toString());
             final String expectedResult = (policy + " Enabled for user : " + upn).toLowerCase();
@@ -537,10 +527,10 @@ public class LabClient implements ILabClient {
      * @return boolean value indicating policy is disabled or not for the upn.
      */
     public boolean disablePolicy(@NonNull final String upn, @NonNull final ProtectionPolicy policy) throws LabApiException {
-        final String disablePolicyFunctionCode = getKeyVaultSecret(
-                DisablePolicyApi.AZURE_FUNCTION_CODE_SECRET_NAME
+        Configuration.getDefaultApiClient().setAccessToken(
+                mLabApiAuthenticationClient.getAccessToken()
         );
-        final DisablePolicyApi disablePolicyApi = new DisablePolicyApi(disablePolicyFunctionCode);
+        final DisablePolicyApi disablePolicyApi = new DisablePolicyApi();
         try {
             final CustomSuccessResponse disablePolicyResponse = disablePolicyApi.apiDisablePolicyPut(upn, policy.toString());
             final String expectedResult = (policy + " Disabled for user : " + upn).toLowerCase();

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -329,7 +329,7 @@ public class LabClient implements ILabClient {
         final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi();
 
         try {
-            final CustomSuccessResponse successResponse = deleteDeviceApi.apiDeleteDeviceDelete(
+            final String successResponse = deleteDeviceApi.apiDeleteDeviceDelete(
                     upn, deviceId
             );
 
@@ -339,12 +339,12 @@ public class LabClient implements ILabClient {
 
             // we probably need a more sophisticated logger integrated into LabApi
             // for now this is fine
-            System.out.println(successResponse.getResult());
+            System.out.println(successResponse);
 
             final String expectedResult = String.format(
                     "Device : %s, successfully deleted from AAD.", deviceId
             );
-            return expectedResult.equalsIgnoreCase(successResponse.getResult());
+            return expectedResult.equalsIgnoreCase(successResponse);
         } catch (final com.microsoft.identity.internal.test.labapi.ApiException ex) {
             throw new LabApiException(
                     LabError.FAILED_TO_DELETE_DEVICE, ex,

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/LabConstants.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/LabConstants.java
@@ -163,8 +163,8 @@ public class LabConstants {
     }
 
     static final class ResetOperation {
-        public static final String MFA = "MFA";
-        public static final String PASSWORD = "Password";
+        public static final String MFA = "mfa";
+        public static final String PASSWORD = "password";
     }
 
     static final class HasAltId {

--- a/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
+++ b/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
@@ -171,7 +171,6 @@ public class LabClientTest {
     }
 
     @Test
-    @Ignore
     public void canResetPassword() {
         try {
             final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
@@ -183,7 +182,6 @@ public class LabClientTest {
     }
 
     @Test
-    @Ignore
     public void canEnablePolicy() {
         try {
             final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
@@ -195,7 +193,6 @@ public class LabClientTest {
     }
 
     @Test
-    @Ignore
     public void canDisablePolicy() {
         try {
             final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.MAM_CA);

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/CreateTempUserApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/CreateTempUserApi.java
@@ -20,15 +20,9 @@ import com.microsoft.identity.internal.test.labapi.Configuration;
 import com.microsoft.identity.internal.test.labapi.Pair;
 import com.microsoft.identity.internal.test.labapi.ProgressRequestBody;
 import com.microsoft.identity.internal.test.labapi.ProgressResponseBody;
-
 import com.google.gson.reflect.TypeToken;
-
 import java.io.IOException;
-
-
-import com.microsoft.identity.internal.test.labapi.model.CustomErrorResponse;
 import com.microsoft.identity.internal.test.labapi.model.TempUser;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,16 +31,13 @@ import java.util.Map;
 
 public class CreateTempUserApi {
     private ApiClient apiClient;
-    private final String mAzureFunctionCode;
-    public static final String AZURE_FUNCTION_CODE_SECRET_NAME = "CreateTempUser";
 
-    public CreateTempUserApi(final String azureFunctionCode) {
-        this(Configuration.getDefaultApiClient(), azureFunctionCode);
+    public CreateTempUserApi() {
+        this(Configuration.getDefaultApiClient());
     }
 
-    public CreateTempUserApi(final ApiClient apiClient, final String azureFunctionCode) {
+    public CreateTempUserApi(final ApiClient apiClient) {
         this.apiClient = apiClient;
-        mAzureFunctionCode = azureFunctionCode;
     }
 
     public ApiClient getApiClient() {
@@ -75,8 +66,6 @@ public class CreateTempUserApi {
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
         if (usertype != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("usertype", usertype));
-
-        localVarQueryParams.addAll(apiClient.parameterToPair("code", mAzureFunctionCode));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DeleteDeviceApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DeleteDeviceApi.java
@@ -68,7 +68,7 @@ public class DeleteDeviceApi {
         if (upn != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("upn", upn));
         if (deviceid != null)
-            localVarQueryParams.addAll(apiClient.parameterToPair("deviceid", deviceid));
+            localVarQueryParams.addAll(apiClient.parameterToPair("deviceId", deviceid));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -117,8 +117,8 @@ public class DeleteDeviceApi {
      * @return CustomSuccessResponse
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public CustomSuccessResponse apiDeleteDeviceDelete(String upn, String deviceid) throws ApiException {
-        ApiResponse<CustomSuccessResponse> resp = apiDeleteDeviceDeleteWithHttpInfo(upn, deviceid);
+    public String apiDeleteDeviceDelete(String upn, String deviceid) throws ApiException {
+        ApiResponse<String> resp = apiDeleteDeviceDeleteWithHttpInfo(upn, deviceid);
         return resp.getData();
     }
 
@@ -130,9 +130,9 @@ public class DeleteDeviceApi {
      * @return ApiResponse&lt;CustomSuccessResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<CustomSuccessResponse> apiDeleteDeviceDeleteWithHttpInfo(String upn, String deviceid) throws ApiException {
+    public ApiResponse<String> apiDeleteDeviceDeleteWithHttpInfo(String upn, String deviceid) throws ApiException {
         com.squareup.okhttp.Call call = apiDeleteDeviceDeleteValidateBeforeCall(upn, deviceid, null, null);
-        Type localVarReturnType = TypeToken.get(CustomSuccessResponse.class).getType();
+        Type localVarReturnType = TypeToken.get(String.class).getType();
         return apiClient.execute(call, localVarReturnType);
     }
 

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DeleteDeviceApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DeleteDeviceApi.java
@@ -20,15 +20,9 @@ import com.microsoft.identity.internal.test.labapi.Configuration;
 import com.microsoft.identity.internal.test.labapi.Pair;
 import com.microsoft.identity.internal.test.labapi.ProgressRequestBody;
 import com.microsoft.identity.internal.test.labapi.ProgressResponseBody;
-
 import com.google.gson.reflect.TypeToken;
-
 import java.io.IOException;
-
-
-import com.microsoft.identity.internal.test.labapi.model.CustomErrorResponse;
 import com.microsoft.identity.internal.test.labapi.model.CustomSuccessResponse;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,16 +31,13 @@ import java.util.Map;
 
 public class DeleteDeviceApi {
     private ApiClient apiClient;
-    private final String mAzureFunctionCode;
-    public static final String AZURE_FUNCTION_CODE_SECRET_NAME = "DeleteDevice";
 
-    public DeleteDeviceApi(final String azureFunctionCode) {
-        this(Configuration.getDefaultApiClient(), azureFunctionCode);
+    public DeleteDeviceApi() {
+        this(Configuration.getDefaultApiClient());
     }
 
-    public DeleteDeviceApi(ApiClient apiClient, final String azureFunctionCode) {
+    public DeleteDeviceApi(ApiClient apiClient) {
         this.apiClient = apiClient;
-        mAzureFunctionCode = azureFunctionCode;
     }
 
     public ApiClient getApiClient() {
@@ -79,8 +70,6 @@ public class DeleteDeviceApi {
         if (deviceid != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("deviceid", deviceid));
 
-        localVarQueryParams.addAll(apiClient.parameterToPair("code", mAzureFunctionCode));
-
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -110,7 +99,7 @@ public class DeleteDeviceApi {
         }
 
         String[] localVarAuthNames = new String[] {  };
-        return apiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
 
     @SuppressWarnings("rawtypes")

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DisablePolicyApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/DisablePolicyApi.java
@@ -36,16 +36,13 @@ import java.util.Map;
 
 public class DisablePolicyApi {
     private ApiClient apiClient;
-    private final String mAzureFunctionCode;
-    public static final String AZURE_FUNCTION_CODE_SECRET_NAME = "DisablePolicy";
 
-    public DisablePolicyApi(final String azureFunctionCode) {
-        this(Configuration.getDefaultApiClient(), azureFunctionCode);
+    public DisablePolicyApi() {
+        this(Configuration.getDefaultApiClient());
     }
 
-    public DisablePolicyApi(ApiClient apiClient, final String azureFunctionCode) {
+    public DisablePolicyApi(ApiClient apiClient) {
         this.apiClient = apiClient;
-        mAzureFunctionCode = azureFunctionCode;
     }
 
     public ApiClient getApiClient() {
@@ -78,8 +75,6 @@ public class DisablePolicyApi {
         if (policy != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("policy", policy));
 
-        localVarQueryParams.addAll(apiClient.parameterToPair("code", mAzureFunctionCode));
-
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -109,7 +104,7 @@ public class DisablePolicyApi {
         }
 
         String[] localVarAuthNames = new String[] {  };
-        return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
 
     @SuppressWarnings("rawtypes")

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/EnablePolicyApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/EnablePolicyApi.java
@@ -35,16 +35,13 @@ import java.util.Map;
 
 public class EnablePolicyApi {
     private ApiClient apiClient;
-    private final String mAzureFunctionCode;
-    public static final String AZURE_FUNCTION_CODE_SECRET_NAME = "EnablePolicy";
 
-    public EnablePolicyApi(final String azureFunctionCode) {
-        this(Configuration.getDefaultApiClient(), azureFunctionCode);
+    public EnablePolicyApi() {
+        this(Configuration.getDefaultApiClient());
     }
 
-    public EnablePolicyApi(ApiClient apiClient, final String azureFunctionCode) {
+    public EnablePolicyApi(ApiClient apiClient) {
         this.apiClient = apiClient;
-        mAzureFunctionCode = azureFunctionCode;
     }
 
     public ApiClient getApiClient() {
@@ -77,8 +74,6 @@ public class EnablePolicyApi {
         if (policy != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("policy", policy));
 
-        localVarQueryParams.addAll(apiClient.parameterToPair("code", mAzureFunctionCode));
-
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -108,7 +103,7 @@ public class EnablePolicyApi {
         }
 
         String[] localVarAuthNames = new String[] {  };
-        return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
 
     @SuppressWarnings("rawtypes")

--- a/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/ResetApi.java
+++ b/labapi/src/main/java/com/microsoft/identity/internal/test/labapi/api/ResetApi.java
@@ -20,15 +20,9 @@ import com.microsoft.identity.internal.test.labapi.Configuration;
 import com.microsoft.identity.internal.test.labapi.Pair;
 import com.microsoft.identity.internal.test.labapi.ProgressRequestBody;
 import com.microsoft.identity.internal.test.labapi.ProgressResponseBody;
-
 import com.google.gson.reflect.TypeToken;
-
 import java.io.IOException;
-
-
-import com.microsoft.identity.internal.test.labapi.model.CustomErrorResponse;
 import com.microsoft.identity.internal.test.labapi.model.CustomSuccessResponse;
-
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,16 +31,13 @@ import java.util.Map;
 
 public class ResetApi {
     private ApiClient apiClient;
-    private final String mAzureFunctionCode;
-    public static final String AZURE_FUNCTION_CODE_SECRET_NAME = "ResetApi";
 
-    public ResetApi(final String azureFunctionCode) {
-        this(Configuration.getDefaultApiClient(), azureFunctionCode);
+    public ResetApi() {
+        this(Configuration.getDefaultApiClient());
     }
 
-    public ResetApi(ApiClient apiClient, final String azureFunctionCode) {
+    public ResetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
-        mAzureFunctionCode = azureFunctionCode;
     }
 
     public ApiClient getApiClient() {
@@ -79,8 +70,6 @@ public class ResetApi {
         if (operation != null)
             localVarQueryParams.addAll(apiClient.parameterToPair("operation", operation));
 
-        localVarQueryParams.addAll(apiClient.parameterToPair("code", mAzureFunctionCode));
-
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
@@ -110,7 +99,7 @@ public class ResetApi {
         }
 
         String[] localVarAuthNames = new String[] {  };
-        return apiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
+        return apiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, progressRequestListener);
     }
 
     @SuppressWarnings("rawtypes")

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabDeviceHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabDeviceHelper.java
@@ -25,9 +25,6 @@ package com.microsoft.identity.internal.testutils.labutils;
 import com.microsoft.identity.internal.test.labapi.ApiException;
 import com.microsoft.identity.internal.test.labapi.api.DeleteDeviceApi;
 import com.microsoft.identity.internal.test.labapi.model.CustomSuccessResponse;
-import com.microsoft.identity.internal.testutils.BuildConfig;
-import com.microsoft.identity.labapi.utilities.authentication.LabApiAuthenticationClient;
-import com.microsoft.identity.labapi.utilities.client.LabClient;
 import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 import com.microsoft.identity.labapi.utilities.exception.LabError;
 
@@ -37,7 +34,6 @@ import com.microsoft.identity.labapi.utilities.exception.LabError;
 public class LabDeviceHelper {
 
     public static final ConfidentialClientHelper INSTANCE = LabAuthenticationHelper.getInstance();
-    private static final LabClient mLabClient = new LabClient(new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET));
 
     /**
      * Deletes the provided device from the directory.
@@ -49,10 +45,7 @@ public class LabDeviceHelper {
     public static boolean deleteDevice(final String upn, final String deviceId) throws LabApiException {
         INSTANCE.setupApiClientWithAccessToken();
         try {
-            final String deleteDeviceFunctionCode = mLabClient.getKeyVaultSecret(
-                    DeleteDeviceApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi(deleteDeviceFunctionCode);
+            final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi();
             final CustomSuccessResponse customSuccessResponse;
             customSuccessResponse = deleteDeviceApi.apiDeleteDeviceDelete(upn, deviceId);
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabDeviceHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabDeviceHelper.java
@@ -46,15 +46,17 @@ public class LabDeviceHelper {
         INSTANCE.setupApiClientWithAccessToken();
         try {
             final DeleteDeviceApi deleteDeviceApi = new DeleteDeviceApi();
-            final CustomSuccessResponse customSuccessResponse;
-            customSuccessResponse = deleteDeviceApi.apiDeleteDeviceDelete(upn, deviceId);
+            final String successResponse;
+            successResponse = deleteDeviceApi.apiDeleteDeviceDelete(upn, deviceId);
 
-            if (customSuccessResponse == null) {
+            if (successResponse == null) {
                 return false;
             }
 
-            final String expectedResult = "Device removed Successfully.";
-            return expectedResult.equalsIgnoreCase(customSuccessResponse.getMessage());
+            final String expectedResult = String.format(
+                    "Device : %s, successfully deleted from AAD.", deviceId
+            );
+            return expectedResult.equalsIgnoreCase(successResponse);
         } catch (final ApiException e) {
             throw new LabApiException(LabError.FAILED_TO_DELETE_DEVICE);
         }

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabResetHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabResetHelper.java
@@ -27,10 +27,6 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.internal.test.labapi.ApiException;
 import com.microsoft.identity.internal.test.labapi.api.ResetApi;
 import com.microsoft.identity.internal.test.labapi.model.CustomSuccessResponse;
-import com.microsoft.identity.internal.testutils.BuildConfig;
-import com.microsoft.identity.labapi.utilities.authentication.LabApiAuthenticationClient;
-import com.microsoft.identity.labapi.utilities.client.LabClient;
-import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 
 /**
  * Utilities to interact with Lab {@link ResetApi}.
@@ -38,7 +34,6 @@ import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 public class LabResetHelper {
 
     public static final ConfidentialClientHelper INSTANCE = LabAuthenticationHelper.getInstance();
-    private static final LabClient mLabClient = new LabClient(new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET));
 
     /**
      * Reset the password for the supplied account.
@@ -46,14 +41,11 @@ public class LabResetHelper {
      * @param upn the upn of the user for which to reset password
      * @return a boolean indicating if password reset was successful
      */
-    public static boolean resetPassword(@NonNull final String upn) throws LabApiException {
+    public static boolean resetPassword(@NonNull final String upn) {
         INSTANCE.setupApiClientWithAccessToken();
 
         try {
-            final String resetApiFunctionCode = mLabClient.getKeyVaultSecret(
-                    ResetApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final ResetApi resetApi = new ResetApi(resetApiFunctionCode);
+            final ResetApi resetApi = new ResetApi();
             final CustomSuccessResponse resetResponse = resetApi.apiResetPut(upn, LabConstants.ResetOperation.PASSWORD);
 
             if (resetResponse == null) {
@@ -77,10 +69,7 @@ public class LabResetHelper {
         INSTANCE.setupApiClientWithAccessToken();
 
         try {
-            final String resetApiFunctionCode = mLabClient.getKeyVaultSecret(
-                    ResetApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final ResetApi resetApi = new ResetApi(resetApiFunctionCode);
+            final ResetApi resetApi = new ResetApi();
             final CustomSuccessResponse resetResponse = resetApi.apiResetPut(upn, LabConstants.ResetOperation.MFA);
 
             if (resetResponse == null) {
@@ -92,8 +81,6 @@ public class LabResetHelper {
             );
         } catch (ApiException e) {
             throw new RuntimeException(e.getMessage());
-        } catch (LabApiException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/LabUserHelper.java
@@ -33,9 +33,6 @@ import com.microsoft.identity.internal.test.labapi.model.ConfigInfo;
 import com.microsoft.identity.internal.test.labapi.model.LabInfo;
 import com.microsoft.identity.internal.test.labapi.model.TempUser;
 import com.microsoft.identity.internal.test.labapi.model.UserInfo;
-import com.microsoft.identity.internal.testutils.BuildConfig;
-import com.microsoft.identity.labapi.utilities.authentication.LabApiAuthenticationClient;
-import com.microsoft.identity.labapi.utilities.client.LabClient;
 import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 
 import java.util.ArrayList;
@@ -48,7 +45,6 @@ public class LabUserHelper {
 
     private static final Map<LabUserQuery, LabConfig> sLabConfigCache = new HashMap<>();
     private volatile static ConfidentialClientHelper instance = LabAuthenticationHelper.getInstance();
-    private static final LabClient mLabClient = new LabClient(new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET));
 
     private static final int TEMP_USER_API_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(15);
 
@@ -255,10 +251,7 @@ public class LabUserHelper {
         TempUser tempUser;
 
         try {
-            final String createTempUserFunctionCode = mLabClient.getKeyVaultSecret(
-                    CreateTempUserApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final CreateTempUserApi createTempUserApi = new CreateTempUserApi(createTempUserFunctionCode);
+            final CreateTempUserApi createTempUserApi = new CreateTempUserApi();
 
             createTempUserApi.getApiClient().setReadTimeout(TEMP_USER_API_READ_TIMEOUT);
 
@@ -268,7 +261,7 @@ public class LabUserHelper {
             final String password = LabHelper.getPasswordForLab(tempUser.getCredentialVaultKeyName());
             LabConfig labConfig = new LabConfig(tempUser, password);
             LabConfig.setCurrentLabConfig(labConfig);
-        } catch (ApiException | LabApiException e) {
+        } catch (ApiException e) {
             throw new RuntimeException("Error retrieving lab user", e);
         }
 
@@ -278,14 +271,11 @@ public class LabUserHelper {
     public static TempUser loadTempUserForTest(final String userType) {
         instance.setupApiClientWithAccessToken();
         try {
-            final String createTempUserFunctionCode = mLabClient.getKeyVaultSecret(
-                    CreateTempUserApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final CreateTempUserApi createTempUserApi = new CreateTempUserApi(createTempUserFunctionCode);
+            final CreateTempUserApi createTempUserApi = new CreateTempUserApi();
 
             createTempUserApi.getApiClient().setReadTimeout(TEMP_USER_API_READ_TIMEOUT);
             return createTempUserApi.apiCreateTempUserPost(userType);
-        } catch (ApiException | LabApiException e) {
+        } catch (ApiException e) {
             throw new RuntimeException("Error retrieving lab user", e);
         }
     }
@@ -342,10 +332,7 @@ public class LabUserHelper {
     public static void resetPassword(final String upn) throws LabApiException {
         instance.setupApiClientWithAccessToken();
         try {
-            final String resetApiFunctionCode = mLabClient.getKeyVaultSecret(
-                    ResetApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            ResetApi resetApi = new ResetApi(resetApiFunctionCode);
+            ResetApi resetApi = new ResetApi();
 
             resetApi.apiResetPut(upn, "Password");
         } catch (ApiException e) {

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/PolicyHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/PolicyHelper.java
@@ -28,10 +28,6 @@ import com.microsoft.identity.internal.test.labapi.ApiException;
 import com.microsoft.identity.internal.test.labapi.api.DisablePolicyApi;
 import com.microsoft.identity.internal.test.labapi.api.EnablePolicyApi;
 import com.microsoft.identity.internal.test.labapi.model.CustomSuccessResponse;
-import com.microsoft.identity.internal.testutils.BuildConfig;
-import com.microsoft.identity.labapi.utilities.authentication.LabApiAuthenticationClient;
-import com.microsoft.identity.labapi.utilities.client.LabClient;
-import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 
 import org.junit.Assert;
 
@@ -44,7 +40,6 @@ public class PolicyHelper {
 
     private static final String TAG = PolicyHelper.class.getName();
     private static final ConfidentialClientHelper instance = LabAuthenticationHelper.getInstance();
-    private static final LabClient mLabClient = new LabClient(new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET));
 
     /**
      * Enable CA/Special Policies for any Locked User.
@@ -54,14 +49,11 @@ public class PolicyHelper {
      * @param policy Enable Policy can be used for GlobalMFA, MAMCA, MDMCA, MFAONSPO, MFAONEXO. (optional)
      * @return boolean value indicating policy enabled or not.
      */
-    public boolean enablePolicy(@NonNull final String upn, @NonNull final String policy) throws LabApiException {
+    public boolean enablePolicy(@NonNull final String upn, @NonNull final String policy) {
         instance.setupApiClientWithAccessToken();
 
         try {
-            final String enablePolicyFunctionCode = mLabClient.getKeyVaultSecret(
-                    EnablePolicyApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final EnablePolicyApi enablePolicyApi = new EnablePolicyApi(enablePolicyFunctionCode);
+            final EnablePolicyApi enablePolicyApi = new EnablePolicyApi();
 
             final CustomSuccessResponse enablePolicyResult = enablePolicyApi.apiEnablePolicyPut(upn, policy);
             final String expectedResult = (policy +" Enabled for user : " + upn).toLowerCase();
@@ -81,14 +73,11 @@ public class PolicyHelper {
      * @param policy Disable Policy can be used for GlobalMFA, MAMCA, MDMCA, MFAONSPO, MFAONEXO. (optional)
      * @return boolean value indicating policy is disabled or not for the upn.
      */
-    public boolean disablePolicy(@NonNull final String upn, @NonNull final String policy) throws LabApiException {
+    public boolean disablePolicy(@NonNull final String upn, @NonNull final String policy) {
         instance.setupApiClientWithAccessToken();
 
         try {
-            final String disablePolicyFunctionCode = mLabClient.getKeyVaultSecret(
-                    DisablePolicyApi.AZURE_FUNCTION_CODE_SECRET_NAME
-            );
-            final DisablePolicyApi disablePolicyApi = new DisablePolicyApi(disablePolicyFunctionCode);
+            final DisablePolicyApi disablePolicyApi = new DisablePolicyApi();
             final CustomSuccessResponse disablePolicyResponse = disablePolicyApi.apiDisablePolicyPut(upn, policy);
             final String expectedResult = (policy + " Disabled for user : " + upn).toLowerCase();
             Assert.assertNotNull(disablePolicyResponse);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/AdbShellUtils.java
@@ -97,7 +97,7 @@ public class AdbShellUtils {
         final String result = executeShellCommand(installCmdBuilder.toString());
         final String result2 = executeShellCommand("ls /data/local/tmp");
         Assert.assertNotNull(result);
-        Assert.assertEquals("Files in /data/local/tmp: \n" + result2, "Success", result.trim());
+        Assert.assertEquals("Failed to install \"" + packageName + "\". Files in /data/local/tmp: \n" + result2, "Success", result.trim());
     }
 
     /**


### PR DESCRIPTION
We no longer need to pass the functions keys when calling lab api, just having the certificate token in headers is enough when making the request. All Lab APIs are now working again, needed to update their http request methods as well, all should use POST.

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1560386&view=results

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1560092&view=results

[AB#3430779](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3430779), 3429582