### PR TITLE
Support tracking loaded urls in authorization fragment, Fixes AB#3494119

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add tracking for urls loaded by our webvie (#2892)
 - [MINOR] Rework OpenTelemetry spans for secret key generation and retrieval operations (#2869)
 - [MAJOR] add isBrokerProcess to IPlatformUtil (#2882)
 - [MINOR] Remove OpenTelemetry from keep rules (#2881)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add tracking for urls loaded by our webvie (#2892)
+- [MINOR] Add tracking for urls loaded by our webview (#2892)
 - [MINOR] Rework OpenTelemetry spans for secret key generation and retrieval operations (#2869)
 - [MAJOR] add isBrokerProcess to IPlatformUtil (#2882)
 - [MINOR] Remove OpenTelemetry from keep rules (#2881)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1283,6 +1283,11 @@ public final class AuthenticationConstants {
         public static final String AAD_INTUNE_MDM_URL_HOST_SUFFIX = ".microsoft.com";
 
         /**
+         * Suffix for MSA urls
+         */
+        public static final String MSA_URL_HOST_SUFFIX = ".live.com";
+
+        /**
          * Encoded delimiter for redirect.
          */
         public static final Object REDIRECT_DELIMETER_ENCODED = "%2C";

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -74,11 +74,12 @@ class AuthUxJavaScriptInterface {
             val host = uri.host
 
             // Otherwise, make sure uri is a valid uri
-            // We only want to allow URIs that have the AAD or MSA uri hosts
+            // We only want to allow URIs that have the AAD uri hosts
             return host.endsWith(AuthenticationConstants.Broker.AAD_GLOBAL_URL_HOST_SUFFIX) ||
                     host.endsWith(AuthenticationConstants.Broker.AAD_INTUNE_MDM_URL_HOST_SUFFIX) ||
                     host.endsWith(AuthenticationConstants.Broker.AAD_US_URL_HOST_SUFFIX) ||
-                    host.endsWith(AuthenticationConstants.Broker.AAD_CHINA_URL_HOST_SUFFIX)
+                    host.endsWith(AuthenticationConstants.Broker.AAD_CHINA_URL_HOST_SUFFIX) ||
+                    host.endsWith(AuthenticationConstants.Broker.MSA_URL_HOST_SUFFIX)
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/AuthUxJavaScriptInterface.kt
@@ -78,8 +78,7 @@ class AuthUxJavaScriptInterface {
             return host.endsWith(AuthenticationConstants.Broker.AAD_GLOBAL_URL_HOST_SUFFIX) ||
                     host.endsWith(AuthenticationConstants.Broker.AAD_INTUNE_MDM_URL_HOST_SUFFIX) ||
                     host.endsWith(AuthenticationConstants.Broker.AAD_US_URL_HOST_SUFFIX) ||
-                    host.endsWith(AuthenticationConstants.Broker.AAD_CHINA_URL_HOST_SUFFIX) ||
-                    host.endsWith(AuthenticationConstants.Broker.MSA_URL_HOST_SUFFIX)
+                    host.endsWith(AuthenticationConstants.Broker.AAD_CHINA_URL_HOST_SUFFIX)
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -301,3 +301,4 @@ public abstract class AuthorizationFragment extends Fragment {
         return new LinkedHashMap<>(mUrlLoadTracker);
     }
 }
+

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -255,7 +255,7 @@ public abstract class AuthorizationFragment extends Fragment {
 
     /**
      * Tracks the URLs loaded in the WebView along with their load status.
-     * Key: Load order (int), Value: URL and success status (boolean).
+     * Key: Load order (int), Value: URL Status object
      */
     private final Map<Integer, UrlStatus> mUrlStatusTracker = new LinkedHashMap<>();
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -251,25 +251,37 @@ public abstract class AuthorizationFragment extends Fragment {
      */
     private static class UrlLoadStatus {
         private final String url;
-        private final boolean isSuccess;
-        private final String error; // Error message if the load fails
+        private boolean isFinishedLoading;
 
-        UrlLoadStatus(String url, boolean isSuccess, String error) {
+        private String sslError;
+        private String serverError; // Error from server-side
+
+        UrlLoadStatus(final String url, final boolean isFinishedLoading, final String serverError) {
             this.url = sanitizeUrl(url);
-            this.isSuccess = isSuccess;
-            this.error = error;
+            this.isFinishedLoading = isFinishedLoading;
+            this.serverError = serverError;
         }
 
         public String getUrl() {
             return url;
         }
 
-        public boolean isSuccess() {
-            return isSuccess;
+        public boolean isFinishedLoading() {
+            return isFinishedLoading;
         }
 
-        public String getError() {
-            return error;
+        public String getServerError() {
+            return serverError;
+        }
+
+        public String toString() {
+            final StringBuilder sb = new StringBuilder();
+            sb.append("url=").append(url);
+            sb.append(", isFinishedLoading=").append(isFinishedLoading);
+            if (serverError != null) {
+                sb.append(", error=").append(serverError);
+            }
+            return sb.toString();
         }
 
         /**
@@ -282,14 +294,18 @@ public abstract class AuthorizationFragment extends Fragment {
     }
 
     /**
-     * Tracks a URL load event.
+     * Tracks a URL load event. Returns the index it was added at.
      *
      * @param url       The URL being loaded.
-     * @param isSuccess Whether the load was successful.
+     * @param finishedLoading Whether the load was successful.
      * @param error     The error message if the load fails (null if successful).
      */
-    protected void trackUrlLoad(String url, boolean isSuccess, String error) {
-        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, isSuccess, error));
+    protected void trackUrlLoadStatus(String url, boolean finishedLoading, String error) {
+        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, error));
+    }
+
+    protected void updateLatestUrlLoadStatus( final String url, final boolean finishedLoading, final String error) {
+        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, error));
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -202,6 +202,9 @@ public abstract class AuthorizationFragment extends Fragment {
             );
             Telemetry.emit(new UiEndEvent().isUserCancelled());
             sendResult(RawAuthorizationResult.ResultCode.SDK_CANCELLED);
+
+            // Log hosting activity destruction in the url tracker
+            updateLatestUrlStatus(null, "SDK_CANCELLED: Activity destroyed before auth completion");
         }
 
         LocalBroadcaster.INSTANCE.unregisterCallback(CANCEL_AUTHORIZATION_REQUEST);
@@ -220,6 +223,9 @@ public abstract class AuthorizationFragment extends Fragment {
         final String methodTag = TAG + ":sendResult";
         Logger.info(methodTag, "Sending result from Authorization Activity, resultCode: " + result.getResultCode());
 
+        // Track the final result code we got for this authorization flow
+        finalResultCode = result.getResultCode();
+
         final PropertyBag propertyBag = RawAuthorizationResult.toPropertyBag(result);
         propertyBag.put(REQUEST_CODE, BROWSER_FLOW);
 
@@ -232,9 +238,15 @@ public abstract class AuthorizationFragment extends Fragment {
         if (isCancelledByUser) {
             Logger.info(methodTag, "Received Authorization flow cancelled by the user");
             sendResult(RawAuthorizationResult.ResultCode.CANCELLED);
+
+            // Log this in the url load status tracker
+            updateLatestUrlStatus(null, "CANCELLED: Authorization cancelled by user.");
         } else {
             Logger.info(methodTag, "Received Authorization flow cancel request from SDK");
             sendResult(RawAuthorizationResult.ResultCode.SDK_CANCELLED);
+
+            // Log this in the url load status tracker
+            updateLatestUrlStatus(null, "SDK_CANCELLED: Authorization cancelled by SDK.");
         }
 
         Telemetry.emit(new UiEndEvent().isUserCancelled());
@@ -245,13 +257,16 @@ public abstract class AuthorizationFragment extends Fragment {
      * Tracks the URLs loaded in the WebView along with their load status.
      * Key: Load order (int), Value: URL and success status (boolean).
      */
-    private final Map<Integer, UrlLoadStatus> mUrlLoadTracker = new LinkedHashMap<>();
+    private final Map<Integer, UrlStatus> mUrlStatusTracker = new LinkedHashMap<>();
+
+    @Getter
+    private RawAuthorizationResult.ResultCode finalResultCode;
     private int mUrlLoadCounter = 0;
 
     /**
-     * Class to represent the URL, its load status, and an optional error message.
+     * Class to represent the URL loaded and whether or not it received a loading error or a server error
      */
-    public static class UrlLoadStatus {
+    public static class UrlStatus {
         @Getter
         private final String url;
 
@@ -265,12 +280,12 @@ public abstract class AuthorizationFragment extends Fragment {
          * Error returned from server
          */
         @Getter
-        private String serverError;
+        private String authError;
 
-        UrlLoadStatus(final String url, final String loadingError, final String serverError) {
+        UrlStatus(final String url, final String loadingError, final String authError) {
             this.url = sanitizeUrl(url);
             this.loadingError = loadingError;
-            this.serverError = serverError;
+            this.authError = authError;
         }
 
         @NonNull
@@ -280,8 +295,8 @@ public abstract class AuthorizationFragment extends Fragment {
             if (loadingError != null) {
                 sb.append(", loadingError=").append(loadingError);
             }
-            if (serverError != null) {
-                sb.append(", serverError=").append(serverError);
+            if (authError != null) {
+                sb.append(", authError=").append(authError);
             }
             return sb.toString();
         }
@@ -300,21 +315,27 @@ public abstract class AuthorizationFragment extends Fragment {
      *
      * @param url       The URL being loaded.
      * @param loadingError The error if the load failed (null if successful).
-     * @param serverError The error received from server-side.
+     * @param authError The error received from server-side.
      */
-    protected void trackUrlLoadStatus(final String url, final String loadingError, final String serverError) {
-        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, loadingError, serverError));
+    protected void trackUrlStatus(final String url, final String loadingError, final String authError) {
+        mUrlStatusTracker.put(++mUrlLoadCounter, new UrlStatus(url, loadingError, authError));
     }
 
     /**
      * Updates the most recent URL load event with new status information.
      *
-     * @param url The URL being updated.
      * @param loadingError The error if the load failed (null if successful).
-     * @param serverError The error received from server-side.
+     * @param authError The error received from server-side.
      */
-    protected void updateLatestUrlLoadStatus( final String url, final String loadingError, final String serverError) {
-        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, loadingError, serverError));
+    protected void updateLatestUrlStatus(final String loadingError, final String authError) {
+        final UrlStatus latestStatus = mUrlStatusTracker.get(mUrlLoadCounter);
+
+        if (latestStatus == null) {
+            Logger.warn(TAG, "No URL load status to update.");
+            return;
+        }
+
+        mUrlStatusTracker.put(mUrlLoadCounter, new UrlStatus(latestStatus.getUrl(), loadingError, authError));
     }
 
     /**
@@ -322,8 +343,8 @@ public abstract class AuthorizationFragment extends Fragment {
      *
      * @return A copy of the URL load tracker map.
      */
-    public Map<Integer, UrlLoadStatus> getUrlLoadTracker() {
-        return new LinkedHashMap<>(mUrlLoadTracker);
+    public Map<Integer, UrlStatus> getUrlLoadTracker() {
+        return new LinkedHashMap<>(mUrlStatusTracker);
     }
 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -53,6 +53,7 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBr
 import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * This base classes
@@ -276,12 +277,14 @@ public abstract class AuthorizationFragment extends Fragment {
          * Error encountered during loading
          */
         @Getter
+        @Setter
         private String loadingError;
 
         /**
          * Error returned from server
          */
         @Getter
+        @Setter
         private String authError;
 
         UrlStatus(final String url, final String loadingError, final String authError) {
@@ -382,7 +385,10 @@ public abstract class AuthorizationFragment extends Fragment {
             return;
         }
 
-        mUrlStatusTracker.put(mUrlLoadCounter, new UrlStatus(latestStatus.getUrl(), loadingError, authError));
+        latestStatus.setLoadingError(loadingError);
+        latestStatus.setAuthError(authError);
+
+        mUrlStatusTracker.put(mUrlLoadCounter, latestStatus);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -33,6 +33,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.events.UiEndEvent;
 import com.microsoft.identity.common.java.logging.RequestContext;
@@ -42,6 +43,7 @@ import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -303,10 +305,55 @@ public abstract class AuthorizationFragment extends Fragment {
 
         /**
          * Sanitize the URL to ensure no sensitive data is tracked.
+         * Only allows URLs with known AAD/MSA host suffixes.
+         * All query parameters are stripped for privacy.
+         *
+         * @param url The URL to sanitize.
+         * @return The sanitized URL (scheme + host + path only) or "[REDACTED]" if host is not allowed.
          */
-        private static String sanitizeUrl(String url) {
-            // Implement URL sanitization logic here
-            return url.replaceAll("[?&]sensitive_param=[^&]*", "");
+        private static String sanitizeUrl(final String url) {
+            if (url == null || url.isEmpty()) {
+                return url;
+            }
+
+            try {
+                final URI uri = new URI(url);
+                final String host = uri.getHost();
+
+                if (host == null || host.isEmpty()) {
+                    return host;
+                }
+
+                // Only allow URLs with known AAD/MSA host suffixes
+                final boolean isAllowedHost =
+                        host.endsWith(AuthenticationConstants.Broker.AAD_GLOBAL_URL_HOST_SUFFIX) ||
+                        host.endsWith(AuthenticationConstants.Broker.AAD_INTUNE_MDM_URL_HOST_SUFFIX) ||
+                        host.endsWith(AuthenticationConstants.Broker.AAD_US_URL_HOST_SUFFIX) ||
+                        host.endsWith(AuthenticationConstants.Broker.AAD_CHINA_URL_HOST_SUFFIX) ||
+                        host.endsWith(AuthenticationConstants.Broker.MSA_URL_HOST_SUFFIX);
+
+                if (!isAllowedHost) {
+                    return "[REDACTED]";
+                }
+
+                // Build sanitized URL: scheme + host + path only (no query params or fragments)
+                final StringBuilder sanitizedUrl = new StringBuilder();
+                final String scheme = uri.getScheme();
+                if (scheme != null) {
+                    sanitizedUrl.append(scheme).append("://");
+                }
+                sanitizedUrl.append(host);
+
+                final String path = uri.getPath();
+                if (path != null && !path.isEmpty()) {
+                    sanitizedUrl.append(path);
+                }
+
+                return sanitizedUrl.toString();
+            } catch (final Exception e) {
+                // If URL parsing fails, redact the entire URL for safety
+                return "[PARSING_ERROR]";
+            }
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -224,7 +224,7 @@ public abstract class AuthorizationFragment extends Fragment {
         Logger.info(methodTag, "Sending result from Authorization Activity, resultCode: " + result.getResultCode());
 
         // Track the final result code we got for this authorization flow
-        finalResultCode = result.getResultCode();
+        mFinalResultCode = result.getResultCode();
 
         final PropertyBag propertyBag = RawAuthorizationResult.toPropertyBag(result);
         propertyBag.put(REQUEST_CODE, BROWSER_FLOW);
@@ -260,7 +260,7 @@ public abstract class AuthorizationFragment extends Fragment {
     private final Map<Integer, UrlStatus> mUrlStatusTracker = new LinkedHashMap<>();
 
     @Getter
-    private RawAuthorizationResult.ResultCode finalResultCode;
+    private RawAuthorizationResult.ResultCode mFinalResultCode;
     private int mUrlLoadCounter = 0;
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -42,6 +42,9 @@ import com.microsoft.identity.common.java.util.ported.LocalBroadcaster;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.CANCEL_AUTHORIZATION_REQUEST;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterAliases.RETURN_AUTHORIZATION_REQUEST_RESULT;
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
@@ -234,5 +237,67 @@ public abstract class AuthorizationFragment extends Fragment {
 
         Telemetry.emit(new UiEndEvent().isUserCancelled());
         finish();
+    }
+
+    /**
+     * Tracks the URLs loaded in the WebView along with their load status.
+     * Key: Load order (int), Value: URL and success status (boolean).
+     */
+    private final Map<Integer, UrlLoadStatus> mUrlLoadTracker = new LinkedHashMap<>();
+    private int mUrlLoadCounter = 0;
+
+    /**
+     * Class to represent the URL, its load status, and an optional error message.
+     */
+    private static class UrlLoadStatus {
+        private final String url;
+        private final boolean isSuccess;
+        private final String error; // Error message if the load fails
+
+        UrlLoadStatus(String url, boolean isSuccess, String error) {
+            this.url = sanitizeUrl(url);
+            this.isSuccess = isSuccess;
+            this.error = error;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public boolean isSuccess() {
+            return isSuccess;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        /**
+         * Sanitize the URL to ensure no sensitive data is tracked.
+         */
+        private static String sanitizeUrl(String url) {
+            // Implement URL sanitization logic here
+            return url.replaceAll("[?&]sensitive_param=[^&]*", "");
+        }
+    }
+
+    /**
+     * Tracks a URL load event.
+     *
+     * @param url       The URL being loaded.
+     * @param isSuccess Whether the load was successful.
+     * @param error     The error message if the load fails (null if successful).
+     */
+    protected void trackUrlLoad(String url, boolean isSuccess, String error) {
+        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, isSuccess, error));
+    }
+
+    /**
+     * Retrieves the tracked URL load events.
+     *
+     * @return A copy of the URL load tracker map.
+     */
+    public Map<Integer, UrlLoadStatus> getUrlLoadTracker() {
+        return new LinkedHashMap<>(mUrlLoadTracker);
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -50,6 +50,8 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBr
 import static com.microsoft.identity.common.java.AuthenticationConstants.LocalBroadcasterFields.REQUEST_CODE;
 import static com.microsoft.identity.common.java.AuthenticationConstants.UIRequest.BROWSER_FLOW;
 
+import lombok.Getter;
+
 /**
  * This base classes
  * - handles how AuthorizationFragments communicates with the outside world.
@@ -249,37 +251,41 @@ public abstract class AuthorizationFragment extends Fragment {
     /**
      * Class to represent the URL, its load status, and an optional error message.
      */
-    private static class UrlLoadStatus {
+    public static class UrlLoadStatus {
+        @Getter
         private final String url;
+        @Getter
         private boolean isFinishedLoading;
 
-        private String sslError;
-        private String serverError; // Error from server-side
+        /**
+         * Error encountered during loading
+         */
+        @Getter
+        private String loadingError;
 
-        UrlLoadStatus(final String url, final boolean isFinishedLoading, final String serverError) {
+        /**
+         * Error returned from server
+         */
+        @Getter
+        private String serverError;
+
+        UrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
             this.url = sanitizeUrl(url);
             this.isFinishedLoading = isFinishedLoading;
+            this.loadingError = loadingError;
             this.serverError = serverError;
         }
 
-        public String getUrl() {
-            return url;
-        }
-
-        public boolean isFinishedLoading() {
-            return isFinishedLoading;
-        }
-
-        public String getServerError() {
-            return serverError;
-        }
-
+        @NonNull
         public String toString() {
             final StringBuilder sb = new StringBuilder();
             sb.append("url=").append(url);
             sb.append(", isFinishedLoading=").append(isFinishedLoading);
+            if (loadingError != null) {
+                sb.append(", loadingError=").append(loadingError);
+            }
             if (serverError != null) {
-                sb.append(", error=").append(serverError);
+                sb.append(", serverError=").append(serverError);
             }
             return sb.toString();
         }
@@ -298,14 +304,23 @@ public abstract class AuthorizationFragment extends Fragment {
      *
      * @param url       The URL being loaded.
      * @param finishedLoading Whether the load was successful.
-     * @param error     The error message if the load fails (null if successful).
+     * @param loadingError The error if the load failed (null if successful).
+     * @param serverError The error received from server-side.
      */
-    protected void trackUrlLoadStatus(String url, boolean finishedLoading, String error) {
-        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, error));
+    protected void trackUrlLoadStatus(final String url, final boolean finishedLoading, final String loadingError, final String serverError) {
+        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, loadingError, serverError));
     }
 
-    protected void updateLatestUrlLoadStatus( final String url, final boolean finishedLoading, final String error) {
-        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, error));
+    /**
+     * Updates the most recent URL load event with new status information.
+     *
+     * @param url The URL being updated.
+     * @param finishedLoading Whether the load was successful.
+     * @param loadingError The error if the load failed (null if successful).
+     * @param serverError The error received from server-side.
+     */
+    protected void updateLatestUrlLoadStatus( final String url, final boolean finishedLoading, final String loadingError, final String serverError) {
+        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, loadingError, serverError));
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -254,8 +254,6 @@ public abstract class AuthorizationFragment extends Fragment {
     public static class UrlLoadStatus {
         @Getter
         private final String url;
-        @Getter
-        private boolean isFinishedLoading;
 
         /**
          * Error encountered during loading
@@ -269,9 +267,8 @@ public abstract class AuthorizationFragment extends Fragment {
         @Getter
         private String serverError;
 
-        UrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
+        UrlLoadStatus(final String url, final String loadingError, final String serverError) {
             this.url = sanitizeUrl(url);
-            this.isFinishedLoading = isFinishedLoading;
             this.loadingError = loadingError;
             this.serverError = serverError;
         }
@@ -280,7 +277,6 @@ public abstract class AuthorizationFragment extends Fragment {
         public String toString() {
             final StringBuilder sb = new StringBuilder();
             sb.append("url=").append(url);
-            sb.append(", isFinishedLoading=").append(isFinishedLoading);
             if (loadingError != null) {
                 sb.append(", loadingError=").append(loadingError);
             }
@@ -303,24 +299,22 @@ public abstract class AuthorizationFragment extends Fragment {
      * Tracks a URL load event. Returns the index it was added at.
      *
      * @param url       The URL being loaded.
-     * @param finishedLoading Whether the load was successful.
      * @param loadingError The error if the load failed (null if successful).
      * @param serverError The error received from server-side.
      */
-    protected void trackUrlLoadStatus(final String url, final boolean finishedLoading, final String loadingError, final String serverError) {
-        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, loadingError, serverError));
+    protected void trackUrlLoadStatus(final String url, final String loadingError, final String serverError) {
+        mUrlLoadTracker.put(++mUrlLoadCounter, new UrlLoadStatus(url, loadingError, serverError));
     }
 
     /**
      * Updates the most recent URL load event with new status information.
      *
      * @param url The URL being updated.
-     * @param finishedLoading Whether the load was successful.
      * @param loadingError The error if the load failed (null if successful).
      * @param serverError The error received from server-side.
      */
-    protected void updateLatestUrlLoadStatus( final String url, final boolean finishedLoading, final String loadingError, final String serverError) {
-        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, finishedLoading, loadingError, serverError));
+    protected void updateLatestUrlLoadStatus( final String url, final String loadingError, final String serverError) {
+        mUrlLoadTracker.put(mUrlLoadCounter, new UrlLoadStatus(url, loadingError, serverError));
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -83,6 +83,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID;
 
@@ -271,13 +272,18 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 isWebViewWebcpEnabledInBrokerlessCase,
                 new IUrlLoadTracker() {
                     @Override
-                    public void trackUrlLoad(@NonNull String url, boolean isFinishedLoading, @Nullable String error) {
-                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, isFinishedLoading, error);
+                    public void trackNewUrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
+                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, isFinishedLoading, loadingError, serverError);
                     }
 
                     @Override
-                    public void updateLatestUrlStatus(@NonNull String url, boolean isFinishedLoading, @Nullable String error) {
-                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, isFinishedLoading, error);
+                    public void updateLatestUrlStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
+                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, isFinishedLoading, loadingError, serverError);
+                    }
+
+                    @Override
+                    public Map<Integer, UrlLoadStatus> getUrlStatusList() {
+                        return WebViewAuthorizationFragment.this.getUrlLoadTracker();
                     }
                 }
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -272,13 +272,13 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 isWebViewWebcpEnabledInBrokerlessCase,
                 new IUrlLoadTracker() {
                     @Override
-                    public void trackNewUrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
-                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, isFinishedLoading, loadingError, serverError);
+                    public void trackNewUrlLoadStatus(final String url, final String loadingError, final String serverError) {
+                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, loadingError, serverError);
                     }
 
                     @Override
-                    public void updateLatestUrlStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError) {
-                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, isFinishedLoading, loadingError, serverError);
+                    public void updateLatestUrlStatus(final String url, final String loadingError, final String serverError) {
+                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, loadingError, serverError);
                     }
 
                     @Override

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -272,17 +272,17 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 isWebViewWebcpEnabledInBrokerlessCase,
                 new IUrlLoadTracker() {
                     @Override
-                    public void trackNewUrlLoadStatus(final String url, final String loadingError, final String serverError) {
-                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, loadingError, serverError);
+                    public void trackNewUrlStatus(final String url, final String loadingError, final String authError) {
+                        WebViewAuthorizationFragment.this.trackUrlStatus(url, loadingError, authError);
                     }
 
                     @Override
-                    public void updateLatestUrlStatus(final String url, final String loadingError, final String serverError) {
-                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, loadingError, serverError);
+                    public void updateLatestUrlStatus(final String loadingError, final String authError) {
+                        WebViewAuthorizationFragment.this.updateLatestUrlStatus(loadingError, authError);
                     }
 
                     @Override
-                    public Map<Integer, UrlLoadStatus> getUrlStatusList() {
+                    public Map<Integer, UrlStatus> getUrlStatusList() {
                         return WebViewAuthorizationFragment.this.getUrlLoadTracker();
                     }
                 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -271,8 +271,13 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 isWebViewWebcpEnabledInBrokerlessCase,
                 new IUrlLoadTracker() {
                     @Override
-                    public void trackUrlLoad(@NonNull String url, boolean isSuccess, @Nullable String error) {
-                        WebViewAuthorizationFragment.this.trackUrlLoad(url, isSuccess, error);
+                    public void trackUrlLoad(@NonNull String url, boolean isFinishedLoading, @Nullable String error) {
+                        WebViewAuthorizationFragment.this.trackUrlLoadStatus(url, isFinishedLoading, error);
+                    }
+
+                    @Override
+                    public void updateLatestUrlStatus(@NonNull String url, boolean isFinishedLoading, @Nullable String error) {
+                        WebViewAuthorizationFragment.this.updateLatestUrlLoadStatus(url, isFinishedLoading, error);
                     }
                 }
         );

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -282,7 +282,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     }
 
                     @Override
-                    public Map<Integer, UrlStatus> getUrlStatusList() {
+                    public Map<Integer, UrlStatus> getUrlStatusMap() {
                         return WebViewAuthorizationFragment.this.getUrlLoadTracker();
                     }
                 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -63,6 +63,7 @@ import com.microsoft.identity.common.internal.fido.LegacyFido2ApiObject;
 import com.microsoft.identity.common.internal.fido.LegacyFidoActivityResultContract;
 import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient;
 import com.microsoft.identity.common.internal.ui.webview.ISendResultCallback;
+import com.microsoft.identity.common.internal.ui.webview.IUrlLoadTracker;
 import com.microsoft.identity.common.internal.ui.webview.OnPageLoadedCallback;
 import com.microsoft.identity.common.internal.ui.webview.ProcessUtil;
 import com.microsoft.identity.common.internal.ui.webview.WebViewUtil;
@@ -267,7 +268,13 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 mRedirectUri,
                 getSwitchBrowserCoordinator().getSwitchBrowserRequestHandler(),
                 mUtid,
-                isWebViewWebcpEnabledInBrokerlessCase
+                isWebViewWebcpEnabledInBrokerlessCase,
+                new IUrlLoadTracker() {
+                    @Override
+                    public void trackUrlLoad(@NonNull String url, boolean isSuccess, @Nullable String error) {
+                        WebViewAuthorizationFragment.this.trackUrlLoad(url, isSuccess, error);
+                    }
+                }
         );
         setUpWebView(view, mAADWebViewClient);
         mAADWebViewClient.initializeAuthUxJavaScriptApi(mWebView, mAuthorizationRequestUrl);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -29,9 +29,11 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.net.http.SslError;
 import android.os.Build;
 import android.os.Handler;
 import android.webkit.ClientCertRequest;
+import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 
@@ -1140,7 +1142,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Track URL load started
         if (mUrlLoadTracker != null) {
             // Initially track as in-progress (success will be updated in onPageFinished or error methods)
-            mUrlLoadTracker.trackUrlLoad(url, true, null);
+            mUrlLoadTracker.trackUrlLoad(url, false, null);
         }
         // Evaluate JavaScript for Passkey Registration if script is set and origin is allowed.
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
@@ -1154,7 +1156,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         super.onPageFinished(view, url);
         // Track successful URL load completion
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackUrlLoad(url, true, null);
+            mUrlLoadTracker.updateLatestUrlStatus(url, true, null);
         }
 
         if (mAuthUxJavaScriptInterfaceAdded) {
@@ -1176,9 +1178,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                 final String failingUrl) {
         final String methodTag = TAG + ":onReceivedError";
         Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + errorCode + ", Description: " + description);
-        // Track URL load failure
+        // Track URL load status, and error from server-side
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackUrlLoad(failingUrl, false, "Code:" + errorCode + ", " + description);
+            mUrlLoadTracker.trackUrlLoad(failingUrl, true, "Code:" + errorCode + ", " + description);
         }
         super.onReceivedError(view, errorCode, description, failingUrl);
     }
@@ -1194,10 +1196,18 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 ", Description: " + error.getDescription());
         // Track URL load failure for main frame only
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.trackUrlLoad(failingUrl, false, "Code:" + error.getErrorCode() + 
+            mUrlLoadTracker.trackUrlLoad(failingUrl, true, "Code:" + error.getErrorCode() +
                     ", " + error.getDescription());
         }
         super.onReceivedError(view, request, error);
+    }
+
+    @Override
+    public void onReceivedSslError(final WebView view,
+                                   final SslErrorHandler handler,
+                                   final SslError error) {
+        final String methodTag = TAG + ":onReceivedSslError";
+
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -35,6 +35,7 @@ import android.os.Handler;
 import android.webkit.ClientCertRequest;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -1153,7 +1154,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Track URL load started
         if (mUrlLoadTracker != null) {
             // Initially track as in-progress (success will be updated in onPageFinished or error methods)
-            mUrlLoadTracker.trackNewUrlLoadStatus(url, false, null,null);
+            mUrlLoadTracker.trackNewUrlLoadStatus(url, null,null);
         }
         // Evaluate JavaScript for Passkey Registration if script is set and origin is allowed.
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
@@ -1165,10 +1166,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     @Override
     public void onPageFinished(final WebView view, final String url) {
         super.onPageFinished(view, url);
-        // Track successful URL load completion
-        if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.updateLatestUrlStatus(url, true, null,null);
-        }
 
         if (mAuthUxJavaScriptInterfaceAdded) {
             // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
@@ -1189,9 +1186,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                 final String failingUrl) {
         final String methodTag = TAG + ":onReceivedError";
         Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + errorCode + ", Description: " + description);
-        // Track URL load status, and error from server-side
+        // Track error from server side
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, true, null, "Code:" + errorCode + ", " + description);
+            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, null, "Code:" + errorCode + ", " + description);
         }
         super.onReceivedError(view, errorCode, description, failingUrl);
     }
@@ -1205,9 +1202,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String failingUrl = request.getUrl() != null ? request.getUrl().toString() : "unknown";
         Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + error.getErrorCode() + 
                 ", Description: " + error.getDescription());
-        // Track URL load failure for main frame only
+        // Track error from server-side for main frame requests, as onReceivedError can be called for both main frame and sub resource requests,
+        // we only want to track for main frame requests to avoid noise in telemetry.
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, true, null, "Code:" + error.getErrorCode() +
+            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, null, "Code:" + error.getErrorCode() +
                     ", " + error.getDescription());
         }
         super.onReceivedError(view, request, error);
@@ -1219,10 +1217,21 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                    final SslError error) {
         // Track SSL error for the URL
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(error.getUrl(), false, error.toString(), null);
+            mUrlLoadTracker.trackNewUrlLoadStatus(error.getUrl(), error.toString(), null);
         }
 
         super.onReceivedSslError(view, handler, error);
+    }
+
+    @Override
+    public void onReceivedHttpError(final WebView view,
+                                    final WebResourceRequest request,
+                                    final WebResourceResponse errorResponse) {
+        // Track HTTP error for the URL
+        if (mUrlLoadTracker != null && request.isForMainFrame()) {
+            mUrlLoadTracker.trackNewUrlLoadStatus(request.getUrl().toString(), "HTTP Error Code: " + errorResponse.getStatusCode(), null);
+        }
+        super.onReceivedHttpError(view, request, errorResponse);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -197,6 +197,21 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         }
     }
 
+    @Override
+    public void onPageFinished(final WebView view, final String url) {
+        super.onPageFinished(view, url);
+
+        if (mAuthUxJavaScriptInterfaceAdded) {
+            // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
+            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending message in a dict
+            String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
+                    "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
+                    "};";
+
+            view.evaluateJavascript(jsScript, null);
+        }
+    }
+
     /**
      * Give the host application a chance to take over the control when a new url is about to be loaded in the current WebView.
      * This method was deprecated in API level 24.
@@ -1159,21 +1174,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
             Logger.verbose(TAG, "Executing onPageStarted PasskeyRegistration script for URL: " + url);
             view.evaluateJavascript(mPasskeyRegistrationScript, null);
-        }
-    }
-
-    @Override
-    public void onPageFinished(final WebView view, final String url) {
-        super.onPageFinished(view, url);
-
-        if (mAuthUxJavaScriptInterfaceAdded) {
-            // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
-            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending message in a dict
-            String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
-                    "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
-                    "};";
-
-            view.evaluateJavascript(jsScript, null);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -96,6 +96,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import android.webkit.WebResourceError;
+
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AMAZON_APP_REDIRECT_PREFIX;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.COMPANY_PORTAL_APP_PACKAGE_NAME;
@@ -145,13 +147,19 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private String mPasskeyRegistrationScript;
 
+    /**
+     * Callback for tracking URL load events.
+     */
+    private final IUrlLoadTracker mUrlLoadTracker;
+
     public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
                                              @NonNull final IAuthorizationCompletionCallback completionCallback,
                                              @NonNull final OnPageLoadedCallback pageLoadedCallback,
                                              @NonNull final String redirectUrl,
                                              @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
                                              @Nullable final String utid,
-                                             final boolean isWebViewWebCpEnabledInBrokerlessCase) {
+                                             final boolean isWebViewWebCpEnabledInBrokerlessCase,
+                                             @Nullable final IUrlLoadTracker urlLoadTracker) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
@@ -159,6 +167,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         mUtid = utid;
         mSpanContext = activity instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         mIsWebViewWebCpEnabledInBrokerlessCase = isWebViewWebCpEnabledInBrokerlessCase;
+        mUrlLoadTracker = urlLoadTracker;
     }
 
     /**
@@ -172,22 +181,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             Logger.info(TAG, "Adding AuthUx JavaScript Interface");
             view.addJavascriptInterface(new AuthUxJavaScriptInterface(), AuthUxJavaScriptInterface.Companion.getInterfaceName());
             mAuthUxJavaScriptInterfaceAdded = true;
-        }
-    }
-
-    @Override
-    public void onPageFinished(final WebView view,
-                               final String url) {
-        super.onPageFinished(view, url);
-
-        if (mAuthUxJavaScriptInterfaceAdded) {
-            // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
-            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending message in a dict
-            String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
-                    "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
-                    "};";
-
-            view.evaluateJavascript(jsScript, null);
         }
     }
 
@@ -1144,11 +1137,67 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     @Override
     public void onPageStarted(final WebView view, final String url, final Bitmap favicon) {
         super.onPageStarted(view, url, favicon);
+        // Track URL load started
+        if (mUrlLoadTracker != null) {
+            // Initially track as in-progress (success will be updated in onPageFinished or error methods)
+            mUrlLoadTracker.trackUrlLoad(url, true, null);
+        }
         // Evaluate JavaScript for Passkey Registration if script is set and origin is allowed.
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
             Logger.verbose(TAG, "Executing onPageStarted PasskeyRegistration script for URL: " + url);
             view.evaluateJavascript(mPasskeyRegistrationScript, null);
         }
+    }
+
+    @Override
+    public void onPageFinished(final WebView view, final String url) {
+        super.onPageFinished(view, url);
+        // Track successful URL load completion
+        if (mUrlLoadTracker != null) {
+            mUrlLoadTracker.trackUrlLoad(url, true, null);
+        }
+
+        if (mAuthUxJavaScriptInterfaceAdded) {
+            // Add a function to the api. Must do this to first stringify the dict object, as Android @JavaScriptInterface does not support
+            // passing dict objects through Javascript APIs, only Strings and primitive types. Server side will be sending message in a dict
+            String jsScript = "window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".postMessageToBroker = function(message) { " +
+                    "    window." + AuthUxJavaScriptInterface.Companion.getInterfaceName() + ".receiveAuthUxMessage(JSON.stringify(message)); " +
+                    "};";
+
+            view.evaluateJavascript(jsScript, null);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void onReceivedError(final WebView view,
+                                final int errorCode,
+                                final String description,
+                                final String failingUrl) {
+        final String methodTag = TAG + ":onReceivedError";
+        Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + errorCode + ", Description: " + description);
+        // Track URL load failure
+        if (mUrlLoadTracker != null) {
+            mUrlLoadTracker.trackUrlLoad(failingUrl, false, "Code:" + errorCode + ", " + description);
+        }
+        super.onReceivedError(view, errorCode, description, failingUrl);
+    }
+
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public void onReceivedError(@NonNull final WebView view,
+                                @NonNull final WebResourceRequest request,
+                                @NonNull final WebResourceError error) {
+        final String methodTag = TAG + ":onReceivedError";
+        final String failingUrl = request.getUrl() != null ? request.getUrl().toString() : "unknown";
+        Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + error.getErrorCode() + 
+                ", Description: " + error.getDescription());
+        // Track URL load failure for main frame only
+        if (mUrlLoadTracker != null && request.isForMainFrame()) {
+            mUrlLoadTracker.trackUrlLoad(failingUrl, false, "Code:" + error.getErrorCode() + 
+                    ", " + error.getDescription());
+        }
+        super.onReceivedError(view, request, error);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -1224,7 +1224,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
             mUrlLoadTracker.updateLatestUrlStatus("HTTP Error Code: " + errorResponse.getStatusCode(), null);
         }
-        super.onReceivedHttpError(view, request, errorResponse);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -96,6 +96,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import android.webkit.WebResourceError;
@@ -170,6 +171,16 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         mSpanContext = activity instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         mIsWebViewWebCpEnabledInBrokerlessCase = isWebViewWebCpEnabledInBrokerlessCase;
         mUrlLoadTracker = urlLoadTracker;
+    }
+
+    public AzureActiveDirectoryWebViewClient(@NonNull final Activity activity,
+                                             @NonNull final IAuthorizationCompletionCallback completionCallback,
+                                             @NonNull final OnPageLoadedCallback pageLoadedCallback,
+                                             @NonNull final String redirectUrl,
+                                             @NonNull final SwitchBrowserRequestHandler switchBrowserRequestHandler,
+                                             @Nullable final String utid,
+                                             final boolean isWebViewWebCpEnabledInBrokerlessCase) {
+        this(activity, completionCallback, pageLoadedCallback, redirectUrl, switchBrowserRequestHandler, utid, isWebViewWebCpEnabledInBrokerlessCase, null);
     }
 
     /**
@@ -1142,7 +1153,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Track URL load started
         if (mUrlLoadTracker != null) {
             // Initially track as in-progress (success will be updated in onPageFinished or error methods)
-            mUrlLoadTracker.trackUrlLoad(url, false, null);
+            mUrlLoadTracker.trackNewUrlLoadStatus(url, false, null,null);
         }
         // Evaluate JavaScript for Passkey Registration if script is set and origin is allowed.
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
@@ -1156,7 +1167,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         super.onPageFinished(view, url);
         // Track successful URL load completion
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.updateLatestUrlStatus(url, true, null);
+            mUrlLoadTracker.updateLatestUrlStatus(url, true, null,null);
         }
 
         if (mAuthUxJavaScriptInterfaceAdded) {
@@ -1180,7 +1191,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + errorCode + ", Description: " + description);
         // Track URL load status, and error from server-side
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackUrlLoad(failingUrl, true, "Code:" + errorCode + ", " + description);
+            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, true, null, "Code:" + errorCode + ", " + description);
         }
         super.onReceivedError(view, errorCode, description, failingUrl);
     }
@@ -1196,7 +1207,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 ", Description: " + error.getDescription());
         // Track URL load failure for main frame only
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.trackUrlLoad(failingUrl, true, "Code:" + error.getErrorCode() +
+            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, true, null, "Code:" + error.getErrorCode() +
                     ", " + error.getDescription());
         }
         super.onReceivedError(view, request, error);
@@ -1206,8 +1217,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public void onReceivedSslError(final WebView view,
                                    final SslErrorHandler handler,
                                    final SslError error) {
-        final String methodTag = TAG + ":onReceivedSslError";
+        // Track SSL error for the URL
+        if (mUrlLoadTracker != null) {
+            mUrlLoadTracker.trackNewUrlLoadStatus(error.getUrl(), false, error.toString(), null);
+        }
 
+        super.onReceivedSslError(view, handler, error);
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -198,7 +198,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     }
 
     @Override
-    public void onPageFinished(final WebView view, final String url) {
+    public void onPageFinished(final WebView view,
+                               final String url) {
         super.onPageFinished(view, url);
 
         if (mAuthUxJavaScriptInterfaceAdded) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -97,7 +97,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import android.webkit.WebResourceError;
@@ -1154,7 +1153,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Track URL load started
         if (mUrlLoadTracker != null) {
             // Initially track as in-progress (success will be updated in onPageFinished or error methods)
-            mUrlLoadTracker.trackNewUrlLoadStatus(url, null,null);
+            mUrlLoadTracker.trackNewUrlStatus(url, null,null);
         }
         // Evaluate JavaScript for Passkey Registration if script is set and origin is allowed.
         if (mPasskeyRegistrationScript != null && PasskeyOriginRulesManager.isAllowedOrigin(url)) {
@@ -1184,11 +1183,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                 final int errorCode,
                                 final String description,
                                 final String failingUrl) {
-        final String methodTag = TAG + ":onReceivedError";
-        Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + errorCode + ", Description: " + description);
         // Track error from server side
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, null, "Code:" + errorCode + ", " + description);
+            mUrlLoadTracker.updateLatestUrlStatus(null, "Code:" + errorCode + ", " + description);
         }
         super.onReceivedError(view, errorCode, description, failingUrl);
     }
@@ -1198,14 +1195,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public void onReceivedError(@NonNull final WebView view,
                                 @NonNull final WebResourceRequest request,
                                 @NonNull final WebResourceError error) {
-        final String methodTag = TAG + ":onReceivedError";
-        final String failingUrl = request.getUrl() != null ? request.getUrl().toString() : "unknown";
-        Logger.warn(methodTag, "Received error loading URL. ErrorCode: " + error.getErrorCode() + 
-                ", Description: " + error.getDescription());
         // Track error from server-side for main frame requests, as onReceivedError can be called for both main frame and sub resource requests,
         // we only want to track for main frame requests to avoid noise in telemetry.
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(failingUrl, null, "Code:" + error.getErrorCode() +
+            mUrlLoadTracker.updateLatestUrlStatus(null, "Code:" + error.getErrorCode() +
                     ", " + error.getDescription());
         }
         super.onReceivedError(view, request, error);
@@ -1217,7 +1210,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                    final SslError error) {
         // Track SSL error for the URL
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(error.getUrl(), error.toString(), null);
+            mUrlLoadTracker.updateLatestUrlStatus(error.toString(), null);
         }
 
         super.onReceivedSslError(view, handler, error);
@@ -1229,7 +1222,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                     final WebResourceResponse errorResponse) {
         // Track HTTP error for the URL
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.trackNewUrlLoadStatus(request.getUrl().toString(), "HTTP Error Code: " + errorResponse.getStatusCode(), null);
+            mUrlLoadTracker.updateLatestUrlStatus("HTTP Error Code: " + errorResponse.getStatusCode(), null);
         }
         super.onReceivedHttpError(view, request, errorResponse);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -1186,7 +1186,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                 final String failingUrl) {
         // Track error from server side
         if (mUrlLoadTracker != null) {
-            mUrlLoadTracker.updateLatestUrlStatus(null, "Code:" + errorCode + ", " + description);
+            mUrlLoadTracker.updateLatestUrlStatus( "Code:" + errorCode + ", " + description, null);
         }
         super.onReceivedError(view, errorCode, description, failingUrl);
     }
@@ -1199,8 +1199,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         // Track error from server-side for main frame requests, as onReceivedError can be called for both main frame and sub resource requests,
         // we only want to track for main frame requests to avoid noise in telemetry.
         if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.updateLatestUrlStatus(null, "Code:" + error.getErrorCode() +
-                    ", " + error.getDescription());
+            mUrlLoadTracker.updateLatestUrlStatus("Code:" + error.getErrorCode() + ", " + error.getDescription(), null);
         }
         super.onReceivedError(view, request, error);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -54,5 +54,5 @@ public interface IUrlLoadTracker {
       *
       * @return A map of URL load statuses, where the key is an integer identifier and the value is the corresponding UrlLoadStatus.
       */
-     Map<Integer, AuthorizationFragment.UrlStatus> getUrlStatusList();
+     Map<Integer, AuthorizationFragment.UrlStatus> getUrlStatusMap();
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -35,8 +35,17 @@ public interface IUrlLoadTracker {
      * Called to track a URL load event.
      *
      * @param url       The URL being loaded.
-     * @param isSuccess Whether the load was successful.
+     * @param isFinishedLoading Whether the load was successful.
      * @param error     The error message if the load failed (null if successful).
      */
-    void trackUrlLoad(@NonNull String url, boolean isSuccess, @Nullable String error);
+    void trackUrlLoad(@NonNull String url, boolean isFinishedLoading, @Nullable String error);
+
+    /**
+     * Called to update the most recent Url status.
+     *
+     * @param url The URL being updated.
+     * @param isSuccess Whether the load was successful.
+     * @param error The error message if the load failed (null if successful).
+     */
+     void updateLatestUrlStatus(@NonNull String url, boolean isSuccess, @Nullable String error);
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Callback interface for tracking URL load events in WebView.
+ * This is used to improve understanding of user experience during authorization requests.
+ */
+public interface IUrlLoadTracker {
+
+    /**
+     * Called to track a URL load event.
+     *
+     * @param url       The URL being loaded.
+     * @param isSuccess Whether the load was successful.
+     * @param error     The error message if the load failed (null if successful).
+     */
+    void trackUrlLoad(@NonNull String url, boolean isSuccess, @Nullable String error);
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -22,9 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.ui.webview;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationFragment;
 
 import java.util.Map;
@@ -40,23 +37,22 @@ public interface IUrlLoadTracker {
      *
      * @param url       The URL being loaded.
      * @param loadingError The error if the load failed (null if successful).
-     * @param serverError The error received from server side.
+     * @param authError The error received from server side.
      */
-    void trackNewUrlLoadStatus(final String url, final String loadingError, final String serverError);
+    void trackNewUrlStatus(final String url, final String loadingError, final String authError);
 
     /**
      * Called to update the most recent Url status.
      *
-     * @param url The URL being updated.
      * @param loadingError The error if the load failed (null if successful).
-     * @param serverError The error received from server side.
+     * @param authError The error received from server side.
      */
-     void updateLatestUrlStatus(final String url, final String loadingError, final String serverError);
+     void updateLatestUrlStatus(final String loadingError, final String authError);
 
      /**
       * Gets the list of URL load statuses tracked so far.
       *
       * @return A map of URL load statuses, where the key is an integer identifier and the value is the corresponding UrlLoadStatus.
       */
-     Map<Integer, AuthorizationFragment.UrlLoadStatus> getUrlStatusList();
+     Map<Integer, AuthorizationFragment.UrlStatus> getUrlStatusList();
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -39,21 +39,19 @@ public interface IUrlLoadTracker {
      * Called to track a new URL load event.
      *
      * @param url       The URL being loaded.
-     * @param isFinishedLoading Whether the load was successful.
      * @param loadingError The error if the load failed (null if successful).
      * @param serverError The error received from server side.
      */
-    void trackNewUrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError);
+    void trackNewUrlLoadStatus(final String url, final String loadingError, final String serverError);
 
     /**
      * Called to update the most recent Url status.
      *
      * @param url The URL being updated.
-     * @param isFinishedLoading Whether the load was successful.
      * @param loadingError The error if the load failed (null if successful).
      * @param serverError The error received from server side.
      */
-     void updateLatestUrlStatus(final String url, boolean isFinishedLoading, final String loadingError, final String serverError);
+     void updateLatestUrlStatus(final String url, final String loadingError, final String serverError);
 
      /**
       * Gets the list of URL load statuses tracked so far.

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/IUrlLoadTracker.java
@@ -25,6 +25,10 @@ package com.microsoft.identity.common.internal.ui.webview;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationFragment;
+
+import java.util.Map;
+
 /**
  * Callback interface for tracking URL load events in WebView.
  * This is used to improve understanding of user experience during authorization requests.
@@ -32,20 +36,29 @@ import androidx.annotation.Nullable;
 public interface IUrlLoadTracker {
 
     /**
-     * Called to track a URL load event.
+     * Called to track a new URL load event.
      *
      * @param url       The URL being loaded.
      * @param isFinishedLoading Whether the load was successful.
-     * @param error     The error message if the load failed (null if successful).
+     * @param loadingError The error if the load failed (null if successful).
+     * @param serverError The error received from server side.
      */
-    void trackUrlLoad(@NonNull String url, boolean isFinishedLoading, @Nullable String error);
+    void trackNewUrlLoadStatus(final String url, final boolean isFinishedLoading, final String loadingError, final String serverError);
 
     /**
      * Called to update the most recent Url status.
      *
      * @param url The URL being updated.
-     * @param isSuccess Whether the load was successful.
-     * @param error The error message if the load failed (null if successful).
+     * @param isFinishedLoading Whether the load was successful.
+     * @param loadingError The error if the load failed (null if successful).
+     * @param serverError The error received from server side.
      */
-     void updateLatestUrlStatus(@NonNull String url, boolean isSuccess, @Nullable String error);
+     void updateLatestUrlStatus(final String url, boolean isFinishedLoading, final String loadingError, final String serverError);
+
+     /**
+      * Gets the list of URL load statuses tracked so far.
+      *
+      * @return A map of URL load statuses, where the key is an integer identifier and the value is the corresponding UrlLoadStatus.
+      */
+     Map<Integer, AuthorizationFragment.UrlLoadStatus> getUrlStatusList();
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragmentUrlTrackingTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragmentUrlTrackingTest.java
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.providers.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationFragment.UrlStatus;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Map;
+
+/**
+ * Tests for URL-load tracking in {@link AuthorizationFragment} and its nested
+ * {@link AuthorizationFragment.UrlStatus} class.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AuthorizationFragmentUrlTrackingTest {
+
+    /**
+     * Minimal concrete subclass that allows direct access to the protected
+     * tracking helpers without needing a full Fragment lifecycle.
+     */
+    private static class TestAuthorizationFragment extends AuthorizationFragment {
+
+        // Expose protected methods for testing
+
+        void trackUrl(final String url, final String loadingError, final String authError) {
+            trackUrlStatus(url, loadingError, authError);
+        }
+
+        void updateLatest(final String loadingError, final String authError) {
+            updateLatestUrlStatus(loadingError, authError);
+        }
+
+        Map<Integer, UrlStatus> getTracker() {
+            return getUrlLoadTracker();
+        }
+    }
+
+    private TestAuthorizationFragment mFragment;
+
+    @Before
+    public void setUp() {
+        mFragment = new TestAuthorizationFragment();
+    }
+
+    // -----------------------------------------------------------------------
+    // UrlStatus.sanitizeUrl – tested indirectly via the package-private
+    // constructor which calls sanitizeUrl on the supplied url.
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testUrlStatus_aadGlobalHost_notRedacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=abc",
+                null, null);
+        assertEquals("https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+                status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_aadChinaHost_notRedacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.partner.microsoftonline.cn/common/oauth2/v2.0/authorize?x=1",
+                null, null);
+        assertEquals("https://login.partner.microsoftonline.cn/common/oauth2/v2.0/authorize",
+                status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_aadUsHost_notRedacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.microsoftonline.us/common/oauth2/v2.0/authorize?x=1",
+                null, null);
+        assertEquals("https://login.microsoftonline.us/common/oauth2/v2.0/authorize",
+                status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_msaHost_notRedacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.live.com/oauth20_authorize.srf?client_id=abc",
+                null, null);
+        assertEquals("https://login.live.com/oauth20_authorize.srf", status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_microsoftComHost_notRedacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://account.microsoft.com/some/path?query=value",
+                null, null);
+        assertEquals("https://account.microsoft.com/some/path", status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_nonAadHost_redacted() {
+        final UrlStatus status = new UrlStatus(
+                "https://evil.example.com/steal?token=secret",
+                null, null);
+        assertEquals("[REDACTED]", status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_queryParamsStripped_forAllowedHost() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.microsoftonline.com/authorize?code=secret_code&state=abc",
+                null, null);
+        // Query params must be stripped; only scheme+host+path retained
+        assertEquals("https://login.microsoftonline.com/authorize", status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_nullUrl_handledGracefully() {
+        final UrlStatus status = new UrlStatus(null, null, null);
+        assertNull(status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_emptyUrl_handledGracefully() {
+        final UrlStatus status = new UrlStatus("", null, null);
+        assertEquals("", status.getUrl());
+    }
+
+    @Test
+    public void testUrlStatus_gettersReturnSuppliedValues() {
+        final UrlStatus status = new UrlStatus(
+                "https://login.microsoftonline.com/authorize",
+                "loading error",
+                "auth error");
+        assertNotNull(status.getUrl());
+        assertEquals("loading error", status.getLoadingError());
+        assertEquals("auth error", status.getAuthError());
+    }
+
+    // -----------------------------------------------------------------------
+    // AuthorizationFragment tracking methods
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testTrackUrlStatus_addsEntryToTracker() {
+        mFragment.trackUrl("https://login.microsoftonline.com/authorize", null, null);
+
+        final Map<Integer, UrlStatus> tracker = mFragment.getTracker();
+        assertEquals(1, tracker.size());
+        assertNotNull(tracker.get(1));
+        // URL is sanitized; query params stripped
+        assertEquals("https://login.microsoftonline.com/authorize",
+                tracker.get(1).getUrl());
+    }
+
+    @Test
+    public void testTrackUrlStatus_multipleUrls_incrementsKeys() {
+        mFragment.trackUrl("https://login.microsoftonline.com/step1", null, null);
+        mFragment.trackUrl("https://login.microsoftonline.com/step2", null, null);
+
+        final Map<Integer, UrlStatus> tracker = mFragment.getTracker();
+        assertEquals(2, tracker.size());
+        assertNotNull(tracker.get(1));
+        assertNotNull(tracker.get(2));
+    }
+
+    @Test
+    public void testUpdateLatestUrlStatus_updatesLatestEntry() {
+        mFragment.trackUrl("https://login.microsoftonline.com/authorize", null, null);
+        mFragment.updateLatest("network error", null);
+
+        final UrlStatus entry = mFragment.getTracker().get(1);
+        assertNotNull(entry);
+        assertEquals("network error", entry.getLoadingError());
+        assertNull(entry.getAuthError());
+    }
+
+    @Test
+    public void testUpdateLatestUrlStatus_preservesUrl() {
+        mFragment.trackUrl("https://login.microsoftonline.com/authorize", null, null);
+        mFragment.updateLatest("error", null);
+
+        final UrlStatus entry = mFragment.getTracker().get(1);
+        assertNotNull(entry);
+        assertEquals("https://login.microsoftonline.com/authorize", entry.getUrl());
+    }
+
+    @Test
+    public void testUpdateLatestUrlStatus_noExistingEntry_noException() {
+        // updateLatestUrlStatus with nothing tracked yet should not throw
+        mFragment.updateLatest("some error", null);
+        // Tracker must still be empty
+        assertEquals(0, mFragment.getTracker().size());
+    }
+
+    @Test
+    public void testGetUrlLoadTracker_returnsDefensiveCopy() {
+        mFragment.trackUrl("https://login.microsoftonline.com/authorize", null, null);
+
+        final Map<Integer, UrlStatus> copy1 = mFragment.getTracker();
+        final Map<Integer, UrlStatus> copy2 = mFragment.getTracker();
+
+        // Each call should return a distinct map object (defensive copy)
+        assertNotSame(copy1, copy2);
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -41,6 +41,9 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.net.http.SslError;
 import android.webkit.SslErrorHandler;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -704,5 +707,142 @@ public class AzureActiveDirectoryWebViewClientTest {
         // Verify that the error message is about browser not found
         assertTrue("Expected error message about browser not found",
                 capturedResult.getException().getMessage().contains("No browser found to open the link"));
+    }
+
+    // -----------------------------------------------------------------------
+    // URL tracking tests (IUrlLoadTracker integration)
+    // -----------------------------------------------------------------------
+
+    private AzureActiveDirectoryWebViewClient createWebViewClientWithTracker(
+            final IUrlLoadTracker tracker) throws ClientException {
+        return new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                Mockito.mock(IAuthorizationCompletionCallback.class),
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                false,
+                tracker);
+    }
+
+    @Test
+    public void testUrlTracker_onPageStarted_callsTrackNewUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+        final String url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
+
+        client.onPageStarted(mMockWebView, url, null);
+
+        Mockito.verify(mockTracker).trackNewUrlStatus(url, null, null);
+    }
+
+    @Test
+    public void testUrlTracker_onPageStarted_nullTracker_noException() throws ClientException {
+        // Uses constructor without IUrlLoadTracker; should not throw
+        final AzureActiveDirectoryWebViewClient client = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                Mockito.mock(IAuthorizationCompletionCallback.class),
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                false);
+
+        // Should complete without NullPointerException
+        client.onPageStarted(mMockWebView, "https://login.microsoftonline.com/common/oauth2/v2.0/authorize", null);
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedError_deprecated_callsUpdateLatestUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+        final int errorCode = -2;
+        final String description = "net::ERR_NAME_NOT_RESOLVED";
+
+        client.onReceivedError(mMockWebView, errorCode, description,
+                "https://login.microsoftonline.com/common/oauth2/v2.0/authorize");
+
+        Mockito.verify(mockTracker).updateLatestUrlStatus("Code:" + errorCode + ", " + description, null);
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedError_mainFrame_callsUpdateLatestUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceError mockError = Mockito.mock(WebResourceError.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(true);
+        Mockito.when(mockError.getErrorCode()).thenReturn(-2);
+        Mockito.when(mockError.getDescription()).thenReturn("net::ERR_NAME_NOT_RESOLVED");
+
+        client.onReceivedError(mMockWebView, mockRequest, mockError);
+
+        Mockito.verify(mockTracker).updateLatestUrlStatus("Code:-2, net::ERR_NAME_NOT_RESOLVED", null);
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedError_subResource_doesNotCallUpdateLatestUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceError mockError = Mockito.mock(WebResourceError.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(false);
+
+        client.onReceivedError(mMockWebView, mockRequest, mockError);
+
+        Mockito.verify(mockTracker, never()).updateLatestUrlStatus(any(), any());
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedSslError_callsUpdateLatestUrlStatus() throws ClientException {
+        final IFlightsManager mockFlightsManager = Mockito.mock(IFlightsManager.class);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(eq(CommonFlight.SHOULD_PRESERVE_WEBVIEW_FLOW_ON_SSL_ERROR))).thenReturn(false);
+        when(mockFlightsManager.getFlightsProvider(anyLong())).thenReturn(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);
+
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final SslError mockError = Mockito.mock(SslError.class);
+        final SslErrorHandler mockHandler = Mockito.mock(SslErrorHandler.class);
+        Mockito.when(mockError.toString()).thenReturn("SslError(SSL_EXPIRED)");
+
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+
+        client.onReceivedSslError(new WebView(mContext), mockHandler, mockError);
+
+        Mockito.verify(mockTracker).updateLatestUrlStatus("SslError(SSL_EXPIRED)", null);
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedHttpError_mainFrame_callsUpdateLatestUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(true);
+        Mockito.when(mockErrorResponse.getStatusCode()).thenReturn(403);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        Mockito.verify(mockTracker).updateLatestUrlStatus("HTTP Error Code: 403", null);
+    }
+
+    @Test
+    public void testUrlTracker_onReceivedHttpError_subResource_doesNotCallUpdateLatestUrlStatus() throws ClientException {
+        final IUrlLoadTracker mockTracker = Mockito.mock(IUrlLoadTracker.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithTracker(mockTracker);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(false);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        Mockito.verify(mockTracker, never()).updateLatestUrlStatus(any(), any());
     }
 }


### PR DESCRIPTION
Add a list for tracking urls loaded by our webview. This will be used by oneauth to imporve their telemetry.

[AB#3494119](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3494119)