### PR TITLE
Fix test_2828864_DCF_CheckSignInFromOtherDeviceOptionAvailable, Fixes AB#3537345

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -281,9 +281,6 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     public void handleSignInFromOtherDevice() {
         this.handleSignInOptions();
         UiAutomatorUtils.handleButtonClickForObjectWithText(SIGN_IN_FROM_OTHER_DEVICE);
-
-        // verify the remote device login url is displayed.
-        Assert.assertTrue(UiAutomatorUtils.obtainUiObjectWithText(expectedDeviceLoginUrl).exists());
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -278,7 +278,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
     }
 
     @Override
-    public void handleSignInFromOtherDevice(@NonNull final String expectedDeviceLoginUrl) {
+    public void handleSignInFromOtherDevice() {
         this.handleSignInOptions();
         UiAutomatorUtils.handleButtonClickForObjectWithText(SIGN_IN_FROM_OTHER_DEVICE);
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/IMicrosoftStsLoginComponentHandler.java
@@ -87,10 +87,8 @@ public interface IMicrosoftStsLoginComponentHandler extends IOAuth2LoginComponen
 
     /**
      * Handle interaction for "Sign in from other device".
-     * @param expectedDeviceLoginUrl the expected remote login url when "Sign in from other device" option is
-     *                               exercised.
      */
-    void handleSignInFromOtherDevice(@NonNull final String expectedDeviceLoginUrl);
+    void handleSignInFromOtherDevice();
 
     /**
      * Handle interaction with "Sign in options".


### PR DESCRIPTION
To fix the failure test_2828864_DCF_CheckSignInFromOtherDeviceOptionAvailable, which currently verifies DCF url.

The device URL has changed form microsoft.com/devicelogin to login.microsoft.com/device.

The test case is primarily about having an option to "Sign-in in using another device". So, fixing it by just verifying that option is available and can be clicked. Removing the verification to actually check the DCF url to reduce dependency on server UX.

There's corresponding MSAL PR as well: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2482

Fixes [AB#3537345](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3537345)

test passed here: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1604835&view=ms.vss-test-web.build-test-results-tab