### PR TITLE
Add handling for AssumptionViolatedException in RetryTestRule to skip tests without retrying, Fixes AB#3505565

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/rules/RetryTestRule.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.powerlift.IPowerLiftIntegratedApp;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -82,6 +83,10 @@ public class RetryTestRule implements TestRule {
                         base.evaluate();
                         Logger.i(TAG, "Attempt #" + (i + 1) + " has succeeded!!");
                         return;
+                    } catch (final AssumptionViolatedException assumptionException) {
+                        // Test assumptions not met - skip the test without retrying
+                        Logger.i(TAG, "Test " + description.getMethodName() + " skipped due to assumption violation: " + assumptionException.getMessage());
+                        throw assumptionException;
                     } catch (final Throwable throwable) {
                         caughtThrowable = throwable;
                         Logger.e(TAG, description.getMethodName() + ": Attempt " + (i + 1) +


### PR DESCRIPTION
This pull request makes a targeted improvement to the `RetryTestRule` by ensuring that tests skipped due to failed assumptions are not retried. Instead, these tests are logged as skipped and immediately exited, which aligns with JUnit's expected behavior for assumption violations.

Why now?
In tests where the supported broker has Powerlift capabilities, AssumptionViolatedException is masked as ThrowableWithPowerLiftIncident.

[AB#3505565](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3505565)]

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1591956&view=ms.vss-test-web.build-test-results-tab&runId=5608463&resultId=100002&paneView=debug