### PR TITLE
Add flight thread pool size based on CPU count for Silent Broker Token request, Fixes AB#3520568

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ vNext
 - [MAJOR] add isBrokerProcess to IPlatformUtil (#2882)
 - [MINOR] Remove OpenTelemetry from keep rules (#2881)
 - [MINOR] Adding ExtraQueryStringParametersForWebApps (#2891)
+- [MINOR] Added flight-controlled option to enable Broker CommandDispatcher silent thread pool size based on processor count and default to 12 threads.
 
 Version 23.3.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ vNext
 - [MAJOR] add isBrokerProcess to IPlatformUtil (#2882)
 - [MINOR] Remove OpenTelemetry from keep rules (#2881)
 - [MINOR] Adding ExtraQueryStringParametersForWebApps (#2891)
-- [MINOR] Added flight-controlled option to enable Broker CommandDispatcher silent thread pool size based on processor count and default to 12 threads.
+- [MINOR] Added flight-controlled option to enable Broker CommandDispatcher silent thread pool size based on processor count and default to 12 threads (#2897)
 
 Version 23.3.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -112,7 +112,7 @@ public class CommandDispatcherTest {
     private static final long TASK_STABILIZATION_DELAY_MS = 100;
 
     /** Thread pool size for silent requests (matches CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE) */
-    private static final int SILENT_THREAD_POOL_SIZE = 5;
+    private static final int SILENT_THREAD_POOL_SIZE = 12;
 
     /** Number of concurrent requests for state collision test */
     private static final int CONCURRENT_REQUEST_COUNT = 20;

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -106,8 +106,10 @@ public class CommandDispatcher {
     private static final int DCF_REQUEST_THREAD_POOL_SIZE = 5;
     private static final int EXECUTOR_GRACEFUL_TERMINATION_TIMEOUT_MS = 500;
     private static final int EXECUTOR_FORCED_TERMINATION_TIMEOUT_MS = 1000;
+    // Cache the pool size for the session
+    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = computeSilentRequestThreadPoolSize();
     private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
-    private static ExecutorService sSilentExecutor = Executors.newFixedThreadPool(getSilentRequestThreadPoolSize());
+    private static ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final ExecutorService sDCFExecutor = Executors.newFixedThreadPool(DCF_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
@@ -162,15 +164,25 @@ public class CommandDispatcher {
     private static final String TIMEOUT_MSG_UNKNOWN_STATE = 
         "Unknown state '%s'.";
 
-    // Get the actual default pool size from flight configuration
-    private static int getSilentRequestThreadPoolSize() {
+    // Compute the thread pool size based on flight configuration
+    private static int computeSilentRequestThreadPoolSize() {
         if (CommonFlightsManager.INSTANCE.getFlightsProvider() != null) {
             boolean useIncreasedPoolSize = CommonFlightsManager.INSTANCE.getFlightsProvider()
                     .getBooleanValue(CommonFlight.USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE);
             return useIncreasedPoolSize ? DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE
                     : LEGACY_SILENT_REQUEST_THREAD_POOL_SIZE;
         }
-        return DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE;
+        return LEGACY_SILENT_REQUEST_THREAD_POOL_SIZE;
+    }
+
+    /**
+     * Returns the cached thread pool size for silent requests.
+     * This value is computed once during class initialization based on flight configuration.
+     *
+     * @return the cached pool size for the session
+     */
+    private static int getSilentRequestThreadPoolSize() {
+        return SILENT_REQUEST_THREAD_POOL_SIZE;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -580,13 +580,6 @@ public class CommandDispatcher {
                     getSilentExecutorPoolSize()
             );
 
-            boolean isIncreasedDefaultSilentRequestPoolSize = CommonFlightsManager.INSTANCE.getFlightsProvider()
-                    .getBooleanValue(CommonFlight.USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE);
-            SpanExtension.current().setAttribute(
-                    AttributeName.flight_increased_default_silent_request_pool_size.name(),
-                    isIncreasedDefaultSilentRequestPoolSize
-            );
-
             commandExecutor.execute(OtelContextExtension.wrap(new Runnable() {
                 @Override
                 public void run() {

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -88,6 +88,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -98,8 +99,9 @@ import lombok.NonNull;
 public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
-    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 5;
-    private static final int SILENT_REQUEST_THREAD_POOL_SIZE_EXPANDED = 8;
+    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 12;
+    // CPU core count is used as a reference for sizing SilentRequestThreadPool.
+    private static final int CPU_CORE_COUNT = Runtime.getRuntime().availableProcessors();
     private static final int DCF_REQUEST_THREAD_POOL_SIZE = 5;
     private static final int EXECUTOR_GRACEFUL_TERMINATION_TIMEOUT_MS = 500;
     private static final int EXECUTOR_FORCED_TERMINATION_TIMEOUT_MS = 1000;
@@ -1089,14 +1091,14 @@ public class CommandDispatcher {
     }
 
     /**
-     * Initializes the silent executor with expanded thread pool size (8 threads).
+     * Initializes the silent executor with expanded thread pool size based on Processor count.
      * <p>
      * This method should ONLY be called by Broker during its initialization phase
      * when the flight check determines that expanded pool is enabled.
      * MSAL client apps should NOT call this method - they will use the default pool size.
      * </p>
      * <p>
-     * This enables Broker to handle more concurrent silent token requests (8 vs 5 threads)
+     * This enables Broker to handle more concurrent silent token requests (12 vs CPU count based on flight)
      * without affecting MSAL client apps which run in separate processes.
      * </p>
      *
@@ -1115,8 +1117,8 @@ public class CommandDispatcher {
             );
         }
 
-        Logger.info(methodTag, "Expanding silent thread pool size for Broker to " + SILENT_REQUEST_THREAD_POOL_SIZE_EXPANDED);
-        resetSilentRequestExecutorWithSize(SILENT_REQUEST_THREAD_POOL_SIZE_EXPANDED);
+        Logger.info(methodTag, "Expanding silent thread pool size for Broker to core pool size " + CPU_CORE_COUNT + ", based on processor count.");
+        resetSilentRequestExecutorWithSize(CPU_CORE_COUNT);
     }
 
 
@@ -1150,7 +1152,12 @@ public class CommandDispatcher {
         final ExecutorService oldExecutor;
         synchronized (mapAccessLock) {
             oldExecutor = sSilentExecutor;
-            sSilentExecutor = Executors.newFixedThreadPool(effectivePoolSize);
+            sSilentExecutor = new ThreadPoolExecutor(
+                    poolSize, // core pool size
+                    poolSize*2, // max pool size
+                    30L, // keep-alive time for idle threads above core pool size
+                    TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>());
             Logger.info(methodTag, "Swapped to new executor with " + effectivePoolSize + " threads");
             sExecutingCommandMap.clear();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -1153,11 +1153,11 @@ public class CommandDispatcher {
         synchronized (mapAccessLock) {
             oldExecutor = sSilentExecutor;
             sSilentExecutor = new ThreadPoolExecutor(
-                    poolSize, // core pool size
-                    poolSize*2, // max pool size
+                    effectivePoolSize, // core pool size
+                    effectivePoolSize*2, // max pool size
                     30L, // keep-alive time for idle threads above core pool size
                     TimeUnit.SECONDS,
-                    new LinkedBlockingQueue<>());
+                    new LinkedBlockingQueue<Runnable>(effectivePoolSize));
             Logger.info(methodTag, "Swapped to new executor with " + effectivePoolSize + " threads");
             sExecutingCommandMap.clear();
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -99,14 +99,15 @@ import lombok.NonNull;
 public class CommandDispatcher {
 
     private static final String TAG = CommandDispatcher.class.getSimpleName();
-    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = 12;
+    private static final int DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE = 12;
+    private static final int LEGACY_SILENT_REQUEST_THREAD_POOL_SIZE = 5;
     // CPU core count is used as a reference for sizing SilentRequestThreadPool.
     private static final int CPU_CORE_COUNT = Runtime.getRuntime().availableProcessors();
     private static final int DCF_REQUEST_THREAD_POOL_SIZE = 5;
     private static final int EXECUTOR_GRACEFUL_TERMINATION_TIMEOUT_MS = 500;
     private static final int EXECUTOR_FORCED_TERMINATION_TIMEOUT_MS = 1000;
     private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
-    private static ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
+    private static ExecutorService sSilentExecutor = Executors.newFixedThreadPool(getSilentRequestThreadPoolSize());
     private static final ExecutorService sDCFExecutor = Executors.newFixedThreadPool(DCF_REQUEST_THREAD_POOL_SIZE);
     private static final Object sLock = new Object();
     private static InteractiveTokenCommand sCommand = null;
@@ -161,6 +162,17 @@ public class CommandDispatcher {
     private static final String TIMEOUT_MSG_UNKNOWN_STATE = 
         "Unknown state '%s'.";
 
+    // Get the actual default pool size from flight configuration
+    private static int getSilentRequestThreadPoolSize() {
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider() != null) {
+            boolean useIncreasedPoolSize = CommonFlightsManager.INSTANCE.getFlightsProvider()
+                    .getBooleanValue(CommonFlight.USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE);
+            return useIncreasedPoolSize ? DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE
+                    : LEGACY_SILENT_REQUEST_THREAD_POOL_SIZE;
+        }
+        return DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE;
+    }
+
     /**
      * Returns the approximate number of threads that are actively
      * executing tasks in the silent request thread pool.
@@ -185,7 +197,7 @@ public class CommandDispatcher {
      * @return the default pool size constant
      */
     public static int getDefaultSilentExecutorPoolSize() {
-        return SILENT_REQUEST_THREAD_POOL_SIZE;
+        return getSilentRequestThreadPoolSize();
     }
 
     /**
@@ -239,7 +251,7 @@ public class CommandDispatcher {
         sInteractiveExecutor.shutdownNow();
         Field f = CommandDispatcher.class.getDeclaredField("sSilentExecutor");
         f.setAccessible(true);
-        f.set(null, Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE));
+        f.set(null, Executors.newFixedThreadPool(getSilentRequestThreadPoolSize()));
         f.setAccessible(false);
 
         f = CommandDispatcher.class.getDeclaredField("sInteractiveExecutor");
@@ -264,7 +276,7 @@ public class CommandDispatcher {
             final int queueSize) {
         return String.format(
             "Timeout in %s: %s [ActiveThreads=%d, QueueSize=%d, PoolSize=%d]",
-            location, message, activeThreads, queueSize, SILENT_REQUEST_THREAD_POOL_SIZE);
+            location, message, activeThreads, queueSize, getSilentRequestThreadPoolSize());
     }
 
     /**
@@ -307,7 +319,7 @@ public class CommandDispatcher {
                     break;
                 case QUEUED:
                     // All threads busy AND requests queued = Pool completely saturated
-                    if (activeThreads >= SILENT_REQUEST_THREAD_POOL_SIZE && queueSize > 0) {
+                    if (activeThreads >= getSilentRequestThreadPoolSize() && queueSize > 0) {
                         errorCode = ClientException.TIMED_OUT_THREAD_POOL_SATURATED;
                         reasonMessage = String.format(TIMEOUT_MSG_THREAD_POOL_SATURATED, activeThreads, queueSize);
                     } else {
@@ -554,6 +566,13 @@ public class CommandDispatcher {
             SpanExtension.current().setAttribute(
                     AttributeName.silent_executor_pool_size.name(),
                     getSilentExecutorPoolSize()
+            );
+
+            boolean isIncreasedDefaultSilentRequestPoolSize = CommonFlightsManager.INSTANCE.getFlightsProvider()
+                    .getBooleanValue(CommonFlight.USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE);
+            SpanExtension.current().setAttribute(
+                    AttributeName.flight_increased_default_silent_request_pool_size.name(),
+                    isIncreasedDefaultSilentRequestPoolSize
             );
 
             commandExecutor.execute(OtelContextExtension.wrap(new Runnable() {
@@ -1139,8 +1158,9 @@ public class CommandDispatcher {
 
         final int effectivePoolSize;
         if (poolSize <= 0) {
-            Logger.error(methodTag, "Invalid poolSize: " + poolSize + ". Using default: " + SILENT_REQUEST_THREAD_POOL_SIZE, null);
-            effectivePoolSize = SILENT_REQUEST_THREAD_POOL_SIZE;
+            final int defaultPoolSize = getSilentRequestThreadPoolSize();
+            Logger.error(methodTag, "Invalid poolSize: " + poolSize + ". Using default: " + defaultPoolSize, null);
+            effectivePoolSize = defaultPoolSize;
         } else {
             effectivePoolSize = poolSize;
         }
@@ -1230,7 +1250,7 @@ public class CommandDispatcher {
      * This should be called if previously the Executor was stopped using 'stopSilentRequestExecutor'
      */
     public static void resetSilentRequestExecutor() {
-        resetSilentRequestExecutorWithSize(SILENT_REQUEST_THREAD_POOL_SIZE);
+        resetSilentRequestExecutorWithSize(getSilentRequestThreadPoolSize());
     }
 }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -206,7 +206,12 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable the use of locks in name value storage to prevent concurrent access issues.
      */
-    USE_LOCKS_IN_NAME_VALUE_STORAGE("UseLocksInNameValueStorage", false);
+    USE_LOCKS_IN_NAME_VALUE_STORAGE("UseLocksInNameValueStorage", false),
+    /**
+     * Flight to enable increased thread pool size for silent requests.
+     * When true, uses 12 threads. When false, uses legacy 5 threads.
+     */
+    USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -211,7 +211,7 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable increased thread pool size for silent requests.
      * When true, uses 12 threads. When false, uses legacy 5 threads.
      */
-    USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", true);
+    USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -161,8 +161,6 @@ public enum AttributeName {
      */
     silent_executor_pool_size,
 
-    flight_increased_default_silent_request_pool_size,
-
     /**
      * The time (in milliseconds) spent in executing the save method in OAuth2TokenCache.
      */

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -161,6 +161,8 @@ public enum AttributeName {
      */
     silent_executor_pool_size,
 
+    flight_increased_default_silent_request_pool_size,
+
     /**
      * The time (in milliseconds) spent in executing the save method in OAuth2TokenCache.
      */


### PR DESCRIPTION
[AB#3520568](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3520568)
1.  Implements [AB#3520568](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3520568)
2. Updated default thread pool size to 12. Reason, WXP client uses 12 thread pool count and also android Binder IPC thread pool size is 16. Therefore, for better performance default thread count increased to 12.
3. Also, added logic to enable dynamic thread pool size based on device processor count with ThreadpoolExecutor supported core thread pool size and maximum pool size. This protected behind flight controlled from broker.