### PR TITLE
Fix failing CommandDispatcherTest test for Feb2026 AB#3505387, Fixes AB#3505387

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ Version 23.3.0-RC1
 - [PATCH] Implement State-Based Timeout Classification for Silent Token Requests (#2870)
 - [MINOR] Added Authentication Constants to be used for broker version and name (#2859)
 - [PATCH] Adding WebAppsNonce to JWT request body (#2867)
+- [MINOR] Fixed CommandDispatcherTest to avoid race condition (#2875)
 
 Version 23.2.0
 

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -69,7 +69,9 @@ import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod;
 import com.microsoft.identity.common.java.util.ported.PropertyBag;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -114,6 +116,16 @@ public class CommandDispatcherTest {
 
     /** Number of concurrent requests for state collision test */
     private static final int CONCURRENT_REQUEST_COUNT = 20;
+
+    @Before
+    public void setUp() throws Exception {
+        CommandDispatcher.clearState();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CommandDispatcher.clearState();
+    }
 
     @Test
     public void testSubmitSilentShouldRefresh() throws Exception {
@@ -1484,21 +1496,20 @@ public class CommandDispatcherTest {
         return new TestBaseController() {
             @Override
             public AcquireTokenResult acquireTokenSilent(final SilentTokenCommandParameters parameters) {
-                controllerLatch.countDown();
                 acquireTokenSilentCallCount.getAndIncrement();
                 if(shouldRefresh){
                     final RefreshOnCommand refreshOnCommand = new RefreshOnCommand(parameters, this.asControllerFactory(), "LocalMSALControllerMockPubId");
                     CommandDispatcher.submitAndForgetReturningFuture(refreshOnCommand);
                 }
-
+                controllerLatch.countDown();
                 return expectedAcquireTokenResult;
             }
 
             @Override
             public TokenResult renewAccessToken(@NonNull SilentTokenCommandParameters parameters) throws ServiceException {
                 if(!throwRenewAccessTokenError) {
-                    controllerLatch.countDown();
                     renewAccessTokenCallCount.getAndIncrement();
+                    controllerLatch.countDown();
                 }else{
                     throw new ServiceException(SERVICE_NOT_AVAILABLE, "AAD is not available.", 503, null);
                 }


### PR DESCRIPTION
Fixes [AB#3505387](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3505387) (#2875)

Problem:
[AB#3505387](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3505387) CommandDispatcherTest tests were failing in pipeline with assertion error
(expected renewAccessTokenCallCount=1, but was 0).

Cause:

1. Race condition in test synchronization. 
2. In getTestRefreshInController(), the renewAccessToken() method had incorrect ordering
3. controllerLatch.countDown() was called before renewAccessTokenCallCount.getAndIncrement(),
allowing the test thread to read the counter before it was updated.

Solution:
1. Swap the order in renewAccessToken() - increment counter before
2. countdown to ensure counter is updated before releasing test thread.
3. Also, added test setup and teardown to ensure each test runs from clean state.

Why it surfaced after recent changes:
1. The bug was always latent in the test code
2. Recent source code changes (likely thread pool configuration or timing-related) altered thread scheduling
4. This exposed the race condition that previously passed due to favorable timing

NOTE: locally test was passing but failing in pipelines. Validated the fix with pipeline runs and test passed.

---------