### PR TITLE
Handle target="_blank" links in authorization WebView, Fixes AB#3535641

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ vNext
 - [MINOR] Remove LruCache from SharedPreferencesFileManager (#2910)
 - [MINOR] Edge TB: Claims (#2925)
 - [PATCH] Update Moshi to 1.15.2 to resolve okio CVE-2023-3635 vulnerability (#3005)
+- [MINOR] Handle target="_blank" links in authorization WebView (#3010)
 
 Version 24.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1507,6 +1507,11 @@ public final class AuthenticationConstants {
         public static final String WEBVIEW_TARGET_BLANK_ROUTE_TLR = "tlr_flow";
 
         /**
+         * WebView routing value when the popup was not initiated by a user gesture.
+         */
+        public static final String WEBVIEW_TARGET_BLANK_ROUTE_NO_USER_GESTURE = "no_user_gesture";
+
+        /**
          * Prefix in the redirect for PlayStore.
          */
         public static final String PLAY_STORE_INSTALL_PREFIX = "market://details?id=";

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1482,6 +1482,31 @@ public final class AuthenticationConstants {
         public static final String REDIRECT_SSL_PREFIX = "https://";
 
         /**
+         * Path segment for the TLR (Total loss recovery) start page.
+         */
+        public static final String TLR_START_PATH = "/tlr/start";
+
+        /**
+         * WebView routing value when the target URL from a target=_blank navigation is null.
+         */
+        public static final String WEBVIEW_TARGET_BLANK_ROUTE_NULL_URL = "null_url";
+
+        /**
+         * WebView routing value when the target URL is not SSL-protected.
+         */
+        public static final String WEBVIEW_TARGET_BLANK_ROUTE_NON_SSL = "non_ssl";
+
+        /**
+         * WebView routing value when the target URL is loaded inline (non-TLR page).
+         */
+        public static final String WEBVIEW_TARGET_BLANK_ROUTE_NON_TLR = "non_tlr_flow";
+
+        /**
+         * WebView routing value when the target URL is delegated to the system browser (TLR page).
+         */
+        public static final String WEBVIEW_TARGET_BLANK_ROUTE_TLR = "tlr_flow";
+
+        /**
          * Prefix in the redirect for PlayStore.
          */
         public static final String PLAY_STORE_INSTALL_PREFIX = "market://details?id=";

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -46,8 +46,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.PermissionRequest;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -87,8 +89,13 @@ import java.util.Map;
 
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID;
 
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
 
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 
 /**
  * Authorization fragment with embedded webview.
@@ -352,6 +359,13 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mWebView.getSettings().setUseWideViewPort(true);
         mWebView.getSettings().setBuiltInZoomControls(webViewZoomControlsEnabled);
         mWebView.getSettings().setSupportZoom(webViewZoomEnabled);
+
+        // Enable multiple windows so that target="_blank" links trigger onCreateWindow
+        // instead of being silently dropped by the WebView - controlled by flight.
+        final boolean multipleWindowsEnabled = CommonFlightsManager.INSTANCE.getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_MULTIPLE_WINDOWS);
+        mWebView.getSettings().setSupportMultipleWindows(multipleWindowsEnabled);
+
         mWebView.setVisibility(View.INVISIBLE);
         mWebView.setWebViewClient(webViewClient);
         mWebView.setWebChromeClient(new WebChromeClient() {
@@ -375,6 +389,46 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 // This method allows the ChromeClient to provide that default image.
                 // We will return a 10x10 empty image, instead of the default grey playback image. #2424
                 return Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
+            }
+
+            @Override
+            public boolean onCreateWindow(final WebView view, boolean isDialog,
+                                          boolean isUserGesture, final android.os.Message resultMsg) {
+                if (!multipleWindowsEnabled) {
+                    // Flight is off; should not reach here, but guard anyway.
+                    return false;
+                }
+                // Handles target="_blank" links by opening them in the device's default browser
+                // instead of silently dropping the navigation.
+                final SpanContext parentSpanContext = requireActivity() instanceof AuthorizationActivity
+                        ? ((AuthorizationActivity) requireActivity()).getSpanContext() : null;
+                final Span span = OTelUtility.createSpanFromParent(
+                        SpanName.WebViewTargetBlankNavigation.name(), parentSpanContext);
+                try (final Scope scope = span.makeCurrent()) {
+                    Logger.info(methodTag, "onCreateWindow: intercepting target=_blank navigation.");
+                    final WebView tempWebView = new WebView(view.getContext());
+                    tempWebView.setWebViewClient(new WebViewClient() {
+                        @Override
+                        public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
+                            final String url = request.getUrl().toString();
+                            Logger.info(methodTag, "onCreateWindow: opening target=_blank URL in external browser.");
+                            span.setAttribute("target_blank_url", url);
+                            final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                            view.getContext().startActivity(browserIntent);
+                            return true;
+                        }
+                    });
+                    final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
+                    transport.setWebView(tempWebView);
+                    resultMsg.sendToTarget();
+                    span.setStatus(StatusCode.OK);
+                } catch (final Exception e) {
+                    Logger.error(methodTag, "Error handling target=_blank navigation.", e);
+                    span.setStatus(StatusCode.ERROR, e.getMessage());
+                } finally {
+                    span.end();
+                }
+                return true;
             }
         });
         setupPasskeyWebListener(mWebView, webViewClient);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -450,7 +450,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
      * @param span               The telemetry span to record which routing path is taken.
      * @param isUserGesture      Whether the popup was initiated by a user gesture (e.g. a click).
      */
-    private void handleInterceptedUrlFromNewWindow(@NonNull final WebView mainWebView,
+    @VisibleForTesting
+    void handleInterceptedUrlFromNewWindow(@NonNull final WebView mainWebView,
                                                    @NonNull final WebView interceptorWebView,
                                                    @NonNull final WebResourceRequest request,
                                                    @NonNull final Span span,
@@ -504,7 +505,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
      * @param url The URL to check.
      * @return {@code true} if the URL is a TLR start page, {@code false} otherwise.
      */
-    private boolean isTlrUrl(@Nullable final String url) {
+    @VisibleForTesting
+    boolean isTlrUrl(@Nullable final String url) {
         if (url == null) {
             return false;
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -416,7 +416,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     interceptorWebView.setWebViewClient(new WebViewClient() {
                         @Override
                         public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
-                            handleInterceptedUrlFromNewWindow(view, v, request, span);
+                            handleInterceptedUrlFromNewWindow(view, v, request, span, isUserGesture);
                             return true;
                         }
                     });
@@ -448,11 +448,13 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
      * @param interceptorWebView The temporary interceptor WebView (will be destroyed after handling).
      * @param request            The intercepted URL request.
      * @param span               The telemetry span to record which routing path is taken.
+     * @param isUserGesture      Whether the popup was initiated by a user gesture (e.g. a click).
      */
     private void handleInterceptedUrlFromNewWindow(@NonNull final WebView mainWebView,
                                                    @NonNull final WebView interceptorWebView,
                                                    @NonNull final WebResourceRequest request,
-                                                   @NonNull final Span span) {
+                                                   @NonNull final Span span,
+                                                   final boolean isUserGesture) {
         final String methodTag = TAG + ":handleInterceptedUrlFromNewWindow";
         try {
             final String targetUrl = request.getUrl().toString();
@@ -461,6 +463,12 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             if (targetUrl == null) {
                 span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NULL_URL);
                 Logger.warn(methodTag, "onCreateWindow: target URL is null, ignoring.");
+            } else if (!isUserGesture) {
+                // Not initiated by user gesture: load inline as a safe fallback instead of
+                // opening an external browser, to prevent programmatic/scripted popups.
+                span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NO_USER_GESTURE);
+                Logger.warn(methodTag, "onCreateWindow: popup not initiated by user gesture, loading URL inline.");
+                mainWebView.loadUrl(targetUrl);
             } else if (!targetUrl.toLowerCase().startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)) {
                 // Non-SSL URL: refuse to open, matching AzureActiveDirectoryWebViewClient behavior.
                 span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_SSL);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -400,6 +400,10 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     // Flight is off; should not reach here, but guard anyway.
                     return false;
                 }
+                if (resultMsg.obj == null) {
+                    Logger.error(methodTag, "onCreateWindow: resultMsg.obj is null, cannot set up transport.", null);
+                    return false;
+                }
                 // Handles target="_blank" links by opening them in the device's default browser
                 // instead of silently dropping the navigation.
                 final SpanContext parentSpanContext = requireActivity() instanceof AuthorizationActivity
@@ -432,11 +436,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                             return true;
                         }
                     });
-                    if (resultMsg.obj == null) {
-                        Logger.error(methodTag, "onCreateWindow: resultMsg.obj is null, cannot set up transport.", null);
-                        span.setStatus(StatusCode.ERROR, "resultMsg.obj is null");
-                        return false;
-                    }
                     final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
                     transport.setWebView(interceptorWebView);
                     resultMsg.sendToTarget();

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -40,6 +40,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Message;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -393,7 +394,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
             @Override
             public boolean onCreateWindow(final WebView view, boolean isDialog,
-                                          boolean isUserGesture, final android.os.Message resultMsg) {
+                                          boolean isUserGesture, final Message resultMsg) {
                 if (!multipleWindowsEnabled) {
                     // Flight is off; should not reach here, but guard anyway.
                     return false;
@@ -404,31 +405,42 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                         ? ((AuthorizationActivity) requireActivity()).getSpanContext() : null;
                 final Span span = OTelUtility.createSpanFromParent(
                         SpanName.WebViewTargetBlankNavigation.name(), parentSpanContext);
+                boolean windowHandled = false;
                 try (final Scope scope = span.makeCurrent()) {
                     Logger.info(methodTag, "onCreateWindow: intercepting target=_blank navigation.");
-                    final WebView tempWebView = new WebView(view.getContext());
-                    tempWebView.setWebViewClient(new WebViewClient() {
+                    final WebView interceptorWebView = new WebView(view.getContext());
+                    interceptorWebView.setWebViewClient(new WebViewClient() {
                         @Override
                         public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
-                            final String url = request.getUrl().toString();
-                            Logger.info(methodTag, "onCreateWindow: opening target=_blank URL in external browser.");
-                            span.setAttribute("target_blank_url", url);
-                            final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                            view.getContext().startActivity(browserIntent);
+                            try {
+                                final String url = request.getUrl().toString();
+                                Logger.info(methodTag, "onCreateWindow: opening target=_blank URL in external browser.");
+                                span.setAttribute("target_blank_url", url);
+                                final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                                view.getContext().startActivity(browserIntent);
+                            } catch (final Exception e) {
+                                Logger.error(methodTag, "Error opening target=_blank URL in external browser.", e);
+                            }
                             return true;
                         }
                     });
+                    if (resultMsg.obj == null) {
+                        Logger.error(methodTag, "onCreateWindow: resultMsg.obj is null, cannot set up transport.", null);
+                        span.setStatus(StatusCode.ERROR, "resultMsg.obj is null");
+                        return false;
+                    }
                     final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
-                    transport.setWebView(tempWebView);
+                    transport.setWebView(interceptorWebView);
                     resultMsg.sendToTarget();
                     span.setStatus(StatusCode.OK);
-                } catch (final Exception e) {
+                    windowHandled = true;
+                } catch (@NonNull final Exception e) {
                     Logger.error(methodTag, "Error handling target=_blank navigation.", e);
-                    span.setStatus(StatusCode.ERROR, e.getMessage());
+                    span.setStatus(StatusCode.ERROR, e.getMessage() != null ? e.getMessage() : "Unknown error");
                 } finally {
                     span.end();
                 }
-                return true;
+                return windowHandled;
             }
         });
         setupPasskeyWebListener(mWebView, webViewClient);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -91,6 +91,7 @@ import java.util.Map;
 import static com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID;
 
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.opentelemetry.SpanName;
 
 import io.opentelemetry.api.trace.Span;
@@ -406,7 +407,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                 final Span span = OTelUtility.createSpanFromParent(
                         SpanName.WebViewTargetBlankNavigation.name(), parentSpanContext);
                 boolean windowHandled = false;
-                try (final Scope scope = span.makeCurrent()) {
+                try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
                     Logger.info(methodTag, "onCreateWindow: intercepting target=_blank navigation.");
                     final WebView interceptorWebView = new WebView(view.getContext());
                     interceptorWebView.setWebViewClient(new WebViewClient() {
@@ -414,12 +415,19 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                         public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
                             try {
                                 final String url = request.getUrl().toString();
+                                final String scheme = request.getUrl().getScheme();
+                                if (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme)) {
+                                    Logger.warn(methodTag, "onCreateWindow: ignoring non-http(s) scheme: " + scheme);
+                                    return true;
+                                }
                                 Logger.info(methodTag, "onCreateWindow: opening target=_blank URL in external browser.");
-                                span.setAttribute("target_blank_url", url);
                                 final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                                 view.getContext().startActivity(browserIntent);
                             } catch (final Exception e) {
                                 Logger.error(methodTag, "Error opening target=_blank URL in external browser.", e);
+                            } finally {
+                                // Destroy the interceptor WebView after it has served its purpose
+                                v.post(() -> v.destroy());
                             }
                             return true;
                         }
@@ -436,7 +444,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     windowHandled = true;
                 } catch (@NonNull final Exception e) {
                     Logger.error(methodTag, "Error handling target=_blank navigation.", e);
-                    span.setStatus(StatusCode.ERROR, e.getMessage() != null ? e.getMessage() : "Unknown error");
+                    span.recordException(e);
+                    span.setStatus(StatusCode.ERROR);
                 } finally {
                     span.end();
                 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -82,6 +82,7 @@ import com.microsoft.identity.common.java.util.ClientExtraSku;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Arrays;
@@ -156,6 +157,7 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         if (activity != null) {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
         }
+
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC)
                 && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             mFidoLauncher = registerForActivityResult(
@@ -273,6 +275,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                         if (!mAuthResultSent && !StringExtensions.isNullOrBlank(javascriptToExecute[0])) {
                             mWebView.evaluateJavascript(javascriptToExecute[0], null);
                         }
+
+                        // Dynamically toggle multiple-windows support so that target="_blank"
+                        // interception is active ONLY on the TLR start page. On all other
+                        // pages the WebView behaves exactly as before.
+                        if (CommonFlightsManager.INSTANCE.getFlightsProvider()
+                                .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_MULTIPLE_WINDOWS)) {
+                            mWebView.getSettings().setSupportMultipleWindows(isTlrUrl(url));
+                        }
                     }
                 },
                 mRedirectUri,
@@ -362,12 +372,6 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         mWebView.getSettings().setBuiltInZoomControls(webViewZoomControlsEnabled);
         mWebView.getSettings().setSupportZoom(webViewZoomEnabled);
 
-        // Enable multiple windows so that target="_blank" links trigger onCreateWindow
-        // instead of being silently dropped by the WebView - controlled by flight.
-        final boolean multipleWindowsEnabled = CommonFlightsManager.INSTANCE.getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_MULTIPLE_WINDOWS);
-        mWebView.getSettings().setSupportMultipleWindows(multipleWindowsEnabled);
-
         mWebView.setVisibility(View.INVISIBLE);
         mWebView.setWebViewClient(webViewClient);
         mWebView.setWebChromeClient(new WebChromeClient() {
@@ -396,16 +400,11 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             @Override
             public boolean onCreateWindow(final WebView view, boolean isDialog,
                                           boolean isUserGesture, final Message resultMsg) {
-                if (!multipleWindowsEnabled) {
-                    // Flight is off; should not reach here, but guard anyway.
-                    return false;
-                }
                 if (resultMsg.obj == null) {
                     Logger.error(methodTag, "onCreateWindow: resultMsg.obj is null, cannot set up transport.", null);
                     return false;
                 }
-                // Handles target="_blank" links by opening them in the device's default browser
-                // instead of silently dropping the navigation.
+
                 final SpanContext parentSpanContext = requireActivity() instanceof AuthorizationActivity
                         ? ((AuthorizationActivity) requireActivity()).getSpanContext() : null;
                 final Span span = OTelUtility.createSpanFromParent(
@@ -417,41 +416,93 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     interceptorWebView.setWebViewClient(new WebViewClient() {
                         @Override
                         public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest request) {
-                            try {
-                                final String url = request.getUrl().toString();
-                                final String scheme = request.getUrl().getScheme();
-                                if (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme)) {
-                                    Logger.warn(methodTag, "onCreateWindow: ignoring non-http(s) scheme: " + scheme);
-                                    return true;
-                                }
-                                Logger.info(methodTag, "onCreateWindow: opening target=_blank URL in external browser.");
-                                final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                                view.getContext().startActivity(browserIntent);
-                            } catch (final Exception e) {
-                                Logger.error(methodTag, "Error opening target=_blank URL in external browser.", e);
-                            } finally {
-                                // Destroy the interceptor WebView after it has served its purpose
-                                v.post(() -> v.destroy());
-                            }
+                            handleInterceptedUrlFromNewWindow(view, v, request, span);
                             return true;
                         }
                     });
                     final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
                     transport.setWebView(interceptorWebView);
                     resultMsg.sendToTarget();
-                    span.setStatus(StatusCode.OK);
+                    // Span status and end are handled in handleInterceptedUrlFromNewWindow,
+                    // which fires asynchronously when shouldOverrideUrlLoading is called.
                     windowHandled = true;
                 } catch (@NonNull final Exception e) {
                     Logger.error(methodTag, "Error handling target=_blank navigation.", e);
                     span.recordException(e);
                     span.setStatus(StatusCode.ERROR);
-                } finally {
                     span.end();
                 }
                 return windowHandled;
             }
         });
         setupPasskeyWebListener(mWebView, webViewClient);
+    }
+
+    /**
+     * Handles the URL intercepted from a target=_blank navigation (onCreateWindow).
+     * Routes the URL based on whether the main WebView is currently on a TLR page:
+     * - TLR page: opens the URL in an external browser.
+     * - Non-TLR page: loads the URL inline in the main WebView.
+     *
+     * @param mainWebView        The main authentication WebView.
+     * @param interceptorWebView The temporary interceptor WebView (will be destroyed after handling).
+     * @param request            The intercepted URL request.
+     * @param span               The telemetry span to record which routing path is taken.
+     */
+    private void handleInterceptedUrlFromNewWindow(@NonNull final WebView mainWebView,
+                                                   @NonNull final WebView interceptorWebView,
+                                                   @NonNull final WebResourceRequest request,
+                                                   @NonNull final Span span) {
+        final String methodTag = TAG + ":handleInterceptedUrlFromNewWindow";
+        try {
+            final String targetUrl = request.getUrl().toString();
+            final String currentPageUrl = mainWebView.getUrl();
+
+            if (targetUrl == null) {
+                span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NULL_URL);
+                Logger.warn(methodTag, "onCreateWindow: target URL is null, ignoring.");
+            } else if (!targetUrl.toLowerCase().startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)) {
+                // Non-SSL URL: refuse to open, matching AzureActiveDirectoryWebViewClient behavior.
+                span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_SSL);
+                Logger.error(methodTag, "onCreateWindow: URL is not SSL protected, refusing to open.", null);
+            } else if (!isTlrUrl(currentPageUrl)) {
+                // Non-TLR page: load inline, same as WebView default behavior.
+                span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_TLR);
+                Logger.warn(methodTag, "onCreateWindow: non-TLR page, loading URL inline as fallback.");
+                mainWebView.loadUrl(targetUrl);
+            } else {
+                // TLR page: delegate to system browser so user can view terms externally.
+                span.setAttribute(AttributeName.target_blank_navigation_route.name(), AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_TLR);
+                Logger.info(methodTag, "onCreateWindow: TLR page, delegating URL to system browser.");
+                final Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(targetUrl));
+                mainWebView.getContext().startActivity(browserIntent);
+            }
+            span.setStatus(StatusCode.OK);
+        } catch (final Exception e) {
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR);
+            Logger.error(methodTag, "Error handling target=_blank URL.", e);
+        } finally {
+            span.end();
+            // Destroy the interceptor WebView after it has served its purpose
+            interceptorWebView.post(interceptorWebView::destroy);
+        }
+    }
+
+    /**
+     * Checks whether the given URL corresponds to a TLR (Terms, License, and Restrictions)
+     * start page.
+     *
+     * @param url The URL to check.
+     * @return {@code true} if the URL is a TLR start page, {@code false} otherwise.
+     */
+    private boolean isTlrUrl(@Nullable final String url) {
+        if (url == null) {
+            return false;
+        }
+        final String lowerUrl = url.toLowerCase();
+        return lowerUrl.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)
+                && lowerUrl.contains(AuthenticationConstants.Broker.TLR_START_PATH);
     }
 
     /**

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentMultiWindowTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentMultiWindowTest.java
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.providers.oauth2;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.Uri;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+
+/**
+ * Tests for the multi-window (target=_blank) URL handling logic and
+ * TLR URL detection in {@link WebViewAuthorizationFragment}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class WebViewAuthorizationFragmentMultiWindowTest {
+
+    private WebViewAuthorizationFragment mFragment;
+    private Context mContext;
+
+    // TLR URLs
+    private static final String TLR_URL = "https://login.microsoftonline.com/tlr/start?param=1";
+    private static final String TLR_URL_UPPER_CASE = "HTTPS://LOGIN.MICROSOFTONLINE.COM/TLR/START?PARAM=1";
+    private static final String TLR_URL_MIXED_CASE = "https://Login.Microsoftonline.com/Tlr/Start?param=1";
+
+    // Non-TLR URLs
+    private static final String NON_TLR_HTTPS_URL = "https://login.microsoftonline.com/common/oauth2/authorize";
+    private static final String HTTP_URL = "http://example.com/tlr/start";
+    private static final String FTP_URL = "ftp://files.example.com/document.pdf";
+
+    // Target URLs for handleInterceptedUrlFromNewWindow
+    private static final String HTTPS_TARGET_URL = "https://terms.example.com/privacy";
+    private static final String HTTP_TARGET_URL = "http://terms.example.com/privacy";
+
+    @Before
+    public void setUp() throws Exception {
+        mContext = ApplicationProvider.getApplicationContext();
+        mFragment = new WebViewAuthorizationFragment();
+    }
+
+    // -----------------------------------------------------------------------
+    // isTlrUrl tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testIsTlrUrl_nullUrl_returnsFalse() {
+        assertFalse(mFragment.isTlrUrl(null));
+    }
+
+    @Test
+    public void testIsTlrUrl_emptyString_returnsFalse() {
+        assertFalse(mFragment.isTlrUrl(""));
+    }
+
+    @Test
+    public void testIsTlrUrl_validTlrUrl_returnsTrue() {
+        assertTrue(mFragment.isTlrUrl(TLR_URL));
+    }
+
+    @Test
+    public void testIsTlrUrl_upperCaseTlrUrl_returnsTrue() {
+        assertTrue(mFragment.isTlrUrl(TLR_URL_UPPER_CASE));
+    }
+
+    @Test
+    public void testIsTlrUrl_mixedCaseTlrUrl_returnsTrue() {
+        assertTrue(mFragment.isTlrUrl(TLR_URL_MIXED_CASE));
+    }
+
+    @Test
+    public void testIsTlrUrl_httpsNonTlrPath_returnsFalse() {
+        assertFalse(mFragment.isTlrUrl(NON_TLR_HTTPS_URL));
+    }
+
+    @Test
+    public void testIsTlrUrl_httpWithTlrPath_returnsFalse() {
+        // Must be HTTPS to be considered a TLR URL
+        assertFalse(mFragment.isTlrUrl(HTTP_URL));
+    }
+
+    @Test
+    public void testIsTlrUrl_ftpScheme_returnsFalse() {
+        assertFalse(mFragment.isTlrUrl(FTP_URL));
+    }
+
+    @Test
+    public void testIsTlrUrl_tlrPathOnly_returnsFalse() {
+        // No scheme prefix, just path
+        assertFalse(mFragment.isTlrUrl("/tlr/start"));
+    }
+
+    // -----------------------------------------------------------------------
+    // handleInterceptedUrlFromNewWindow tests
+    // -----------------------------------------------------------------------
+
+    private WebResourceRequest mockRequest(final String url) {
+        final WebResourceRequest request = mock(WebResourceRequest.class);
+        when(request.getUrl()).thenReturn(Uri.parse(url));
+        return request;
+    }
+
+    private Span mockSpan() {
+        return mock(Span.class);
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_nonUserGesture_loadsInline() {
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTPS_TARGET_URL);
+
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, false);
+
+        // Should load URL inline in the main WebView
+        verify(mainWebView).loadUrl(eq(HTTPS_TARGET_URL));
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NO_USER_GESTURE));
+        verify(span).setStatus(StatusCode.OK);
+        verify(span).end();
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_nonSslUrl_refusesToOpen() {
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTP_TARGET_URL);
+
+        // User gesture = true, but URL is http (not https)
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, true);
+
+        // Should NOT load URL anywhere
+        verify(mainWebView, never()).loadUrl(ArgumentMatchers.anyString());
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_SSL));
+        verify(span).setStatus(StatusCode.OK);
+        verify(span).end();
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_nonTlrPage_loadsInline() {
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTPS_TARGET_URL);
+
+        // mainWebView is on a non-TLR page
+        // Robolectric WebView.getUrl() returns null by default (no page loaded), which is non-TLR
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, true);
+
+        // Should load URL inline
+        verify(mainWebView).loadUrl(eq(HTTPS_TARGET_URL));
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_TLR));
+        verify(span).setStatus(StatusCode.OK);
+        verify(span).end();
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_tlrPage_delegatesToBrowser() {
+        final Activity activity = Robolectric.buildActivity(Activity.class).get();
+        final WebView mainWebView = mock(WebView.class);
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTPS_TARGET_URL);
+
+        // Simulate main WebView being on a TLR page
+        when(mainWebView.getUrl()).thenReturn(TLR_URL);
+        when(mainWebView.getContext()).thenReturn(activity);
+
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, true);
+
+        // Should NOT load inline
+        verify(mainWebView, never()).loadUrl(ArgumentMatchers.anyString());
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_TLR));
+        verify(span).setStatus(StatusCode.OK);
+        verify(span).end();
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_spanEndsInFinally() {
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTPS_TARGET_URL);
+
+        // Even for a normal non-TLR case, span.end() should always be called
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, true);
+        verify(span).end();
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_nonUserGesture_nonSslUrl_loadsInline() {
+        // Non-user-gesture takes priority over non-SSL check
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(HTTP_TARGET_URL);
+
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, false);
+
+        // Even though URL is http, non-user-gesture check comes first and loads inline
+        verify(mainWebView).loadUrl(eq(HTTP_TARGET_URL));
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NO_USER_GESTURE));
+    }
+
+    @Test
+    public void testHandleInterceptedUrl_ftpScheme_refusesToOpen() {
+        final WebView mainWebView = spy(new WebView(mContext));
+        final WebView interceptorWebView = spy(new WebView(mContext));
+        final Span span = mockSpan();
+        final WebResourceRequest request = mockRequest(FTP_URL);
+
+        mFragment.handleInterceptedUrlFromNewWindow(mainWebView, interceptorWebView, request, span, true);
+
+        // FTP is not https, should be blocked
+        verify(mainWebView, never()).loadUrl(ArgumentMatchers.anyString());
+        verify(span).setAttribute(
+                eq(AttributeName.target_blank_navigation_route.name()),
+                eq(AuthenticationConstants.Broker.WEBVIEW_TARGET_BLANK_ROUTE_NON_SSL));
+        verify(span).setStatus(StatusCode.OK);
+        verify(span).end();
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -211,7 +211,13 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable increased thread pool size for silent requests.
      * When true, uses 12 threads. When false, uses legacy 5 threads.
      */
-    USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", false);
+    USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", false),
+
+    /**
+     * Flight to enable multiple window support in WebView, which allows target="_blank" links
+     * to be intercepted via onCreateWindow and opened in an external browser.
+     */
+    ENABLE_WEBVIEW_MULTIPLE_WINDOWS("EnableWebViewMultipleWindows", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -609,4 +609,14 @@ public enum AttributeName {
     secret_key_serialization_duration,
     
     //endregion
+
+    //region WebView target=_blank navigation
+
+    /**
+     * Indicates which routing path was taken for a target=_blank URL intercepted
+     * by onCreateWindow: "null_url", "non_ssl", "non_tlr_inline", or "tlr_browser".
+     */
+    target_blank_navigation_route,
+
+    //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -101,5 +101,9 @@ public enum SpanName {
     /**
      * Span name for secret key retrieval operations.
      */
-    SecretKeyRetrieval
+    SecretKeyRetrieval,
+    /**
+     * Span name for WebView target="_blank" navigation interception.
+     */
+    WebViewTargetBlankNavigation
 }


### PR DESCRIPTION
**Problem**
Total loss recovery is a feature provided by VID to recover the user's account. This gets initiated from inside of the webview. See below screenshot for reference. Once the user clicks on "Recover your account", the flow goes through a set of redirects - sometimes to 3P identity verifiers where they may handle button clicks differently. They may contain links with target="_blank" (ideally used in websites where they want to open a new tab upon a button or link click)(e.g., Terms of Use, privacy links), the Android WebView silently drops these navigations. Users tap the link and nothing happens — no browser opens, no feedback is given.

**Solution**
Override onCreateWindow to intercept target="_blank" navigations and open them in the device's default external browser via intent. 
Note : This will ONLY be enabled for TLR links. The check is made in OnPageLoadedCallback method of WebViewAuthorizationFragment. 
- **How are we gating it only for TLR URLs?** : When a page is loaded, we know its url, we check if it matches the TLR url pattern.. If it does, we enable multiple windows support in webview by calling the method setSupportMultipleWindows(true). Else, it is the same as today (set to false).
- **Would onCreateWindow method be called even when setSupportMultipleWindows is false?** : No, it completely needs setSupportMultipleWindows to be true. So, the code in onCreateWindow need not be behind a flight as the code triggering it is already behind the flight.

**Feature gating**
The change is gated behind ENABLE_WEBVIEW_MULTIPLE_WINDOWS
CommonFlight: default false (safe for MSAL/non-broker callers)
BrokerFlight: overrides to true (enabled in broker context)

**Telemetry**
The change also involves adding a new span with default sampling rate. But we expect this span to be emitted in very low numbers (10 to 20 per day) once Total loss recovery feature is enabled. Once this feature is stabilized, we can remove this span.

 Fixes [AB#3535641](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3535641)