### PR TITLE
Bug fix : Selecting text in login page is causing the input field to be hidden, Fixes AB#3447997

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -575,6 +575,7 @@ Version 6.0.0
 - [PATCH] Added Base64 encode for the AuthorizationRequest state parameter (#1750)
 - [PATCH] Fix missing authority_url when creating the authority audience (#1753)
 - [PATCH] Add filter for broker telemetry event fields. (#1793)
+- [MINOR] Bug fix : Selecting text in login page is causing the input field to be hidden (#2826)
 
 Version 5.0.1
 ----------

--- a/common/src/main/res/values/styles.xml
+++ b/common/src/main/res/values/styles.xml
@@ -60,6 +60,6 @@
     <!-- Theme for DualScreenActivity.
         Force set to a light theme (to status and navigation bars) since broker/common activities always have white background. -->
     <style name="DualScreenActivityTheme" parent="Theme.AppCompat.Light">
-        <item name="android:background">@color/com_microsoft_identity_common_white</item>
+        <item name="android:windowBackground">@color/com_microsoft_identity_common_white</item>
     </style>
 </resources>

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -138,7 +138,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable handling the UI in edge to edge mode
      */
-    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true),
+    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", false),
 
     /**
      * Flight to enable the Web CP in WebView.

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -138,7 +138,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable handling the UI in edge to edge mode
      */
-    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", false),
+    ENABLE_HANDLING_FOR_EDGE_TO_EDGE("EnableHandlingEdgeToEdge", true),
 
     /**
      * Flight to enable the Web CP in WebView.


### PR DESCRIPTION
**Problem**: Adding android:background to an Activity theme causes input text fields to disappear when selected as reported in this bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3383676

**Root Cause**: The android:background attribute sets a background drawable at the view level, which interferes with EditText's own background drawable that handles the focus state, underline, and cursor rendering.

**Solution**: Changed from android:background to android:windowBackground. The android:windowBackground attribute sets the background at the window level (behind all views) without affecting individual view backgrounds, allowing EditText fields to maintain their focus states and remain visible.
The style now correctly uses android:windowBackground which will set the white background for the entire activity window without interfering with input fields' rendering and focus behavior.

Fixes [AB#3447997](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3447997)