### PR TITLE
Remove test for trustDebugBrokerFlag, Fixes AB#3529118

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/BuildConfigTest.kt
@@ -39,12 +39,4 @@ class BuildConfigTest {
 
         assert(!BuildConfig.bypassRedirectUriCheck)
     }
-
-    @Test
-    fun failIfTrustDebugBrokerFlagEnabled(){
-        // Do not run this on scheduled test.
-        Assume.assumeFalse(isBuildReason(BuildReason.Schedule))
-
-        assert(!BuildConfig.trustDebugBrokerFlag)
-    }
 }


### PR DESCRIPTION
Removed test for trustDebugBrokerFlag in BuildConfigTest.


why?
Now we have scheduled and manual builds with trustDebugBrokerFlag for testing

[AB#3529118](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3529118)
