### PR TITLE
Fixes AB#3465209 Add telemetry data

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.OtelContextExtension;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
@@ -76,10 +77,11 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         super(sharedPreferencesFileManager);
         Logger.verbose(TAG, "Init: " + TAG);
         mCacheValueDelegate = accountCacheValueDelegate;
-        new Thread(() -> load()).start();
+        new Thread(OtelContextExtension.wrap(() -> load())).start();
     }
 
     private void load() {
+        final long loadStartTime = System.currentTimeMillis();
         final String methodTag = TAG + ":load";
 
         synchronized (mCacheLock) {
@@ -93,6 +95,8 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             } finally {
                 mLoaded = true;
                 mCacheLock.notifyAll();
+                OTelUtility.recordElapsedTime(AttributeName.out_of_memory_exception_stacktrace.name(),
+                        loadStartTime);
             }
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -95,7 +95,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             } finally {
                 mLoaded = true;
                 mCacheLock.notifyAll();
-                OTelUtility.recordElapsedTime(AttributeName.out_of_memory_exception_stacktrace.name(),
+                OTelUtility.recordElapsedTime(AttributeName.elapsed_time_in_memory_cache_load.name(),
                         loadStartTime);
             }
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -346,6 +346,11 @@ public class CommandDispatcher {
                     AttributeName.num_concurrent_silent_requests.name(),
                     sExecutingCommandMap.size()
             );
+            int queueSize = ((ThreadPoolExecutor)sSilentExecutor).getQueue().size();
+            SpanExtension.current().setAttribute(
+                    AttributeName.silent_requests_queue_size.name(),
+                    queueSize
+            );
 
             commandExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                 @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -502,6 +502,11 @@ public enum AttributeName {
     in_memory_cache_used_for_accounts_and_credentials,
 
     /**
+     * Elapsed time (in milliseconds) spent in executing the load() method in BrokerOAuth2TokenCache for in memory cache.
+     */
+    elapsed_time_in_memory_cache_load,
+
+    /**
      * Passkey operation type (e.g., registration, authentication).
      */
     passkey_operation_type,

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -146,9 +146,16 @@ public enum AttributeName {
     http_status_code,
 
     /**
-     * The size of the silent command executor queue when starting to process an ATS request.
+     * The number of unique cacheable silent requests currently being tracked in the executing command map.
+     * This represents deduplicated commands that are either executing or waiting in the thread pool queue.
      */
     num_concurrent_silent_requests,
+
+    /**
+     * The number of tasks waiting in the silent request thread pool queue to be executed.
+     * This does not include tasks currently being executed by worker threads.
+     */
+    silent_requests_queue_size,
 
     /**
      * The time (in milliseconds) spent in executing the save method in OAuth2TokenCache.


### PR DESCRIPTION
Fixes [AB#3465209](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3465209)
This PR adds 2 telemetry data points - 
1. to measure the time taken to load accounts and credentials in-memory.
2. to measure the queue depth to identify the number of threads that wait to be picked up due to THREAD_POOL_SIZE=5 configuration.