### PR TITLE
Fix CommandDispatcherTest by using SILENT_REQUEST_THREAD_POOL_SIZE, Fixes AB#3524740

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,6 @@ Version 24.0.0-RC1
 - [MINOR] Adding ExtraQueryStringParametersForWebApps (#2891)
 - [MINOR] Added flight-controlled option to enable Broker CommandDispatcher silent thread pool size based on processor count and default to 12 threads (#2897)
 - [MINOR] Edge TB: Allow For Lookup Mode (#2898)
-- [MINOR] Fix test failure due to flight-controlled thread pool size mismatch (#2905)
 
 Version 23.3.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Version 24.0.0-RC1
 - [MINOR] Adding ExtraQueryStringParametersForWebApps (#2891)
 - [MINOR] Added flight-controlled option to enable Broker CommandDispatcher silent thread pool size based on processor count and default to 12 threads (#2897)
 - [MINOR] Edge TB: Allow For Lookup Mode (#2898)
+- [MINOR] Fix test failure due to flight-controlled thread pool size mismatch (#2905)
 
 Version 23.3.0
 ----------

--- a/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
+++ b/common/src/androidTest/java/com/microsoft/identity/common/CommandDispatcherTest.java
@@ -111,9 +111,6 @@ public class CommandDispatcherTest {
     /** Small delay to ensure blocking tasks are fully blocking before submitting test request */
     private static final long TASK_STABILIZATION_DELAY_MS = 100;
 
-    /** Thread pool size for silent requests (matches CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE) */
-    private static final int SILENT_THREAD_POOL_SIZE = 12;
-
     /** Number of concurrent requests for state collision test */
     private static final int CONCURRENT_REQUEST_COUNT = 20;
 
@@ -891,7 +888,7 @@ public class CommandDispatcherTest {
      *
      * <p>Test Strategy:
      * <ol>
-     *   <li>Fill all {@link #SILENT_THREAD_POOL_SIZE} thread pool threads with blocking tasks</li>
+     *   <li>Fill all thread pool threads with blocking tasks</li>
      *   <li>Submit a new request that will be queued (state: QUEUED)</li>
      *   <li>Request times out after 30 seconds while still in queue</li>
      *   <li>Verify error code is TIMED_OUT_THREAD_POOL_SATURATED</li>
@@ -904,7 +901,7 @@ public class CommandDispatcherTest {
     @Test
     public void testTimeoutClassification_ThreadPoolSaturated() throws Exception {
         Log.d(TAG, "testTimeoutClassification_ThreadPoolSaturated: Starting test");
-        final int POOL_SIZE = SILENT_THREAD_POOL_SIZE;
+        final int POOL_SIZE = CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE;
         final CountDownLatch tasksStarted = new CountDownLatch(POOL_SIZE);
         final CountDownLatch releaseBlockingTasks = new CountDownLatch(1);
         final CountDownLatch tasksCompleted = new CountDownLatch(POOL_SIZE); // Track completion

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/CommandDispatcher.java
@@ -107,7 +107,8 @@ public class CommandDispatcher {
     private static final int EXECUTOR_GRACEFUL_TERMINATION_TIMEOUT_MS = 500;
     private static final int EXECUTOR_FORCED_TERMINATION_TIMEOUT_MS = 1000;
     // Cache the pool size for the session
-    private static final int SILENT_REQUEST_THREAD_POOL_SIZE = computeSilentRequestThreadPoolSize();
+    //@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public static final int SILENT_REQUEST_THREAD_POOL_SIZE = computeSilentRequestThreadPoolSize();
     private static ExecutorService sInteractiveExecutor = Executors.newSingleThreadExecutor();
     private static ExecutorService sSilentExecutor = Executors.newFixedThreadPool(SILENT_REQUEST_THREAD_POOL_SIZE);
     private static final ExecutorService sDCFExecutor = Executors.newFixedThreadPool(DCF_REQUEST_THREAD_POOL_SIZE);


### PR DESCRIPTION
Fixes [AB#3524740](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3524740)

The test was failing because it hardcoded SILENT_THREAD_POOL_SIZE = 12, but CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE is now flight-controlled:
- CommonFlight sets USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE to false (5 threads)
- BrokerFlight overrides it to true (12 threads)

Tests running in common module context got 5 threads at runtime, causing mismatch with hardcoded 12, leading to test failures.

Fix: Reference CommandDispatcher.SILENT_REQUEST_THREAD_POOL_SIZE directly instead of caching a hardcoded value, ensuring tests use the correct flight-controlled pool size.