### PR TITLE
Add homeObjectId to ILabAcccount, Fixes AB#3463642

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/ILabAccount.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/ILabAccount.java
@@ -59,6 +59,13 @@ public interface ILabAccount {
     String getHomeTenantId();
 
     /**
+     * Get the object id in home tenant.
+     *
+     * @return a String representing the account's object id in home tenant
+     */
+    String getHomeObjectId();
+
+    /**
      * A client id that can be used alongside this account to get a token.
      *
      * @return a String representing a client id

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabAccount.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabAccount.java
@@ -52,6 +52,9 @@ public class LabAccount implements ILabAccount {
     @NonNull
     private final String mHomeTenantId;
 
+    @NonNull
+    private final String mHomeObjectId;
+
     // nullable
     // dependency for Nullable annotation not currently added to LabApiUtilities
     private final ConfigInfo mConfigInfo;

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/client/LabClient.java
@@ -144,6 +144,7 @@ public class LabClient implements ILabClient {
                 .password(password)
                 .userType(UserType.fromName(configInfo.getUserInfo().getUserType()))
                 .homeTenantId(configInfo.getUserInfo().getHomeTenantID())
+                .homeObjectId(configInfo.getUserInfo().getHomeObjectId())
                 .configInfo(configInfo)
                 .build();
     }
@@ -252,6 +253,7 @@ public class LabClient implements ILabClient {
                 // all temp users created by Lab Api are currently cloud users
                 .userType(UserType.CLOUD)
                 .homeTenantId(tempUser.getTenantId())
+                .homeObjectId(tempUser.getObjectId())
                 .build();
     }
 

--- a/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
+++ b/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
@@ -33,7 +33,6 @@ import com.microsoft.identity.labapi.utilities.rules.RetryTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -73,12 +72,7 @@ public class LabClientTest {
 
         try {
             final ILabAccount labAccount = mLabClient.getLabAccount(query);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("msidlab4"));
-            Assert.assertEquals(UserType.CLOUD, labAccount.getUserType());
+            assertLabAccount(labAccount, UserType.CLOUD, "msidlab4");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -92,12 +86,7 @@ public class LabClientTest {
 
         try {
             final ILabAccount labAccount = mLabClient.getLabAccount(query);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("outlook"));
-            Assert.assertEquals(UserType.MSA, labAccount.getUserType());
+            assertLabAccount(labAccount, UserType.MSA, "outlook");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -111,12 +100,7 @@ public class LabClientTest {
 
         try {
             final ILabAccount labAccount = mLabClient.getLabAccount(query);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("msidlab4"));
-            Assert.assertEquals(UserType.GUEST, labAccount.getUserType());
+            assertLabAccount(labAccount, UserType.GUEST, "msidlab4");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -130,12 +114,7 @@ public class LabClientTest {
 
         try {
             final ILabAccount labAccount = mLabClient.getLabAccount(query);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("msidlab4"));
-            Assert.assertEquals(UserType.FEDERATED, labAccount.getUserType());
+            assertLabAccount(labAccount, UserType.FEDERATED, "msidlab4");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -145,12 +124,7 @@ public class LabClientTest {
     public void canCreateBasicTempUser() {
         try {
             final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("msidlab4"));
-            Assert.assertEquals(UserType.CLOUD, labAccount.getUserType());
+            assertLabAccount(labAccount, UserType.CLOUD, "msidlab4");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -160,11 +134,7 @@ public class LabClientTest {
     public void canCreateMAMCATempUser() {
         try {
             final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.MAM_CA);
-            Assert.assertNotNull(labAccount);
-            Assert.assertNotNull(labAccount.getUsername());
-            Assert.assertNotNull(labAccount.getPassword());
-            Assert.assertNotNull(labAccount.getUserType());
-            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains("msidlab4"));
+            assertLabAccount(labAccount, UserType.CLOUD, "msidlab4");
         } catch (final LabApiException e) {
             throw new AssertionError(e);
         }
@@ -203,4 +173,22 @@ public class LabClientTest {
         }
     }
 
+
+    // Helper to assert common properties of a lab account
+    private void assertLabAccount(final ILabAccount labAccount,
+                                  final UserType expectedUserType,
+                                  final String expectedUsernameContains) {
+        Assert.assertNotNull(labAccount);
+        Assert.assertNotNull(labAccount.getUsername());
+        Assert.assertNotNull(labAccount.getPassword());
+        Assert.assertNotNull(labAccount.getUserType());
+        if (expectedUsernameContains != null) {
+            Assert.assertTrue(labAccount.getUsername().toLowerCase().contains(expectedUsernameContains));
+        }
+        if (expectedUserType != null) {
+            Assert.assertEquals(expectedUserType, labAccount.getUserType());
+        }
+        Assert.assertNotNull(labAccount.getHomeObjectId());
+        Assert.assertNotNull(labAccount.getHomeTenantId());
+    }
 }


### PR DESCRIPTION
Add homeObjectId to ILabAcccount.

The value will be used in Resource account automation and can potentially be used for other purposes in future.


Fixes [AB#3463642](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3463642)