### PR TITLE
Add GitHub Actions workflow to notify on changes to versions.gradle, Fixes AB#1234567

### DIFF
--- a/.github/workflows/gradle-versions-watcher.yml
+++ b/.github/workflows/gradle-versions-watcher.yml
@@ -17,7 +17,6 @@ on:
 permissions:
   pull-requests: write
 
-
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-versions-watcher.yml
+++ b/.github/workflows/gradle-versions-watcher.yml
@@ -1,0 +1,33 @@
+name: Notify on versions.gradle changes
+
+on:
+  push:
+    paths:
+      - 'gradle/versions.gradle'
+    branches:
+      - dev
+      - 'release/**'
+  pull_request:
+    paths:
+      - 'gradle/versions.gradle'
+    branches:
+      - dev
+      - 'release/**'
+
+permissions:
+  pull-requests: write
+
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log changes
+        run: |
+          echo "Changes detected in the 'gradle/versions.gradle' file."
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: "⚠️ **Warning:** Changes detected in the 'versions.gradle' file! ⚠️\n\nPlease refer to [this document](https://dev.azure.com/IdentityDivision/IdentityWiki/_wiki/wikis/IdentityWiki.wiki/82085/Adding-or-Updating-Gradle-Dependencies) for more details."

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -33,7 +33,6 @@ jobs:
   # Extracts the AB ID from the pull_request body using regex and store the result using outputs 
       - name: Get AB ID from comment
         id: get
-        shell: bash
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -39,8 +39,8 @@ jobs:
           # Sanitize PR body by removing backticks to prevent command substitution
           clean=$(printf "%s" "$PR_BODY" | tr -d '`')
       
-          # Extract AB ID (AB#1234567)
-          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+')
+          # Extract AB ID (AB#1234567) - takes first match if multiple exist
+          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+' | head -n 1)
       
           echo "id=$result" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Sanitize PR body by removing backticks (they break bash)
+          # Sanitize PR body by removing backticks to prevent command substitution
           clean=$(printf "%s" "$PR_BODY" | tr -d '`')
       
           # Extract AB ID (AB#1234567)

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -33,9 +33,17 @@ jobs:
   # Extracts the AB ID from the pull_request body using regex and store the result using outputs 
       - name: Get AB ID from comment
         id: get
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          result=$(echo "${{ github.event.pull_request.body }}" | grep -oP '(?<=#)\d+')
-          echo "id=${result}" >> "$GITHUB_OUTPUT"
+          # Sanitize PR body by removing backticks (they break bash)
+          clean=$(printf "%s" "$PR_BODY" | tr -d '`')
+      
+          # Extract AB ID (AB#1234567)
+          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+')
+      
+          echo "id=$result" >> "$GITHUB_OUTPUT"
 
   # Get Pull request ID
   get_pr_id:

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,4 +1,4 @@
-// Variables for entire project
+// Variables for entire project.
 // Taken from android-complete.
 ext {
     // SDK


### PR DESCRIPTION
This pull request introduces improvements to GitHub Actions workflows to enhance automation and reliability around Gradle version changes and AB ID extraction from pull requests. The main changes include the addition of a new workflow for monitoring updates to the `gradle/versions.gradle` file and a more robust method for extracting AB IDs from PR bodies.

**Workflow automation enhancements:**

* Added a new workflow `.github/workflows/gradle-versions-watcher.yml` that triggers on changes to `gradle/versions.gradle` in the `dev` and `release/**` branches, logging changes and commenting on pull requests with a warning and documentation link.

**Improved AB ID extraction logic:**

* Updated the `validate-pr-ab-id.yml` workflow to sanitize the pull request body by removing backticks and to extract the AB ID using the pattern `[[AB#1234567](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/1234567)]` instead of just `#1234567`, improving reliability and accuracy.


[AB#3424644](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3424644)