### PR TITLE
Added an attribute to track whether a redirect url is opened in browser, Fixes AB#3503311

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -608,6 +608,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      */
     private void handleBrowserRedirect(@NonNull final String methodTag, @NonNull final String url) {
         Logger.info(methodTag, "Not a device CA request. Redirecting to browser.");
+        SpanExtension.current().setAttribute(AttributeName.is_redirect_url_opened_in_browser.name(), true);
         openLinkInBrowser(url);
         final RawAuthorizationResult.ResultCode resultCode = mInWebCpFlow
                 ? RawAuthorizationResult.ResultCode.MDM_FLOW

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -543,6 +543,11 @@ public enum AttributeName {
     /**
      * Indicates if account aggregation is skipped during saveTokenResult() call.
      */
-    is_account_aggregation_skipped;
+    is_account_aggregation_skipped,
+
+    /**
+     * Indicates if the redirect URL in webview is opened in browser.
+     */
+    is_redirect_url_opened_in_browser;
 
 }


### PR DESCRIPTION
Added an attribute to track whether a redirect url is opened in browser.

Need this to understand the pattern of redirects happening in device CA flow. Right now, there is a gap which will be addressed once we see whether the url is being opened successfully in the browser or not.

Fixes [AB#3503311](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3503311)