### PR TITLE
AB#3455870 Adds Authentication Constants to be used for broker latency timestamp in response, Fixes AB#3455870

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ vNext
 - [MINOR] Share SharedPreferencesInMemoryCache across instances of BrokerOAuth2TokenCache
 - [MINOR] Use SharedPreferencesInMemoryCache implementation in Broker (#2802)
 - [MINOR] Fix for SDL violation in device pop scenarios, Fixes AB#3284510 (#2744)
+- [MINOR] Adds Authentication Constants to be used for broker latency timestamp in response (#2831)
 
 Version 23.1.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1564,16 +1564,6 @@ public final class AuthenticationConstants {
         public static final String BROKER_APP_LINK_REDIRECT_URL_PATH_PREFIX = "androidbroker";
 
         /**
-         * Timestamp when the broker received the authentication request.
-         */
-        public static final String BROKER_REQUEST_RECEIVED_TIMESTAMP = "broker_request_received_timestamp";
-
-        /**
-         * Timestamp when the broker generated the authentication response.
-         */
-        public static final String BROKER_RESPONSE_GENERATION_TIMESTAMP = "broker_response_generation_timestamp";
-
-        /**
          * Bundle identifiers for x-ms-clitelem info.
          */
         public static final class CliTelemInfo {

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1564,6 +1564,16 @@ public final class AuthenticationConstants {
         public static final String BROKER_APP_LINK_REDIRECT_URL_PATH_PREFIX = "androidbroker";
 
         /**
+         * Timestamp when the broker received the authentication request.
+         */
+        public static final String BROKER_REQUEST_RECEIVED_TIMESTAMP = "broker_request_received_timestamp";
+
+        /**
+         * Timestamp when the broker generated the authentication response.
+         */
+        public static final String BROKER_RESPONSE_GENERATION_TIMESTAMP = "broker_response_generation_timestamp";
+
+        /**
          * Bundle identifiers for x-ms-clitelem info.
          */
         public static final class CliTelemInfo {

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -568,6 +568,15 @@ public class AuthenticationConstants {
          * String of broker client ID.
          */
         public static final String BROKER_CLIENT_ID = "29d9ed98-a469-4536-ade2-f981bc1d605e";
+        /**
+         * Timestamp when the broker received the authentication request.
+         */
+        public static final String BROKER_REQUEST_RECEIVED_TIMESTAMP = "broker_request_received_timestamp";
+
+        /**
+         * Timestamp when the broker generated the authentication response.
+         */
+        public static final String BROKER_RESPONSE_GENERATION_TIMESTAMP = "broker_response_generation_timestamp";
 
     }
 


### PR DESCRIPTION
[AB#3455870](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3455870) Adding Authentication constants necessary to support passing AST request latency timestamps from Broker to OneAuth.