### PR TITLE
lab tweak, one auth client, Fixes AB#3447250

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
@@ -51,26 +51,20 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
     private final static int ATTEMPT_RETRY_WAIT = 3;
     private final String mLabCredential;
     private final String mLabCertPassword;
-    private final String mScope;
+    private final String defaultScope = LabConstants.DEFAULT_LAB_SCOPE;
     private final String mClientId;
 
-
     public LabApiAuthenticationClient(@NonNull final String labSecret) {
-        this(labSecret, null, null, null);
+        this(labSecret, null, null);
     }
 
     public LabApiAuthenticationClient(@NonNull final String labSecret, final String labCertPassword) {
-        this(labSecret, labCertPassword, null, null);
+        this(labSecret, labCertPassword, null);
     }
 
-    public LabApiAuthenticationClient(@NonNull final String labSecret, @NonNull final String scope, @NonNull final String clientId) {
-        this(labSecret, null, scope, clientId);
-    }
-
-    public LabApiAuthenticationClient(@NonNull final String labSecret, final String labCertPassword, final String scope, final String clientId) {
+    public LabApiAuthenticationClient(@NonNull final String labSecret, final String labCertPassword, final String clientId) {
         mLabCredential = labSecret;
         mLabCertPassword = labCertPassword;
-        mScope = scope != null ? scope : LabConstants.DEFAULT_LAB_SCOPE;
         mClientId = clientId != null ? clientId : LabConstants.DEFAULT_LAB_CLIENT_ID;
     }
 
@@ -126,10 +120,13 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
     }
 
     private String getAccessTokenInternal(final String customScope) throws LabApiException {
-        String authScope = mScope;
+        final String authScope;
         if (customScope != null) {
             authScope = customScope;
+        } else {
+            authScope = defaultScope;
         }
+
         final IConfidentialAuthClient confidentialAuthClient = new Msal4jAuthClient();
         final TokenParameters tokenParameters = TokenParameters.builder()
                 .clientId(mClientId)

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
@@ -76,23 +76,28 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
 
     @Override
     public String getAccessToken() throws LabApiException {
-        return getAccessToken(DEFAULT_ACCESS_TOKEN_RETRIES);
+        return getAccessToken(DEFAULT_ACCESS_TOKEN_RETRIES, null);
+    }
+
+    public String getAccessTokenForCustomScope(final String scope) throws LabApiException {
+        return getAccessToken(DEFAULT_ACCESS_TOKEN_RETRIES, scope);
     }
 
     /**
      * Attempt to acquire an access token. Accepts a parameter to denote number of retries
      * @param retries how many times to attempt acquire access token before returning a failure.
+     * @param customScope the custom scope for which the access token is requested. If null, use the default scope.
      * @return an access token for Lab API
      * @throws LabApiException exception given back by Lab API
      */
-    public String getAccessToken(final int retries) throws LabApiException {
+    public String getAccessToken(final int retries, final String customScope) throws LabApiException {
 
         // Do this in a loop, if we get an exception or null result, try again
         for (int i = 1; i <= retries; i++) {
             System.out.printf(Locale.ENGLISH, "getAccessToken attempt #%d%n", i);
 
             try {
-                final String result = getAccessTokenInternal();
+                final String result = getAccessTokenInternal(customScope);
                 if (result != null) {
                     return result;
                 }
@@ -120,12 +125,16 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
         return null;
     }
 
-    private String getAccessTokenInternal() throws LabApiException {
+    private String getAccessTokenInternal(final String customScope) throws LabApiException {
+        String authScope = mScope;
+        if (customScope != null) {
+            authScope = customScope;
+        }
         final IConfidentialAuthClient confidentialAuthClient = new Msal4jAuthClient();
         final TokenParameters tokenParameters = TokenParameters.builder()
                 .clientId(mClientId)
                 .authority(AUTHORITY)
-                .scope(mScope)
+                .scope(authScope)
                 .build();
 
         final IAuthenticationResult authenticationResult;

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -61,9 +61,6 @@ import lombok.NonNull;
 public class LabClient implements ILabClient {
 
     private final LabApiAuthenticationClient mLabApiAuthenticationClient;
-    private final LabApiAuthenticationClient mLabApiAuthenticationClientForKeyVault = new LabApiAuthenticationClient(
-            BuildConfig.LAB_CLIENT_SECRET, KEYVAULT_SCOPE, DEFAULT_LAB_CLIENT_ID
-    );
     private final long PASSWORD_RESET_WAIT_DURATION = TimeUnit.SECONDS.toMillis(65);
     private final long LAB_API_RETRY_WAIT = TimeUnit.SECONDS.toMillis(5);
 
@@ -308,7 +305,7 @@ public class LabClient implements ILabClient {
     @Override
     public String getKeyVaultSecret(@NonNull final String secretName) throws LabApiException {
         Configuration.getKeyVaultApiClient().setAccessToken(
-                mLabApiAuthenticationClientForKeyVault.getAccessToken()
+                mLabApiAuthenticationClient.getAccessTokenForCustomScope(KEYVAULT_SCOPE)
         );
         final KeyVaultSecretsApi keyVaultSecretsApi = new KeyVaultSecretsApi();
 

--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -16,7 +16,9 @@ variables:
     versionNumber: ${{ variables.customVersion }}
 
 pool:
-  name: Hosted Windows 2019 with VS2019
+  name: MSSecurity-1ES-Build-Agents-Pool
+  image: MSSecurity-1ES-Windows-2022
+  os: windows
 jobs:
 # Key Vault
 - job: keyvault_phase

--- a/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/ConfidentialClientHelper.java
+++ b/testutils/src/main/java/com/microsoft/identity/internal/testutils/labutils/ConfidentialClientHelper.java
@@ -70,7 +70,7 @@ abstract class ConfidentialClientHelper {
 
     private String requestAccessTokenForKeyVault()
             throws LabApiException {
-        return (new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET, KEYVAULT_SCOPE, DEFAULT_LAB_CLIENT_ID)).getAccessToken();
+        return (new LabApiAuthenticationClient(BuildConfig.LAB_CLIENT_SECRET)).getAccessTokenForCustomScope(KEYVAULT_SCOPE);
     }
 
     void setupApiClientWithAccessToken() {


### PR DESCRIPTION
Only need one auth client. Having a second one referencing BuildConfigs will cause issues if the build configs are not passed at library build time.

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1565324&view=results
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1565339&view=results

[AB#3447250](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3447250)