### PR TITLE
Fixes AB#3496484 Add utility and attributes that calculate elapsed_time using nanos

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add attributes that calculate elapsed_times using nanos (#2871)
 - [MINOR] Cleanup code related to emitting ests telemetry (#2868)
 - [MINOR] Skip account aggregation when responding to AcquireTokenSilent api call for OneAuth (#2863)
 - [MINOR] Introduce locks at NameValueStorageFileManagerSimpleCacheImpl layer (#2842)

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -317,6 +317,7 @@ public class BrokerOAuth2TokenCache
                                                          final @NonNull ICacheRecord cacheRecord) {
         final String methodName = ":loadAggregatedAccountData";
         final long loadStartTime = System.currentTimeMillis();
+        final long loadStartTimeInNanos = System.nanoTime();
 
         final String clientId = cacheRecord.getAccessToken().getClientId();
         final String target = cacheRecord.getAccessToken().getTarget();
@@ -347,6 +348,8 @@ public class BrokerOAuth2TokenCache
         );
         OTelUtility.recordElapsedTime(AttributeName.elapsed_time_load_aggregated_account_data.name(),
                 loadStartTime);
+        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_load_aggregated_account_data_using_nanos.name(),
+                loadStartTimeInNanos);
         return cacheRecordList;
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftRefreshToken;
@@ -203,7 +204,7 @@ public class BrokerOAuth2TokenCacheTelemetryWrapper
     @Override
     public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
         final long startTime = System.currentTimeMillis();
-
+        final long startTimeInNanos = System.nanoTime();
         try {
             return mCacheToWrap.getAccountByLocalAccountId(environment, clientId, localAccountId);
         } finally {
@@ -213,6 +214,8 @@ public class BrokerOAuth2TokenCacheTelemetryWrapper
                     AttributeName.elapsed_time_cache_get_account_by_local_account_id.name(),
                     elapsedTime
             );
+            OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_cache_get_account_by_local_account_id_using_nanos.name(),
+                    startTimeInNanos);
         }
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -203,6 +203,11 @@ public enum AttributeName {
     elapsed_time_cache_get_account_by_local_account_id,
 
     /**
+     * The time (in milliseconds), calculated using nanos, spent in executing the getAccountByLocalAccountId method in OAuth2TokenCache.
+     */
+    elapsed_time_cache_get_account_by_local_account_id_using_nanos,
+
+    /**
      * The time (in milliseconds) spent in executing the getAccountWithAggregatedAccountDataByLocalAccountId method in OAuth2TokenCache.
      */
     elapsed_time_cache_get_account_with_aggregated_account_data_by_local_account_id,
@@ -256,6 +261,11 @@ public enum AttributeName {
      * The time (in milliseconds) spent on network when acquiring AT.
      */
     elapsed_time_network_acquire_at,
+
+    /**
+     * The time (in milliseconds), calculated using nanos, spent on network when acquiring AT.
+     */
+    elapsed_time_network_acquire_at_using_nanos,
 
     /**
      * The broker operation name.
@@ -520,6 +530,11 @@ public enum AttributeName {
      *  Elapsed time (in milliseconds) spent in executing the loadAggregatedAccountData() method in BrokerOAuth2TokenCache.
      */
     elapsed_time_load_aggregated_account_data,
+
+    /**
+     *  Elapsed time (in milliseconds), calculated using nanos, spent in executing the loadAggregatedAccountData() method in BrokerOAuth2TokenCache.
+     */
+    elapsed_time_load_aggregated_account_data_using_nanos,
 
     /**
      * Indicates if account aggregation is skipped during saveTokenResult() call.

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/OTelUtility.kt
@@ -26,6 +26,7 @@ import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanContext
+import java.util.concurrent.TimeUnit
 
 object OTelUtility {
     private val TAG = OTelUtility::class.java.simpleName
@@ -113,6 +114,19 @@ object OTelUtility {
     fun recordElapsedTime(attributeName: String, startTimeMillis: Long) {
         val endTimeMillis = System.currentTimeMillis()
         val elapsedTimeMillis = endTimeMillis - startTimeMillis
+        SpanExtension.current().setAttribute(attributeName, elapsedTimeMillis)
+    }
+
+    /**
+     * Records the elapsed time in milliseconds since the provided start time in nanoseconds as a span attribute.
+     *
+     * @param attributeName The name of the attribute to record in the telemetry.
+     * @param startTimeNanos The start time in nanoseconds.
+     *                       The elapsed time is calculated using System.nanoTime() and converted to milliseconds.
+     */
+    @JvmStatic
+    fun recordElapsedTimeFromNanos(attributeName: String, startTimeNanos: Long) {
+        val elapsedTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos)
         SpanExtension.current().setAttribute(attributeName, elapsedTimeMillis)
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.common.java.net.HttpConstants;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.net.UrlConnectionHttpClient;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.platform.Device;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenRequest;
@@ -256,6 +257,7 @@ public abstract class OAuth2Strategy
 
         final URL requestUrl = new URL(getTokenEndpoint());
         final long networkStartTime = System.currentTimeMillis();
+        final long networkStartTimeInNanos = System.nanoTime();
         final HttpResponse response = httpClient.post(
                 requestUrl,
                 headers,
@@ -264,7 +266,8 @@ public abstract class OAuth2Strategy
         final long networkEndTime = System.currentTimeMillis();
         final long networkTime = networkEndTime - networkStartTime;
         SpanExtension.current().setAttribute(AttributeName.elapsed_time_network_acquire_at.name(), networkTime);
-
+        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_network_acquire_at_using_nanos.name(),
+                networkStartTimeInNanos);
 
         // Record the clock skew between *this device* and EVO...
         if (null != response.getDate()) {


### PR DESCRIPTION
Fixes [AB#3496484](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3496484) From the telemetry, we have seen cases where total elapsed_time is less than the time taken by a certain operation. We believe it is due to the way elapsed time is calculated using System.milliseconds() which is dependent on external factors like System clock change etc.
This PBI is to start using nano to calculate starttime and endtime of an operation and then, convert it to milliseconds before emitting telemetry.
We're testing this with some fields first so that we can compare and tell whether the perf gain in the upcoming release is due to currentTimeMillis() vs nanoTime(), or an actual fix.