### PR TITLE
Allow apps to setShouldTrustDebugBrokers, Fixes AB#3533160

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -89,14 +89,10 @@ data class BrokerData(
         @JvmStatic
         fun setShouldTrustDebugBrokers(value: Boolean) {
             val methodTag = "$TAG:setShouldTrustDebugBrokers"
-            if (BuildConfig.DEBUG) {
-                sShouldTrustDebugBrokers = value
-                Logger.info(methodTag, "Setting shouldTrustDebugBrokers to $value." +
-                        " This should only be used for testing purposes.")
-            } else {
-                Logger.warn(methodTag, "Attempting to set shouldTrustDebugBrokers to $value. " +
-                        "This change will be ignored since the current build is not a debug build.")
+            if (!BuildConfig.DEBUG && value) {
+                Logger.warn(methodTag, "You are forcing to trust debug brokers in non-debug builds.")
             }
+            sShouldTrustDebugBrokers = value
         }
 
         @JvmStatic


### PR DESCRIPTION
Revert [#2900](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2900)
[AB#3533160](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3533160)

Reason: 
We removed an ability for apps [to trust debug brokers](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2900) last month
because LTW were enforcing this to "NOT Trust debug broker" (meaning all of our tests involving LTW and brokerhost would fail)
and they were on holiday.

As a side effect, this means OneAuthTestApp cannot test with BrokerHost either.
(OneAuthTestApp needs to "pretend" to be Outlook,Word,etc, so they cannot test with prod broker.)

The Fix:
Revert this change = OneAuth apps can select to trust debug broker apps.
(and I already reached out to LTW to undo the blocking code on their side).