### PR TITLE
Revert Ignore setShouldTrustDebugBrokers if is not a Debug build #2900, Fixes AB#3529118

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerData.kt
@@ -89,14 +89,10 @@ data class BrokerData(
         @JvmStatic
         fun setShouldTrustDebugBrokers(value: Boolean) {
             val methodTag = "$TAG:setShouldTrustDebugBrokers"
-            if (BuildConfig.DEBUG) {
-                sShouldTrustDebugBrokers = value
-                Logger.info(methodTag, "Setting shouldTrustDebugBrokers to $value." +
-                        " This should only be used for testing purposes.")
-            } else {
-                Logger.warn(methodTag, "Attempting to set shouldTrustDebugBrokers to $value. " +
-                        "This change will be ignored since the current build is not a debug build.")
+            if (!BuildConfig.DEBUG && value) {
+                Logger.warn(methodTag, "You are forcing to trust debug brokers in non-debug builds.")
             }
+            sShouldTrustDebugBrokers = value
         }
 
         @JvmStatic


### PR DESCRIPTION
[AB#3529118](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3529118)

**Context / Issue Summary:**
Historically, the Device Registration (DR) API was permissive and allowed any app to call it, so our tests were written with relaxed validation. When we tightened security to ensure only trusted broker apps can call the DR API, some of those tests were impacted. To preserve coverage, we relaxed validation only in specific test scenarios while keeping strict enforcement elsewhere to ensure security is still validated.

**Environment behavior:**
• Local flights: debug + prod brokers, tests run with relaxed validation where required
• ECS: prod broker only, tests that require relaxed validation are skipped

For LTW tests, validation must be relaxed so the broker host can call LTW. However, LTW was overwriting this by forcing BrokerData.setShouldTrustDebugBrokers(false) at build time, which caused local test failures. While the LTW team was OOF for Lunar New Year, we ignored that overwrite to unblock testing.

**Current problem:**
That workaround now breaks OneAuth UI tests, which use  release common (trusts only prod brokers) and rely on setShouldTrustDebugBrokers(true) to use the broker host as a broker app.

**Plan:**
Revert the ignore on our side and have LTW remove their overwrite (they’re back now). Once that’s done, tests should behave correctly without any workarounds.


