### PR TITLE
Fixes AB#3448445 add telemetry points inside saveAndLoadAggregatedAccountData

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
@@ -278,6 +279,7 @@ public class BrokerOAuth2TokenCache
                              @Nullable RefreshTokenRecord refreshTokenRecord,
                              @Nullable String familyId) throws ClientException {
         final String methodName = ":save (5 args)";
+        final long saveStartTime = System.currentTimeMillis();
 
         final ICacheRecord result;
 
@@ -319,7 +321,7 @@ public class BrokerOAuth2TokenCache
                 familyId,
                 mUid
         );
-
+        OTelUtility.recordElapsedTime(AttributeName.elapsed_time_save_aggregated_account_data.name(), saveStartTime);
         return result;
     }
 
@@ -366,6 +368,7 @@ public class BrokerOAuth2TokenCache
     private List<ICacheRecord> loadAggregatedAccountData(final @NonNull AbstractAuthenticationScheme authScheme,
                                                          final @NonNull ICacheRecord cacheRecord) {
         final String methodName = ":loadAggregatedAccountData";
+        final long saveStartTime = System.currentTimeMillis();
 
         final String clientId = cacheRecord.getAccessToken().getClientId();
         final String target = cacheRecord.getAccessToken().getTarget();
@@ -386,7 +389,7 @@ public class BrokerOAuth2TokenCache
             return null;
         }
 
-        return cache.loadWithAggregatedAccountData(
+        List<ICacheRecord> cacheRecordList =  cache.loadWithAggregatedAccountData(
                 clientId,
                 applicationIdentifier,
                 mamEnrollmentIdentifier,
@@ -394,6 +397,9 @@ public class BrokerOAuth2TokenCache
                 cacheRecord.getAccount(),
                 authScheme
         );
+        OTelUtility.recordElapsedTime(AttributeName.elapsed_time_load_aggregated_account_data.name(),
+                saveStartTime);
+        return cacheRecordList;
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -368,7 +368,7 @@ public class BrokerOAuth2TokenCache
     private List<ICacheRecord> loadAggregatedAccountData(final @NonNull AbstractAuthenticationScheme authScheme,
                                                          final @NonNull ICacheRecord cacheRecord) {
         final String methodName = ":loadAggregatedAccountData";
-        final long saveStartTime = System.currentTimeMillis();
+        final long loadStartTime = System.currentTimeMillis();
 
         final String clientId = cacheRecord.getAccessToken().getClientId();
         final String target = cacheRecord.getAccessToken().getTarget();
@@ -398,7 +398,7 @@ public class BrokerOAuth2TokenCache
                 authScheme
         );
         OTelUtility.recordElapsedTime(AttributeName.elapsed_time_load_aggregated_account_data.name(),
-                saveStartTime);
+                loadStartTime);
         return cacheRecordList;
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -502,5 +502,15 @@ public enum AttributeName {
     /**
      * Passkey DOM exception name (if any).
      */
-    passkey_dom_exception_name
+    passkey_dom_exception_name,
+
+    /**
+     *  Elapsed time (in milliseconds) spent in executing the save() method in BrokerOAuth2TokenCache.
+     */
+    elapsed_time_save_aggregated_account_data,
+
+    /**
+     *  Elapsed time (in milliseconds) spent in executing the loadAggregatedAccountData() method in BrokerOAuth2TokenCache.
+     */
+    elapsed_time_load_aggregated_account_data
 }


### PR DESCRIPTION
Fixes [AB#3448445](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3448445) From the analysis of the added telemetry points, we identified that saveTokenResult() is a problematic area. This method internally call saveAndLoadAggregatedAccountData. So this PR adds more telemetry to identify the main bottleneck.