### PR TITLE
Move our Libraries to only use artifact feed for packages, no Maven Central, Fixes AB#3395409

### DIFF
--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -15,8 +15,8 @@ plugins {
 
 apply from: '../versioning/version_tasks.gradle'
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 version = getAppVersionName()
 

--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -113,7 +113,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
@@ -121,7 +121,7 @@ publishing {
             }
         }
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-legacy-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply from: '../versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 version = getAppVersionName()
 
@@ -117,7 +117,7 @@ publishing {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername
-                password project.ext.vstsPassword
+                password project.ext.vstsMavenAccessToken
             }
         }
         maven {
@@ -125,7 +125,7 @@ publishing {
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
     }

--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -113,15 +113,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-new-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-            credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsPassword
-            }
-        }
-        maven {
-            name "vsts-maven-legacy-adal-android"
+            name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -114,7 +114,7 @@ publishing {
     repositories {
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
                 password project.ext.vstsPassword

--- a/LabApiUtilities/build.gradle
+++ b/LabApiUtilities/build.gradle
@@ -121,6 +121,14 @@ publishing {
             }
         }
         maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.ext.vstsUsername
+                password project.ext.vstsPassword
+            }
+        }
+        maven {
             name "vsts-maven-android"
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/authentication/LabApiAuthenticationClient.java
@@ -51,7 +51,6 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
     private final static int ATTEMPT_RETRY_WAIT = 3;
     private final String mLabCredential;
     private final String mLabCertPassword;
-    private final String defaultScope = LabConstants.DEFAULT_LAB_SCOPE;
     private final String mClientId;
 
     public LabApiAuthenticationClient(@NonNull final String labSecret) {
@@ -124,7 +123,7 @@ public class LabApiAuthenticationClient implements IAccessTokenSupplier {
         if (customScope != null) {
             authScope = customScope;
         } else {
-            authScope = defaultScope;
+            authScope = LabConstants.DEFAULT_LAB_SCOPE;
         }
 
         final IConfidentialAuthClient confidentialAuthClient = new Msal4jAuthClient();

--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -1,6 +1,5 @@
 # File: azure-pipelines/continuous-delivery/common-cd.yml
 # Description: Assemble & publish latest keyvault, labapi, labapiutilities, testutil release to internal vsts feed
-# Variable: 'ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME' was defined in the Variables tab
 # Variable: 'customVersion' overrides the version number of the published libraries
 
 name: 0.0.$(Date:yyyyMMdd)$(Rev:.r) # $(Build.BuildNumber) = name

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -1,6 +1,5 @@
 # File: azure-pipelines\pull-request-validation\build-consumers.yml
 # Description: Test new common in ADAL / MSAL / Broker (assembleLocal and testLocalDebugUnitTest)
-# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 # Variable: 'commonBranchName' common branch to be used when running the pipeline manually
 # Variable: 'skipConsumerValidationLabel' PR label used to skip the checks in this pipeline
@@ -117,8 +116,8 @@ stages:
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
     - bash: |
-        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
-        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
       displayName: 'Set VSTS Fields in Environment'
     - task: Gradle@3
       displayName: Assemble msal
@@ -154,8 +153,8 @@ stages:
       submodules: recursive
       persistCredentials: True
     - bash: |
-        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME]VSTS"
-        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
       displayName: 'Set VSTS Fields in Environment'
     - template: ../templates/steps/automation-cert.yml
     - task: CmdLine@2
@@ -199,8 +198,8 @@ stages:
         submodules: recursive
         persistCredentials: True
       - bash: |
-          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME]VSTS"
-          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)"
+          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
         displayName: 'Set VSTS Fields in Environment'
       - task: AzureKeyVault@2
         displayName: 'Get Key vault LabAuth'

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -116,6 +116,10 @@ stages:
           git status
           git rev-parse HEAD
         workingDirectory: $(Agent.BuildDirectory)/s/common
+    - bash: |
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+      displayName: 'Set VSTS Fields in Environment'
     - task: Gradle@3
       displayName: Assemble msal
       inputs:
@@ -149,6 +153,10 @@ stages:
       clean: true
       submodules: recursive
       persistCredentials: True
+    - bash: |
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME]VSTS"
+        echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)"
+      displayName: 'Set VSTS Fields in Environment'
     - template: ../templates/steps/automation-cert.yml
     - task: CmdLine@2
       displayName: Checkout common submodule $(commonBranch)
@@ -190,6 +198,10 @@ stages:
         clean: true
         submodules: recursive
         persistCredentials: True
+      - bash: |
+          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME]VSTS"
+          echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)"
+        displayName: 'Set VSTS Fields in Environment'
       - task: AzureKeyVault@2
         displayName: 'Get Key vault LabAuth'
         inputs:
@@ -203,11 +215,6 @@ stages:
         inputs:
           targetType: inline
           script: java -version
-      - task: CmdLine@1
-        displayName: Set MVN Access Token in Environment
-        inputs:
-          filename: echo
-          arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN]$(System.AccessToken)'
       - task: CmdLine@1
         displayName: Set Office MVN Access Token in Environment
         inputs:

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -29,17 +29,12 @@ resources:
   - repository: msal
     type: github
     name: AzureAD/microsoft-authentication-library-for-android
-    ref: dev
+    ref: fadi/mavenCentral
     endpoint: ANDROID_GITHUB
   - repository: broker
     type: github
     name: AzureAD/ad-accounts-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
-  - repository: adal
-    type: github
-    name: AzureAD/azure-activedirectory-library-for-android
-    ref: dev
+    ref: fadi/mavenCentral
     endpoint: ANDROID_GITHUB
 
 stages:
@@ -257,40 +252,3 @@ stages:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/TEST-*.xml'
           searchFolder: 'LinuxBroker'
-  # adal
-  - job: adalValidation
-    displayName: ADAL
-    dependsOn:
-      - setupBranch
-    variables:
-      commonBranch: $[ dependencies.setupBranch.outputs['setvarStep.commonBranch'] ]  # map in the variable
-    condition: and( succeeded(), not(contains(variables['prLabels'], variables['skipConsumerValidationLabel'])) )
-    steps:
-    - checkout: adal
-      displayName: Checkout adal repository
-      clean: true
-      submodules: recursive
-      persistCredentials: True
-    - task: CmdLine@2
-      displayName: Checkout common submodule $(commonBranch)
-      inputs:
-        script: |
-          git fetch
-          git checkout $(commonBranch)
-          git pull
-          git status
-          git rev-parse HEAD
-        workingDirectory: $(Agent.BuildDirectory)/s/common
-    - template: ../templates/steps/automation-cert.yml
-    - task: Gradle@3
-      displayName: Assemble adal
-      inputs:
-        tasks: clean adal:assembleLocal
-        jdkArchitecture: x64
-        jdkVersionOption: "1.17"
-    - task: Gradle@3
-      displayName: Run adal Unit tests
-      inputs:
-        tasks: adal:testLocalDebugUnitTest -Plabtest -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PlabSecret=$(LabVaultAppCert)
-        jdkArchitecture: x64
-        jdkVersionOption: "1.17"

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -28,12 +28,12 @@ resources:
   - repository: msal
     type: github
     name: AzureAD/microsoft-authentication-library-for-android
-    ref: fadi/mavenCentral
+    ref: dev
     endpoint: ANDROID_GITHUB
   - repository: broker
     type: github
     name: AzureAD/ad-accounts-for-android
-    ref: fadi/mavenCentral
+    ref: dev
     endpoint: ANDROID_GITHUB
 
 stages:

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -28,11 +28,10 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - template: ../templates/steps/automation-cert.yml
-  - task: CmdLine@1
-    displayName: Set Office MVN Access Token in Environment
-    inputs:
-      filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)'
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - task: CodeQL3000Init@0
   - task: Gradle@3
     name: Gradle3   
@@ -78,11 +77,10 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
-  - task: CmdLine@1
-    displayName: Set Office MVN Access Token in Environment
-    inputs:
-      filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)'
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - task: Gradle@3
     displayName: Lint
     inputs:

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -32,7 +32,7 @@ jobs:
     displayName: Set Office MVN Access Token in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)'
   - task: CodeQL3000Init@0
   - task: Gradle@3
     name: Gradle3   
@@ -82,7 +82,7 @@ jobs:
     displayName: Set Office MVN Access Token in Environment
     inputs:
       filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)'
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)'
   - task: Gradle@3
     displayName: Lint
     inputs:

--- a/azure-pipelines/templates/steps/automation-cert.yml
+++ b/azure-pipelines/templates/steps/automation-cert.yml
@@ -5,11 +5,10 @@ parameters:
   default: ENV_VSTS_MVN_CRED_ACCESSTOKEN
 
 steps:
-- task: CmdLine@1
-  displayName: Set MVN Access Token in Environment
-  inputs:
-    filename: echo
-    arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAt }}]$(System.AccessToken)'
+- bash: |
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
+  displayName: 'Set VSTS Fields in Environment'
 - task: AzureKeyVault@2
   displayName: 'Azure Key Vault: Download Cert for Automation'
   inputs:

--- a/azure-pipelines/templates/steps/automation-cert.yml
+++ b/azure-pipelines/templates/steps/automation-cert.yml
@@ -2,7 +2,7 @@
 
 parameters:
 - name: envVstsMvnAt
-  default: ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN
+  default: ENV_VSTS_MVN_CRED_ACCESSTOKEN
 
 steps:
 - task: CmdLine@1

--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -10,7 +10,7 @@
 parameters:
 - name: project
 - name: envVstsMvnAt
-  default: 'ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN'
+  default: 'ENV_VSTS_MVN_CRED_ACCESSTOKEN'
 - name: variant
   default: ''
 - name: buildArguments
@@ -26,12 +26,12 @@ steps:
   submodules: recursive
   persistCredentials: True
 - bash: |
-    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME]VSTS"
-    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
   displayName: 'Set VSTS Fields in Environment'
 - template: ../automation-cert.yml
   parameters:
-    envVstsMvnAt: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+    envVstsMvnAt: ENV_VSTS_MVN_CRED_ACCESSTOKEN
 - task: Gradle@2
   displayName: Assemble ${{ parameters.project }} ${{ parameters.variant }}
   inputs:

--- a/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
+++ b/azure-pipelines/templates/steps/continuous-delivery/assemble-publish-projversion.yml
@@ -25,11 +25,10 @@ steps:
   clean: true
   submodules: recursive
   persistCredentials: True
-- task: CmdLine@1
-  displayName: Set MVN Access Token in Environment
-  inputs:
-    filename: echo
-    arguments: '##vso[task.setvariable variable=${{ parameters.envVstsMvnAt }}]$(System.AccessToken)'
+- bash: |
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME]VSTS"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)"
+  displayName: 'Set VSTS Fields in Environment'
 - template: ../automation-cert.yml
   parameters:
     envVstsMvnAt: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -13,6 +13,10 @@ parameters:
 - name: javaVersion
   default: "1.17"
 steps:
+- bash: |
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME]VSTS"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)"
+  displayName: 'Set VSTS Fields in Environment'
 - task: Gradle@3
   displayName: 'Run Spotbugs'
   inputs:

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -12,15 +12,11 @@ parameters:
   default: $(Build.SourcesDirectory)
 - name: javaVersion
   default: "1.17"
-- name: vstsUsernameVariable
-  default: ENV_VSTS_MVN_CRED_USERNAME
-- name: vstsAccessTokenVariable
-  default: ENV_VSTS_MVN_CRED_ACCESSTOKEN
 
 steps:
 - bash: |
-    echo "##vso[task.setvariable variable=${{ parameters.vstsUsernameVariable }}]VSTS"
-    echo "##vso[task.setvariable variable=${{ parameters.vstsAccessTokenVariable }}]$(System.AccessToken)"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
   displayName: 'Set VSTS Fields in Environment'
 - task: Gradle@3
   displayName: 'Run Spotbugs'

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -12,10 +12,15 @@ parameters:
   default: $(Build.SourcesDirectory)
 - name: javaVersion
   default: "1.17"
+- name: vstsUsernameVariable
+  default: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
+- name: vstsAccessTokenVariable
+  default: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+
 steps:
 - bash: |
-    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME]VSTS"
-    echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN]$(System.AccessToken)"
+    echo "##vso[task.setvariable variable=${{ parameters.vstsUsernameVariable }}]VSTS"
+    echo "##vso[task.setvariable variable=${{ parameters.vstsAccessTokenVariable }}]$(System.AccessToken)"
   displayName: 'Set VSTS Fields in Environment'
 - task: Gradle@3
   displayName: 'Run Spotbugs'

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -13,9 +13,9 @@ parameters:
 - name: javaVersion
   default: "1.17"
 - name: vstsUsernameVariable
-  default: ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME
+  default: ENV_VSTS_MVN_CRED_USERNAME
 - name: vstsAccessTokenVariable
-  default: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+  default: ENV_VSTS_MVN_CRED_ACCESSTOKEN
 
 steps:
 - bash: |

--- a/azure-pipelines/templates/steps/spotbugs.yml
+++ b/azure-pipelines/templates/steps/spotbugs.yml
@@ -12,7 +12,6 @@ parameters:
   default: $(Build.SourcesDirectory)
 - name: javaVersion
   default: "1.17"
-
 steps:
 - bash: |
     echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"

--- a/azure-pipelines/templates/steps/vsts-release.yml
+++ b/azure-pipelines/templates/steps/vsts-release.yml
@@ -1,6 +1,5 @@
 # File: azure-pipelines\templates\steps\nightly-snapshot-releases\vsts-release.yml
 # Description: Template to assemble and publish Snapshot/Latest versions of ${{ parameters.projectName }}
-# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gradleTasks' list all the gradle tasks to be used.
 # Variable: 'accessTokenName'  secret used to access the private azure devops maven feed.
 # Variable: 'runUnitTest' boolean: refers to whether the pipeline will run unit tests or not.

--- a/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
+++ b/azure-pipelines/templates/steps/vsts-release/vsts-release-template.yml
@@ -26,6 +26,11 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - task: CmdLine@1
+    displayName: Set MVN Username in Environment
+    inputs:
+      filename: echo
+      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS'
+  - task: CmdLine@1
     displayName: Set MVN AccessToken in Environment
     inputs:
       filename: echo

--- a/azure-pipelines/vsts-releases/common.yml
+++ b/azure-pipelines/vsts-releases/common.yml
@@ -1,7 +1,5 @@
 # File: azure-pipelines\vsts-releases\common.yml
 # Description: Publish common to internal feed
-# https://identitydivision.visualstudio.com/Engineering/_packaging?_a=feed&feed=AndroidADAL
-# Variable: 'ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(date:yyyyMMdd)$(rev:.r)
 
@@ -18,7 +16,7 @@ jobs:
 - template: ../templates/steps/vsts-release/vsts-release-template.yml
   parameters:
     project: common
-    envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+    envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_CRED_ACCESSTOKEN
     assembleTask: assembleRelease
     publishTask: publish
     sbomConfiguration: distReleaseRuntimeClasspath

--- a/azure-pipelines/vsts-releases/common4j.yml
+++ b/azure-pipelines/vsts-releases/common4j.yml
@@ -1,7 +1,5 @@
 # File: azure-pipelines\vsts-releases\common4j.yml
 # Description: Publish common4j to internal feed
-# https://identitydivision.visualstudio.com/Engineering/_packaging?_a=package&feed=AndroidADAL&package=com.microsoft.identity%3Acommon4j&protocolType=maven
-# Variable: 'ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME' was defined in the Variables tab
 # https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate
 name: $(date:yyyyMMdd)$(rev:.r)
 
@@ -18,7 +16,7 @@ jobs:
 - template: ../templates/steps/vsts-release/vsts-release-template.yml
   parameters:
     project: common4j
-    envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
+    envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_CRED_ACCESSTOKEN
     assembleTask: assemble
     publishTask: publish
     sbomConfiguration: runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
@@ -36,7 +36,7 @@ allprojects {
         mavenLocal()
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.vstsUsername
                 password project.vstsPassword

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,9 @@ buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
     
     repositories {
-        google()
+        // If you don't have access to the package feed uncomment these repositories
+        //  google()
+        //  mavenCentral()
         maven {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
@@ -32,7 +34,9 @@ allprojects {
     Order of repositories is important.
      */
     repositories {
-        google()
+        // If you don't have access to the package feed uncomment these repositories
+        //  google()
+        //  mavenCentral()
         mavenLocal()
         maven {
             name "vsts-maven-adal-android"

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ allprojects {
      */
     repositories {
         // If you don't have access to the package feed uncomment these repositories
-        //  google()
-        //  mavenCentral()
+        // mavenCentral()
+        google()
         mavenLocal()
         maven {
             name "vsts-maven-adal-android"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,14 @@ buildscript {
     
     repositories {
         google()
-        mavenCentral()
+        maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsPassword
+            }
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${rootProject.ext.gradleVersion}"
@@ -24,11 +31,7 @@ allprojects {
      */
     repositories {
         google()
-        mavenCentral()
-        // Adding here because Travis cannot access AndroidADAL feed.
-        maven {
-            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
-        }
+        mavenLocal()
         maven {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
@@ -43,7 +43,7 @@ allprojects {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
     
     repositories {
+        google()
         // If you don't have access to the package feed uncomment these repositories
-        //  google()
         //  mavenCentral()
         maven {
             name "vsts-maven-adal-android"

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,10 @@ buildscript {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username project.vstsUsername
-                password project.vstsPassword
+                credentials {
+                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
+                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
@@ -14,8 +15,8 @@ buildscript {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 credentials {
-                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                    username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+                    password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
                 }
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Remove MavenCentral repository from build.gradle files (#2830)
 - [MINOR] Determine whether broker app opts out from battery optimization (#2819)
 - [MINOR] Cache Active Broker In Memory (BrokerDiscoveryClient) (#2817)
 - [MINOR] Enable Broker Discovery by default in MSAL/Broker API (#2818)

--- a/common-java-root/build.gradle
+++ b/common-java-root/build.gradle
@@ -41,8 +41,8 @@ allprojects {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsMavenAccessToken
+                username project.vstsUsername
+                password project.vstsMavenAccessToken
             }
         }
         //Required for google published packages not published to maven central

--- a/common-java-root/build.gradle
+++ b/common-java-root/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("../gradle/versions.gradle")
@@ -19,10 +19,13 @@ allprojects {
     Order of repositories is important.
      */
     repositories {
+        // If you don't have access to the package feed uncomment these repositories
+        //  mavenCentral()
+
         /*
         This is the project main repository and contains all of the packages we publish.
         This azure devops feed also has an upstream to Maven Central as well as several other
-        internal azure devops respositories
+        internal azure devops repositories
 
         NOTE: This repository is not currently available to our public CI (Travis)
          */
@@ -34,13 +37,16 @@ allprojects {
                 password project.vstsMavenAccessToken
             }
         }
+        maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
+            credentials {
+                username project.ext.vstsUsername
+                password project.ext.vstsMavenAccessToken
+            }
+        }
         //Required for google published packages not published to maven central
         google()
-
-        /*
-         * Required for packages published to Maven Central.
-         */
-        mavenCentral()
     }
 }
 

--- a/common-java-root/build.gradle
+++ b/common-java-root/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("../gradle/versions.gradle")
@@ -31,7 +31,7 @@ allprojects {
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
         //Required for google published packages not published to maven central

--- a/common-java-root/settings.gradle
+++ b/common-java-root/settings.gradle
@@ -1,7 +1,8 @@
 pluginManagement {
     repositories {
+        // If you don't have access to the package feed uncomment these repositories
+        //  mavenCentral()
         google()
-        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,9 +26,6 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
-project.ext.vstsUsername System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-
 // https://blog.gradle.org/gradle-flaky-test-retry-plugin
 tasks.withType(Test) {
     retry {
@@ -375,16 +372,16 @@ afterEvaluate {
                 name "vsts-maven-new-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
-                    username project.ext.vstsUsername
-                    password project.ext.vstsPassword
+                    username project.vstsUsername
+                    password project.vstsPassword
                 }
             }
             maven {
                 name "vsts-maven-legacy-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
-                    username project.ext.vstsUsername
-                    password project.ext.vstsPassword
+                    username project.vstsUsername
+                    password project.vstsPassword
                 }
             }
         }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -372,7 +372,7 @@ afterEvaluate {
         // Repositories to which Gradle can publish artifacts
         repositories {
             maven {
-                name "vsts-maven-adal-android"
+                name "vsts-maven-new-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
@@ -380,8 +380,7 @@ afterEvaluate {
                 }
             }
             maven {
-                name "vsts-maven-adal-android"
-                name "vsts-maven-new-android"
+                name "vsts-maven-legacy-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -369,15 +369,7 @@ afterEvaluate {
         // Repositories to which Gradle can publish artifacts
         repositories {
             maven {
-                name "vsts-maven-new-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-                credentials {
-                    username project.vstsUsername
-                    password project.vstsPassword
-                }
-            }
-            maven {
-                name "vsts-maven-legacy-adal-android"
+                name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.vstsUsername

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -373,7 +373,7 @@ afterEvaluate {
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.vstsUsername
-                    password project.vstsPassword
+                    password project.vstsMavenAccessToken
                 }
             }
         }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -370,7 +370,7 @@ afterEvaluate {
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
                     password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     implementation "androidx.credentials:credentials-play-services-auth:$rootProject.ext.AndroidCredentialsVersion"
     implementation "com.google.android.gms:play-services-fido:$rootProject.ext.LegacyFidoApiVersion"
     implementation "com.google.android.libraries.identity.googleid:googleid:$rootProject.ext.GoogleIdVersion"
-    implementation "com.github.stephenc.jcip-jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
+    implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
 
     constraints {
         implementation ("com.squareup.okio:okio:3.4.0") {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     implementation "androidx.credentials:credentials-play-services-auth:$rootProject.ext.AndroidCredentialsVersion"
     implementation "com.google.android.gms:play-services-fido:$rootProject.ext.LegacyFidoApiVersion"
     implementation "com.google.android.libraries.identity.googleid:googleid:$rootProject.ext.GoogleIdVersion"
-    implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
+    implementation "com.github.stephenc.jcip-jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
 
     constraints {
         implementation ("com.squareup.okio:okio:3.4.0") {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,6 +26,9 @@ codeCoverageReport {
     coverage.enabled = enableCodeCoverage
 }
 
+project.ext.vstsUsername System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsPassword System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+
 // https://blog.gradle.org/gradle-flaky-test-retry-plugin
 tasks.withType(Test) {
     retry {
@@ -372,8 +375,17 @@ afterEvaluate {
                 name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
-                    username System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-                    password System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                    username project.ext.vstsUsername
+                    password project.ext.vstsPassword
+                }
+            }
+            maven {
+                name "vsts-maven-adal-android"
+                name "vsts-maven-new-android"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                credentials {
+                    username project.ext.vstsUsername
+                    password project.ext.vstsPassword
                 }
             }
         }

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -273,7 +273,7 @@ dependencies {
     implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
     implementation 'org.apache.httpcomponents.core5:httpcore5:5.3'
 
-    testImplementation "cz.msebera.android:httpclient:4.5.+"
+    testImplementation "cz.msebera.android:httpclient:4.5.8"
 
     testCompileOnly "com.github.spotbugs:spotbugs-annotations:$rootProject.ext.spotBugsAnnotationVersion"
     testCompileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -64,8 +64,8 @@ project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") 
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 repositories {
+    google()
     // If you don't have access to the package feed uncomment these repositories
-    //  google()
     //  mavenCentral()
     maven {
         name "vsts-maven-adal-android"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -270,7 +270,7 @@ dependencies {
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "org.json:json:$rootProject.ext.jsonVersion"
-    implementation "com.github.stephenc.jcip-jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
+    implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
     implementation 'org.apache.httpcomponents.core5:httpcore5:5.3'
 
     testImplementation "cz.msebera.android:httpclient:4.5.+"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -63,7 +63,6 @@ tasks.withType(Test) {
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
-
 repositories {
     maven {
         name "vsts-maven-adal-android"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -60,15 +60,22 @@ tasks.withType(Test) {
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
-apply from: './versioning/version_tasks.gradle'
-
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
+
+repositories {
+    maven {
+        name "vsts-maven-adal-android"
+        url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+        credentials {
+            username project.ext.vstsUsername
+            password project.ext.vstsPassword
+        }
+    }
+}
+
+apply from: './versioning/version_tasks.gradle'
 version = getAppVersionName()
 
 task sourcesJar(type: Jar) {

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -64,6 +64,9 @@ project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") 
 project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 repositories {
+    // If you don't have access to the package feed uncomment these repositories
+    //  google()
+    //  mavenCentral()
     maven {
         name "vsts-maven-adal-android"
         url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -66,7 +66,7 @@ project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN
 repositories {
     maven {
         name "vsts-maven-adal-android"
-        url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+        url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
         credentials {
             username project.ext.vstsUsername
             password project.ext.vstsPassword
@@ -155,7 +155,7 @@ publishing {
     repositories {
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
                 password project.ext.vstsPassword

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -61,7 +61,7 @@ tasks.withType(Test) {
 }
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 repositories {
     google()
@@ -72,7 +72,7 @@ repositories {
         url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
         credentials {
             username project.ext.vstsUsername
-            password project.ext.vstsPassword
+            password project.ext.vstsMavenAccessToken
         }
     }
 }
@@ -161,7 +161,7 @@ publishing {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername
-                password project.ext.vstsPassword
+                password project.ext.vstsMavenAccessToken
             }
         }
     }

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -157,15 +157,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-new-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-            credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsPassword
-            }
-        }
-        maven {
-            name "vsts-maven-legacy-adal-android"
+            name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -154,8 +154,16 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
+            credentials {
+                username project.ext.vstsUsername
+                password project.ext.vstsPassword
+            }
+        }
+        maven {
+            name "vsts-maven-legacy-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername
                 password project.ext.vstsPassword
@@ -262,10 +270,10 @@ dependencies {
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "org.json:json:$rootProject.ext.jsonVersion"
-    implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
+    implementation "com.github.stephenc.jcip-jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
     implementation 'org.apache.httpcomponents.core5:httpcore5:5.3'
 
-    testImplementation "cz.msebera.android:httpclient:4.5.8"
+    testImplementation "cz.msebera.android:httpclient:4.5.+"
 
     testCompileOnly "com.github.spotbugs:spotbugs-annotations:$rootProject.ext.spotBugsAnnotationVersion"
     testCompileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -60,8 +60,8 @@ tasks.withType(Test) {
     }
 }
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 repositories {
     google()

--- a/common4j/settings.gradle
+++ b/common4j/settings.gradle
@@ -10,6 +10,7 @@
 pluginManagement {
     repositories {
         mavenLocal()
+        google()
         gradlePluginPortal()
     }
 }

--- a/common4j/settings.gradle
+++ b/common4j/settings.gradle
@@ -10,7 +10,6 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        google()
         gradlePluginPortal()
     }
 }

--- a/common4j/settings.gradle
+++ b/common4j/settings.gradle
@@ -11,7 +11,6 @@ pluginManagement {
     repositories {
         mavenLocal()
         google()
-        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/common4j/settings.gradle
+++ b/common4j/settings.gradle
@@ -9,6 +9,8 @@
 
 pluginManagement {
     repositories {
+        // If you don't have access to the package feed uncomment these repositories
+        //  mavenCentral()
         mavenLocal()
         google()
         gradlePluginPortal()

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -72,7 +72,7 @@ ext {
     mockitoKotlinVersion = "4.1.0"
     androidxAnnotationVersion = "1.4.0"
     spotBugsAnnotationVersion = "4.3.0"
-    jcipAnnotationVersion = "1.0.1"
+    jcipAnnotationVersion = "1.0-1"
     openTelemetryVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     blockstoreVersion="16.2.0"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -72,7 +72,7 @@ ext {
     mockitoKotlinVersion = "4.1.0"
     androidxAnnotationVersion = "1.4.0"
     spotBugsAnnotationVersion = "4.3.0"
-    jcipAnnotationVersion = "1.0-1"
+    jcipAnnotationVersion = "1.0.1"
     openTelemetryVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     blockstoreVersion="16.2.0"

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -36,6 +36,14 @@ publishing {
             }
         }
         maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.ext.vstsUsername
+                password project.ext.vstsPassword
+            }
+        }
+        maven {
             name "vsts-maven-android"
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 apply from: '../versioning/version_tasks.gradle'
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 version = getAppVersionName()
 

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 version = getAppVersionName()
 
@@ -32,7 +32,7 @@ publishing {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername
-                password project.ext.vstsPassword
+                password project.ext.vstsMavenAccessToken
             }
         }
         maven {
@@ -40,7 +40,7 @@ publishing {
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
     }

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -28,7 +28,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
@@ -36,7 +36,7 @@ publishing {
             }
         }
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-legacy-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -28,15 +28,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-new-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-            credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsPassword
-            }
-        }
-        maven {
-            name "vsts-maven-legacy-adal-android"
+            name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/keyvault/build.gradle
+++ b/keyvault/build.gradle
@@ -29,7 +29,7 @@ publishing {
     repositories {
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
                 password project.ext.vstsPassword

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -37,6 +37,14 @@ publishing {
             }
         }
         maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.ext.vstsUsername
+                password project.ext.vstsPassword
+            }
+        }
+        maven {
             name "vsts-maven-android"
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -29,15 +29,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-new-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-            credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsPassword
-            }
-        }
-        maven {
-            name "vsts-maven-legacy-adal-android"
+            name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -29,7 +29,7 @@ publishing {
 
     repositories {
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
@@ -37,7 +37,7 @@ publishing {
             }
         }
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-legacy-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 apply from: '../versioning/version_tasks.gradle'
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 //labapi version.  Let's not change this please
 version = getAppVersionName()

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -30,7 +30,7 @@ publishing {
     repositories {
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.ext.vstsUsername
                 password project.ext.vstsPassword

--- a/labapi/build.gradle
+++ b/labapi/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 //labapi version.  Let's not change this please
 version = getAppVersionName()
@@ -33,7 +33,7 @@ publishing {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
                 username project.ext.vstsUsername
-                password project.ext.vstsPassword
+                password project.ext.vstsMavenAccessToken
             }
         }
         maven {
@@ -41,7 +41,7 @@ publishing {
             url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         google()
-        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 pluginManagement {
     repositories {
-        google()
+        // If you don't have access to the package feed uncomment these repositories
+        //  google()
+        //  mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
 pluginManagement {
     repositories {
         // If you don't have access to the package feed uncomment these repositories
-        //  google()
         //  mavenCentral()
+        google()
         gradlePluginPortal()
     }
 }

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -129,7 +129,7 @@ project.afterEvaluate{
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
                     password project.ext.vstsPassword

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -136,6 +136,14 @@ project.afterEvaluate{
                 }
             }
             maven {
+                name "vsts-maven-adal-android"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                credentials {
+                    username project.ext.vstsUsername
+                    password project.ext.vstsPassword
+                }
+            }
+            maven {
                 name "vsts-maven-android"
                 url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
                 credentials {

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -128,15 +128,7 @@ project.afterEvaluate{
 
         repositories {
             maven {
-                name "vsts-maven-new-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-                credentials {
-                    username project.ext.vstsUsername
-                    password project.ext.vstsPassword
-                }
-            }
-            maven {
-                name "vsts-maven-legacy-adal-android"
+                name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 apply from: '../versioning/version_tasks.gradle'
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 android {
     namespace "com.microsoft.identity.internal.testutils"

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -190,7 +190,7 @@ dependencies {
 
     implementation project(":LabApiUtilities")
 
-    implementation "cz.msebera.android:httpclient:4.5.+"
+    implementation "cz.msebera.android:httpclient:4.5.8"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -190,7 +190,7 @@ dependencies {
 
     implementation project(":LabApiUtilities")
 
-    implementation "cz.msebera.android:httpclient:4.5.8"
+    implementation "cz.msebera.android:httpclient:4.5.+"
     implementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -128,7 +128,7 @@ project.afterEvaluate{
 
         repositories {
             maven {
-                name "vsts-maven-adal-android"
+                name "vsts-maven-new-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
@@ -136,7 +136,7 @@ project.afterEvaluate{
                 }
             }
             maven {
-                name "vsts-maven-adal-android"
+                name "vsts-maven-legacy-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply from: '../versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 android {
     namespace "com.microsoft.identity.internal.testutils"
@@ -132,7 +132,7 @@ project.afterEvaluate{
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
-                    password project.ext.vstsPassword
+                    password project.ext.vstsMavenAccessToken
                 }
             }
             maven {
@@ -140,7 +140,7 @@ project.afterEvaluate{
                 url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
                 credentials {
                     username project.vstsUsername
-                    password project.vstsPassword
+                    password project.vstsMavenAccessToken
                 }
             }
         }

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -174,15 +174,7 @@ project.afterEvaluate{
 
         repositories {
             maven {
-                name "vsts-maven-new-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
-                credentials {
-                    username project.ext.vstsUsername
-                    password project.ext.vstsPassword
-                }
-            }
-            maven {
-                name "vsts-maven-legacy-adal-android"
+                name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -182,6 +182,14 @@ project.afterEvaluate{
                 }
             }
             maven {
+                name "vsts-maven-adal-android"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                credentials {
+                    username project.ext.vstsUsername
+                    password project.ext.vstsPassword
+                }
+            }
+            maven {
                 name "vsts-maven-android"
                 url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
                 credentials {

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply from: '../versioning/version_tasks.gradle'
 
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 def minimumTestAttempts = 3
 
@@ -178,7 +178,7 @@ project.afterEvaluate{
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
-                    password project.ext.vstsPassword
+                    password project.ext.vstsMavenAccessToken
                 }
             }
             maven {
@@ -186,7 +186,7 @@ project.afterEvaluate{
                 url 'https://identitydivision.pkgs.visualstudio.com/IDDP/_packaging/Android/maven/v1'
                 credentials {
                     username project.vstsUsername
-                    password project.vstsPassword
+                    password project.vstsMavenAccessToken
                 }
             }
         }

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -5,8 +5,8 @@ plugins {
 
 apply from: '../versioning/version_tasks.gradle'
 
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDCOMMON_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 def minimumTestAttempts = 3
 

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -174,7 +174,7 @@ project.afterEvaluate{
 
         repositories {
             maven {
-                name "vsts-maven-adal-android"
+                name "vsts-maven-new-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
@@ -182,7 +182,7 @@ project.afterEvaluate{
                 }
             }
             maven {
-                name "vsts-maven-adal-android"
+                name "vsts-maven-legacy-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username project.ext.vstsUsername

--- a/uiautomationutilities/build.gradle
+++ b/uiautomationutilities/build.gradle
@@ -175,7 +175,7 @@ project.afterEvaluate{
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username project.ext.vstsUsername
                     password project.ext.vstsPassword


### PR DESCRIPTION
Received an s360 item asking our libraries to always pull packages from feeds, and not declare mavenCentral as a repository to source dependencies. The feed itself has maven as an upstream. We cannot use AndroidADAL feed as that one has some versions deleted (once a version is deleted from a feed, it cannot be restored, even if an upstream has it). Created a new feed to support this https://identitydivision.visualstudio.com/Engineering/_artifacts/feed/NewAndroid. We pull packages from this new feed, but we still publish our versions to AndroidADAL. The new feed has AndroidADAL as an upstream still, so our existing collection of artifacts is still accessible.

I also took this chance to consolidate the Maven VSTS Username and Access Token fields, which are fields used to authenticate and pull artifacts from the feed. Previously, each library had their own names for these fields with an identifier based on the library in question. These PRs make it so all libraries use the same names, `ENV_VSTS_MVN_CRED_USERNAME` and `ENV_VSTS_MVN_CRED_ACCESSTOKEN`.

**Validation**
Weekly: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1568877&view=results (LTW msal automation app failed because ltw branch does not have these changes, will work once this is in dev and we rebase.
Consumers: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1568839&view=results
Test Library: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1568872&view=results

[AB#3395409](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3395409)

