### PR TITLE
Handle openid-vc urls in webview, Fixes AB#3535641

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [MINOR] Remove LruCache from SharedPreferencesFileManager (#2910)
 - [MINOR] Edge TB: Claims (#2925)
 - [PATCH] Update Moshi to 1.15.2 to resolve okio CVE-2023-3635 vulnerability (#3005)
+- [MINOR] Handle openid-vc urls in webview (#3013)
 
 Version 24.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1313,6 +1313,13 @@ public final class AuthenticationConstants {
         public static final String AMAZON_APP_REDIRECT_PREFIX = "aea://";
 
         /**
+         * Custom URI scheme prefix for OpenID Verifiable Credentials.
+         * WebView cannot load this scheme natively; it must be intercepted and
+         * forwarded to an external handler (wallet app) via an ACTION_VIEW intent.
+         */
+        public static final String OPENID_VC_SCHEME_PREFIX = "openid-vc://";
+
+        /**
          * Prefix for the Authenticator MFA linking.
          */
         public static final String AUTHENTICATOR_MFA_LINKING_PREFIX = "microsoft-authenticator://activatemfa";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -928,19 +928,29 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private void processOpenIdVcRequest(@NonNull final WebView view, @NonNull final String url) {
         final String methodTag = TAG + ":processOpenIdVcRequest";
         view.stopLoading();
-        try {
+        final Span span = createSpanWithAttributesFromParent(SpanName.ProcessOpenIdVcRequest.name());
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
                 getActivity().startActivity(intent);
                 Logger.info(methodTag, "Launched external handler for OpenID VC request.");
+                span.setAttribute(AttributeName.is_openid_vc_handler_found.name(), true);
+                span.setStatus(StatusCode.OK);
             } else {
                 Logger.warn(methodTag, "No application found to handle openid-vc:// URI.");
+                span.setAttribute(AttributeName.is_openid_vc_handler_found.name(), false);
+                span.setStatus(StatusCode.ERROR, "No handler found for openid-vc:// URI");
                 returnError(ErrorStrings.ACTIVITY_NOT_FOUND, "No application found to handle the OpenID Verifiable Credentials request.");
             }
         } catch (final ActivityNotFoundException e) {
             Logger.error(methodTag, "Failed to launch handler for openid-vc:// URI.", e);
+            span.setAttribute(AttributeName.is_openid_vc_handler_found.name(), false);
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR, "Failed to launch handler for openid-vc:// URI");
             returnError(ErrorStrings.ACTIVITY_NOT_FOUND, "Failed to launch handler for the OpenID Verifiable Credentials request.");
+        } finally {
+            span.end();
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -338,6 +338,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (isAmazonAppRedirect(formattedURL)) {
                 Logger.info(methodTag, "It is an Amazon app request");
                 processAmazonAppUri(url);
+            } else if (isOpenIdVcUrl(formattedURL)) {
+                Logger.info(methodTag, "It is an OpenID Verifiable Credentials request.");
+                processOpenIdVcRequest(view, url);
             } else if (isInvalidRedirectUri(url)) {
                 Logger.info(methodTag,"Check for Redirect Uri.");
                 processInvalidRedirectUri(view, url);
@@ -494,6 +497,18 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isAmazonAppRedirect(@NonNull final String url) {
         return url.startsWith(AMAZON_APP_REDIRECT_PREFIX);
+    }
+
+    /**
+     * Checks if the URL uses the openid-vc:// custom scheme.
+     * This scheme is used by OpenID Verifiable Credentials flows and must be
+     * intercepted so a registered wallet app can handle it.
+     *
+     * @param url The lowercase URL to check.
+     * @return true if the URL starts with the openid-vc:// scheme.
+     */
+    private boolean isOpenIdVcUrl(@NonNull final String url) {
+        return url.startsWith(AuthenticationConstants.Broker.OPENID_VC_SCHEME_PREFIX);
     }
 
     private boolean isWebCpEnrollmentUrl(@NonNull final String url) {
@@ -899,6 +914,33 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         getActivity().startActivity(intent);
         Logger.info(methodTag, "Sent Intent to launch Amazon app");
+    }
+
+    /**
+     * Handles an openid-vc:// URL by stopping the WebView and launching an
+     * {@link Intent#ACTION_VIEW} intent so the system can route it to the
+     * registered wallet application.
+     *
+     * @param view The WebView that intercepted the navigation.
+     * @param url  The original (non-lowercased) openid-vc:// URL.
+     */
+    private void processOpenIdVcRequest(@NonNull final WebView view, @NonNull final String url) {
+        final String methodTag = TAG + ":processOpenIdVcRequest";
+        view.stopLoading();
+        try {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
+                getActivity().startActivity(intent);
+                Logger.info(methodTag, "Launched external handler for OpenID VC request.");
+            } else {
+                Logger.warn(methodTag, "No application found to handle openid-vc:// URI.");
+                returnError(ErrorStrings.UNEXPECTED_ERROR, "No application found to handle the OpenID Verifiable Credentials request.");
+            }
+        } catch (final ActivityNotFoundException e) {
+            Logger.error(methodTag, "Failed to launch handler for openid-vc:// URI.", e);
+            returnError(ErrorStrings.UNEXPECTED_ERROR, "Failed to launch handler for the OpenID Verifiable Credentials request.");
+        }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -339,6 +339,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 Logger.info(methodTag, "It is an Amazon app request");
                 processAmazonAppUri(url);
             } else if (isOpenIdVcUrl(formattedURL)) {
+                // TO-DO : Decide whether flight is needed in this case. https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3541420
                 Logger.info(methodTag, "It is an OpenID Verifiable Credentials request.");
                 processOpenIdVcRequest(view, url);
             } else if (isInvalidRedirectUri(url)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -935,11 +935,11 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 Logger.info(methodTag, "Launched external handler for OpenID VC request.");
             } else {
                 Logger.warn(methodTag, "No application found to handle openid-vc:// URI.");
-                returnError(ErrorStrings.UNEXPECTED_ERROR, "No application found to handle the OpenID Verifiable Credentials request.");
+                returnError(ErrorStrings.ACTIVITY_NOT_FOUND, "No application found to handle the OpenID Verifiable Credentials request.");
             }
         } catch (final ActivityNotFoundException e) {
             Logger.error(methodTag, "Failed to launch handler for openid-vc:// URI.", e);
-            returnError(ErrorStrings.UNEXPECTED_ERROR, "Failed to launch handler for the OpenID Verifiable Credentials request.");
+            returnError(ErrorStrings.ACTIVITY_NOT_FOUND, "Failed to launch handler for the OpenID Verifiable Credentials request.");
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -126,6 +126,8 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_WEB_CP_ENROLLMENT_URL = "https://enterprise.google.com/android/enroll";
 
     private static final String TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL = "browser://play.app.goo.gl/?link=https://play.google.com/store/apps/details?id=com.microsoft.windowsintune.companyportal";
+    private static final String TEST_OPENID_VC_URL = "openid-vc://credential-offer?credential_issuer=https%3A%2F%2Fexample.com&credential_configuration_ids=VerifiedEmployee";
+
     @Before
     public void setup() throws ClientException {
         mContext = ApplicationProvider.getApplicationContext();
@@ -188,6 +190,44 @@ public class AzureActiveDirectoryWebViewClientTest {
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_WEBSITE_REQUEST_URL));
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_BROWSER_DEVICE_CA_URL_QUERY_STRING_PARAMETER));
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL));
+    }
+
+    @Test
+    public void testUrlOverrideHandlesOpenIdVcUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_OPENID_VC_URL));
+    }
+
+    @Test
+    public void testOpenIdVcUrl_StopsWebViewAndReturnsError_WhenNoHandlerFound() {
+        // Arrange
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                false
+        );
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Act - Robolectric has no handler registered for openid-vc://, so the no-handler path executes
+        final boolean result = webViewClient.shouldOverrideUrlLoading(mockWebView, TEST_OPENID_VC_URL);
+
+        // Assert
+        assertTrue("shouldOverrideUrlLoading must return true for openid-vc:// URLs", result);
+        Mockito.verify(mockWebView).stopLoading();
+
+        // Verify the callback received an error result
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        assertEquals("Expected UNEXPECTED_ERROR error code",
+                ErrorStrings.UNEXPECTED_ERROR,
+                ((ClientException) capturedResult.getException()).getErrorCode());
+        assertTrue("Expected error message about no application found",
+                capturedResult.getException().getMessage().contains("No application found"));
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -223,8 +223,8 @@ public class AzureActiveDirectoryWebViewClientTest {
         // Verify the callback received an error result
         Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
         final RawAuthorizationResult capturedResult = resultCaptor.getValue();
-        assertEquals("Expected UNEXPECTED_ERROR error code",
-                ErrorStrings.UNEXPECTED_ERROR,
+        assertEquals("Expected ACTIVITY_NOT_FOUND error code",
+                ErrorStrings.ACTIVITY_NOT_FOUND,
                 ((ClientException) capturedResult.getException()).getErrorCode());
         assertTrue("Expected error message about no application found",
                 capturedResult.getException().getMessage().contains("No application found"));

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -607,6 +607,11 @@ public enum AttributeName {
      * The time (in milliseconds) spent on secret key serialization/deserialization.
      */
     secret_key_serialization_duration,
+
+    /**
+     * Indicates if an external handler was found to handle the openid-vc:// URI.
+     */
+    is_openid_vc_handler_found,
     
     //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -71,6 +71,7 @@ public enum SpanName {
     GetAllSsoTokens,
     ProcessWebCpEnrollmentRedirect,
     ProcessWebCpAuthorizeUrlRedirect,
+    ProcessOpenIdVcRequest,
     PasskeyWebListener,
     InstallCertOnWpj,
     /**


### PR DESCRIPTION
**Context** : Total loss recovery is a feature introduced by VID team to recover an account. This feature will be triggered from inside of a webview when the user clicks on "Recover your account" link. After this a 3P identity verifier will verify the user and provide a credential. Once a credential is available, a specific redirect URI is triggered **openid-vc://**? request_uri=https://verifier.example.com/request/123, which will invoke wallet library in Authenticator app --- All this is functionality not connected to broker except the fact that the URLs are all being loaded in our webview.

**What is openid-vc** ? : The openid-vc:// scheme is part of the OpenID4VC family of specifications, which includes:
OpenID4VCI (Verifiable Credential Issuance) — how a wallet receives credentials from an issuer
OpenID4VP (Verifiable Presentations) — how a wallet presents credentials to a verifier

**Problem** : When a web page loaded in the authentication WebView navigates to an openid-vc:// URI (used by OpenID Verifiable Credentials flows), the WebView cannot handle this non-HTTP custom scheme natively. The navigation fails, blocking the VC issuance/presentation flow.

**Solution**  : Intercept **openid-vc://** navigations in AzureActiveDirectoryWebViewClient.handleUrl() and delegate them to the Android system so a registered wallet app can handle the request.

Fixes [AB#3535641](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3535641)