### PR TITLE
add docs on setSecretKey, Fixes AB#3525780

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationSettings.java
@@ -116,7 +116,13 @@ public enum AuthenticationSettings {
     /**
      * Set raw bytes to derive secretKey to use in encrypt/decrypt. KeySpec
      * algorithm is AES.
-     * <p>
+     *
+     * If the calling app needs to set the key,
+     * this method must be invoked before any other MSAL classes,
+     * otherwise the key might not be loaded
+     * (The existing encrypted key will not be readable,
+     * and new data will be encrypted with a Keystore-wrapped key).
+     *
      * Please note: If a device with an existing installation of the ADAL/MSAL host-app is upgraded
      * from API 17 -> API 18+ then the previously-used secret key data must continue to be supplied
      * in order to not lose SSO state when reading cache entries written prior to upgrade.


### PR DESCRIPTION
[AB#3525780](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3525780)

Recently, Intune CP/MAM accidentally swap the invocation order of this method, and end up with the "cache poisoning" issue.

- old data was encrypted with user provided key.
- key was not loaded properly since the static key object was created before they invoke setSecretKey()
- old data = not decryptable, new data = encrypted with keystore-wrapped key.

Since this setSecretKey() was kept due to backward compatibility, we do not want to publish this in public docs.

(back then, Keystore wasn't reliable so this method was used as a default. 
Once KeyStore became reliable, Keystore became the default option for MSAL. 
However, apps that has been using us since ADAL day will still stuck with this legacy method - until we can fund the full migration work for them)

They reached out to us as a postmortem, and agreed that at the very least we should update the docs here.