### PR TITLE
Add PPE origin validation and tests for debug builds in PasskeyOriginRulesManager, Fixes AB#3516248

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManager.kt
@@ -100,8 +100,13 @@ object PasskeyOriginRulesManager {
             val host = uri.host ?: return false
             val origin = "https://$host".lowercase()
 
+            // Check if it's a PPE origin (only in debug builds)
+            if (BuildConfig.DEBUG && ALLOWED_ORIGIN_PPE.contains(origin)) {
+                return true
+            }
+
             // Check if it's a production origin (any path allowed)
-            if (getAllowedOriginRules().contains(origin)){
+            if (PRODUCTION_ORIGINS.contains(origin)){
                 return true
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManager.kt
@@ -101,7 +101,7 @@ object PasskeyOriginRulesManager {
             val origin = "https://$host".lowercase()
 
             // Check if it's a production origin (any path allowed)
-            if (PRODUCTION_ORIGINS.contains(origin)){
+            if (getAllowedOriginRules().contains(origin)){
                 return true
             }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -194,7 +194,7 @@ class PasskeyReplyChannel(
                 span.setAttribute(AttributeName.passkey_dom_exception_name.name, errorMessage.domExceptionName)
                 span.setStatus(StatusCode.ERROR)
                 span.recordException(throwable)
-                Logger.error(methodTag, "RequestType: $requestType failed with error: $errorMessage", null)
+                Logger.error(methodTag, "RequestType: $requestType failed with error: $errorMessage", throwable)
             }
         } catch (unexpectedException: Throwable) {
             span.setStatus(StatusCode.ERROR)

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManagerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyOriginRulesManagerTest.kt
@@ -253,6 +253,66 @@ class PasskeyOriginRulesManagerTest {
         assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://signin.microsoft.com"))
     }
 
+    // ==================== PPE Origins Tests (DEBUG builds only) ====================
+
+    @Test
+    fun `isAllowedOrigin returns true for account live-int com in DEBUG build`() {
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://account.live-int.com"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://account.live-int.com/"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://account.live-int.com/page/webauthn"))
+    }
+
+    @Test
+    fun `isAllowedOrigin returns true for login windows-ppe net in DEBUG build`() {
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows-ppe.net"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows-ppe.net/"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows-ppe.net/common/oauth2/authorize"))
+    }
+
+    @Test
+    fun `isAllowedOrigin returns true for mysignins-ppe microsoft com in DEBUG build`() {
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://mysignins-ppe.microsoft.com"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://mysignins-ppe.microsoft.com/"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://mysignins-ppe.microsoft.com/auth/passkey"))
+    }
+
+    @Test
+    fun `isAllowedOrigin is case insensitive for PPE origins`() {
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HTTPS://account.live-int.com"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://ACCOUNT.LIVE-INT.COM"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HtTpS://Account.Live-Int.Com"))
+
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HTTPS://login.windows-ppe.net"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://LOGIN.WINDOWS-PPE.NET"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HtTpS://Login.Windows-Ppe.Net"))
+
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HTTPS://mysignins-ppe.microsoft.com"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("https://MYSIGNINS-PPE.MICROSOFT.COM"))
+        assertTrue(PasskeyOriginRulesManager.isAllowedOrigin("HtTpS://MySignins-Ppe.Microsoft.Com"))
+    }
+
+    @Test
+    fun `isAllowedOrigin returns false for PPE subdomain spoofing`() {
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://account.live-int.com.evil.com"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows-ppe.net.attacker.io"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://mysignins-ppe.microsoft.com.fake.net"))
+    }
+
+    @Test
+    fun `isAllowedOrigin returns false for PPE prefix attack`() {
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://fake.account.live-int.com"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://evil.login.windows-ppe.net"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://malicious.mysignins-ppe.microsoft.com"))
+    }
+
+    @Test
+    fun `isAllowedOrigin returns false for similar but different PPE hosts`() {
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://accounts.live-int.com"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows.net"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://login.windows-ppe.com"))
+        assertFalse(PasskeyOriginRulesManager.isAllowedOrigin("https://mysignins-prod.microsoft.com"))
+    }
+
     // ==================== Edge Cases ====================
 
     @Test
@@ -297,9 +357,19 @@ class PasskeyOriginRulesManagerTest {
     }
 
     @Test
+    fun `getAllowedOriginRules contains all required PPE origins in DEBUG build`() {
+        val rules = PasskeyOriginRulesManager.getAllowedOriginRules()
+        assertTrue(rules.contains("https://account.live-int.com"))
+        assertTrue(rules.contains("https://login.windows-ppe.net"))
+        assertTrue(rules.contains("https://mysignins-ppe.microsoft.com"))
+    }
+
+    @Test
     fun `getAllowedOriginRules returns non-empty set`() {
         val rules = PasskeyOriginRulesManager.getAllowedOriginRules()
         assertTrue(rules.isNotEmpty())
-        assertTrue(rules.size >= 12) // At least production + sovereign cloud origins
+        // In DEBUG: 6 production + 6 sovereign cloud + 3 PPE = 15 origins
+        // In RELEASE: 6 production + 6 sovereign cloud = 12 origins
+        assertTrue(rules.size >= 12)
     }
 }


### PR DESCRIPTION
* PPE origins are now allowed in debug builds by updating the logic in `PasskeyOriginRulesManager`. This ensures that pre-production environments are only permitted during development and testing, not in production releases.
* Extensive new tests were added to `PasskeyOriginRulesManagerTest` to verify that PPE origins are accepted in debug builds, that the check is case-insensitive, and that common spoofing and prefix attacks are not allowed.
* A new test ensures that `getAllowedOriginRules()` includes all required PPE origins in debug builds, and the minimum expected origin count is updated to account for PPE origins.

**Error Logging Improvement:**

* The `Logger.error` call in `PasskeyReplyChannel` now includes the throwable object, providing more detailed error information for debugging.
[AB#3516248](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3516248)