### PR TITLE
Fix failing CommandDispatcherTest test for Feb2026 AB#3505387, Fixes AB#3505387

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ vNext
 - [PATCH] Implement State-Based Timeout Classification for Silent Token Requests (#2870)
 - [MINOR] Added Authentication Constants to be used for broker version and name (#2859)
 - [PATCH] Adding WebAppsNonce to JWT request body (#2867)
+- [MINOR] Fixed CommandDispatcherTest to avoid race condition (#2875)
 
 Version 23.2.0
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -58,6 +58,8 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.exception.TerminalException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.request.SdkType;
@@ -69,7 +71,9 @@ import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -114,6 +118,18 @@ public class CommandDispatcherTest {
 
     /** Number of concurrent requests for state collision test */
     private static final int CONCURRENT_REQUEST_COUNT = 20;
+
+    @Before
+    public void setUp() throws Exception {
+        Log.d(TAG, "setUp: Clearing CommandDispatcher state before test");
+        CommandDispatcher.clearState();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Log.d(TAG, "tearDown: Clearing CommandDispatcher state after test");
+        CommandDispatcher.clearState();
+    }
 
     @Test
     public void testSubmitSilentShouldRefresh() throws Exception {
@@ -1035,14 +1051,29 @@ public class CommandDispatcherTest {
         // Get initial map size
         int initialSize = getRequestStateMapSizeViaReflection();
 
+        Log.d(TAG, "DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT = " +
+                com.microsoft.identity.common.java.BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT);
+
+        // Check the configured timeout value
+        int timeoutMs = CommonFlightsManager.INSTANCE.getFlightsProvider()
+                .getIntValue(CommonFlight.ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS);
+        Log.d(TAG, "ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS = " + timeoutMs);
+        Log.d(TAG, "SLOW_EXECUTION_DURATION_MS = " + SLOW_EXECUTION_DURATION_MS);
+
         // Execute request that will timeout
         SilentTokenCommandParameters params = createTestSilentTokenParams();
+        long startTime = System.currentTimeMillis();
         SilentTokenCommand slowCommand = createSlowExecutionSilentTokenCommand(params, SLOW_EXECUTION_DURATION_MS);
 
         try {
             CommandDispatcher.submitAcquireTokenSilentSync(slowCommand);
+            long duration = System.currentTimeMillis() - startTime;
+            Log.d(TAG, "1. debugTimeoutBehavior: 5s slow command completed in " + duration + "ms");
+
             Assert.fail("Expected timeout");
         } catch (ClientException e) {
+            long duration = System.currentTimeMillis() - startTime;
+            Log.e(TAG, "2. debugTimeoutBehavior: 5s slow command failed in " + duration + "ms: " + e.getClass().getName() + " - " + e.getMessage());
             // Expected - verify it's a timeout error
             Assert.assertTrue("Should be a timeout error",
                 e.getErrorCode().startsWith("timed_out"));
@@ -1080,6 +1111,7 @@ public class CommandDispatcherTest {
         final AtomicInteger errorCount = new AtomicInteger(0);
         final AtomicReference<Throwable> firstError = new AtomicReference<>(null);
 
+        Log.d(TAG, "Initial RequestStateMap Size: " + getRequestStateMapSizeViaReflection());
         // Launch concurrent requests
         for (int i = 0; i < NUM_REQUESTS; i++) {
             new Thread(() -> {

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -131,7 +131,7 @@ public class CommandDispatcherTest {
         CommandDispatcher.clearState();
     }
 
-    @Test
+    /*@Test
     public void testSubmitSilentShouldRefresh() throws Exception {
         final CountDownLatch callbackLatch = new CountDownLatch(1);
         CountDownLatch tryLatch = new CountDownLatch(1);
@@ -191,6 +191,94 @@ public class CommandDispatcherTest {
 
         silentReturningFuture.isCleanedUp();
         Assert.assertFalse(CommandDispatcher.isCommandOutstanding(silentTokenCommand));
+    }*/
+
+    @Test
+    public void testSubmitSilentShouldRefresh() throws Exception {
+        Log.d(TAG, "=== testSubmitSilentShouldRefresh START ===");
+        final long testStartTime = System.currentTimeMillis();
+
+        final CountDownLatch callbackLatch = new CountDownLatch(1);
+        CountDownLatch tryLatch = new CountDownLatch(1);
+        CountDownLatch executeMethodEntranceVerifierLatch = new CountDownLatch(1);
+
+        CountDownLatch controllerLatch = new CountDownLatch(2);
+        final AtomicInteger renewAccessTokenCallCount = new AtomicInteger(0);
+        final AtomicInteger acquireTokenSilentCallCount = new AtomicInteger(0);
+        final AtomicInteger taskCompleteCount = new AtomicInteger(0);
+
+        final BaseCommand silentTokenCommand = new LatchedRefreshInTestCommand(TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT,
+                getEmptySilentTokenParameters(),
+                new CommandCallback<ILocalAuthenticationResult, Exception>() {
+                    @Override
+                    public void onTaskCompleted(final ILocalAuthenticationResult actual) {
+                        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onTaskCompleted called");
+                        ILocalAuthenticationResult expected = TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT.getLocalAuthenticationResult();
+                        Assert.assertEquals(expected, actual);
+                        taskCompleteCount.getAndIncrement();
+                        callbackLatch.countDown();
+                    }
+
+                    @Override
+                    public void onCancel() {
+                        Log.e(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onCancel called - UNEXPECTED");
+                        callbackLatch.countDown();
+                        Assert.fail();
+                    }
+
+                    @Override
+                    public void onError(Exception error) {
+                        Log.e(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onError called - UNEXPECTED: " + error.getMessage());
+                        callbackLatch.countDown();
+                        Assert.fail();
+                    }
+
+                }, 3, tryLatch, executeMethodEntranceVerifierLatch,
+                renewAccessTokenCallCount, acquireTokenSilentCallCount,
+                controllerLatch, true, false) {
+            @Override
+            public boolean isEligibleForCaching() {
+                return false;
+            }
+
+        };
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Submitting command...");
+        FinalizableResultFuture<CommandResult> silentReturningFuture = CommandDispatcher.submitSilentReturningFuture(silentTokenCommand);
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for executeMethodEntranceVerifierLatch...");
+        executeMethodEntranceVerifierLatch.await();
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Releasing tryLatch...");
+        tryLatch.countDown();
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for controllerLatch (count=" + controllerLatch.getCount() + ")...");
+        boolean controllerLatchResult = controllerLatch.await(30, TimeUnit.SECONDS);
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] controllerLatch.await() returned: " + controllerLatchResult + ", remaining count=" + controllerLatch.getCount());
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for callbackLatch...");
+        boolean callbackLatchResult = callbackLatch.await(10, TimeUnit.SECONDS);
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] callbackLatch.await() returned: " + callbackLatchResult);
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Second controllerLatch.await()...");
+        controllerLatch.await();
+
+        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] === BEFORE ASSERTIONS ===");
+        Log.d(TAG, "  - acquireTokenSilentCallCount: " + acquireTokenSilentCallCount.get());
+        Log.d(TAG, "  - renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
+        Log.d(TAG, "  - taskCompleteCount: " + taskCompleteCount.get());
+        Log.d(TAG, "  - controllerLatch remaining: " + controllerLatch.getCount());
+
+        Assert.assertEquals(TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT.getLocalAuthenticationResult(), silentReturningFuture.get().getResult());
+
+        Assert.assertTrue(silentReturningFuture.isDone());
+        Assert.assertEquals(1, taskCompleteCount.get());
+        Assert.assertEquals("renewAccessTokenCallCount mismatch", 1, renewAccessTokenCallCount.get());
+        Assert.assertEquals(1, acquireTokenSilentCallCount.get());
+
+        silentReturningFuture.isCleanedUp();
+        Assert.assertFalse(CommandDispatcher.isCommandOutstanding(silentTokenCommand));
+        Log.d(TAG, "=== testSubmitSilentShouldRefresh END ===");
     }
 
     @Test
@@ -1514,8 +1602,9 @@ public class CommandDispatcherTest {
                                                              final Boolean shouldRefresh,
                                                              final Boolean throwRenewAccessTokenError) {
         return new TestBaseController() {
-            @Override
+            /*@Override
             public AcquireTokenResult acquireTokenSilent(final SilentTokenCommandParameters parameters) {
+                Log.d(TAG, "acquireTokenSilent called....." + throwRenewAccessTokenError);
                 controllerLatch.countDown();
                 acquireTokenSilentCallCount.getAndIncrement();
                 if(shouldRefresh){
@@ -1524,16 +1613,64 @@ public class CommandDispatcherTest {
                 }
 
                 return expectedAcquireTokenResult;
+            }*/
+            @Override
+            public AcquireTokenResult acquireTokenSilent(final SilentTokenCommandParameters parameters) {
+                Log.d(TAG, ">>> acquireTokenSilent ENTER - Thread: " + Thread.currentThread().getName());
+                // IMPORTANT: Increment counter BEFORE any latch operations
+                acquireTokenSilentCallCount.getAndIncrement();
+                Log.d(TAG, "    acquireTokenSilentCallCount: " + acquireTokenSilentCallCount.get());
+
+                if(shouldRefresh){
+                    Log.d(TAG, "    shouldRefresh=true, submitting RefreshOnCommand...");
+                    final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), "LocalMSALControllerMockPubId");
+                    CommandDispatcher.submitAndForgetReturningFuture(refreshOnCommand);
+                    Log.d(TAG, "    RefreshOnCommand submitted (fire-and-forget)");
+                } else {
+                    Log.d(TAG, "    shouldRefresh=false, skipping refresh");
+                }
+
+                Log.d(TAG, "    controllerLatch count BEFORE countdown: " + controllerLatch.getCount());
+                controllerLatch.countDown();
+                Log.d(TAG, "    controllerLatch count AFTER countdown: " + controllerLatch.getCount());
+
+                Log.d(TAG, "<<< acquireTokenSilent EXIT");
+                return expectedAcquireTokenResult;
             }
 
-            @Override
+            /*@Override
             public TokenResult renewAccessToken(@NonNull SilentTokenCommandParameters parameters) throws ServiceException {
+                Log.d(TAG, "renewAccessToken called....." + throwRenewAccessTokenError);
                 if(!throwRenewAccessTokenError) {
                     controllerLatch.countDown();
                     renewAccessTokenCallCount.getAndIncrement();
+                    Log.d(TAG, "renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
                 }else{
                     throw new ServiceException(SERVICE_NOT_AVAILABLE, "AAD is not available.", 503, null);
                 }
+                return new TokenResult();
+            }*/
+
+            @Override
+            public TokenResult renewAccessToken(@NonNull SilentTokenCommandParameters parameters) throws ServiceException {
+                Log.d(TAG, ">>> renewAccessToken ENTER - Thread: " + Thread.currentThread().getName());
+                Log.d(TAG, "    throwRenewAccessTokenError: " + throwRenewAccessTokenError);
+
+                if(!throwRenewAccessTokenError) {
+                    // FIX: Increment counter BEFORE countdown to avoid race condition
+                    renewAccessTokenCallCount.getAndIncrement();
+                    Log.d(TAG, "    renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
+
+                    Log.d(TAG, "    controllerLatch count BEFORE countdown: " + controllerLatch.getCount());
+                    controllerLatch.countDown();
+                    Log.d(TAG, "    controllerLatch count AFTER countdown: " + controllerLatch.getCount());
+                } else {
+                    Log.e(TAG, "    Throwing ServiceException");
+                    throw new ServiceException(SERVICE_NOT_AVAILABLE, "AAD is not available.", 503, null);
+                }
+
+
+                Log.d(TAG, "<<< renewAccessToken EXIT");
                 return new TokenResult();
             }
         };

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -121,17 +121,15 @@ public class CommandDispatcherTest {
 
     @Before
     public void setUp() throws Exception {
-        Log.d(TAG, "setUp: Clearing CommandDispatcher state before test");
         CommandDispatcher.clearState();
     }
 
     @After
     public void tearDown() throws Exception {
-        Log.d(TAG, "tearDown: Clearing CommandDispatcher state after test");
         CommandDispatcher.clearState();
     }
 
-    /*@Test
+    @Test
     public void testSubmitSilentShouldRefresh() throws Exception {
         final CountDownLatch callbackLatch = new CountDownLatch(1);
         CountDownLatch tryLatch = new CountDownLatch(1);
@@ -191,94 +189,6 @@ public class CommandDispatcherTest {
 
         silentReturningFuture.isCleanedUp();
         Assert.assertFalse(CommandDispatcher.isCommandOutstanding(silentTokenCommand));
-    }*/
-
-    @Test
-    public void testSubmitSilentShouldRefresh() throws Exception {
-        Log.d(TAG, "=== testSubmitSilentShouldRefresh START ===");
-        final long testStartTime = System.currentTimeMillis();
-
-        final CountDownLatch callbackLatch = new CountDownLatch(1);
-        CountDownLatch tryLatch = new CountDownLatch(1);
-        CountDownLatch executeMethodEntranceVerifierLatch = new CountDownLatch(1);
-
-        CountDownLatch controllerLatch = new CountDownLatch(2);
-        final AtomicInteger renewAccessTokenCallCount = new AtomicInteger(0);
-        final AtomicInteger acquireTokenSilentCallCount = new AtomicInteger(0);
-        final AtomicInteger taskCompleteCount = new AtomicInteger(0);
-
-        final BaseCommand silentTokenCommand = new LatchedRefreshInTestCommand(TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT,
-                getEmptySilentTokenParameters(),
-                new CommandCallback<ILocalAuthenticationResult, Exception>() {
-                    @Override
-                    public void onTaskCompleted(final ILocalAuthenticationResult actual) {
-                        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onTaskCompleted called");
-                        ILocalAuthenticationResult expected = TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT.getLocalAuthenticationResult();
-                        Assert.assertEquals(expected, actual);
-                        taskCompleteCount.getAndIncrement();
-                        callbackLatch.countDown();
-                    }
-
-                    @Override
-                    public void onCancel() {
-                        Log.e(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onCancel called - UNEXPECTED");
-                        callbackLatch.countDown();
-                        Assert.fail();
-                    }
-
-                    @Override
-                    public void onError(Exception error) {
-                        Log.e(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] onError called - UNEXPECTED: " + error.getMessage());
-                        callbackLatch.countDown();
-                        Assert.fail();
-                    }
-
-                }, 3, tryLatch, executeMethodEntranceVerifierLatch,
-                renewAccessTokenCallCount, acquireTokenSilentCallCount,
-                controllerLatch, true, false) {
-            @Override
-            public boolean isEligibleForCaching() {
-                return false;
-            }
-
-        };
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Submitting command...");
-        FinalizableResultFuture<CommandResult> silentReturningFuture = CommandDispatcher.submitSilentReturningFuture(silentTokenCommand);
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for executeMethodEntranceVerifierLatch...");
-        executeMethodEntranceVerifierLatch.await();
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Releasing tryLatch...");
-        tryLatch.countDown();
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for controllerLatch (count=" + controllerLatch.getCount() + ")...");
-        boolean controllerLatchResult = controllerLatch.await(30, TimeUnit.SECONDS);
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] controllerLatch.await() returned: " + controllerLatchResult + ", remaining count=" + controllerLatch.getCount());
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Waiting for callbackLatch...");
-        boolean callbackLatchResult = callbackLatch.await(10, TimeUnit.SECONDS);
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] callbackLatch.await() returned: " + callbackLatchResult);
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] Second controllerLatch.await()...");
-        controllerLatch.await();
-
-        Log.d(TAG, "[" + (System.currentTimeMillis() - testStartTime) + "ms] === BEFORE ASSERTIONS ===");
-        Log.d(TAG, "  - acquireTokenSilentCallCount: " + acquireTokenSilentCallCount.get());
-        Log.d(TAG, "  - renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
-        Log.d(TAG, "  - taskCompleteCount: " + taskCompleteCount.get());
-        Log.d(TAG, "  - controllerLatch remaining: " + controllerLatch.getCount());
-
-        Assert.assertEquals(TEST_ACQUIRE_TOKEN_REFRESH_EXPIRED_RESULT.getLocalAuthenticationResult(), silentReturningFuture.get().getResult());
-
-        Assert.assertTrue(silentReturningFuture.isDone());
-        Assert.assertEquals(1, taskCompleteCount.get());
-        Assert.assertEquals("renewAccessTokenCallCount mismatch", 1, renewAccessTokenCallCount.get());
-        Assert.assertEquals(1, acquireTokenSilentCallCount.get());
-
-        silentReturningFuture.isCleanedUp();
-        Assert.assertFalse(CommandDispatcher.isCommandOutstanding(silentTokenCommand));
-        Log.d(TAG, "=== testSubmitSilentShouldRefresh END ===");
     }
 
     @Test
@@ -1602,75 +1512,25 @@ public class CommandDispatcherTest {
                                                              final Boolean shouldRefresh,
                                                              final Boolean throwRenewAccessTokenError) {
         return new TestBaseController() {
-            /*@Override
-            public AcquireTokenResult acquireTokenSilent(final SilentTokenCommandParameters parameters) {
-                Log.d(TAG, "acquireTokenSilent called....." + throwRenewAccessTokenError);
-                controllerLatch.countDown();
-                acquireTokenSilentCallCount.getAndIncrement();
-                if(shouldRefresh){
-                    final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), "LocalMSALControllerMockPubId");
-                    CommandDispatcher.submitAndForgetReturningFuture(refreshOnCommand);
-                }
-
-                return expectedAcquireTokenResult;
-            }*/
             @Override
             public AcquireTokenResult acquireTokenSilent(final SilentTokenCommandParameters parameters) {
-                Log.d(TAG, ">>> acquireTokenSilent ENTER - Thread: " + Thread.currentThread().getName());
-                // IMPORTANT: Increment counter BEFORE any latch operations
                 acquireTokenSilentCallCount.getAndIncrement();
-                Log.d(TAG, "    acquireTokenSilentCallCount: " + acquireTokenSilentCallCount.get());
-
                 if(shouldRefresh){
-                    Log.d(TAG, "    shouldRefresh=true, submitting RefreshOnCommand...");
                     final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), "LocalMSALControllerMockPubId");
                     CommandDispatcher.submitAndForgetReturningFuture(refreshOnCommand);
-                    Log.d(TAG, "    RefreshOnCommand submitted (fire-and-forget)");
-                } else {
-                    Log.d(TAG, "    shouldRefresh=false, skipping refresh");
                 }
-
-                Log.d(TAG, "    controllerLatch count BEFORE countdown: " + controllerLatch.getCount());
                 controllerLatch.countDown();
-                Log.d(TAG, "    controllerLatch count AFTER countdown: " + controllerLatch.getCount());
-
-                Log.d(TAG, "<<< acquireTokenSilent EXIT");
                 return expectedAcquireTokenResult;
             }
 
-            /*@Override
+            @Override
             public TokenResult renewAccessToken(@NonNull SilentTokenCommandParameters parameters) throws ServiceException {
-                Log.d(TAG, "renewAccessToken called....." + throwRenewAccessTokenError);
                 if(!throwRenewAccessTokenError) {
-                    controllerLatch.countDown();
                     renewAccessTokenCallCount.getAndIncrement();
-                    Log.d(TAG, "renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
+                    controllerLatch.countDown();
                 }else{
                     throw new ServiceException(SERVICE_NOT_AVAILABLE, "AAD is not available.", 503, null);
                 }
-                return new TokenResult();
-            }*/
-
-            @Override
-            public TokenResult renewAccessToken(@NonNull SilentTokenCommandParameters parameters) throws ServiceException {
-                Log.d(TAG, ">>> renewAccessToken ENTER - Thread: " + Thread.currentThread().getName());
-                Log.d(TAG, "    throwRenewAccessTokenError: " + throwRenewAccessTokenError);
-
-                if(!throwRenewAccessTokenError) {
-                    // FIX: Increment counter BEFORE countdown to avoid race condition
-                    renewAccessTokenCallCount.getAndIncrement();
-                    Log.d(TAG, "    renewAccessTokenCallCount: " + renewAccessTokenCallCount.get());
-
-                    Log.d(TAG, "    controllerLatch count BEFORE countdown: " + controllerLatch.getCount());
-                    controllerLatch.countDown();
-                    Log.d(TAG, "    controllerLatch count AFTER countdown: " + controllerLatch.getCount());
-                } else {
-                    Log.e(TAG, "    Throwing ServiceException");
-                    throw new ServiceException(SERVICE_NOT_AVAILABLE, "AAD is not available.", 503, null);
-                }
-
-
-                Log.d(TAG, "<<< renewAccessToken EXIT");
                 return new TokenResult();
             }
         };

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -58,8 +58,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.exception.TerminalException;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.request.SdkType;
@@ -1049,29 +1047,14 @@ public class CommandDispatcherTest {
         // Get initial map size
         int initialSize = getRequestStateMapSizeViaReflection();
 
-        Log.d(TAG, "DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT = " +
-                com.microsoft.identity.common.java.BuildConfig.DISABLE_ACQUIRE_TOKEN_SILENT_TIMEOUT);
-
-        // Check the configured timeout value
-        int timeoutMs = CommonFlightsManager.INSTANCE.getFlightsProvider()
-                .getIntValue(CommonFlight.ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS);
-        Log.d(TAG, "ACQUIRE_TOKEN_SILENT_TIMEOUT_MILLISECONDS = " + timeoutMs);
-        Log.d(TAG, "SLOW_EXECUTION_DURATION_MS = " + SLOW_EXECUTION_DURATION_MS);
-
         // Execute request that will timeout
         SilentTokenCommandParameters params = createTestSilentTokenParams();
-        long startTime = System.currentTimeMillis();
         SilentTokenCommand slowCommand = createSlowExecutionSilentTokenCommand(params, SLOW_EXECUTION_DURATION_MS);
 
         try {
             CommandDispatcher.submitAcquireTokenSilentSync(slowCommand);
-            long duration = System.currentTimeMillis() - startTime;
-            Log.d(TAG, "1. debugTimeoutBehavior: 5s slow command completed in " + duration + "ms");
-
             Assert.fail("Expected timeout");
         } catch (ClientException e) {
-            long duration = System.currentTimeMillis() - startTime;
-            Log.e(TAG, "2. debugTimeoutBehavior: 5s slow command failed in " + duration + "ms: " + e.getClass().getName() + " - " + e.getMessage());
             // Expected - verify it's a timeout error
             Assert.assertTrue("Should be a timeout error",
                 e.getErrorCode().startsWith("timed_out"));
@@ -1109,7 +1092,6 @@ public class CommandDispatcherTest {
         final AtomicInteger errorCount = new AtomicInteger(0);
         final AtomicReference<Throwable> firstError = new AtomicReference<>(null);
 
-        Log.d(TAG, "Initial RequestStateMap Size: " + getRequestStateMapSizeViaReflection());
         // Launch concurrent requests
         for (int i = 0; i < NUM_REQUESTS; i++) {
             new Thread(() -> {


### PR DESCRIPTION
Problem: [AB#3505387](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3505387)
CommandDispatcherTest tests were failing in pipeline with assertion error
(expected renewAccessTokenCallCount=1, but was 0).

Cause:

1. Race condition in test synchronization. 
2. In getTestRefreshInController(), the renewAccessToken() method had incorrect ordering
3. controllerLatch.countDown() was called before renewAccessTokenCallCount.getAndIncrement(),
allowing the test thread to read the counter before it was updated.

Solution:
1. Swap the order in renewAccessToken() - increment counter before
2. countdown to ensure counter is updated before releasing test thread.
3. Also, added test setup and teardown to ensure each test runs from clean state.

Why it surfaced after recent changes:
1. The bug was always latent in the test code
2. Recent source code changes (likely thread pool configuration or timing-related) altered thread scheduling
4. This exposed the race condition that previously passed due to favorable timing

NOTE: locally test was passing but failing in pipelines. Validated the fix with pipeline runs and test passed. 