### PR TITLE
Add unit tests for UrlConnectionHttpClient and implement shadow behavior for network simulation, Fixes AB#3318506

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
@@ -51,7 +51,6 @@ class UrlConnectionHttpClientTest {
 
         init {
             try {
-                TEST_HEADERS
                 TEST_URL = URL("https://www.bing.com")
             } catch (e: MalformedURLException) {
                 throw RuntimeException(e)
@@ -101,7 +100,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
             .build()
 
         val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
@@ -130,7 +129,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
             .build()
 
         val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
@@ -158,7 +157,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
             .build()
 
         Assert.assertThrows(ClientException::class.java) {
@@ -183,5 +182,35 @@ class UrlConnectionHttpClientTest {
         val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
         Assert.assertEquals(200, response.statusCode)
         Assert.assertEquals(2, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that SocketTimeoutException is not retried even with retry policy enabled.
+     * Expects: Single request (no retry), ClientException thrown immediately.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testGet_withRetryPolicy_doesNotRetryOnSocketTimeoutException() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Failure(
+                ClientException(
+                    ClientException.IO_ERROR,
+                    "Socket timeout",
+                    java.net.SocketTimeoutException("Connection timed out")
+                )
+            )
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
+            .build()
+
+        Assert.assertThrows(ClientException::class.java) {
+            urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        }
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
@@ -299,5 +299,67 @@ class UrlConnectionHttpClientTest {
         }
         Assert.assertEquals(3, ShadowUrlConnectionHttpClient.getRequestCount())
     }
+
+    /**
+     * Verifies that getIOExceptionRetryPolicy rejects negative retry counts.
+     */
+    @Test
+    fun testGetIOExceptionRetryPolicy_withNegativeRetries_throwsException() {
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", -1, null)
+        }
+    }
+
+    /**
+     * Verifies that non-IO exceptions are not retried.
+     */
+    @Test
+    fun testGet_withNonIOException_doesNotRetry() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Failure(
+                ClientException(
+                    "DIFFERENT_ERROR",
+                    "Not an IO error"
+                )
+            )
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 2, null))
+            .build()
+
+        Assert.assertThrows(ClientException::class.java) {
+            urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        }
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that with attributeNameForRetry set, policy executes successfully.
+     */
+    @Test
+    fun testGet_withAttributeName_executesSuccessfully() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Success(200, "{\"data\":\"value\"}")
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(
+                StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 1, "test_attribute")
+            )
+            .build()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertEquals(200, response.statusCode)
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
 }
+
+
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
@@ -100,7 +100,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 1, null))
             .build()
 
         val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
@@ -129,7 +129,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 1, null))
             .build()
 
         val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
@@ -157,7 +157,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 1, null))
             .build()
 
         Assert.assertThrows(ClientException::class.java) {
@@ -205,7 +205,7 @@ class UrlConnectionHttpClientTest {
             .builder()
             .connectTimeoutMs(1000)
             .readTimeoutMs(1000)
-            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST"))
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 1, null))
             .build()
 
         Assert.assertThrows(ClientException::class.java) {
@@ -213,4 +213,91 @@ class UrlConnectionHttpClientTest {
         }
         Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
     }
+
+    /**
+     * Verifies that retry policy with 0 retries behaves like no retry (only initial attempt).
+     * Expects: Single request, ClientException thrown on failure.
+     */
+    @Test
+    fun testGet_withZeroRetries_failsImmediately() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Failure(
+                ClientException(
+                    ClientException.IO_ERROR,
+                    "Network error"
+                )
+            )
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 0, null))
+            .build()
+
+        Assert.assertThrows(ClientException::class.java) {
+            urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        }
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that retry policy with 2 retries allows up to 3 total attempts.
+     * Expects: Three requests (initial + 2 retries), final success on third attempt.
+     */
+    @Test
+    fun testGet_withTwoRetries_succeedsOnThirdAttempt() {
+        ShadowUrlConnectionHttpClient.setBehavior { attempt ->
+            when (attempt) {
+                1, 2 -> NetworkResult.Failure(
+                    ClientException(
+                        ClientException.IO_ERROR,
+                        "Temporary error"
+                    )
+                )
+                else -> NetworkResult.Success(200, "{\"success\":true}")
+            }
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 2, null))
+            .build()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertEquals(200, response.statusCode)
+        Assert.assertEquals(3, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that all 3 attempts fail when retries are exhausted with 2 retries configured.
+     * Expects: Three requests (initial + 2 retries), ClientException thrown.
+     */
+    @Test
+    fun testGet_withTwoRetries_failsAfterAllAttemptsExhausted() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Failure(
+                ClientException(
+                    ClientException.IO_ERROR,
+                    "Persistent error"
+                )
+            )
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getIOExceptionRetryPolicy("TEST", 2, null))
+            .build()
+
+        Assert.assertThrows(ClientException::class.java) {
+            urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        }
+        Assert.assertEquals(3, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
 }
+

--- a/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/net/UrlConnectionHttpClientTest.kt
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.net
+
+import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.net.NoRetryPolicy
+import com.microsoft.identity.common.java.net.StatusCodeAndExceptionRetry
+import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
+import com.microsoft.identity.common.shadows.NetworkResult
+import com.microsoft.identity.common.shadows.ShadowUrlConnectionHttpClient
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.MalformedURLException
+import java.net.URL
+
+/**
+ * Unit tests for [UrlConnectionHttpClient].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowUrlConnectionHttpClient::class])
+class UrlConnectionHttpClientTest {
+
+    companion object {
+
+        private val TEST_URL: URL
+        private val TEST_HEADERS = mutableMapOf("Header1" to "Value1", "Header2" to "Value2")
+
+        init {
+            try {
+                TEST_HEADERS
+                TEST_URL = URL("https://www.bing.com")
+            } catch (e: MalformedURLException) {
+                throw RuntimeException(e)
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        ShadowUrlConnectionHttpClient.reset()
+    }
+
+    /**
+     * Verifies that a request succeeds on the first attempt when using NoRetryPolicy.
+     * Expects: Single request, 200 status code.
+     */
+    @Test
+    fun testGet_withNoRetryPolicy_succeedsOnFirstAttempt() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Success(200, "{\"data\":\"value\"}")
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(NoRetryPolicy())
+            .build()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertNotNull(response)
+        Assert.assertEquals(200, response.statusCode.toLong())
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that a request succeeds on the first attempt when using default retry policy.
+     * Expects: Single request (no retries needed), 200 status code.
+     */
+    @Test
+    fun testGet_withRetryPolicy_succeedsOnFirstAttempt() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Success(200, "{\"data\":\"value\"}")
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .build()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertNotNull(response)
+        Assert.assertEquals(200, response.statusCode.toLong())
+        Assert.assertEquals(1, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that a request retries after the first attempt fails and succeeds on the second.
+     * Expects: Two requests total, final 200 status code.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testGet_withRetryPolicy_succeedsOnSecondAttemptAfterFailure() {
+        ShadowUrlConnectionHttpClient.setBehavior { attempt ->
+            if (attempt == 1) NetworkResult.Failure(
+                ClientException(
+                    ClientException.IO_ERROR,
+                    "Simulated network error"
+                )
+            )
+            else NetworkResult.Success(200, "{\"ok\":true}")
+        }
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .build()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertNotNull(response)
+        Assert.assertEquals(200, response.statusCode.toLong())
+        Assert.assertEquals(2, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that when all retry attempts fail, an exception is thrown.
+     * Expects: Two requests (initial + 1 retry), ClientException thrown.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun testGet_withRetryPolicy_throwsExceptionWhenAllAttemptsFail() {
+        ShadowUrlConnectionHttpClient.setBehavior { _ ->
+            NetworkResult.Failure(
+                ClientException(
+                    ClientException.IO_ERROR,
+                    "Simulated network error"
+                )
+            )
+        }
+        val urlConnectionHttpClient = UrlConnectionHttpClient
+            .builder()
+            .connectTimeoutMs(1000)
+            .readTimeoutMs(1000)
+            .retryPolicy(StatusCodeAndExceptionRetry.getDefaultRetryPolicy("TEST"))
+            .build()
+
+        Assert.assertThrows(ClientException::class.java) {
+            urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        }
+        Assert.assertEquals(2, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+
+    /**
+     * Verifies that HTTP 500 responses trigger a retry and succeed on the second attempt.
+     * Expects: Two requests, final 200 status code after 500 error.
+     */
+    @Test
+    fun testGet_withRetryPolicy_retriesOnHttp500AndSucceeds() {
+        ShadowUrlConnectionHttpClient.setBehavior { attempt ->
+            if (attempt == 1) NetworkResult.Success(500, "{\"error\":\"internal\"}")
+            else NetworkResult.Success(200, "{\"ok\":true}")
+        }
+
+        val urlConnectionHttpClient = UrlConnectionHttpClient.getDefaultInstance()
+
+        val response = urlConnectionHttpClient.get(TEST_URL, TEST_HEADERS)
+        Assert.assertEquals(200, response.statusCode)
+        Assert.assertEquals(2, ShadowUrlConnectionHttpClient.getRequestCount())
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowUrlConnectionHttpClient.kt
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowUrlConnectionHttpClient.kt
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.shadows
+
+import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.net.HttpRequest
+import com.microsoft.identity.common.java.net.HttpResponse
+import com.microsoft.identity.common.java.net.UrlConnectionHttpClient
+import com.microsoft.identity.common.java.util.ported.Consumer
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Result type for network behavior simulation.
+ */
+sealed class NetworkResult {
+    data class Success(
+        val statusCode: Int = 200,
+        val body: String = "{}",
+        val headers: Map<String, List<String>> = mapOf("Content-Type" to listOf("application/json"))
+    ) : NetworkResult()
+
+    data class Failure(val exception: ClientException) : NetworkResult()
+}
+
+/**
+ * Basic Robolectric shadow for [UrlConnectionHttpClient].
+ * Allows tests to define custom network behavior per request attempt.
+ *
+ * Usage examples:
+ * ```
+ * // Fail on first, succeed on second
+ * ShadowUrlConnectionHttpClient.setBehavior { attempt ->
+ *     if (attempt == 1) NetworkResult.Failure(ClientException("Network error"))
+ *     else NetworkResult.Success(200, "{\"ok\":true}")
+ * }
+ *
+ * // Always fail
+ * ShadowUrlConnectionHttpClient.setBehavior { _ ->
+ *     NetworkResult.Failure(ClientException("Always fails"))
+ * }
+ *
+ * // Always succeed
+ * ShadowUrlConnectionHttpClient.setBehavior { _ ->
+ *     NetworkResult.Success(200, "{\"data\":\"value\"}")
+ * }
+ *
+ * // Fail first two attempts, then succeed
+ * ShadowUrlConnectionHttpClient.setBehavior { attempt ->
+ *     if (attempt <= 2) NetworkResult.Failure(ClientException("Retry me"))
+ *     else NetworkResult.Success(200, "{\"finally\":\"success\"}")
+ * }
+ * ```
+ */
+@Implements(UrlConnectionHttpClient::class)
+@Suppress("unused")
+class ShadowUrlConnectionHttpClient {
+    /**
+     * Shadow executeHttpSend to return the configured response based on behavior.
+     */
+    @Implementation
+    @Throws(ClientException::class)
+    fun executeHttpSend(
+        request: HttpRequest,
+        completionCallback: Consumer<HttpResponse?>
+    ): HttpResponse {
+        val currentAttempt = requestCount.incrementAndGet()
+
+        return when (val result = networkBehavior(currentAttempt)) {
+            is NetworkResult.Failure -> throw result.exception
+            is NetworkResult.Success -> {
+                val response = HttpResponse(
+                    result.statusCode,
+                    result.body,
+                    result.headers.mapKeys { it.key }.mapValues { it.value.toMutableList() }.toMutableMap()
+                )
+                completionCallback.accept(response)
+                response
+            }
+        }
+    }
+
+    companion object {
+        private val requestCount = AtomicInteger(0)
+
+        // Default behavior: always succeed with 200
+        private var networkBehavior: (Int) -> NetworkResult = { _ ->
+            NetworkResult.Success()
+        }
+
+        /**
+         * Resets shadow state to defaults (always succeed with 200).
+         */
+        fun reset() {
+            requestCount.set(0)
+            networkBehavior = { _ -> NetworkResult.Success() }
+        }
+
+        /**
+         * Sets the network behavior for the shadow.
+         * The lambda receives the attempt number (1-based) and returns the result.
+         *
+         * @param behavior Lambda that takes attempt number and returns NetworkResult
+         */
+        fun setBehavior(behavior: (attempt: Int) -> NetworkResult) {
+            networkBehavior = behavior
+        }
+
+        /**
+         * Returns how many times executeHttpSend was called.
+         *
+         * @return request count.
+         */
+        fun getRequestCount(): Int {
+            return requestCount.get()
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/shadows/ShadowUrlConnectionHttpClient.kt
+++ b/common/src/test/java/com/microsoft/identity/common/shadows/ShadowUrlConnectionHttpClient.kt
@@ -90,10 +90,15 @@ class ShadowUrlConnectionHttpClient {
         return when (val result = networkBehavior(currentAttempt)) {
             is NetworkResult.Failure -> throw result.exception
             is NetworkResult.Success -> {
+                // Create unmodifiable headers to match HttpURLConnection#getHeaderFields() behavior
+                val unmodifiableHeaders = result.headers
+                    .mapValues { java.util.Collections.unmodifiableList(it.value) }
+                    .let { java.util.Collections.unmodifiableMap(it) }
+
                 val response = HttpResponse(
                     result.statusCode,
                     result.body,
-                    result.headers.mapKeys { it.key }.mapValues { it.value.toMutableList() }.toMutableMap()
+                    unmodifiableHeaders
                 )
                 completionCallback.accept(response)
                 response

--- a/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
@@ -23,15 +23,17 @@
 package com.microsoft.identity.common.java.net;
 
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.util.ported.Function;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
-import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.Callable;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NonNull;
 
 /**
  * A retry policy that implements exponential backoff based around functions that operate on the
@@ -110,5 +112,20 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
             Thread.currentThread().interrupt();
             return false;
         }
+    }
+
+    public static StatusCodeAndExceptionRetry getDefaultRetryPolicy(@NonNull final String tag) {
+        return StatusCodeAndExceptionRetry.builder()
+                .number(1)
+                .isRetryableException(e -> {
+                    if (e instanceof ClientException
+                            && ((ClientException) e).getErrorCode().equals(ClientException.IO_ERROR)
+                            && !(e.getCause() instanceof SocketTimeoutException)) {
+                        Logger.info(tag + ":getRetryPolicy", "Retrying due to exception: " + e);
+                        return Boolean.TRUE;
+                    }
+                    return Boolean.FALSE;
+                })
+                .build();
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
@@ -114,6 +114,12 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
         }
     }
 
+    /**
+     * Creates a default retry policy that retries once on IO errors, except timeouts.
+     *
+     * @param tag The logging tag for tracing retry attempts
+     * @return A configured {@link StatusCodeAndExceptionRetry} instance
+     */
     public static StatusCodeAndExceptionRetry getDefaultRetryPolicy(@NonNull final String tag) {
         return StatusCodeAndExceptionRetry.builder()
                 .number(1)

--- a/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
@@ -115,19 +115,25 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
     }
 
     /**
-     * Creates a default retry policy that retries once on IO errors, except timeouts.
+     * Creates a retry policy that retries on IO exceptions only.
+     * <p>
+     * This policy retries ONLY on {@link ClientException#IO_ERROR} exceptions
+     * (excluding {@link SocketTimeoutException}).
+     * <p>
+     * Use this for scenarios where you want IO-error-specific retry logic.
+     * For the library's standard retry behavior, use {@link UrlConnectionHttpClient#getDefaultInstance()}.
      *
      * @param tag The logging tag for tracing retry attempts
-     * @return A configured {@link StatusCodeAndExceptionRetry} instance
+     * @return A configured {@link StatusCodeAndExceptionRetry} instance for IO errors only
      */
-    public static StatusCodeAndExceptionRetry getDefaultRetryPolicy(@NonNull final String tag) {
+    public static StatusCodeAndExceptionRetry getIOExceptionRetryPolicy(@NonNull final String tag) {
         return StatusCodeAndExceptionRetry.builder()
                 .number(1)
                 .isRetryableException(e -> {
                     if (e instanceof ClientException
                             && ((ClientException) e).getErrorCode().equals(ClientException.IO_ERROR)
                             && !(e.getCause() instanceof SocketTimeoutException)) {
-                        Logger.info(tag + ":getRetryPolicy", "Retrying due to exception: " + e);
+                        Logger.info(tag + ":getIOExceptionRetryPolicy", "Retrying due to exception: " + e);
                         return Boolean.TRUE;
                     }
                     return Boolean.FALSE;

--- a/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.common.java.net;
 
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.ported.Function;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
@@ -130,6 +132,10 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
         return StatusCodeAndExceptionRetry.builder()
                 .number(1)
                 .isRetryableException(e -> {
+                    SpanExtension.current().setAttribute(
+                            AttributeName.network_retry_operation.name(),
+                            tag
+                    );
                     if (e instanceof ClientException
                             && ((ClientException) e).getErrorCode().equals(ClientException.IO_ERROR)
                             && !(e.getCause() instanceof SocketTimeoutException)) {

--- a/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/StatusCodeAndExceptionRetry.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.java.net;
 
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.logging.Logger;
-import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.ported.Function;
 import net.jcip.annotations.Immutable;
@@ -32,6 +31,9 @@ import net.jcip.annotations.ThreadSafe;
 
 import java.net.SocketTimeoutException;
 import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,9 +58,9 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
         }
     };
     @Builder.Default
-    private final Function<HttpResponse, Boolean> isRetryable = new Function<HttpResponse, Boolean>() {
+    private final BiFunction<HttpResponse, Integer, Boolean> isRetryable = new BiFunction<HttpResponse, Integer, Boolean>() {
         @Override
-        public Boolean apply(HttpResponse input) {
+        public Boolean apply(HttpResponse input, Integer attemptNumber) {
             return Boolean.FALSE;
         }
     };
@@ -84,7 +86,7 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
             try {
                 HttpResponse response = supplier.call();
                 //If there are no retries left, or the response is acceptable, or it is not retryable.
-                if (attemptNumber <= 0 || isAcceptable.apply(response) || !isRetryable.apply(response)) {
+                if (attemptNumber <= 0 || isAcceptable.apply(response) || !isRetryable.apply(response, attemptNumber)) {
                     return response;
                 }
             } catch (final Exception e) {
@@ -122,20 +124,38 @@ public class StatusCodeAndExceptionRetry implements IRetryPolicy<HttpResponse> {
      * This policy retries ONLY on {@link ClientException#IO_ERROR} exceptions
      * (excluding {@link SocketTimeoutException}).
      * <p>
+     * The {@code numberOfRetries} parameter controls how many retry attempts will be made
+     * after the initial attempt fails. For example:
+     * <ul>
+     *     <li>{@code numberOfRetries = 0}: 1 total attempt (no retries)</li>
+     *     <li>{@code numberOfRetries = 1}: 2 total attempts (1 original + 1 retry)</li>
+     *     <li>{@code numberOfRetries = 2}: 3 total attempts (1 original + 2 retries)</li>
+     * </ul>
+     * <p>
      * Use this for scenarios where you want IO-error-specific retry logic.
      * For the library's standard retry behavior, use {@link UrlConnectionHttpClient#getDefaultInstance()}.
      *
      * @param tag The logging tag for tracing retry attempts
+     * @param numberOfRetries The number of retry attempts after the initial attempt (must be non-negative)
      * @return A configured {@link StatusCodeAndExceptionRetry} instance for IO errors only
+     * @throws IllegalArgumentException if numberOfRetries is negative
      */
-    public static StatusCodeAndExceptionRetry getIOExceptionRetryPolicy(@NonNull final String tag) {
+    public static StatusCodeAndExceptionRetry getIOExceptionRetryPolicy(
+            @NonNull final String tag,
+            final int numberOfRetries,
+            @Nullable String attributeNameForRetry) {
+        if (numberOfRetries < 0) {
+            throw new IllegalArgumentException("numberOfRetries must be non-negative, got: " + numberOfRetries);
+        }
         return StatusCodeAndExceptionRetry.builder()
-                .number(1)
+                .number(numberOfRetries)
                 .isRetryableException(e -> {
-                    SpanExtension.current().setAttribute(
-                            AttributeName.network_retry_operation.name(),
-                            tag
-                    );
+                    if (attributeNameForRetry != null) {
+                        SpanExtension.current().setAttribute(
+                                attributeNameForRetry,
+                                numberOfRetries
+                        );
+                    }
                     if (e instanceof ClientException
                             && ((ClientException) e).getErrorCode().equals(ClientException.IO_ERROR)
                             && !(e.getCause() instanceof SocketTimeoutException)) {

--- a/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/net/UrlConnectionHttpClient.java
@@ -48,30 +48,24 @@ import net.jcip.annotations.ThreadSafe;
 
 import java.io.BufferedReader;
 import java.io.Closeable;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.NoRouteToHostException;
-import java.net.ProtocolException;
-import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocketFactory;
 
 import io.opentelemetry.api.trace.Span;
@@ -197,8 +191,8 @@ public class UrlConnectionHttpClient extends AbstractHttpClient {
                                 }
                             })
                             .initialDelay(RETRY_TIME_WAITING_PERIOD_MSEC)
-                            .isRetryable(new Function<HttpResponse, Boolean>() {
-                                public Boolean apply(HttpResponse response) {
+                            .isRetryable(new BiFunction<HttpResponse,Integer, Boolean>() {
+                                public Boolean apply(HttpResponse response, Integer attemptNumber) {
                                     return response != null && isRetryableError(response.getStatusCode());
                                 }
                             })

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -548,6 +548,10 @@ public enum AttributeName {
     /**
      * Indicates if the redirect URL in webview is opened in browser.
      */
-    is_redirect_url_opened_in_browser;
+    is_redirect_url_opened_in_browser,
 
+    /**
+     * Indicates the operation that is being retried in a retry policy.
+     */
+    network_retry_operation,
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -526,9 +526,14 @@ public enum AttributeName {
     is_redirect_url_opened_in_browser,
 
     /**
-     * Indicates the operation that is being retried in a retry policy.
+     * Indicates the number of retry attempts made in DRS discovery when the retry policy is enabled.
      */
-    network_retry_operation,
+    drs_discovery_retry_number,
+
+    /**
+     * Indicates the number of retry attempts made in TLS connection when the retry policy is enabled.
+     */
+    client_tls_retry_number,
 
     //region KeyPair generation
 


### PR DESCRIPTION
This pull request introduces a new set of unit tests for the `UrlConnectionHttpClient` class and adds a Robolectric shadow (`ShadowUrlConnectionHttpClient`) to enable flexible and deterministic testing of network behaviors. It also provides a convenient static method for obtaining a default retry policy in the `StatusCodeAndExceptionRetry` class. These changes improve test coverage, reliability, and maintainability of the HTTP client code.


[AB#3318506](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3318506)