### PR TITLE
Support passing request headers to broker requests, Fixes AB#3386081

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -63,6 +63,7 @@ public class BrokerRequest implements Serializable {
         final static String LOCAL_ACCOUNT_ID = "local_account_id";
         final static String USERNAME = "username";
         final static String EXTRA_QUERY_STRING_PARAMETER = "extra_query_param";
+        final static String REQUEST_HEADERS = "request_headers";
         final static String CORRELATION_ID = "correlation_id";
         final static String PROMPT = "prompt";
         final static String CLAIMS = "claims";
@@ -141,6 +142,13 @@ public class BrokerRequest implements Serializable {
     @Nullable
     @SerializedName(SerializedNames.EXTRA_QUERY_STRING_PARAMETER)
     private String mExtraQueryStringParameter;
+
+    /**
+     * Additional request headers for the request.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.REQUEST_HEADERS)
+    private String mRequestHeaders;
 
     /**
      * Extra options flags for the request.

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -144,7 +144,7 @@ public class BrokerRequest implements Serializable {
     private String mExtraQueryStringParameter;
 
     /**
-     * Additional request headers for the request.
+     * Additional request headers for the request. These values should not be logged anywhere, they may contain sentitive information.
      */
     @Nullable
     @SerializedName(SerializedNames.REQUEST_HEADERS)

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -79,6 +79,7 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.java.util.BrokerProtocolVersionUtil;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.QueryParamsAdapter;
+import com.microsoft.identity.common.java.util.RequestHeaderSerializationUtil;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
@@ -99,6 +100,9 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
         final String extraOptions = parameters.getExtraOptions() != null ?
                 QueryParamsAdapter._toJson(parameters.getExtraOptions()) : null;
 
+        final String requestHeaders = parameters.getRequestHeaders() != null ?
+                RequestHeaderSerializationUtil.toJson(parameters.getRequestHeaders()) : null;
+
         final BrokerRequest.BrokerRequestBuilder brokerRequestBuilder = BrokerRequest.builder()
                 .authority(parameters.getAuthority().getAuthorityURL().toString())
                 .scope(TextUtils.join(" ", parameters.getScopes()))
@@ -109,6 +113,7 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .userName(parameters.getLoginHint())
                 .extraQueryStringParameter(extraQueryStringParameter)
                 .extraOptions(extraOptions)
+                .requestHeaders(requestHeaders)
                 .prompt((OpenIdConnectPromptParameter.UNSET.name().equals(parameters.getPrompt().name())) ? null : parameters.getPrompt().name())
                 .claims(parameters.getClaimsRequestJson())
                 .forceRefresh(parameters.isForceRefresh())

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapterTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapterTests.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_REQUEST_V2_COMPRESSED;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.REQUEST_AUTHORITY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -51,12 +52,14 @@ import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.providers.oauth2.OpenIdConnectPromptParameter;
 import com.microsoft.identity.common.java.request.SdkType;
 import com.microsoft.identity.common.java.ui.BrowserDescriptor;
+import com.microsoft.identity.common.java.util.RequestHeaderSerializationUtil;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -288,6 +291,9 @@ public class MsalBrokerRequestAdapterTests {
 
         final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
 
+        final HashMap<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("header1", "value1");
+
         final InteractiveTokenCommandParameters params = InteractiveTokenCommandParameters.builder()
                 .platformComponents(components)
                 .correlationId("987d8962-3f4d-4054-a852-ac0c4b6a602e")
@@ -309,6 +315,7 @@ public class MsalBrokerRequestAdapterTests {
                 .preferredBrowser(new BrowserDescriptor("chrome", "signature", null, null))
                 .claimsRequestJson("claims_request")
                 .brokerBrowserSupportEnabled(true)
+                .requestHeaders(requestHeaders)
                 .build();
         final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
         final BrokerRequest brokerRequest = msalBrokerRequestAdapter.brokerRequestFromAcquireTokenParameters(params);
@@ -327,6 +334,8 @@ public class MsalBrokerRequestAdapterTests {
         assertEquals(params.getAuthenticationScheme(), brokerRequest.getAuthenticationScheme());
         assertEquals(params.getPrompt().name(), brokerRequest.getPrompt());
         assertEquals(params.isSuppressBrokerAccountPicker(), brokerRequest.isSuppressAccountPicker());
+        assertNotNull(brokerRequest.getRequestHeaders());
+        assertEquals(params.getRequestHeaders(), RequestHeaderSerializationUtil.fromJson(brokerRequest.getRequestHeaders()));
         assertNull(brokerRequest.getSignInWithGoogleCredential());
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.java.util;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import java.util.HashMap;
@@ -34,13 +35,15 @@ import lombok.NonNull;
  * Utility class for serializing and deserializing request header maps
  */
 public class RequestHeaderSerializationUtil {
+
+    private static final Gson mGson = new GsonBuilder().create();
+
     public static String toJson(@NonNull final Map<String, String> headerMap) {
-        return new Gson().toJson(headerMap);
+        return mGson.toJson(headerMap);
     }
 
     public static HashMap<String, String> fromJson(@NonNull final String jsonString) {
-        return new Gson()
-                .fromJson(
+        return mGson.fromJson(
                         jsonString,
                         TypeToken.getParameterized(
                                 HashMap.class,

--- a/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
@@ -1,0 +1,52 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.util;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.NonNull;
+
+/**
+ * Utility class for serializing and deserializing request header maps
+ */
+public class RequestHeaderSerializationUtil {
+    public static String toJson(@NonNull final Map<String, String> headerMap) {
+        return new Gson().toJson(headerMap);
+    }
+
+    public static HashMap<String, String> fromJson(@NonNull final String jsonString) {
+        return new Gson()
+                .fromJson(
+                        jsonString,
+                        TypeToken.getParameterized(
+                                HashMap.class,
+                                String.class,
+                                String.class
+                        ).getType()
+                );
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtil.java
@@ -38,10 +38,20 @@ public class RequestHeaderSerializationUtil {
 
     private static final Gson mGson = new GsonBuilder().create();
 
+    /**
+     * Serializes a map of request headers (Expects a String : String pairing Map) to a JSON string.
+     * @param headerMap Map of request headers
+     * @return the JSON String generated through GSON
+     */
     public static String toJson(@NonNull final Map<String, String> headerMap) {
         return mGson.toJson(headerMap);
     }
 
+    /**
+     * Deserializes a JSON String of request headers into a HashMap<String, String> object.
+     * @param jsonString JSON String representing the request headers
+     * @return the HashMap<String, String> generated through GSON
+     */
     public static HashMap<String, String> fromJson(@NonNull final String jsonString) {
         return mGson.fromJson(
                         jsonString,

--- a/common4j/src/test/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtilTest.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.identity.common.java.util;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequestHeaderSerializationUtilTest {
+
+    @Test
+    public void testSerializeHeaders_returnsValidString() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token");
+        headers.put("Content-Type", "application/json");
+
+        String serialized = RequestHeaderSerializationUtil.toJson(headers);
+
+        assertNotNull(serialized);
+        assertTrue(serialized.contains("Authorization"));
+        assertTrue(serialized.contains("Bearer token"));
+        assertTrue(serialized.contains("Content-Type"));
+    }
+
+    @Test
+    public void testDeserializeHeaders_returnsValidMap() {
+        String input = "{\"Authorization\":\"Bearer token\",\"Content-Type\":\"application/json\"}";
+        Map<String, String> headers = RequestHeaderSerializationUtil.fromJson(input);
+
+        assertNotNull(headers);
+        assertEquals("Bearer token", headers.get("Authorization"));
+        assertEquals("application/json", headers.get("Content-Type"));
+    }
+
+    @Test
+    public void testSerializeEmptyHeaders_returnsEmptyString() {
+        Map<String, String> headers = new HashMap<>();
+        String serialized = RequestHeaderSerializationUtil.toJson(headers);
+        assertEquals("{}", serialized);
+    }
+
+    @Test
+    public void testDeserializeEmptyString_returnsEmptyMap() {
+        Map<String, String> headers = RequestHeaderSerializationUtil.fromJson("{}");
+        assertTrue(headers.isEmpty());
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtilTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/util/RequestHeaderSerializationUtilTest.java
@@ -1,6 +1,25 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.common.java.util;
 
 import org.junit.Test;


### PR DESCRIPTION
As part of supporting the Federated Credential Token testhook, this PR allows requestHeaders object from the interactive token command parameters object to be passed through broker requests. The request Headers field in InteractiveTokenCommandParameters already exists, but it was not being included in the broker requests. This PR fixes that.

[AB#3386081](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3386081)