### PR TITLE
Fixes AB#3527654 Remove Lru cache + few optimizations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Remove LruCache from SharedPreferencesFileManager (#2910)
 - [MINOR] Add tracking for urls loaded by our webview (#2892)
 - [MINOR] Rework OpenTelemetry spans for secret key generation and retrieval operations (#2869)
 - [MAJOR] add isBrokerProcess to IPlatformUtil (#2882)

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -24,8 +24,6 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.LruCache;
-
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -54,10 +52,7 @@ import java.util.concurrent.ConcurrentMap;
 public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage {
 
     private static final String TAG = SharedPreferencesFileManager.class.getSimpleName();
-
     private final Object cacheLock = new Object();
-    @GuardedBy("cacheLock")
-    private final LruCache<String, String> fileCache = new LruCache<>(256);
     @GuardedBy("cacheLock")
     private final SharedPreferences mSharedPreferences;
     private final KeyAccessorStringAdapter mEncryptionManager;
@@ -65,7 +60,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     private final String mSharedPreferencesFileName;
     // This is making a huge assumption - that we don't need to separate this cache by context.
     private static final ConcurrentMap<String, SharedPreferencesFileManager> objectCache =
-            new ConcurrentHashMap<String, SharedPreferencesFileManager>(16, 0.75f, 1);
+            new ConcurrentHashMap<>(16, 0.75f, 1);
 
 
     /**
@@ -139,12 +134,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         final String methodTag = TAG + ":putString";
 
         synchronized (cacheLock) {
-            if (value != null) {
-                fileCache.put(key, value);
-            } else {
-                fileCache.remove(key);
-            }
-
             final SharedPreferences.Editor editor = mSharedPreferences.edit();
 
             if (null == mEncryptionManager || StringUtil.isNullOrEmpty(value)) {
@@ -176,29 +165,26 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     @Nullable
     public final String getString(final String key) {
         final String methodTag = TAG + ":getString";
+        final String storedValue;
 
         synchronized (cacheLock) {
-            String memCache = fileCache.get(key);
-            if (memCache != null) {
-                return memCache;
-            }
+            storedValue = mSharedPreferences.getString(key, null);
+        }
 
-            final String storedValue = mSharedPreferences.getString(key, null);
-            if (StringUtil.isNullOrEmpty(storedValue)) {
-                Logger.info(methodTag, "Data associated to the given key is null or empty", null);
-                return null;
-            }
+        if (StringUtil.isNullOrEmpty(storedValue)) {
+            Logger.info(methodTag, "Data associated to the given key is null or empty", null);
+            return null;
+        }
 
-            if (mEncryptionManager == null){
-                return storedValue;
-            }
+        if (mEncryptionManager == null){
+            return storedValue;
+        }
 
-            try {
-                return mEncryptionManager.decrypt(storedValue);
-            } catch (final ClientException e){
-                Logger.error(methodTag, "Failed to decrypt value", null);
-                return null;
-            }
+        try {
+            return mEncryptionManager.decrypt(storedValue);
+        } catch (final ClientException e){
+            Logger.error(methodTag, "Failed to decrypt value", null);
+            return null;
         }
     }
 
@@ -226,9 +212,19 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
 
         if (null != mEncryptionManager) {
             for (Map.Entry<String, String> entry : entries.entrySet()) {
-                //This is slightly wasteful, but we have no better key iterator and decryption
-                //is probably more painful than the additional file read when we miss in the cache.
-                String decryptedValue = getString(entry.getKey());
+                final String storedValue = entry.getValue();
+                if (StringUtil.isNullOrEmpty(storedValue)) {
+                    continue;
+                }
+
+                final String decryptedValue;
+                try {
+                    decryptedValue = mEncryptionManager.decrypt(storedValue);
+                } catch (final ClientException e) {
+                    Logger.error(TAG + ":getAll", "Failed to decrypt value", null);
+                    continue;
+                }
+
                 if (!StringUtil.isNullOrEmpty(decryptedValue)) {
                     entry.setValue(decryptedValue);
                 }
@@ -259,7 +255,19 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
                     Map.Entry<String, String> nextElement = iterator.next();
                     if (keyFilter.test(nextElement.getKey())) {
                         if (mEncryptionManager != null) {
-                            String decryptedValue = getString(nextElement.getKey());
+                            final String storedValue = nextElement.getValue();
+                            if (StringUtil.isNullOrEmpty(storedValue)) {
+                                continue;
+                            }
+
+                            final String decryptedValue;
+                            try {
+                                decryptedValue = mEncryptionManager.decrypt(storedValue);
+                            } catch (final ClientException e) {
+                                Logger.error(TAG + ":getAllFilteredByKey", "Failed to decrypt value", null);
+                                continue;
+                            }
+
                             if (!StringUtil.isNullOrEmpty(decryptedValue)) {
                                 nextEntry = new AbstractMap.SimpleEntry<String, String>(nextElement.getKey(), decryptedValue);
                             }
@@ -291,7 +299,9 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
 
     @Override
     public final boolean contains(final String key) {
-        return !StringUtil.isNullOrEmpty(getString(key));
+        synchronized (cacheLock) {
+            return !StringUtil.isNullOrEmpty(mSharedPreferences.getString(key, null));
+        }
     }
 
     @Override
@@ -299,7 +309,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         synchronized (cacheLock) {
             final SharedPreferences.Editor editor = mSharedPreferences.edit();
             editor.clear();
-            fileCache.evictAll();
             editor.apply();
         }
     }
@@ -312,7 +321,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
                 "Removing cache key"
         );
         synchronized (cacheLock) {
-            fileCache.remove(key);
             final SharedPreferences.Editor editor = mSharedPreferences.edit();
             editor.remove(key);
             editor.apply();

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -159,9 +159,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     @Nullable
     public final String getString(final String key) {
         final String methodTag = TAG + ":getString";
-        final String storedValue;
-
-        storedValue = mSharedPreferences.getString(key, null);
+        final String storedValue = mSharedPreferences.getString(key, null);
 
         if (StringUtil.isNullOrEmpty(storedValue)) {
             Logger.info(methodTag, "Data associated to the given key is null or empty", null);
@@ -201,7 +199,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         // We're not synchronizing this access, since we're not modifying it here.
         // Suppressing unchecked warnings due to casting Map<String,?> to Map<String,String>
         @SuppressWarnings(WarningType.unchecked_warning) final Map<String, String> entries = (Map<String, String>) mSharedPreferences.getAll();
-
+        final String methodTag = TAG + ":getAll";
         if (null != mEncryptionManager) {
             for (Map.Entry<String, String> entry : entries.entrySet()) {
                 final String storedValue = entry.getValue();
@@ -213,7 +211,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
                 try {
                     decryptedValue = mEncryptionManager.decrypt(storedValue);
                 } catch (final ClientException e) {
-                    Logger.error(TAG + ":getAll", "Failed to decrypt value", null);
+                    Logger.error(methodTag, "Failed to decrypt value", null);
                     continue;
                 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -300,7 +300,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     @Override
     public final boolean contains(final String key) {
         synchronized (cacheLock) {
-            return !StringUtil.isNullOrEmpty(mSharedPreferences.getString(key, null));
+            return mSharedPreferences.contains(key);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManager.java
@@ -24,7 +24,6 @@ package com.microsoft.identity.common.internal.cache;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -52,8 +51,6 @@ import java.util.concurrent.ConcurrentMap;
 public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage {
 
     private static final String TAG = SharedPreferencesFileManager.class.getSimpleName();
-    private final Object cacheLock = new Object();
-    @GuardedBy("cacheLock")
     private final SharedPreferences mSharedPreferences;
     private final KeyAccessorStringAdapter mEncryptionManager;
     @VisibleForTesting
@@ -61,7 +58,6 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
     // This is making a huge assumption - that we don't need to separate this cache by context.
     private static final ConcurrentMap<String, SharedPreferencesFileManager> objectCache =
             new ConcurrentHashMap<>(16, 0.75f, 1);
-
 
     /**
      * Constructs an instance of SharedPreferencesFileManager. Operating mode is always MODE_PRIVATE.
@@ -133,32 +129,30 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
             final String value) {
         final String methodTag = TAG + ":putString";
 
-        synchronized (cacheLock) {
-            final SharedPreferences.Editor editor = mSharedPreferences.edit();
+        final SharedPreferences.Editor editor = mSharedPreferences.edit();
 
-            if (null == mEncryptionManager || StringUtil.isNullOrEmpty(value)) {
-                editor.putString(key, value).apply();
-                return;
-            }
-
-            // What this does is that if the encryption fails, we would still write "null" to the storage.
-            // This might not be the right behavior, but changing this could break stuff.
-            // e.g.
-            //      1. In putString(), we would store data in the in-memory cache first, then try encrypting data.
-            //      2. Assuming the encryption fails, this will persist the key.
-            //      3. the getAll() and getAllFilteredByKey() below relies on the key "in the storage".
-            //         If we don't persist the key to the storage, getAll() will not have any key to pull data from in-memory storage.
-            //
-            // Therefore. i'm leaving this untouched.
-            String encryptedValue = null;
-            try {
-                encryptedValue = mEncryptionManager.encrypt(value);
-            } catch (final ClientException e){
-                Logger.error(methodTag, "Failed to store encrypted value", null);
-            }
-
-            editor.putString(key, encryptedValue).apply();
+        if (null == mEncryptionManager || StringUtil.isNullOrEmpty(value)) {
+            editor.putString(key, value).apply();
+            return;
         }
+
+        // What this does is that if the encryption fails, we would still write "null" to the storage.
+        // This might not be the right behavior, but changing this could break stuff.
+        // e.g.
+        //      1. In putString(), we would store data in the in-memory cache first, then try encrypting data.
+        //      2. Assuming the encryption fails, this will persist the key.
+        //      3. the getAll() and getAllFilteredByKey() below relies on the key "in the storage".
+        //         If we don't persist the key to the storage, getAll() will not have any key to pull data from in-memory storage.
+        //
+        // Therefore. i'm leaving this untouched.
+        String encryptedValue = null;
+        try {
+            encryptedValue = mEncryptionManager.encrypt(value);
+        } catch (final ClientException e){
+            Logger.error(methodTag, "Failed to store encrypted value", null);
+        }
+
+        editor.putString(key, encryptedValue).apply();
     }
 
     @Override
@@ -167,9 +161,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
         final String methodTag = TAG + ":getString";
         final String storedValue;
 
-        synchronized (cacheLock) {
-            storedValue = mSharedPreferences.getString(key, null);
-        }
+        storedValue = mSharedPreferences.getString(key, null);
 
         if (StringUtil.isNullOrEmpty(storedValue)) {
             Logger.info(methodTag, "Data associated to the given key is null or empty", null);
@@ -299,18 +291,14 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
 
     @Override
     public final boolean contains(final String key) {
-        synchronized (cacheLock) {
-            return mSharedPreferences.contains(key);
-        }
+        return mSharedPreferences.contains(key);
     }
 
     @Override
     public final void clear() {
-        synchronized (cacheLock) {
-            final SharedPreferences.Editor editor = mSharedPreferences.edit();
-            editor.clear();
-            editor.apply();
-        }
+        mSharedPreferences.edit()
+                .clear()
+                .apply();
     }
 
     @Override
@@ -320,11 +308,10 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
                 methodTag,
                 "Removing cache key"
         );
-        synchronized (cacheLock) {
-            final SharedPreferences.Editor editor = mSharedPreferences.edit();
-            editor.remove(key);
-            editor.apply();
-        }
+
+        mSharedPreferences.edit()
+            .remove(key)
+            .apply();
 
         Logger.infoPII(
                 methodTag,
@@ -342,9 +329,7 @@ public class SharedPreferencesFileManager implements IMultiTypeNameValueStorage 
      * NOTE: This method is used by OneAuth
      */
     public boolean flushSharedPreference(){
-        synchronized (cacheLock) {
-            final SharedPreferences.Editor editor = mSharedPreferences.edit();
-            return editor.commit();
-        }
+            return mSharedPreferences.edit()
+                    .commit();
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManagerTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/cache/SharedPreferencesFileManagerTest.java
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+
+package com.microsoft.identity.common.internal.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.java.crypto.IKeyAccessor;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.nio.charset.StandardCharsets;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = {Build.VERSION_CODES.N})
+public class SharedPreferencesFileManagerTest {
+
+    private final Context mContext = ApplicationProvider.getApplicationContext();
+    private final Set<String> mCreatedSharedPreferencesFiles = new HashSet<>();
+
+    private static final String PREFIX = "enc:";
+
+    private IKeyAccessor createMockKeyAccessor() throws Exception {
+        final IKeyAccessor keyAccessor = mock(IKeyAccessor.class);
+
+        when(keyAccessor.encrypt(any(byte[].class))).thenAnswer(invocation -> {
+            final byte[] plaintext = invocation.getArgument(0);
+            final String payload = PREFIX + new String(plaintext, StandardCharsets.UTF_8);
+            return payload.getBytes(StandardCharsets.UTF_8);
+        });
+
+        when(keyAccessor.decrypt(any(byte[].class))).thenAnswer(invocation -> {
+            final byte[] ciphertext = invocation.getArgument(0);
+            final String payload = new String(ciphertext, StandardCharsets.UTF_8);
+            if (!payload.startsWith(PREFIX)) {
+                throw new ClientException("invalid_ciphertext", "Missing expected prefix");
+            }
+
+            return payload.substring(PREFIX.length()).getBytes(StandardCharsets.UTF_8);
+        });
+
+        return keyAccessor;
+    }
+
+    private IKeyAccessor createMockKeyAccessorWithDecryptFailure() throws Exception {
+        final IKeyAccessor keyAccessor = createMockKeyAccessor();
+        when(keyAccessor.decrypt(any(byte[].class))).thenThrow(
+                new ClientException("mock_decrypt_error", "Simulated decrypt failure")
+        );
+        return keyAccessor;
+    }
+
+    private String createTestFileName() {
+        final String fileName = "spfm-test-" + UUID.randomUUID();
+        mCreatedSharedPreferencesFiles.add(fileName);
+        return fileName;
+    }
+
+    @After
+    public void cleanup() {
+        for (final String fileName : mCreatedSharedPreferencesFiles) {
+            final SharedPreferences sharedPreferences = mContext.getSharedPreferences(fileName, Context.MODE_PRIVATE);
+            sharedPreferences.edit().clear().commit();
+            mContext.deleteSharedPreferences(fileName);
+        }
+        mCreatedSharedPreferencesFiles.clear();
+        SharedPreferencesFileManager.clearSingletonCache();
+    }
+
+    @Test
+    public void getAll_withEncryptionManager_returnsPlaintextValues() throws Exception {
+        final String fileName = createTestFileName();
+        final String key = "k1";
+        final String plaintext = "value-1";
+
+        final IKeyAccessor encryptionManager = createMockKeyAccessor();
+        final SharedPreferencesFileManager manager = new SharedPreferencesFileManager(mContext, fileName, encryptionManager);
+
+        manager.putString(key, plaintext);
+
+        final Map<String, String> all = manager.getAll();
+        assertEquals(plaintext, all.get(key));
+    }
+
+    @Test
+    public void getAll_whenDecryptionFails_keepsStoredCiphertextValue() throws Exception {
+        final String fileName = createTestFileName();
+        final String key = "k2";
+        final String plaintext = "value-2";
+
+        final SharedPreferencesFileManager writer = new SharedPreferencesFileManager(
+                mContext,
+                fileName,
+            createMockKeyAccessor()
+        );
+        writer.putString(key, plaintext);
+
+        final SharedPreferences preferences = mContext.getSharedPreferences(fileName, Context.MODE_PRIVATE);
+        final String storedCiphertext = preferences.getString(key, null);
+        assertNotNull(storedCiphertext);
+
+        final SharedPreferencesFileManager readerWithDecryptFailure = new SharedPreferencesFileManager(
+                mContext,
+                fileName,
+            createMockKeyAccessorWithDecryptFailure()
+        );
+
+        final Map<String, String> all = readerWithDecryptFailure.getAll();
+        assertTrue(all.containsKey(key));
+        assertEquals(storedCiphertext, all.get(key));
+    }
+
+    @Test
+    public void getAllFilteredByKey_withEncryptionManager_returnsDecryptedFilteredValues() throws Exception {
+        final String fileName = createTestFileName();
+        final IKeyAccessor encryptionManager = createMockKeyAccessor();
+        final SharedPreferencesFileManager manager = new SharedPreferencesFileManager(mContext, fileName, encryptionManager);
+
+        manager.putString("keep-1", "plain-1");
+        manager.putString("drop-1", "plain-2");
+        manager.putString("keep-2", "plain-3");
+
+        final Iterator<Map.Entry<String, String>> iterator =
+                manager.getAllFilteredByKey(key -> key.startsWith("keep-"));
+
+        int count = 0;
+        while (iterator.hasNext()) {
+            final Map.Entry<String, String> entry = iterator.next();
+            assertTrue(entry.getKey().startsWith("keep-"));
+
+            if ("keep-1".equals(entry.getKey())) {
+                assertEquals("plain-1", entry.getValue());
+            }
+
+            if ("keep-2".equals(entry.getKey())) {
+                assertEquals("plain-3", entry.getValue());
+            }
+
+            count++;
+        }
+
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void getAllFilteredByKey_whenDecryptFailsOrValueEmpty_skipsEntry() throws Exception {
+        final String fileName = createTestFileName();
+
+        final SharedPreferencesFileManager writer = new SharedPreferencesFileManager(
+                mContext,
+                fileName,
+                createMockKeyAccessor()
+        );
+        writer.putString("will-fail", "plain-value");
+        writer.putString("empty-value", "");
+
+        final SharedPreferencesFileManager readerWithDecryptFailure = new SharedPreferencesFileManager(
+                mContext,
+                fileName,
+            createMockKeyAccessorWithDecryptFailure()
+        );
+
+        final Iterator<Map.Entry<String, String>> iterator =
+                readerWithDecryptFailure.getAllFilteredByKey(
+                        key -> "will-fail".equals(key) || "empty-value".equals(key)
+                );
+
+        assertFalse(iterator.hasNext());
+    }
+}


### PR DESCRIPTION
Fixes [AB#3527654](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3527654) With the introduction of in-memory cache, the use of LruCache is redundant and can be removed. This PR also introduces few code optimizations in terms of encryption / decryption.