### PR TITLE
Removing cert chain check from broker app verification, Fixes AB#3437920

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.internal.broker
 
 import android.content.Context
 import com.microsoft.identity.common.internal.util.PackageUtils
+import com.microsoft.identity.common.java.flighting.CommonFlight
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager
 import com.microsoft.identity.common.logging.Logger
 import java.security.cert.X509Certificate
 
@@ -89,10 +91,14 @@ open class BrokerValidator: IBrokerValidator {
                 setOf(expectedSigningCertificateThumbprint).iterator()
             )
 
-            // Perform the certificate chain validation. If there is only one cert returned,
-            // no need to perform certificate chain validation.
-            if (signingCertificates.size > 1) {
-                PackageUtils.verifyCertificateChain(signingCertificates)
+            if (CommonFlightsManager.getFlightsProvider()
+                    .isFlightEnabled(CommonFlight.RE_ENABLE_VALIDATE_SIGNING_CERT_CHAIN_BROKER_APPS)
+            ) {
+                // Perform the certificate chain validation. If there is only one cert returned,
+                // no need to perform certificate chain validation.
+                if (signingCertificates.size > 1) {
+                    PackageUtils.verifyCertificateChain(signingCertificates)
+                }
             }
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.kt
@@ -91,6 +91,7 @@ open class BrokerValidator: IBrokerValidator {
                 setOf(expectedSigningCertificateThumbprint).iterator()
             )
 
+            // Removing the outdated check, but we can bring it back with a feature flag.
             if (CommonFlightsManager.getFlightsProvider()
                     .isFlightEnabled(CommonFlight.RE_ENABLE_VALIDATE_SIGNING_CERT_CHAIN_BROKER_APPS)
             ) {

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -200,7 +200,13 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to disable the unnecessary crypto operation purposes in device pop manager like encrypt, decrypt and wrap.
      */
-    DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER ("DisableUnnecessaryCryptoPurposesFromDevicePopManager", false);
+    DISABLE_UNNECESSARY_CRYPTO_PURPOSES_FROM_DEVICE_POP_MANAGER ("DisableUnnecessaryCryptoPurposesFromDevicePopManager", false),
+
+    /**
+     * Flight to re-enable validating signing certificate chain for broker validation
+     * We want to disable the check by default but have the ability to bring it back just in case.
+     */
+    RE_ENABLE_VALIDATE_SIGNING_CERT_CHAIN_BROKER_APPS("ReEnableValidateSigningCertChainBrokerApps", false);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
### Summary
See https://github.com/AzureAD/ad-accounts-for-android/pull/3300. We are going to keep it consistent and also remove this check for broker app validation (but put a feature flag just in case).
[AB#3437920](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3437920)