### PR TITLE
Ignore setShouldTrustDebugBrokers if is not a Debug build, Fixes AB#3515110

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -93,9 +93,10 @@ data class BrokerData(
                 sShouldTrustDebugBrokers = value
                 Logger.info(methodTag, "Setting shouldTrustDebugBrokers to $value." +
                         " This should only be used for testing purposes.")
+            } else {
+                Logger.warn(methodTag, "Attempting to set shouldTrustDebugBrokers to $value. " +
+                        "This change will be ignored since the current build is not a debug build.")
             }
-            Logger.warn(methodTag, "Attempting to set shouldTrustDebugBrokers to $value. " +
-                    "This change will be ignored since the current build is not a debug build.")
         }
 
         @JvmStatic

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -89,10 +89,8 @@ data class BrokerData(
         @JvmStatic
         fun setShouldTrustDebugBrokers(value: Boolean) {
             val methodTag = "$TAG:setShouldTrustDebugBrokers"
-            if (!BuildConfig.DEBUG && value) {
-                Logger.warn(methodTag, "You are forcing to trust debug brokers in non-debug builds.")
-            }
-            sShouldTrustDebugBrokers = value
+            Logger.warn(methodTag, "Ignoring the value of $value for shouldTrustDebugBrokers. " +
+                    "This value is determined by BuildConfig and cannot be overridden at runtime.")
         }
 
         @JvmStatic

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -89,8 +89,13 @@ data class BrokerData(
         @JvmStatic
         fun setShouldTrustDebugBrokers(value: Boolean) {
             val methodTag = "$TAG:setShouldTrustDebugBrokers"
-            Logger.warn(methodTag, "Ignoring the value of $value for shouldTrustDebugBrokers. " +
-                    "This value is determined by BuildConfig and cannot be overridden at runtime.")
+            if (BuildConfig.DEBUG) {
+                sShouldTrustDebugBrokers = value
+                Logger.info(methodTag, "Setting shouldTrustDebugBrokers to $value." +
+                        " This should only be used for testing purposes.")
+            }
+            Logger.warn(methodTag, "Attempting to set shouldTrustDebugBrokers to $value. " +
+                    "This change will be ignored since the current build is not a debug build.")
         }
 
         @JvmStatic


### PR DESCRIPTION
This pull request updates the logic for setting the `shouldTrustDebugBrokers` flag in `BrokerData.kt` to ensure it can only be modified in debug builds, and improves logging to clarify when the setting is ignored.

[AB#3515110](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3515110)
