### PR TITLE
Implement State-Based Timeout Classification for Silent Token Requests, Fixes AB#3495207

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [MINOR] Cleanup code related to emitting ests telemetry (#2868)
 - [MINOR] Skip account aggregation when responding to AcquireTokenSilent api call for OneAuth (#2863)
 - [MINOR] Introduce locks at NameValueStorageFileManagerSimpleCacheImpl layer (#2842)
+- [MINOR] Implement State-Based Timeout Classification for Silent Token Requests
 
 Version 23.2.0
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ vNext
 - [MINOR] Cleanup code related to emitting ests telemetry (#2868)
 - [MINOR] Skip account aggregation when responding to AcquireTokenSilent api call for OneAuth (#2863)
 - [MINOR] Introduce locks at NameValueStorageFileManagerSimpleCacheImpl layer (#2842)
-- [MINOR] Implement State-Based Timeout Classification for Silent Token Requests (#2870)
+- [PATCH] Implement State-Based Timeout Classification for Silent Token Requests (#2870)
 - [MINOR] Added Authentication Constants to be used for broker version and name (#2859)
 - [PATCH] Adding WebAppsNonce to JWT request body (#2867)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@ vNext
 - [MINOR] Cleanup code related to emitting ests telemetry (#2868)
 - [MINOR] Skip account aggregation when responding to AcquireTokenSilent api call for OneAuth (#2863)
 - [MINOR] Introduce locks at NameValueStorageFileManagerSimpleCacheImpl layer (#2842)
-- [MINOR] Implement State-Based Timeout Classification for Silent Token Requests
+- [MINOR] Implement State-Based Timeout Classification for Silent Token Requests (#2870)
 
 Version 23.2.0
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -24,7 +24,10 @@ package com.microsoft.identity.common;
 
 import static com.microsoft.identity.common.java.exception.ServiceException.SERVICE_NOT_AVAILABLE;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -35,6 +38,7 @@ import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.commands.BaseCommand;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.EmptyCommandCallback;
+import com.microsoft.identity.common.java.commands.SilentTokenCommand;
 import com.microsoft.identity.common.java.commands.ICommandResult;
 import com.microsoft.identity.common.java.commands.parameters.CommandParameters;
 import com.microsoft.identity.common.java.commands.parameters.DeviceCodeFlowCommandParameters;
@@ -67,6 +71,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -85,10 +90,31 @@ import java.util.function.Consumer;
 @RunWith(AndroidJUnit4.class)
 public class CommandDispatcherTest {
 
+    private static final String TAG = "CommandDispatcherTest";
+
     private static final AtomicInteger INTEGER = new AtomicInteger(1);
     private static final String TEST_RESULT_STR = "test_result_str";
     private static final AcquireTokenResult TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT = getRefreshExpiredTokenResult();
     private static final AcquireTokenResult TEST_ACQUIRE_TOKEN_REFRESH_UNEXPIRED_RESULT = getRefreshUnexpiredTokenResult();
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // Constants for State-Based Timeout Detection Tests
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /** Duration for slow execution tests - must exceed the 30 second timeout */
+    private static final long SLOW_EXECUTION_DURATION_MS = 35000;
+
+    /** Wait time for runnable's finally block to complete cleanup after future.get() returns */
+    private static final long CLEANUP_WAIT_MS = 500;
+
+    /** Small delay to ensure blocking tasks are fully blocking before submitting test request */
+    private static final long TASK_STABILIZATION_DELAY_MS = 100;
+
+    /** Thread pool size for silent requests (matches CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE) */
+    private static final int SILENT_THREAD_POOL_SIZE = 5;
+
+    /** Number of concurrent requests for state collision test */
+    private static final int CONCURRENT_REQUEST_COUNT = 20;
 
     @Test
     public void testSubmitSilentShouldRefresh() throws Exception {
@@ -736,6 +762,410 @@ public class CommandDispatcherTest {
         }
     }
 
+    // ════════════════════════════════════════════════════════════════════════════
+    // State-Based Timeout Detection Tests
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Test that timeout while queued with saturated pool is classified as
+     * TIMED_OUT_THREAD_POOL_SATURATED.
+     *
+     * <p>Test Strategy:
+     * <ol>
+     *   <li>Fill all {@link #SILENT_THREAD_POOL_SIZE} thread pool threads with blocking tasks</li>
+     *   <li>Submit a new request that will be queued (state: QUEUED)</li>
+     *   <li>Request times out after 30 seconds while still in queue</li>
+     *   <li>Verify error code is TIMED_OUT_THREAD_POOL_SATURATED</li>
+     * </ol>
+     *
+     * <p>Expected Duration: ~30 seconds (timeout duration)
+     *
+     * @throws Exception if test setup fails
+     */
+    @Test
+    public void testTimeoutClassification_ThreadPoolSaturated() throws Exception {
+        Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: Starting test");
+        final int POOL_SIZE = SILENT_THREAD_POOL_SIZE;
+        final CountDownLatch tasksStarted = new CountDownLatch(POOL_SIZE);
+        final CountDownLatch releaseBlockingTasks = new CountDownLatch(1);
+        final CountDownLatch tasksCompleted = new CountDownLatch(POOL_SIZE); // Track completion
+
+        try {
+            // Fill the thread pool with blocking tasks
+            Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: Filling thread pool with " + POOL_SIZE + " blocking tasks");
+            for (int i = 0; i < POOL_SIZE; i++) {
+                BlockingTestCommand blockingCommand = new BlockingTestCommand(
+                    getEmptyTestParams(),
+                    new EmptyCommandCallback(),
+                    tasksStarted,
+                    releaseBlockingTasks,
+                    tasksCompleted
+                );
+                CommandDispatcher.submitSilentReturningFuture(blockingCommand);
+            }
+
+            // Wait for all blocking tasks to start (threads are now busy)
+            Assert.assertTrue("All blocking tasks should start",
+                tasksStarted.await(10, TimeUnit.SECONDS));
+            Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: All blocking tasks started, pool is saturated");
+
+            // Small delay to ensure tasks are fully blocking
+            Thread.sleep(TASK_STABILIZATION_DELAY_MS);
+
+            // Submit request - should timeout in queue (all threads busy)
+            SilentTokenCommandParameters params = createTestSilentTokenParams();
+            SilentTokenCommand command = createTestSilentTokenCommand(params);
+
+            try {
+                CommandDispatcher.submitAcquireTokenSilentSync(command);
+                Assert.fail("Expected ClientException with TIMED_OUT_THREAD_POOL_SATURATED");
+            } catch (ClientException e) {
+                // Verify timeout classified as thread pool saturated
+                Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: Caught expected exception with error code: " + e.getErrorCode());
+                Assert.assertEquals("Expected TIMED_OUT_THREAD_POOL_SATURATED but got " + e.getErrorCode(),
+                    ClientException.TIMED_OUT_THREAD_POOL_SATURATED, e.getErrorCode());
+                Assert.assertTrue("Message should mention thread pool saturated",
+                    e.getMessage().contains("Thread pool saturated"));
+                Assert.assertNotNull("Correlation ID should be set", e.getCorrelationId());
+            }
+        } finally {
+            // Release blocking tasks
+            Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: Releasing blocking tasks");
+            releaseBlockingTasks.countDown();
+
+            // Wait for all blocking tasks to complete (not just sleep)
+            Assert.assertTrue("All blocking tasks should complete",
+                tasksCompleted.await(10, TimeUnit.SECONDS));
+            Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: All blocking tasks completed, test finished");
+        }
+    }
+
+    /**
+     * Test that timeout during execution is classified as TIMED_OUT_EXECUTION.
+     *
+     * <p>Test Strategy:
+     * <ol>
+     *   <li>Submit a command that sleeps for {@link #SLOW_EXECUTION_DURATION_MS} (35s)</li>
+     *   <li>Command starts executing (state: EXECUTING)</li>
+     *   <li>Request times out after 30 seconds while still executing</li>
+     *   <li>Verify error code is TIMED_OUT_EXECUTION</li>
+     * </ol>
+     *
+     * <p>Expected Duration: ~30 seconds (timeout duration)
+     *
+     * @throws Exception if test setup fails
+     */
+    @Test
+    public void testTimeoutClassification_SlowExecution() throws Exception {
+        Log.d(TAG, "testTimeoutClassification_SlowExecution: Starting test with execution duration " + SLOW_EXECUTION_DURATION_MS + "ms");
+        // Create command that executes slowly (SLOW_EXECUTION_DURATION_MS > 30 second timeout)
+        SilentTokenCommandParameters params = createTestSilentTokenParams();
+        SilentTokenCommand slowCommand = createSlowExecutionSilentTokenCommand(params, SLOW_EXECUTION_DURATION_MS);
+
+        try {
+            CommandDispatcher.submitAcquireTokenSilentSync(slowCommand);
+            Assert.fail("Expected ClientException with TIMED_OUT_EXECUTION");
+        } catch (ClientException e) {
+            // Verify timeout classified as slow execution
+            Log.d(TAG, "testTimeoutClassification_SlowExecution: Caught expected exception with error code: " + e.getErrorCode());
+            Assert.assertEquals("Expected TIMED_OUT_EXECUTION error code",
+                ClientException.TIMED_OUT_EXECUTION, e.getErrorCode());
+            Assert.assertTrue("Message should mention slow execution",
+                e.getMessage().contains("Slow execution"));
+            Assert.assertNotNull("Correlation ID should be set", e.getCorrelationId());
+        }
+
+        // Verify cleanup
+        Assert.assertEquals("Timeout location map should be cleaned up",
+            0, getTimeoutLocationMapSizeViaReflection());
+    }
+
+    /**
+     * Test that timeout location map is cleaned up after successful request.
+     *
+     * <p>Verifies that sTimeoutLocationMap entries are properly removed after
+     * a request completes successfully. This prevents memory leaks from
+     * accumulating tracking state.
+     *
+     * <p>Note: A {@link #CLEANUP_WAIT_MS} delay is needed because future.get()
+     * returns when the result is set, but the finally block that removes the
+     * entry from sTimeoutLocationMap runs AFTER that.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    public void testTimeoutLocationMap_CleanupAfterSuccess() throws Exception {
+        // Get initial map size
+        int initialSize = getTimeoutLocationMapSizeViaReflection();
+
+        // Execute successful request
+        TestCommand successCommand = new TestCommand(getEmptyTestParams(), new EmptyCommandCallback(), 999);
+        FinalizableResultFuture<CommandResult> future = CommandDispatcher.submitSilentReturningFuture(successCommand);
+
+        // Wait for completion
+        CommandResult result = future.get(10, TimeUnit.SECONDS);
+        Assert.assertEquals("Command should complete successfully",
+            ICommandResult.ResultStatus.COMPLETED, result.getStatus());
+
+        // Wait for the runnable's finally block to complete cleanup
+        // Note: future.get() returns when result is set, but the finally block
+        // that removes the entry from sTimeoutLocationMap runs AFTER that
+        Thread.sleep(CLEANUP_WAIT_MS);
+
+        // Verify cleanup - map should return to initial size
+        int finalSize = getTimeoutLocationMapSizeViaReflection();
+        Assert.assertEquals("Timeout location map should be cleaned up after success",
+            initialSize, finalSize);
+    }
+
+    /**
+     * Test that timeout location map is cleaned up after timeout.
+     *
+     * <p>Verifies that sTimeoutLocationMap entries are properly removed after
+     * a request times out. Cleanup happens in submitAcquireTokenSilentSync()'s
+     * finally block, which runs immediately when TimeoutException is caught.
+     *
+     * <p>Expected Duration: ~30 seconds (timeout duration)
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    public void testTimeoutLocationMap_CleanupAfterTimeout() throws Exception {
+        // Get initial map size
+        int initialSize = getTimeoutLocationMapSizeViaReflection();
+
+        // Execute request that will timeout
+        SilentTokenCommandParameters params = createTestSilentTokenParams();
+        SilentTokenCommand slowCommand = createSlowExecutionSilentTokenCommand(params, SLOW_EXECUTION_DURATION_MS);
+
+        try {
+            CommandDispatcher.submitAcquireTokenSilentSync(slowCommand);
+            Assert.fail("Expected timeout");
+        } catch (ClientException e) {
+            // Expected - verify it's a timeout error
+            Assert.assertTrue("Should be a timeout error",
+                e.getErrorCode().startsWith("timed_out"));
+        }
+
+        // Verify cleanup - map should return to initial size
+        int finalSize = getTimeoutLocationMapSizeViaReflection();
+        Assert.assertEquals("Timeout location map should be cleaned up after timeout",
+            initialSize, finalSize);
+    }
+
+    /**
+     * Test concurrent requests don't cause state collision in timeout tracking.
+     *
+     * <p>Test Strategy:
+     * <ol>
+     *   <li>Launch {@link #CONCURRENT_REQUEST_COUNT} threads simultaneously</li>
+     *   <li>Each thread submits a unique (non-cacheable) request</li>
+     *   <li>Wait for all requests to complete</li>
+     *   <li>Verify all requests tracked independently (no state collision)</li>
+     *   <li>Verify sTimeoutLocationMap is cleaned up (no memory leaks)</li>
+     * </ol>
+     *
+     * <p>This test validates that correlation ID-based tracking correctly
+     * isolates concurrent requests.
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    public void testConcurrentRequests_NoStateCollision() throws Exception {
+        final int NUM_REQUESTS = CONCURRENT_REQUEST_COUNT;
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch completeLatch = new CountDownLatch(NUM_REQUESTS);
+        final AtomicInteger successCount = new AtomicInteger(0);
+        final AtomicInteger errorCount = new AtomicInteger(0);
+        final AtomicReference<Throwable> firstError = new AtomicReference<>(null);
+
+        // Launch concurrent requests
+        for (int i = 0; i < NUM_REQUESTS; i++) {
+            final int requestId = i;
+            new Thread(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+
+                    TestCommand cmd = new TestCommand(
+                        getEmptyTestParams(),
+                        new EmptyCommandCallback(),
+                        requestId
+                    ) {
+                        @Override
+                        public boolean isEligibleForCaching() {
+                            return false; // Each request is unique
+                        }
+                    };
+
+                    FinalizableResultFuture<CommandResult> future =
+                        CommandDispatcher.submitSilentReturningFuture(cmd);
+                    CommandResult result = future.get(30, TimeUnit.SECONDS);
+
+                    if (result.getStatus() == ICommandResult.ResultStatus.COMPLETED) {
+                        successCount.incrementAndGet();
+                    } else {
+                        errorCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                    firstError.compareAndSet(null, e);
+                } finally {
+                    completeLatch.countDown();
+                }
+            }).start();
+        }
+
+        // Start all requests simultaneously
+        startLatch.countDown();
+
+        // Wait for all requests to complete
+        Assert.assertTrue("All requests should complete within 60 seconds",
+            completeLatch.await(60, TimeUnit.SECONDS));
+
+        // Wait for the runnable's finally blocks to complete cleanup
+        // Note: future.get() returns when result is set, but the finally block
+        // that removes the entry from sTimeoutLocationMap runs AFTER that
+        Thread.sleep(CLEANUP_WAIT_MS);
+
+        // Verify all requests tracked independently
+        Assert.assertEquals("Timeout location map should be cleaned up",
+            0, getTimeoutLocationMapSizeViaReflection());
+
+        // Verify all requests succeeded
+        Assert.assertEquals("All requests should succeed",
+            NUM_REQUESTS, successCount.get());
+        Assert.assertEquals("No requests should fail",
+            0, errorCount.get());
+
+        // Fail if any error occurred
+        if (firstError.get() != null) {
+            Assert.fail("Unexpected error during concurrent execution: " + firstError.get().getMessage());
+        }
+    }
+
+    /**
+     * Test that correlation ID is properly set on timeout exceptions.
+     *
+     * <p>Verifies that when a timeout occurs, the resulting ClientException
+     * contains the same correlation ID that was set on the original command
+     * parameters. This is essential for correlating timeout errors with
+     * specific requests in logs and telemetry.
+     *
+     * <p>Expected Duration: ~30 seconds (timeout duration)
+     *
+     * @throws Exception if test fails
+     */
+    @Test
+    public void testTimeoutException_ContainsCorrelationId() throws Exception {
+        final String expectedCorrelationId = java.util.UUID.randomUUID().toString();
+
+        SilentTokenCommandParameters params = SilentTokenCommandParameters.builder()
+            .platformComponents(AndroidPlatformComponentsFactory.createFromContext(ApplicationProvider.getApplicationContext()))
+            .correlationId(expectedCorrelationId)
+            .build();
+
+        SilentTokenCommand slowCommand = createSlowExecutionSilentTokenCommand(params, SLOW_EXECUTION_DURATION_MS);
+
+        try {
+            CommandDispatcher.submitAcquireTokenSilentSync(slowCommand);
+            Assert.fail("Expected ClientException due to timeout");
+        } catch (ClientException e) {
+            // Verify it's a timeout error
+            Assert.assertTrue("Should be a timeout error",
+                e.getErrorCode().startsWith("timed_out"));
+            // Verify correlation ID is correctly propagated
+            Assert.assertEquals("Correlation ID should match",
+                expectedCorrelationId, e.getCorrelationId());
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // Reflection Helper Methods for Timeout Classification Tests
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Gets the timeout location map size via reflection.
+     */
+    private int getTimeoutLocationMapSizeViaReflection() throws Exception {
+        Field field = CommandDispatcher.class.getDeclaredField("sTimeoutLocationMap");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.concurrent.ConcurrentMap<String, ?> map =
+            (java.util.concurrent.ConcurrentMap<String, ?>) field.get(null);
+        return map.size();
+    }
+
+    /**
+     * Creates SilentTokenCommandParameters with a random correlation ID for testing.
+     */
+    private SilentTokenCommandParameters createTestSilentTokenParams() {
+        return SilentTokenCommandParameters.builder()
+            .platformComponents(AndroidPlatformComponentsFactory.createFromContext(ApplicationProvider.getApplicationContext()))
+            .correlationId(java.util.UUID.randomUUID().toString())
+            .build();
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // Helper Methods for Creating Test SilentTokenCommands
+    // ════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Creates a test SilentTokenCommand that executes quickly.
+     */
+    private SilentTokenCommand createTestSilentTokenCommand(
+            @NonNull final SilentTokenCommandParameters parameters) {
+        return new SilentTokenCommand(
+            parameters,
+            getTestSilentController().asControllerFactory(),
+            new EmptyCommandCallback(),
+            "test_silent_command"
+        );
+    }
+
+    /**
+     * Creates a SilentTokenCommand that executes slowly for the specified duration.
+     */
+    private SilentTokenCommand createSlowExecutionSilentTokenCommand(
+            @NonNull final SilentTokenCommandParameters parameters,
+            final long executionDurationMs) {
+        return new SilentTokenCommand(
+            parameters,
+            getSlowExecutionController(executionDurationMs).asControllerFactory(),
+            new EmptyCommandCallback(),
+            "slow_silent_command"
+        );
+    }
+
+    /**
+     * Returns a test controller for quick-executing SilentTokenCommands.
+     */
+    private static BaseController getTestSilentController() {
+        return new TestBaseController() {
+            @Override
+            public AcquireTokenResult acquireTokenSilent(SilentTokenCommandParameters parameters) throws Exception {
+                return getRefreshUnexpiredTokenResult();
+            }
+        };
+    }
+
+    /**
+     * Returns a controller that sleeps for the specified duration before returning.
+     * Used for testing TIMED_OUT_EXECUTION classification.
+     */
+    private static BaseController getSlowExecutionController(final long executionDurationMs) {
+        return new TestBaseController() {
+            @Override
+            public AcquireTokenResult acquireTokenSilent(SilentTokenCommandParameters parameters) throws Exception {
+                Thread.sleep(executionDurationMs);
+                return getRefreshUnexpiredTokenResult();
+            }
+        };
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // Test Command Classes
+    // ════════════════════════════════════════════════════════════════════════════
+
     static class ExceptionCommand extends BaseCommand<String> {
 
         public ExceptionCommand(@NonNull final CommandParameters parameters,
@@ -900,6 +1330,55 @@ public class CommandDispatcherTest {
             return null;
         }
     }
+
+    /**
+     * Command that blocks until released via CountDownLatch.
+     * Used to saturate the thread pool for testing queue saturation.
+     */
+    static class BlockingTestCommand extends BaseCommand<String> {
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+        private final CountDownLatch completed;
+
+        public BlockingTestCommand(
+                @NonNull final CommandParameters parameters,
+                @NonNull final CommandCallback callback,
+                @NonNull final CountDownLatch started,
+                @NonNull final CountDownLatch release) {
+            this(parameters, callback, started, release, null);
+        }
+
+        public BlockingTestCommand(
+                @NonNull final CommandParameters parameters,
+                @NonNull final CommandCallback callback,
+                @NonNull final CountDownLatch started,
+                @NonNull final CountDownLatch release,
+                @Nullable final CountDownLatch completed) {
+            super(parameters, getTestController().asControllerFactory(), callback, "blocking_test_id");
+            this.started = started;
+            this.release = release;
+            this.completed = completed;
+        }
+
+        @Override
+        public String execute() throws Exception {
+            try {
+                started.countDown(); // Signal that we've started
+                release.await(60, TimeUnit.SECONDS); // Block until released
+                return "completed";
+            } finally {
+                if (completed != null) {
+                    completed.countDown(); // Signal completion
+                }
+            }
+        }
+
+        @Override
+        public boolean isEligibleForCaching() {
+            return false; // Each blocking command is unique
+        }
+    }
+
     private static BaseController getTestController() {
         return new TestBaseController() {
         };

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -877,43 +877,37 @@ public class CommandDispatcherTest {
 
         // Verify cleanup
         Assert.assertEquals("Timeout location map should be cleaned up",
-            0, getTimeoutLocationMapSizeViaReflection());
+            0, getRequestStateMapSizeViaReflection());
     }
 
     /**
      * Test that timeout location map is cleaned up after successful request.
      *
-     * <p>Verifies that sTimeoutLocationMap entries are properly removed after
-     * a request completes successfully. This prevents memory leaks from
-     * accumulating tracking state.
+     * <p>Verifies that sRequestStateMap entries are properly removed after
+     * a request completes successfully via submitAcquireTokenSilentSync().
+     * This prevents memory leaks from accumulating tracking state.
      *
-     * <p>Note: A {@link #CLEANUP_WAIT_MS} delay is needed because future.get()
-     * returns when the result is set, but the finally block that removes the
-     * entry from sTimeoutLocationMap runs AFTER that.
+     * <p>Note: State tracking only happens for requests going through
+     * submitAcquireTokenSilentSync(), which is the real production path.
      *
      * @throws Exception if test fails
      */
     @Test
     public void testTimeoutLocationMap_CleanupAfterSuccess() throws Exception {
         // Get initial map size
-        int initialSize = getTimeoutLocationMapSizeViaReflection();
+        int initialSize = getRequestStateMapSizeViaReflection();
 
-        // Execute successful request
-        TestCommand successCommand = new TestCommand(getEmptyTestParams(), new EmptyCommandCallback(), 999);
-        FinalizableResultFuture<CommandResult> future = CommandDispatcher.submitSilentReturningFuture(successCommand);
+        // Execute successful request through the real entry point
+        SilentTokenCommandParameters params = createTestSilentTokenParams();
+        SilentTokenCommand successCommand = createTestSilentTokenCommand(params);
 
-        // Wait for completion
-        CommandResult result = future.get(10, TimeUnit.SECONDS);
-        Assert.assertEquals("Command should complete successfully",
-            ICommandResult.ResultStatus.COMPLETED, result.getStatus());
+        // This is the real production path that tracks and cleans up state
+        ILocalAuthenticationResult result = CommandDispatcher.submitAcquireTokenSilentSync(successCommand);
+        Assert.assertNotNull("Command should return a result", result);
 
-        // Wait for the runnable's finally block to complete cleanup
-        // Note: future.get() returns when result is set, but the finally block
-        // that removes the entry from sTimeoutLocationMap runs AFTER that
-        Thread.sleep(CLEANUP_WAIT_MS);
-
-        // Verify cleanup - map should return to initial size
-        int finalSize = getTimeoutLocationMapSizeViaReflection();
+        // Verify cleanup - map should return to initial size immediately
+        // (cleanup happens in submitAcquireTokenSilentSync's finally block)
+        int finalSize = getRequestStateMapSizeViaReflection();
         Assert.assertEquals("Timeout location map should be cleaned up after success",
             initialSize, finalSize);
     }
@@ -921,7 +915,7 @@ public class CommandDispatcherTest {
     /**
      * Test that timeout location map is cleaned up after timeout.
      *
-     * <p>Verifies that sTimeoutLocationMap entries are properly removed after
+     * <p>Verifies that sRequestStateMap entries are properly removed after
      * a request times out. Cleanup happens in submitAcquireTokenSilentSync()'s
      * finally block, which runs immediately when TimeoutException is caught.
      *
@@ -932,7 +926,7 @@ public class CommandDispatcherTest {
     @Test
     public void testTimeoutLocationMap_CleanupAfterTimeout() throws Exception {
         // Get initial map size
-        int initialSize = getTimeoutLocationMapSizeViaReflection();
+        int initialSize = getRequestStateMapSizeViaReflection();
 
         // Execute request that will timeout
         SilentTokenCommandParameters params = createTestSilentTokenParams();
@@ -948,7 +942,7 @@ public class CommandDispatcherTest {
         }
 
         // Verify cleanup - map should return to initial size
-        int finalSize = getTimeoutLocationMapSizeViaReflection();
+        int finalSize = getRequestStateMapSizeViaReflection();
         Assert.assertEquals("Timeout location map should be cleaned up after timeout",
             initialSize, finalSize);
     }
@@ -959,14 +953,14 @@ public class CommandDispatcherTest {
      * <p>Test Strategy:
      * <ol>
      *   <li>Launch {@link #CONCURRENT_REQUEST_COUNT} threads simultaneously</li>
-     *   <li>Each thread submits a unique (non-cacheable) request</li>
+     *   <li>Each thread submits a unique request via submitAcquireTokenSilentSync()</li>
      *   <li>Wait for all requests to complete</li>
      *   <li>Verify all requests tracked independently (no state collision)</li>
-     *   <li>Verify sTimeoutLocationMap is cleaned up (no memory leaks)</li>
+     *   <li>Verify sRequestStateMap is cleaned up (no memory leaks)</li>
      * </ol>
      *
      * <p>This test validates that correlation ID-based tracking correctly
-     * isolates concurrent requests.
+     * isolates concurrent requests through the real production path.
      *
      * @throws Exception if test fails
      */
@@ -981,27 +975,19 @@ public class CommandDispatcherTest {
 
         // Launch concurrent requests
         for (int i = 0; i < NUM_REQUESTS; i++) {
-            final int requestId = i;
             new Thread(() -> {
                 try {
                     startLatch.await(); // Wait for all threads to be ready
 
-                    TestCommand cmd = new TestCommand(
-                        getEmptyTestParams(),
-                        new EmptyCommandCallback(),
-                        requestId
-                    ) {
-                        @Override
-                        public boolean isEligibleForCaching() {
-                            return false; // Each request is unique
-                        }
-                    };
+                    // Use real production path with unique correlation ID
+                    SilentTokenCommandParameters params = createTestSilentTokenParams();
+                    SilentTokenCommand cmd = createTestSilentTokenCommand(params);
 
-                    FinalizableResultFuture<CommandResult> future =
-                        CommandDispatcher.submitSilentReturningFuture(cmd);
-                    CommandResult result = future.get(30, TimeUnit.SECONDS);
+                    // This is the real production path
+                    ILocalAuthenticationResult result = 
+                        CommandDispatcher.submitAcquireTokenSilentSync(cmd);
 
-                    if (result.getStatus() == ICommandResult.ResultStatus.COMPLETED) {
+                    if (result != null) {
                         successCount.incrementAndGet();
                     } else {
                         errorCount.incrementAndGet();
@@ -1022,14 +1008,11 @@ public class CommandDispatcherTest {
         Assert.assertTrue("All requests should complete within 60 seconds",
             completeLatch.await(60, TimeUnit.SECONDS));
 
-        // Wait for the runnable's finally blocks to complete cleanup
-        // Note: future.get() returns when result is set, but the finally block
-        // that removes the entry from sTimeoutLocationMap runs AFTER that
-        Thread.sleep(CLEANUP_WAIT_MS);
-
-        // Verify all requests tracked independently
+        // Verify cleanup - should be immediate since cleanup happens in
+        // submitAcquireTokenSilentSync's finally block
+        int finalSize = getRequestStateMapSizeViaReflection();
         Assert.assertEquals("Timeout location map should be cleaned up",
-            0, getTimeoutLocationMapSizeViaReflection());
+            0, finalSize);
 
         // Verify all requests succeeded
         Assert.assertEquals("All requests should succeed",
@@ -1084,10 +1067,11 @@ public class CommandDispatcherTest {
     // ════════════════════════════════════════════════════════════════════════════
 
     /**
-     * Gets the timeout location map size via reflection.
+     * Gets the request state map size via reflection.
+     * Used to verify cleanup of sRequestStateMap entries after requests complete.
      */
-    private int getTimeoutLocationMapSizeViaReflection() throws Exception {
-        Field field = CommandDispatcher.class.getDeclaredField("sTimeoutLocationMap");
+    private int getRequestStateMapSizeViaReflection() throws Exception {
+        Field field = CommandDispatcher.class.getDeclaredField("sRequestStateMap");
         field.setAccessible(true);
         @SuppressWarnings("unchecked")
         java.util.concurrent.ConcurrentMap<String, ?> map =

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -104,9 +104,6 @@ public class CommandDispatcherTest {
     /** Duration for slow execution tests - must exceed the 30 second timeout */
     private static final long SLOW_EXECUTION_DURATION_MS = 35000;
 
-    /** Wait time for runnable's finally block to complete cleanup after future.get() returns */
-    private static final long CLEANUP_WAIT_MS = 500;
-
     /** Small delay to ensure blocking tasks are fully blocking before submitting test request */
     private static final long TASK_STABILIZATION_DELAY_MS = 100;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -114,6 +114,36 @@ public class CommandDispatcher {
     private static ConcurrentMap<BaseCommand, FinalizableResultFuture<CommandResult>> sExecutingCommandMap = new ConcurrentHashMap<>();
 
     /**
+     * Enum representing the lifecycle states of a request for timeout classification.
+     * This enables precise tracking of where a timeout occurred in the request processing pipeline.
+     */
+    private enum RequestState {
+        /** Request is waiting to acquire the mapAccessLock (lock contention) */
+        WAITING_FOR_LOCK,
+        /** Request has been queued in the thread pool executor (thread pool contention) */
+        QUEUED,
+        /** Request is actively being executed by a worker thread (slow execution) */
+        EXECUTING
+    }
+
+    // Track timeout location per request for timeout classification
+    // Maps correlation ID to its current state in the request lifecycle
+    private static final ConcurrentMap<String, RequestState> sTimeoutLocationMap =
+        new ConcurrentHashMap<>();
+
+    // Timeout diagnostic message templates
+    private static final String TIMEOUT_MSG_LOCK_CONTENTION = 
+        "Lock contention detected. Request timed out waiting to acquire mapAccessLock.";
+    private static final String TIMEOUT_MSG_THREAD_POOL_SATURATED = 
+        "Thread pool saturated. All %d threads busy, %d requests queued.";
+    private static final String TIMEOUT_MSG_THREAD_POOL_CONTENTION = 
+        "Thread pool contention. Request queued but not picked up in time.";
+    private static final String TIMEOUT_MSG_EXECUTION_SLOW = 
+        "Slow execution. Request was executing but didn't complete in time.";
+    private static final String TIMEOUT_MSG_UNKNOWN_STATE = 
+        "Unknown state '%s'.";
+
+    /**
      * Returns the approximate number of threads that are actively
      * executing tasks in the silent request thread pool.
      */
@@ -165,6 +195,9 @@ public class CommandDispatcher {
         synchronized (mapAccessLock) {
             sExecutingCommandMap.clear();
         }
+        // Clear timeout tracking map
+        sTimeoutLocationMap.clear();
+        
         sSilentExecutor.shutdownNow();
         sInteractiveExecutor.shutdownNow();
         Field f = CommandDispatcher.class.getDeclaredField("sSilentExecutor");
@@ -176,6 +209,94 @@ public class CommandDispatcher {
         f.setAccessible(true);
         f.set(null, Executors.newSingleThreadExecutor());
         f.setAccessible(false);
+    }
+
+    /**
+     * Builds a consistent diagnostic message for timeout exceptions.
+     *
+     * @param location The method where timeout occurred
+     * @param message The specific timeout reason message
+     * @param activeThreads Number of active threads in the pool
+     * @param queueSize Number of requests waiting in the queue
+     * @return Formatted diagnostic message
+     */
+    private static String buildTimeoutDiagnosticMessage(
+            @NonNull final String location,
+            @NonNull final String message,
+            final int activeThreads,
+            final int queueSize) {
+        return String.format(
+            "Timeout in %s: %s [ActiveThreads=%d, QueueSize=%d, PoolSize=%d]",
+            location, message, activeThreads, queueSize, SILENT_REQUEST_THREAD_POOL_SIZE);
+    }
+
+    /**
+     * Creates a ClientException with a specific timeout error code based on the request state.
+     * This enables definitive classification of timeout root causes for telemetry and diagnostics.
+     *
+     * Classification logic:
+     * - WAITING_FOR_LOCK: Timeout while waiting for mapAccessLock (lock contention)
+     * - QUEUED + pool saturated: All threads busy AND queue has waiting requests (severe saturation)
+     * - QUEUED + not saturated: Threads busy but queue not fully saturated (moderate contention)
+     * - EXECUTING: Request was picked up but didn't complete (slow execution)
+     * - null/unknown: Fallback to generic timeout
+     *
+     * @param timeoutLocation The method where timeout occurred
+     * @param correlationId The correlation ID of the request
+     * @param state The request state at timeout (WAITING_FOR_LOCK, QUEUED, EXECUTING, or null)
+     * @param activeThreads Number of active threads in the pool
+     * @param queueSize Number of requests waiting in the queue
+     * @param cause The original TimeoutException
+     * @return ClientException with classified error code and diagnostic message
+     */
+    private static ClientException createTimeoutException(
+            @NonNull final String timeoutLocation,
+            @NonNull final String correlationId,
+            @Nullable final RequestState state,
+            final int activeThreads,
+            final int queueSize,
+            @NonNull final TimeoutException cause) {
+        final String errorCode;
+        final String reasonMessage;
+        
+        if (state == null) {
+            errorCode = ClientException.TIMED_OUT;
+            reasonMessage = String.format(TIMEOUT_MSG_UNKNOWN_STATE, "null");
+        } else {
+            switch (state) {
+                case WAITING_FOR_LOCK:
+                    errorCode = ClientException.TIMED_OUT_LOCK_CONTENTION;
+                    reasonMessage = TIMEOUT_MSG_LOCK_CONTENTION;
+                    break;
+                case QUEUED:
+                    // All threads busy AND requests queued = Pool completely saturated
+                    if (activeThreads >= SILENT_REQUEST_THREAD_POOL_SIZE && queueSize > 0) {
+                        errorCode = ClientException.TIMED_OUT_THREAD_POOL_SATURATED;
+                        reasonMessage = String.format(TIMEOUT_MSG_THREAD_POOL_SATURATED, activeThreads, queueSize);
+                    } else {
+                        // Threads busy but pool not saturated = Temporary contention
+                        errorCode = ClientException.TIMED_OUT_THREAD_POOL_CONTENTION;
+                        reasonMessage = TIMEOUT_MSG_THREAD_POOL_CONTENTION;
+                    }
+                    break;
+                case EXECUTING:
+                    errorCode = ClientException.TIMED_OUT_EXECUTION;
+                    reasonMessage = TIMEOUT_MSG_EXECUTION_SLOW;
+                    break;
+                default:
+                    errorCode = ClientException.TIMED_OUT;
+                    reasonMessage = String.format(TIMEOUT_MSG_UNKNOWN_STATE, state.name());
+                    break;
+            }
+        }
+        
+        final String diagnosticMessage = buildTimeoutDiagnosticMessage(
+            timeoutLocation, reasonMessage, activeThreads, queueSize);
+        Logger.error(TAG, diagnosticMessage, cause);
+
+        final ClientException exception = new ClientException(errorCode, diagnosticMessage, cause);
+        exception.setCorrelationId(correlationId);
+        return exception;
     }
 
     /**
@@ -254,15 +375,31 @@ public class CommandDispatcher {
     public static ILocalAuthenticationResult submitAcquireTokenSilentSync(@NonNull final SilentTokenCommand command)
             throws BaseException {
         final CommandResult commandResult;
+        // Get or generate correlation ID early - this is the tracking key
+        final String correlationId = command.getParameters().getCorrelationId();
+
         try {
+            final FinalizableResultFuture<CommandResult> future = submitSilentReturningFuture(command);
             if (BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT){
-                commandResult = submitSilentReturningFuture(command).get();
+                commandResult = future.get();
             } else {
                 final int silentTokenTimeOutMs = CommonFlightsManager.INSTANCE.getFlightsProvider().getIntValue(CommonFlight.ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS);
-                commandResult = submitSilentReturningFuture(command).get(silentTokenTimeOutMs, TimeUnit.MILLISECONDS);
+                commandResult = future.get(silentTokenTimeOutMs, TimeUnit.MILLISECONDS);
             }
-        } catch (final InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (final TimeoutException e) {
+            // Classify timeout based on request state using correlation ID
+            throw createTimeoutException(
+                    "submitAcquireTokenSilentSync",
+                    correlationId,
+                    sTimeoutLocationMap.get(correlationId),
+                    getSilentRequestActiveCount(),
+                    ((ThreadPoolExecutor) sSilentExecutor).getQueue().size(),
+                    e);
+        } catch (final InterruptedException | ExecutionException e) {
             throw ExceptionAdapter.baseExceptionFromException(e);
+        } finally {
+            // Always clean up the tracking map entry
+            sTimeoutLocationMap.remove(correlationId);
         }
 
         if (commandResult.getStatus() == ICommandResult.ResultStatus.COMPLETED){
@@ -312,7 +449,14 @@ public class CommandDispatcher {
 
         logParameters(TAG + methodName, correlationId, commandParameters, command.getPublicApiId());
 
+        // Track state BEFORE entering synchronized block using correlation ID
+        // This enables detection of lock contention timeouts
+        sTimeoutLocationMap.put(correlationId, RequestState.WAITING_FOR_LOCK);
+
         synchronized (mapAccessLock) {
+            // Update state: lock acquired, now queued for thread pool
+            sTimeoutLocationMap.put(correlationId, RequestState.QUEUED);
+
             final FinalizableResultFuture<CommandResult> finalFuture;
             if (command.isEligibleForCaching()) {
                 FinalizableResultFuture<CommandResult> future = sExecutingCommandMap.get(command);
@@ -353,6 +497,9 @@ public class CommandDispatcher {
             commandExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                 @Override
                 public void run() {
+                    // Update state: thread has picked up the request, now executing
+                    sTimeoutLocationMap.put(correlationId, RequestState.EXECUTING);
+
                     codeMarkerManager.markCode(isDeviceCodeFlowRequest ? ACQUIRE_TOKEN_DCF_EXECUTOR_START : ACQUIRE_TOKEN_SILENT_EXECUTOR_START);
                     try {
                         //initializing again since the request is transferred to a different thread pool
@@ -377,6 +524,9 @@ public class CommandDispatcher {
                         Logger.info(TAG + methodName, "Request encountered an exception with correlation id : **" + correlationId);
                         finalFuture.setException(new ExecutionException(t));
                     } finally {
+                        // Clean up timeout tracking - execution completed (success or failure)
+                        sTimeoutLocationMap.remove(correlationId);
+                        
                         synchronized (mapAccessLock) {
                             if (command.isEligibleForCaching()) {
                                 final FinalizableResultFuture mapFuture = sExecutingCommandMap.remove(command);

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -375,11 +375,13 @@ public class CommandDispatcher {
     public static ILocalAuthenticationResult submitAcquireTokenSilentSync(@NonNull final SilentTokenCommand command)
             throws BaseException {
         final CommandResult commandResult;
-        // Get or generate correlation ID early - this is the tracking key
-        final String correlationId = command.getParameters().getCorrelationId();
+        // Initialize to null, will be set after submitSilentReturningFuture returns
+        // when it's guaranteed to be initialized on the parameters
+        String correlationId = null;
 
         try {
             final FinalizableResultFuture<CommandResult> future = submitSilentReturningFuture(command);
+            correlationId = command.getParameters().getCorrelationId();
             if (BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT){
                 commandResult = future.get();
             } else {
@@ -388,18 +390,21 @@ public class CommandDispatcher {
             }
         } catch (final TimeoutException e) {
             // Classify timeout based on request state using correlation ID
+            final String effectiveCorrelationId = correlationId != null ? correlationId : "unknown";
             throw createTimeoutException(
                     "submitAcquireTokenSilentSync",
-                    correlationId,
-                    sRequestStateMap.get(correlationId),
+                    effectiveCorrelationId,
+                    correlationId != null ? sRequestStateMap.get(correlationId) : null,
                     getSilentRequestActiveCount(),
                     ((ThreadPoolExecutor) sSilentExecutor).getQueue().size(),
                     e);
         } catch (final InterruptedException | ExecutionException e) {
             throw ExceptionAdapter.baseExceptionFromException(e);
         } finally {
-            // Always clean up the tracking map entry
-            sRequestStateMap.remove(correlationId);
+            // Only clean up if correlationId was initialized
+            if (correlationId != null) {
+                sRequestStateMap.remove(correlationId);
+            }
         }
 
         if (commandResult.getStatus() == ICommandResult.ResultStatus.COMPLETED){
@@ -476,10 +481,20 @@ public class CommandDispatcher {
                     } else {
                         // Our value was not inserted, grab the one that was and hang a new listener off it
                         putValue.whenComplete(getCommandResultConsumer(command));
+                        // This request is sharing another request's future - it's effectively EXECUTING
+                        // Update state to prevent incorrect timeout classification as QUEUED
+                        if (!isDeviceCodeFlowRequest) {
+                            sRequestStateMap.put(correlationId, RequestState.EXECUTING);
+                        }
                         return putValue;
                     }
                 } else {
                     future.whenComplete(getCommandResultConsumer(command));
+                    // This request is sharing another request's future - it's effectively EXECUTING
+                    // Update state to prevent incorrect timeout classification as QUEUED
+                    if (!isDeviceCodeFlowRequest) {
+                        sRequestStateMap.put(correlationId, RequestState.EXECUTING);
+                    }
                     return future;
                 }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -126,9 +126,9 @@ public class CommandDispatcher {
         EXECUTING
     }
 
-    // Track timeout location per request for timeout classification
+    // Track request state per request for timeout classification
     // Maps correlation ID to its current state in the request lifecycle
-    private static final ConcurrentMap<String, RequestState> sTimeoutLocationMap =
+    private static final ConcurrentMap<String, RequestState> sRequestStateMap =
         new ConcurrentHashMap<>();
 
     // Timeout diagnostic message templates
@@ -196,7 +196,7 @@ public class CommandDispatcher {
             sExecutingCommandMap.clear();
         }
         // Clear timeout tracking map
-        sTimeoutLocationMap.clear();
+        sRequestStateMap.clear();
         
         sSilentExecutor.shutdownNow();
         sInteractiveExecutor.shutdownNow();
@@ -391,7 +391,7 @@ public class CommandDispatcher {
             throw createTimeoutException(
                     "submitAcquireTokenSilentSync",
                     correlationId,
-                    sTimeoutLocationMap.get(correlationId),
+                    sRequestStateMap.get(correlationId),
                     getSilentRequestActiveCount(),
                     ((ThreadPoolExecutor) sSilentExecutor).getQueue().size(),
                     e);
@@ -399,7 +399,7 @@ public class CommandDispatcher {
             throw ExceptionAdapter.baseExceptionFromException(e);
         } finally {
             // Always clean up the tracking map entry
-            sTimeoutLocationMap.remove(correlationId);
+            sRequestStateMap.remove(correlationId);
         }
 
         if (commandResult.getStatus() == ICommandResult.ResultStatus.COMPLETED){
@@ -451,11 +451,16 @@ public class CommandDispatcher {
 
         // Track state BEFORE entering synchronized block using correlation ID
         // This enables detection of lock contention timeouts
-        sTimeoutLocationMap.put(correlationId, RequestState.WAITING_FOR_LOCK);
+        // Only track state for non-DCF requests
+        if (!isDeviceCodeFlowRequest) {
+            sRequestStateMap.put(correlationId, RequestState.WAITING_FOR_LOCK);
+        }
 
         synchronized (mapAccessLock) {
-            // Update state: lock acquired, now queued for thread pool
-            sTimeoutLocationMap.put(correlationId, RequestState.QUEUED);
+            // Update state: lock acquired, now queued for thread pool, only track non-DCF requests
+            if (!isDeviceCodeFlowRequest) {
+                sRequestStateMap.put(correlationId, RequestState.QUEUED);
+            }
 
             final FinalizableResultFuture<CommandResult> finalFuture;
             if (command.isEligibleForCaching()) {
@@ -498,7 +503,10 @@ public class CommandDispatcher {
                 @Override
                 public void run() {
                     // Update state: thread has picked up the request, now executing
-                    sTimeoutLocationMap.put(correlationId, RequestState.EXECUTING);
+                    // Only track non-DCF requests (timeout classification only in submitAcquireTokenSilentSync)
+                    if (!isDeviceCodeFlowRequest) {
+                        sRequestStateMap.put(correlationId, RequestState.EXECUTING);
+                    }
 
                     codeMarkerManager.markCode(isDeviceCodeFlowRequest ? ACQUIRE_TOKEN_DCF_EXECUTOR_START : ACQUIRE_TOKEN_SILENT_EXECUTOR_START);
                     try {
@@ -524,9 +532,6 @@ public class CommandDispatcher {
                         Logger.info(TAG + methodName, "Request encountered an exception with correlation id : **" + correlationId);
                         finalFuture.setException(new ExecutionException(t));
                     } finally {
-                        // Clean up timeout tracking - execution completed (success or failure)
-                        sTimeoutLocationMap.remove(correlationId);
-                        
                         synchronized (mapAccessLock) {
                             if (command.isEligibleForCaching()) {
                                 final FinalizableResultFuture mapFuture = sExecutingCommandMap.remove(command);

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -452,6 +452,32 @@ public class ClientException extends BaseException {
     public static final String TIMED_OUT = "timed_out";
 
     /**
+     * Timeout occurred while waiting to acquire the mapAccessLock.
+     * Indicates high lock contention - many requests competing for the synchronized block.
+     */
+    public static final String TIMED_OUT_LOCK_CONTENTION = "timed_out_lock_contention";
+
+    /**
+     * Timeout occurred while request was queued waiting for a thread.
+     * All thread pool threads are busy AND queue has waiting requests.
+     * Indicates severe thread pool saturation - consider increasing pool size or reducing load.
+     */
+    public static final String TIMED_OUT_THREAD_POOL_SATURATED = "timed_out_thread_pool_saturated";
+
+    /**
+     * Timeout occurred while request was queued waiting for a thread.
+     * Threads are busy but queue is not fully saturated.
+     * Indicates moderate thread pool contention.
+     */
+    public static final String TIMED_OUT_THREAD_POOL_CONTENTION = "timed_out_thread_pool_contention";
+
+    /**
+     * Timeout occurred during actual execution (network, token processing, etc.).
+     * Request was picked up by a thread but didn't complete in time.
+     */
+    public static final String TIMED_OUT_EXECUTION = "timed_out_execution";
+
+    /**
      * A NullPointerException was thrown.
      */
     public static final String NULL_POINTER_ERROR = "null_pointer_error";

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ClientException.java
@@ -452,28 +452,28 @@ public class ClientException extends BaseException {
     public static final String TIMED_OUT = "timed_out";
 
     /**
-     * Timeout occurred while waiting to acquire the mapAccessLock.
-     * Indicates high lock contention - many requests competing for the synchronized block.
+     * Timeout occurred while waiting to acquire a synchronization lock.
+     * Indicates high lock contention - many operations competing for the same lock.
      */
     public static final String TIMED_OUT_LOCK_CONTENTION = "timed_out_lock_contention";
 
     /**
-     * Timeout occurred while request was queued waiting for a thread.
-     * All thread pool threads are busy AND queue has waiting requests.
-     * Indicates severe thread pool saturation - consider increasing pool size or reducing load.
+     * Timeout occurred while waiting for an available worker thread.
+     * All thread pool threads are busy AND requests are queued.
+     * Indicates severe thread pool saturation.
      */
     public static final String TIMED_OUT_THREAD_POOL_SATURATED = "timed_out_thread_pool_saturated";
 
     /**
-     * Timeout occurred while request was queued waiting for a thread.
-     * Threads are busy but queue is not fully saturated.
+     * Timeout occurred while waiting for thread pool resources.
+     * Threads are busy but pool is not fully saturated.
      * Indicates moderate thread pool contention.
      */
     public static final String TIMED_OUT_THREAD_POOL_CONTENTION = "timed_out_thread_pool_contention";
 
     /**
-     * Timeout occurred during actual execution (network, token processing, etc.).
-     * Request was picked up by a thread but didn't complete in time.
+     * Timeout occurred during operation execution (network, processing, etc.).
+     * Operation was started but didn't complete within the allowed time.
      */
     public static final String TIMED_OUT_EXECUTION = "timed_out_execution";
 


### PR DESCRIPTION
Fixes [AB#3495207](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3495207)

**Problem:**
Generic TIMED_OUT errors provide no insight into timeout root cause, making production debugging difficult.

**Solution:**
Track request lifecycle state using correlation ID to classify timeouts.

**CommandDispatcher.java:**
- Add TimeoutTrackingState enum (WAITING_FOR_LOCK, QUEUED, EXECUTING)
- Add sTimeoutLocationMap for correlation ID → state tracking
- Add createTimeoutException() for state-based classification
- Track state transitions in submitSilentReturningFuture()
- Classify and cleanup in submitAcquireTokenSilentSync()

**ClientException.java:**
- Add TIMED_OUT_LOCK_CONTENTION
- Add TIMED_OUT_THREAD_POOL_SATURATED
- Add TIMED_OUT_THREAD_POOL_CONTENTION
- Add TIMED_OUT_EXECUTION

**CommandDispatcherTest.java:**
- Add 6 tests for timeout classification and state tracking
- Add helper methods and test utilities