### PR TITLE
Added telemetry to capture encrypt and decrypt operations in device PoP scenarios, Fixes AB#3468126

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ vNext
 - [MINOR] Adds Authentication Constants to be used for broker latency timestamp in response (#2831)
 - [MINOR] Implemented Common logic to retrieve broker latency duration from result Broker Bundle (#2835)
 - [MINOR] Add support for WebApps getToken API (#2803)
+- [MINOR] Added telemetry to capture the DRSNonce call (#3302)
 
 Version 23.1.1
 -----------

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -84,5 +84,8 @@ public enum SpanName {
      * Span name for DRS (Device Registration Service) nonce request operations.
      */
     DRSNonceRequest,
+    /**
+     * Span name for Device POP crypto operations.
+     */
     DevicePopCryptoOperation
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -83,5 +83,10 @@ public enum SpanName {
     /**
      * Span name for DRS (Device Registration Service) nonce request operations.
      */
-    DRSNonceRequest
+    DRSNonceRequest,
+    /**
+     * Span name for Device PoP decrypt operations.
+     */
+    DevicePopDecrypt,
+    DevicePopEncrypt
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -84,9 +84,5 @@ public enum SpanName {
      * Span name for DRS (Device Registration Service) nonce request operations.
      */
     DRSNonceRequest,
-    /**
-     * Span name for Device PoP decrypt operations.
-     */
-    DevicePopDecrypt,
-    DevicePopEncrypt
+    DevicePopCryptoOperation
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -39,6 +39,7 @@ import static com.microsoft.identity.common.java.exception.ClientException.NO_SU
 import static com.microsoft.identity.common.java.exception.ClientException.NO_SUCH_PADDING;
 import static com.microsoft.identity.common.java.exception.ClientException.SIGNING_FAILURE;
 import static com.microsoft.identity.common.java.exception.ClientException.THUMBPRINT_COMPUTATION_FAILURE;
+import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_CRYPTO_ERROR;
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_EXPORT_FORMAT;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.GENERATE_AT_POP_ASYMMETRIC_KEYPAIR_END;
 import static com.microsoft.identity.common.java.marker.PerfConstants.CodeMarkerConstants.GENERATE_AT_POP_ASYMMETRIC_KEYPAIR_START;
@@ -626,6 +627,15 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         }
     }
 
+    /**
+     * Maps cryptographic exceptions to corresponding ClientException error code constants.
+     * This helper method is used by both encrypt and decrypt operations to provide consistent
+     * error code mappings for various cryptographic failure scenarios.
+     *
+     * @param e The exception to map to an error code. Must be non-null.
+     * @return The corresponding ClientException error code constant.
+     * Note : Returns {@link ClientException#UNKNOWN_CRYPTO_ERROR} as the default fallback when the exception type doesn't match any known types.
+     */
     private String mapCryptoExceptionToErrorCode(@NonNull final Exception e) {
         if (e instanceof NoSuchAlgorithmException) {
             return NO_SUCH_ALGORITHM;
@@ -644,7 +654,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         } else if (e instanceof InvalidAlgorithmParameterException) {
             return INVALID_ALG_PARAMETER;
         }
-        return INVALID_KEY; // default fallback
+        return UNKNOWN_CRYPTO_ERROR; // default fallback
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -61,6 +61,7 @@ import com.microsoft.identity.common.java.marker.CodeMarkerManager;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.opentelemetry.SpanName;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.TaskCompletedCallbackWithError;
 import com.nimbusds.jose.JOSEException;
@@ -202,7 +203,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
 
     /**
      * Properties embedded in the SignedHttpRequest.
-     * Roughly conforms to: https://tools.ietf.org/html/draft-ietf-oauth-signed-http-request-03
+     * Roughly conforms to: <a href="https://tools.ietf.org/html/draft-ietf-oauth-signed-http-request-03">...</a>
      */
     private static final class SignedHttpRequestJwtClaims {
 
@@ -590,7 +591,8 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     @Override
     public byte[] encrypt(@NonNull final Cipher cipher, @NonNull final byte[] plaintext) throws ClientException {
         final String methodTag = TAG + ":encrypt";
-        final Span span = OTelUtility.createSpan(SpanName.DevicePopEncrypt.name());
+        final Span span = OTelUtility.createSpan(SpanName.DevicePopCryptoOperation.name());
+        span.setAttribute(AttributeName.crypto_operation.name(), "encrypt");
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Load our key material
             final KeyStore.PrivateKeyEntry privateKeyEntry = mKeyManager.getEntry();
@@ -654,7 +656,8 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
     @Override
     public byte[] decrypt(@NonNull Cipher cipher, byte[] ciphertext) throws ClientException {
         final String methodTag = TAG + ":decrypt";
-        final Span span = OTelUtility.createSpan(SpanName.DevicePopDecrypt.name());
+        final Span span = OTelUtility.createSpan(SpanName.DevicePopCryptoOperation.name());
+        span.setAttribute(AttributeName.crypto_operation.name(), "decrypt");
         try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Load our key material
             final KeyStore.PrivateKeyEntry privateKeyEntry = mKeyManager.getEntry();

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -626,7 +626,7 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         }
     }
 
-    private String mapCryptoExceptionToErrorCode(Exception e) {
+    private String mapCryptoExceptionToErrorCode(@NonNull final Exception e) {
         if (e instanceof NoSuchAlgorithmException) {
             return NO_SUCH_ALGORITHM;
         } else if (e instanceof NoSuchPaddingException) {

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -702,7 +702,6 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
         }
     }
 
-
     @Override
     public SecureHardwareState getSecureHardwareState() throws ClientException {
         final String methodTag = TAG + ":getSecureHardwareState";

--- a/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/platform/AbstractDevicePopManager.java
@@ -589,10 +589,9 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
 
     @Override
     public byte[] encrypt(@NonNull final Cipher cipher, @NonNull final byte[] plaintext) throws ClientException {
-        String errCode;
-        Exception exception;
         final String methodTag = TAG + ":encrypt";
-        try {
+        final Span span = OTelUtility.createSpan(SpanName.DevicePopEncrypt.name());
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Load our key material
             final KeyStore.PrivateKeyEntry privateKeyEntry = mKeyManager.getEntry();
 
@@ -607,46 +606,43 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
                 input.init(javax.crypto.Cipher.ENCRYPT_MODE, publicKey);
             }
 
-            return input.doFinal(plaintext);
-        } catch (final InvalidKeyException e) {
-            errCode = INVALID_KEY;
-            exception = e;
-        } catch (final UnrecoverableEntryException e) {
-            errCode = INVALID_PROTECTION_PARAMS;
-            exception = e;
-        } catch (final NoSuchAlgorithmException e) {
-            errCode = NO_SUCH_ALGORITHM;
-            exception = e;
-        } catch (final KeyStoreException e) {
-            errCode = KEYSTORE_NOT_INITIALIZED;
-            exception = e;
-        } catch (final NoSuchPaddingException e) {
-            errCode = NO_SUCH_PADDING;
-            exception = e;
-        } catch (final InvalidAlgorithmParameterException e) {
-            errCode = INVALID_ALG_PARAMETER;
-            exception = e;
-        } catch (final BadPaddingException e) {
-            errCode = BAD_PADDING;
-            exception = e;
-        } catch (final IllegalBlockSizeException e) {
-            errCode = INVALID_BLOCK_SIZE;
-            exception = e;
+            final byte[] result = input.doFinal(plaintext);
+            span.setStatus(StatusCode.OK);
+            return result;
+        } catch (final InvalidKeyException | UnrecoverableEntryException | NoSuchAlgorithmException |
+                       KeyStoreException | NoSuchPaddingException | InvalidAlgorithmParameterException |
+                       BadPaddingException | IllegalBlockSizeException e) {
+            final String errCode = mapCryptoExceptionToErrorCode(e);
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR);
+
+            final ClientException clientException = new ClientException(errCode, e.getMessage(), e);
+            Logger.error(methodTag, errCode, e);
+            throw clientException;
+        } finally {
+            span.end();
         }
+    }
 
-        final ClientException clientException = new ClientException(
-                errCode,
-                exception.getMessage(),
-                exception
-        );
-
-        Logger.error(
-                methodTag,
-                errCode,
-                exception
-        );
-
-        throw clientException;
+    private String mapCryptoExceptionToErrorCode(Exception e) {
+        if (e instanceof NoSuchAlgorithmException) {
+            return NO_SUCH_ALGORITHM;
+        } else if (e instanceof NoSuchPaddingException) {
+            return NO_SUCH_PADDING;
+        } else if (e instanceof InvalidKeyException) {
+            return INVALID_KEY;
+        } else if (e instanceof UnrecoverableEntryException) {
+            return INVALID_PROTECTION_PARAMS;
+        } else if (e instanceof KeyStoreException) {
+            return KEYSTORE_NOT_INITIALIZED;
+        } else if (e instanceof BadPaddingException) {
+            return BAD_PADDING;
+        } else if (e instanceof IllegalBlockSizeException) {
+            return INVALID_BLOCK_SIZE;
+        } else if (e instanceof InvalidAlgorithmParameterException) {
+            return INVALID_ALG_PARAMETER;
+        }
+        return INVALID_KEY; // default fallback
     }
 
     @Override
@@ -657,10 +653,9 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
 
     @Override
     public byte[] decrypt(@NonNull Cipher cipher, byte[] ciphertext) throws ClientException {
-        String errCode;
-        Exception exception;
         final String methodTag = TAG + ":decrypt";
-        try {
+        final Span span = OTelUtility.createSpan(SpanName.DevicePopDecrypt.name());
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             // Load our key material
             final KeyStore.PrivateKeyEntry privateKeyEntry = mKeyManager.getEntry();
 
@@ -676,47 +671,24 @@ public abstract class AbstractDevicePopManager implements IDevicePopManager {
             } else {
                 outputCipher.init(javax.crypto.Cipher.DECRYPT_MODE, privateKey);
             }
-            return outputCipher.doFinal(ciphertext);
-        } catch (final NoSuchAlgorithmException e) {
-            errCode = NO_SUCH_ALGORITHM;
-            exception = e;
-        } catch (final InvalidKeyException e) {
-            errCode = INVALID_KEY;
-            exception = e;
-        } catch (final UnrecoverableEntryException e) {
-            errCode = INVALID_PROTECTION_PARAMS;
-            exception = e;
-        } catch (final NoSuchPaddingException e) {
-            errCode = NO_SUCH_ALGORITHM;
-            exception = e;
-        } catch (final KeyStoreException e) {
-            errCode = KEYSTORE_NOT_INITIALIZED;
-            exception = e;
-        } catch (final BadPaddingException e) {
-            errCode = BAD_PADDING;
-            exception = e;
-        } catch (final IllegalBlockSizeException e) {
-            errCode = INVALID_BLOCK_SIZE;
-            exception = e;
-        } catch (final InvalidAlgorithmParameterException e) {
-            errCode = INVALID_ALG_PARAMETER;
-            exception = e;
+            final byte[] result = outputCipher.doFinal(ciphertext);
+            span.setStatus(StatusCode.OK);
+            return result;
+        } catch (final NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                       UnrecoverableEntryException | KeyStoreException | BadPaddingException |
+                       IllegalBlockSizeException | InvalidAlgorithmParameterException e) {
+            final String errCode = mapCryptoExceptionToErrorCode(e);
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR);
+
+            final ClientException clientException = new ClientException(errCode, e.getMessage(), e);
+            Logger.error(methodTag, errCode, e);
+            throw clientException;
+        } finally {
+            span.end();
         }
-
-        final ClientException clientException = new ClientException(
-                errCode,
-                exception.getMessage(),
-                exception
-        );
-
-        Logger.error(
-                methodTag,
-                errCode,
-                exception
-        );
-
-        throw clientException;
     }
+
 
     @Override
     public SecureHardwareState getSecureHardwareState() throws ClientException {


### PR DESCRIPTION
**What :** Adding telemetry to capture Encrypt and Decrypt crypto operations in device PoP cases

**Why :** We think these operations are not invoked at all and we marked it as deprecated in previous PRs. But to remove them completely, we need the telemetry to check if they are for sure not being invoked.

**Testing :** Verified that the spans are getting created correctly.

Fixes [AB#3468126](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3468126)