### PR TITLE
Fixes AB#3520044 Add telemetry to measure the time taken to write to SharedPreferences + telemetry cleanup

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -316,7 +316,6 @@ public class BrokerOAuth2TokenCache
     private List<ICacheRecord> loadAggregatedAccountData(final @NonNull AbstractAuthenticationScheme authScheme,
                                                          final @NonNull ICacheRecord cacheRecord) {
         final String methodName = ":loadAggregatedAccountData";
-        final long loadStartTime = System.currentTimeMillis();
         final long loadStartTimeInNanos = System.nanoTime();
 
         final String clientId = cacheRecord.getAccessToken().getClientId();
@@ -346,9 +345,7 @@ public class BrokerOAuth2TokenCache
                 cacheRecord.getAccount(),
                 authScheme
         );
-        OTelUtility.recordElapsedTime(AttributeName.elapsed_time_load_aggregated_account_data.name(),
-                loadStartTime);
-        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_load_aggregated_account_data_using_nanos.name(),
+        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_load_aggregated_account_data.name(),
                 loadStartTimeInNanos);
         return cacheRecordList;
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCache.java
@@ -317,7 +317,6 @@ public class BrokerOAuth2TokenCache
                                                          final @NonNull ICacheRecord cacheRecord) {
         final String methodName = ":loadAggregatedAccountData";
         final long loadStartTimeInNanos = System.nanoTime();
-
         final String clientId = cacheRecord.getAccessToken().getClientId();
         final String target = cacheRecord.getAccessToken().getTarget();
         final String environment = cacheRecord.getAccessToken().getEnvironment();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/BrokerOAuth2TokenCacheTelemetryWrapper.java
@@ -203,18 +203,11 @@ public class BrokerOAuth2TokenCacheTelemetryWrapper
 
     @Override
     public AccountRecord getAccountByLocalAccountId(String environment, String clientId, String localAccountId) {
-        final long startTime = System.currentTimeMillis();
         final long startTimeInNanos = System.nanoTime();
         try {
             return mCacheToWrap.getAccountByLocalAccountId(environment, clientId, localAccountId);
         } finally {
-            final long endTime = System.currentTimeMillis();
-            final long elapsedTime = endTime - startTime;
-            SpanExtension.current().setAttribute(
-                    AttributeName.elapsed_time_cache_get_account_by_local_account_id.name(),
-                    elapsedTime
-            );
-            OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_cache_get_account_by_local_account_id_using_nanos.name(),
+            OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_cache_get_account_by_local_account_id.name(),
                     startTimeInNanos);
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -141,7 +141,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             }
 
             final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
+            final long sharedPreferencesSaveStartTime = System.nanoTime();
             mSharedPreferencesFileManager.put(cacheKey, cacheValue);
+            OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_save_account_shared_preferences.name(), sharedPreferencesSaveStartTime);
             mCachedAccountRecordsWithKeys.put(cacheKey, accountToSave);
         }
     }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -207,14 +207,14 @@ public enum AttributeName {
     elapsed_time_cache_get_account_by_local_account_id,
 
     /**
-     * The time (in milliseconds), calculated using nanos, spent in executing the getAccountByLocalAccountId method in OAuth2TokenCache.
-     */
-    elapsed_time_cache_get_account_by_local_account_id_using_nanos,
-
-    /**
      * The time (in milliseconds) spent in executing the getAccountWithAggregatedAccountDataByLocalAccountId method in OAuth2TokenCache.
      */
     elapsed_time_cache_get_account_with_aggregated_account_data_by_local_account_id,
+
+    /**
+     * The time (in milliseconds) spent in saving account data to Shared Preferences.
+     */
+    elapsed_time_save_account_shared_preferences,
 
     /**
      * The time (in milliseconds) spent in executing the getAccounts method in OAuth2TokenCache.
@@ -265,11 +265,6 @@ public enum AttributeName {
      * The time (in milliseconds) spent on network when acquiring AT.
      */
     elapsed_time_network_acquire_at,
-
-    /**
-     * The time (in milliseconds), calculated using nanos, spent on network when acquiring AT.
-     */
-    elapsed_time_network_acquire_at_using_nanos,
 
     /**
      * The broker operation name.
@@ -509,11 +504,6 @@ public enum AttributeName {
      *  Elapsed time (in milliseconds) spent in executing the loadAggregatedAccountData() method in BrokerOAuth2TokenCache.
      */
     elapsed_time_load_aggregated_account_data,
-
-    /**
-     *  Elapsed time (in milliseconds), calculated using nanos, spent in executing the loadAggregatedAccountData() method in BrokerOAuth2TokenCache.
-     */
-    elapsed_time_load_aggregated_account_data_using_nanos,
 
     /**
      * Indicates if account aggregation is skipped during saveTokenResult() call.

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/OAuth2Strategy.java
@@ -256,17 +256,13 @@ public abstract class OAuth2Strategy
         }
 
         final URL requestUrl = new URL(getTokenEndpoint());
-        final long networkStartTime = System.currentTimeMillis();
         final long networkStartTimeInNanos = System.nanoTime();
         final HttpResponse response = httpClient.post(
                 requestUrl,
                 headers,
                 requestBody.getBytes(ObjectMapper.ENCODING_SCHEME)
         );
-        final long networkEndTime = System.currentTimeMillis();
-        final long networkTime = networkEndTime - networkStartTime;
-        SpanExtension.current().setAttribute(AttributeName.elapsed_time_network_acquire_at.name(), networkTime);
-        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_network_acquire_at_using_nanos.name(),
+        OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_network_acquire_at.name(),
                 networkStartTimeInNanos);
 
         // Record the clock skew between *this device* and EVO...


### PR DESCRIPTION
Fixes [AB#3520044](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3520044)
This PR takes care of two telemetry related work items 
1. Add telemetry to measure the time taken to write to SharedPreferences
2. Cleanup extra telemetry attributes added last month to compare time calculated using nanos vs milliseconds