### PR TITLE
Add JavascriptInterface rules to consumer proguard rules, Fixes AB#3463796

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Add JavascriptInterface rules to consumer proguard rules
+- [PATCH] Add JavascriptInterface rules to consumer proguard rules (#2837)
 - [MINOR] Add optimized saveAndLoadAggregatedAccountData method in BrokerOAuth2TokenCache (#2832)
 - [MINOR] Remove MavenCentral repository from build.gradle files (#2830)
 - [MINOR] Determine whether broker app opts out from battery optimization (#2819)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Add JavascriptInterface rules to consumer proguard
+- [PATCH] Add JavascriptInterface rules to consumer proguard rules
 - [MINOR] Add optimized saveAndLoadAggregatedAccountData method in BrokerOAuth2TokenCache (#2832)
 - [MINOR] Remove MavenCentral repository from build.gradle files (#2830)
 - [MINOR] Determine whether broker app opts out from battery optimization (#2819)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Add JavascriptInterface rules to consumer proguard
 - [MINOR] Add optimized saveAndLoadAggregatedAccountData method in BrokerOAuth2TokenCache (#2832)
 - [MINOR] Remove MavenCentral repository from build.gradle files (#2830)
 - [MINOR] Determine whether broker app opts out from battery optimization (#2819)

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -26,6 +26,10 @@
 -keep class * extends com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme { *; }
 -keep class com.microsoft.identity.common.internal.broker.AuthUxJsonPayload { *; }
 
+# Keep WebView JS bridge methods annotated with @JavascriptInterface
+-keepclassmembers class com.microsoft.identity.** {
+    @android.webkit.JavascriptInterface <methods>;
+}
 
 #For Android Credential Manager: https://developer.android.com/training/sign-in/passkeys#proguard
 -if class androidx.credentials.CredentialManager


### PR DESCRIPTION
Adding keep for methods annotated with JavascriptInterface explicitly in consumer proguard files.

Although default android proguard rules from proguard-android-optimize.txt or proguard-android.txt already keeps all JavascriptInterface methods.

Fixes [AB#3463796](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3463796)