### PR TITLE
Enhance WebAuthn telemetry for passkey registration, Fixes AB#3540659

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [PATCH] Update Moshi to 1.15.2 to resolve okio CVE-2023-3635 vulnerability (#3005)
 - [MINOR] Handle target="_blank" links in authorization WebView (#3010)
 - [MINOR] Handle openid-vc urls in webview (#3013)
+- [MINOR] Enhance WebAuthn telemetry for passkey registration (#3018)
 
 Version 24.0.1
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -275,6 +275,7 @@ dependencies {
     })
 
     implementation "io.opentelemetry:opentelemetry-api:$rootProject.ext.openTelemetryVersion"
+    implementation("io.opentelemetry:opentelemetry-extension-kotlin:$rootProject.ext.openTelemetryVersion")
     implementation "androidx.fragment:fragment:1.3.2"
 }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/LegacyFidoActivityResultContract.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/LegacyFidoActivityResultContract.kt
@@ -33,7 +33,7 @@ import com.google.android.gms.fido.Fido
 import com.google.android.gms.fido.fido2.api.common.AuthenticatorAssertionResponse
 import com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
 import com.google.android.gms.fido.fido2.api.common.PublicKeyCredential
-import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil.Companion.createAssertionString
+import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil.createAssertionString
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.common.logging.Logger
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -27,6 +27,8 @@ import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_LENGTH
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_OFFSET
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_FLAGS_OFFSET
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_REGISTRATION_ATTESTATION_OBJECT_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_REGISTRATION_ORIGIN_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY
@@ -219,34 +221,60 @@ object WebAuthnJsonUtil {
     /**
      * Parses a base64url-encoded CBOR attestation object and extracts the AAGUID.
      *
-     * The AAGUID is located at byte offset 37 within the authenticator data (authData) field
-     * of the attestation object, and is 16 bytes long. It is returned as a formatted UUID string.
+     * The AAGUID is read from the attested credential data section of `authData`.
+     * This method first verifies the attested credential data flag at
+     * [WEBAUTHN_AUTHDATA_FLAGS_OFFSET], then reads the AAGUID from
+     * [WEBAUTHN_AUTHDATA_AAGUID_OFFSET] for [WEBAUTHN_AUTHDATA_AAGUID_LENGTH] bytes.
      *
-     * @param attestationObjectB64 Base64url-encoded CBOR attestation object.
-     * @return The AAGUID as a UUID string.
-     * @throws Exception if the attestation object cannot be decoded or authData is not found.
+     * @param attestationString String representation of the attestation object, as received in the WebAuthn registration response JSON.
+     * @return The AAGUID as a UUID string, or null if attested credential data is missing or the payload is truncated.
+     * @throws Exception if the attestation object cannot be decoded.
      */
-    fun extractAaguidFromAttestationObject(attestationObjectB64: String): String {
-        // 1. Decode Base64URL
-        val decoded = attestationObjectB64.decodeBase64()?.toByteArray()
+    fun extractAaguidFromAttestationObject(attestationString: String): String? {
+        // 1. Decode Base64URL.
+        val attestationObject = attestationString.decodeBase64()?.toByteArray()
             ?: throw Exception("Failed to decode attestation object from Base64URL")
-        // 2. Find the "authData" key in the CBOR map
-        // The key "authData" is hex: 68 61 75 74 68 44 61 74 61
-        val authDataKey = "authData".toByteArray()
-        val keyIndex = indexOf(decoded, authDataKey)
-        if (keyIndex == -1) throw Exception("authData not found")
+        val key = "authData".toByteArray(Charsets.UTF_8)
+        val keyIndex = indexOf(attestationObject, key)
+        if (keyIndex == -1) return null
 
-        // 3. Skip the key and the CBOR byte string header
-        // In your string, it's followed by 0x58 (header) and 0x55 (length 85)
-        // So we skip the key length + 2 bytes for the CBOR header
-        val authDataStart = keyIndex + authDataKey.size + 2
+        // 2. Determine where the authData byte string starts.
+        // CBOR uses the low 5 bits of the initial byte to describe how the byte-string length is encoded:
+        // 0..23 = inline length, 24 = next 1 byte, 25 = next 2 bytes, 26 = next 4 bytes.
+        val pointer = keyIndex + key.size
+        if (pointer >= attestationObject.size) return null
 
-        // 4. AAGUID is at offset 37 within authData
+        val initialByte = attestationObject[pointer].toInt() and 0xFF
+        val headerSize = when (initialByte and 0x1F) {
+            in 0..23 -> 1
+            24 -> 2
+            25 -> 3
+            26 -> 5
+            else -> return null
+        }
+
+        val authDataStart = pointer + headerSize
+
+        // 3. Check the WebAuthn flags byte to confirm attested credential data is present.
+        val flagsByteIndex = authDataStart + WEBAUTHN_AUTHDATA_FLAGS_OFFSET
+        if (flagsByteIndex >= attestationObject.size) return null
+
+        val flags = attestationObject[flagsByteIndex].toInt()
+        val hasAttestedCredentialData =
+            (flags and WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG) != 0
+        if (!hasAttestedCredentialData) {
+            return null
+        }
+
+        // 4. Extract the fixed-length AAGUID from authData.
         val aaguidStart = authDataStart + WEBAUTHN_AUTHDATA_AAGUID_OFFSET
-        val aaguidBytes = decoded.copyOfRange(aaguidStart, aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH)
+        if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > attestationObject.size) return null
 
-        // 5. Convert to formatted UUID
-        return formatToUUID(aaguidBytes)
+        val aaguidBytes = attestationObject.copyOfRange(
+            aaguidStart,
+            aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH
+        )
+        return formatToUuid(aaguidBytes)
     }
 
     /**
@@ -263,9 +291,8 @@ object WebAuthnJsonUtil {
     /**
      * Converts a 16-byte AAGUID byte array into a formatted UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000").
      */
-    private fun formatToUUID(bytes: ByteArray): String {
+    private fun formatToUuid(bytes: ByteArray): String {
         val bb = ByteBuffer.wrap(bytes)
         return UUID(bb.long, bb.long).toString()
     }
-
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -231,105 +231,91 @@ object WebAuthnJsonUtil {
      * @throws Exception if the attestation object is malformed or cannot be decoded.
      */
     fun extractAaguidFromAttestationObject(attestationString: String): String {
-        // 1. Decode Base64URL.
+        // 1. Base64URL-decode the attestation object.
         val attestationObject = attestationString.decodeBase64()?.toByteArray()
             ?: throw Exception("Failed to base64url-decode the attestation object.")
+
+        // 2. Locate the 'authData' CBOR key and read its byte-string payload.
         val key = "authData".toByteArray(Charsets.UTF_8)
         val keyIndex = indexOf(attestationObject, key)
         if (keyIndex == -1) throw Exception("'authData' key not found in attestation object (size: ${attestationObject.size} bytes).")
 
-        // 2. Determine where the authData byte string starts.
-        // CBOR uses the low 5 bits of the initial byte to describe how the byte-string length is encoded:
-        // 0..23 = inline length, 24 = next 1 byte, 25 = next 2 bytes, 26 = next 4 bytes.
-        val pointer = keyIndex + key.size
-        if (pointer >= attestationObject.size) {
+        val valueOffset = keyIndex + key.size
+        if (valueOffset >= attestationObject.size) {
             throw Exception("Attestation object truncated after 'authData' key (offset: $keyIndex, size: ${attestationObject.size} bytes).")
         }
 
-        val initialByte = attestationObject[pointer].toInt() and 0xFF
+        val initialByte = attestationObject[valueOffset].toInt() and 0xFF
         val majorType = (initialByte shr 5) and 0x07
         if (majorType != 2) {
-            throw Exception("Invalid CBOR major type for 'authData': expected byte string (major type 2) but found $majorType at offset $pointer.")
+            throw Exception("Invalid CBOR major type for 'authData': expected byte string (major type 2) but found $majorType at offset $valueOffset.")
         }
 
-        val additionalInfo = initialByte and 0x1F
-        val (headerSize, authDataLength) = when (additionalInfo) {
-            in 0..23 -> {
-                // Length is encoded directly in the additional info.
-                1 to additionalInfo
-            }
-            24 -> {
-                // Next 1 byte is the length.
-                val lengthIndex = pointer + 1
-                if (lengthIndex >= attestationObject.size) {
-                    throw Exception("Attestation object truncated while reading 'authData' length (need 1 byte at offset $lengthIndex, size: ${attestationObject.size} bytes).")
-                }
-                2 to (attestationObject[lengthIndex].toInt() and 0xFF)
-            }
-            25 -> {
-                // Next 2 bytes are the length (big endian).
-                val lengthIndex = pointer + 1
-                val endIndex = lengthIndex + 1
-                if (endIndex >= attestationObject.size) {
-                    throw Exception("Attestation object truncated while reading 'authData' length (need 2 bytes starting at offset $lengthIndex, size: ${attestationObject.size} bytes).")
-                }
-                val length = ((attestationObject[lengthIndex].toInt() and 0xFF) shl 8) or
-                    (attestationObject[endIndex].toInt() and 0xFF)
-                3 to length
-            }
-            26 -> {
-                // Next 4 bytes are the length (big endian).
-                val lengthIndex = pointer + 1
-                val endIndex = lengthIndex + 3
-                if (endIndex >= attestationObject.size) {
-                    throw Exception("Attestation object truncated while reading 'authData' length (need 4 bytes starting at offset $lengthIndex, size: ${attestationObject.size} bytes).")
-                }
-                val length =
-                    ((attestationObject[lengthIndex].toInt() and 0xFF) shl 24) or
-                        ((attestationObject[lengthIndex + 1].toInt() and 0xFF) shl 16) or
-                        ((attestationObject[lengthIndex + 2].toInt() and 0xFF) shl 8) or
-                        (attestationObject[lengthIndex + 3].toInt() and 0xFF)
-                5 to length
-            }
-            else -> {
-                throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $pointer.")
-            }
-        }
-
-        if (authDataLength < 0) {
-            throw Exception("Invalid negative 'authData' length: $authDataLength.")
-        }
-
-        val authDataStart = pointer + headerSize
+        val (headerSize, authDataLength) = parseCborByteStringHeader(attestationObject, valueOffset, initialByte)
+        val authDataStart = valueOffset + headerSize
         val authDataEnd = authDataStart + authDataLength
         if (authDataEnd > attestationObject.size) {
             throw Exception("Attestation object truncated: declared 'authData' length $authDataLength at offset $authDataStart exceeds buffer size ${attestationObject.size} bytes.")
         }
 
-        // 3. Check the WebAuthn flags byte to confirm attested credential data is present.
+        // 3. Verify the AT flag — confirms attested credential data (and therefore AAGUID) is present.
         val flagsByteIndex = authDataStart + WEBAUTHN_AUTHDATA_FLAGS_OFFSET
         if (flagsByteIndex >= authDataEnd) {
             throw Exception("authData truncated: flags byte missing at offset $flagsByteIndex (authData length: $authDataLength bytes).")
         }
-
-        val flags = attestationObject[flagsByteIndex].toInt()
-        val hasAttestedCredentialData =
-            (flags and WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG) != 0
-        if (!hasAttestedCredentialData) {
+        if ((attestationObject[flagsByteIndex].toInt() and WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG) == 0) {
             throw Exception("AT flag not set in authData flags, attested credential data is absent, AAGUID cannot be extracted.")
         }
 
-        // 4. Extract the fixed-length AAGUID from authData.
+        // 4. Extract the fixed-length AAGUID.
         val aaguidStart = authDataStart + WEBAUTHN_AUTHDATA_AAGUID_OFFSET
         if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > authDataEnd) {
             throw Exception("authData truncated: expected $WEBAUTHN_AUTHDATA_AAGUID_LENGTH AAGUID bytes at offset $aaguidStart (authData length: $authDataLength bytes).")
         }
+        return formatToUuid(attestationObject.copyOfRange(aaguidStart, aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH))
+    }
 
-        val aaguidBytes = attestationObject.copyOfRange(
-            aaguidStart,
-            aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH
-        )
-        return formatToUuid(aaguidBytes)
+    /**
+     * Reads the CBOR byte-string length starting at [offset] in [buf].
+     *
+     * CBOR encodes the length in the low 5 bits of the initial byte:
+     * - 0–23  → length is the value itself (1-byte header)
+     * - 24    → next 1 byte holds the length (2-byte header)
+     * - 25    → next 2 bytes hold the length, big-endian (3-byte header)
+     * - 26    → next 4 bytes hold the length, big-endian (5-byte header)
+     *
+     * @param buf         The raw bytes of the attestation object.
+     * @param offset      Index of the initial CBOR byte (already verified to be major type 2).
+     * @param initialByte The byte at [offset], pre-read by the caller.
+     * @return Pair of (headerSize, byteStringLength).
+     * @throws Exception if the buffer is truncated or the length encoding is unsupported.
+     */
+    private fun parseCborByteStringHeader(buf: ByteArray, offset: Int, initialByte: Int): Pair<Int, Int> {
+        val additionalInfo = initialByte and 0x1F
+        return when (additionalInfo) {
+            in 0..23 -> 1 to additionalInfo
+            24 -> {
+                val li = offset + 1
+                if (li >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 1 byte at offset $li, size: ${buf.size} bytes).")
+                2 to (buf[li].toInt() and 0xFF)
+            }
+            25 -> {
+                val li = offset + 1
+                if (li + 1 >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 2 bytes starting at offset $li, size: ${buf.size} bytes).")
+                val length = ((buf[li].toInt() and 0xFF) shl 8) or (buf[li + 1].toInt() and 0xFF)
+                3 to length
+            }
+            26 -> {
+                val li = offset + 1
+                if (li + 3 >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 4 bytes starting at offset $li, size: ${buf.size} bytes).")
+                val length = ((buf[li].toInt() and 0xFF) shl 24) or
+                    ((buf[li + 1].toInt() and 0xFF) shl 16) or
+                    ((buf[li + 2].toInt() and 0xFF) shl 8) or
+                    (buf[li + 3].toInt() and 0xFF)
+                5 to length
+            }
+            else -> throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $offset.")
+        }
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -57,7 +57,7 @@ object WebAuthnJsonUtil {
      * @param challenge challenge string
      * @param relyingPartyIdentifier rpId string
      * @param allowedCredentials allowedCredentials string
-     * @param userVerificationPolicy yserVerificationPolicy string
+     * @param userVerificationPolicy userVerificationPolicy string
      * @return a string representation of PublicKeyCredentialRequestOptionsJSON.
      */
     fun createJsonAuthRequest(
@@ -227,8 +227,8 @@ object WebAuthnJsonUtil {
      * [WEBAUTHN_AUTHDATA_AAGUID_OFFSET] for [WEBAUTHN_AUTHDATA_AAGUID_LENGTH] bytes.
      *
      * @param attestationString String representation of the attestation object, as received in the WebAuthn registration response JSON.
-     * @return The AAGUID as a UUID string, or null if attested credential data is missing or the payload is truncated.
-     * @throws Exception if the attestation object cannot be decoded.
+     * @return The AAGUID as a UUID string.
+     * @throws Exception if the attestation object is malformed or cannot be decoded.
      */
     fun extractAaguidFromAttestationObject(attestationString: String): String {
         // 1. Decode Base64URL.
@@ -247,21 +247,69 @@ object WebAuthnJsonUtil {
         }
 
         val initialByte = attestationObject[pointer].toInt() and 0xFF
-        val headerSize = when (initialByte and 0x1F) {
-            in 0..23 -> 1
-            24 -> 2
-            25 -> 3
-            26 -> 5
-            else -> throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $pointer.")
+        val majorType = (initialByte shr 5) and 0x07
+        if (majorType != 2) {
+            throw Exception("Invalid CBOR major type for 'authData': expected byte string (major type 2) but found $majorType at offset $pointer.")
+        }
+
+        val additionalInfo = initialByte and 0x1F
+        val (headerSize, authDataLength) = when (additionalInfo) {
+            in 0..23 -> {
+                // Length is encoded directly in the additional info.
+                1 to additionalInfo
+            }
+            24 -> {
+                // Next 1 byte is the length.
+                val lengthIndex = pointer + 1
+                if (lengthIndex >= attestationObject.size) {
+                    throw Exception("Attestation object truncated while reading 'authData' length (need 1 byte at offset $lengthIndex, size: ${attestationObject.size} bytes).")
+                }
+                2 to (attestationObject[lengthIndex].toInt() and 0xFF)
+            }
+            25 -> {
+                // Next 2 bytes are the length (big endian).
+                val lengthIndex = pointer + 1
+                val endIndex = lengthIndex + 1
+                if (endIndex >= attestationObject.size) {
+                    throw Exception("Attestation object truncated while reading 'authData' length (need 2 bytes starting at offset $lengthIndex, size: ${attestationObject.size} bytes).")
+                }
+                val length = ((attestationObject[lengthIndex].toInt() and 0xFF) shl 8) or
+                    (attestationObject[endIndex].toInt() and 0xFF)
+                3 to length
+            }
+            26 -> {
+                // Next 4 bytes are the length (big endian).
+                val lengthIndex = pointer + 1
+                val endIndex = lengthIndex + 3
+                if (endIndex >= attestationObject.size) {
+                    throw Exception("Attestation object truncated while reading 'authData' length (need 4 bytes starting at offset $lengthIndex, size: ${attestationObject.size} bytes).")
+                }
+                val length =
+                    ((attestationObject[lengthIndex].toInt() and 0xFF) shl 24) or
+                        ((attestationObject[lengthIndex + 1].toInt() and 0xFF) shl 16) or
+                        ((attestationObject[lengthIndex + 2].toInt() and 0xFF) shl 8) or
+                        (attestationObject[lengthIndex + 3].toInt() and 0xFF)
+                5 to length
+            }
+            else -> {
+                throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $pointer.")
+            }
+        }
+
+        if (authDataLength < 0) {
+            throw Exception("Invalid negative 'authData' length: $authDataLength.")
         }
 
         val authDataStart = pointer + headerSize
+        val authDataEnd = authDataStart + authDataLength
+        if (authDataEnd > attestationObject.size) {
+            throw Exception("Attestation object truncated: declared 'authData' length $authDataLength at offset $authDataStart exceeds buffer size ${attestationObject.size} bytes.")
+        }
 
         // 3. Check the WebAuthn flags byte to confirm attested credential data is present.
         val flagsByteIndex = authDataStart + WEBAUTHN_AUTHDATA_FLAGS_OFFSET
-        if (flagsByteIndex >= attestationObject.size)
-        {
-            throw Exception("Attestation object truncated: flags byte missing at offset $flagsByteIndex (size: ${attestationObject.size} bytes).")
+        if (flagsByteIndex >= authDataEnd) {
+            throw Exception("authData truncated: flags byte missing at offset $flagsByteIndex (authData length: $authDataLength bytes).")
         }
 
         val flags = attestationObject[flagsByteIndex].toInt()
@@ -273,8 +321,8 @@ object WebAuthnJsonUtil {
 
         // 4. Extract the fixed-length AAGUID from authData.
         val aaguidStart = authDataStart + WEBAUTHN_AUTHDATA_AAGUID_OFFSET
-        if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > attestationObject.size) {
-            throw Exception("Attestation object truncated: expected $WEBAUTHN_AUTHDATA_AAGUID_LENGTH AAGUID bytes at offset $aaguidStart (size: ${attestationObject.size} bytes).")
+        if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > authDataEnd) {
+            throw Exception("authData truncated: expected $WEBAUTHN_AUTHDATA_AAGUID_LENGTH AAGUID bytes at offset $aaguidStart (authData length: $authDataLength bytes).")
         }
 
         val aaguidBytes = attestationObject.copyOfRange(

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -230,19 +230,21 @@ object WebAuthnJsonUtil {
      * @return The AAGUID as a UUID string, or null if attested credential data is missing or the payload is truncated.
      * @throws Exception if the attestation object cannot be decoded.
      */
-    fun extractAaguidFromAttestationObject(attestationString: String): String? {
+    fun extractAaguidFromAttestationObject(attestationString: String): String {
         // 1. Decode Base64URL.
         val attestationObject = attestationString.decodeBase64()?.toByteArray()
-            ?: throw Exception("Failed to decode attestation object from Base64URL")
+            ?: throw Exception("Failed to base64url-decode the attestation object.")
         val key = "authData".toByteArray(Charsets.UTF_8)
         val keyIndex = indexOf(attestationObject, key)
-        if (keyIndex == -1) return null
+        if (keyIndex == -1) throw Exception("'authData' key not found in attestation object (size: ${attestationObject.size} bytes).")
 
         // 2. Determine where the authData byte string starts.
         // CBOR uses the low 5 bits of the initial byte to describe how the byte-string length is encoded:
         // 0..23 = inline length, 24 = next 1 byte, 25 = next 2 bytes, 26 = next 4 bytes.
         val pointer = keyIndex + key.size
-        if (pointer >= attestationObject.size) return null
+        if (pointer >= attestationObject.size) {
+            throw Exception("Attestation object truncated after 'authData' key (offset: $keyIndex, size: ${attestationObject.size} bytes).")
+        }
 
         val initialByte = attestationObject[pointer].toInt() and 0xFF
         val headerSize = when (initialByte and 0x1F) {
@@ -250,25 +252,30 @@ object WebAuthnJsonUtil {
             24 -> 2
             25 -> 3
             26 -> 5
-            else -> return null
+            else -> throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $pointer.")
         }
 
         val authDataStart = pointer + headerSize
 
         // 3. Check the WebAuthn flags byte to confirm attested credential data is present.
         val flagsByteIndex = authDataStart + WEBAUTHN_AUTHDATA_FLAGS_OFFSET
-        if (flagsByteIndex >= attestationObject.size) return null
+        if (flagsByteIndex >= attestationObject.size)
+        {
+            throw Exception("Attestation object truncated: flags byte missing at offset $flagsByteIndex (size: ${attestationObject.size} bytes).")
+        }
 
         val flags = attestationObject[flagsByteIndex].toInt()
         val hasAttestedCredentialData =
             (flags and WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG) != 0
         if (!hasAttestedCredentialData) {
-            return null
+            throw Exception("AT flag not set in authData flags, attested credential data is absent, AAGUID cannot be extracted.")
         }
 
         // 4. Extract the fixed-length AAGUID from authData.
         val aaguidStart = authDataStart + WEBAUTHN_AUTHDATA_AAGUID_OFFSET
-        if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > attestationObject.size) return null
+        if (aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH > attestationObject.size) {
+            throw Exception("Attestation object truncated: expected $WEBAUTHN_AUTHDATA_AAGUID_LENGTH AAGUID bytes at offset $aaguidStart (size: ${attestationObject.size} bytes).")
+        }
 
         val aaguidBytes = attestationObject.copyOfRange(
             aaguidStart,

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -24,119 +24,248 @@ package com.microsoft.identity.common.internal.fido
 
 import android.util.Base64
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
-import com.microsoft.identity.common.java.constants.FidoConstants
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_LENGTH
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_OFFSET
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_REGISTRATION_ATTESTATION_OBJECT_JSON_KEY
+import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_REGISTRATION_ORIGIN_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_ID_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY
 import com.microsoft.identity.common.logging.Logger
+import okio.ByteString.Companion.decodeBase64
 import org.json.JSONException
 import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.util.UUID
+import kotlin.text.toByteArray
 
 /**
  * A utility class to help convert to and from strings in WebAuthn json format.
  */
-class WebAuthnJsonUtil {
-        companion object {
+object WebAuthnJsonUtil {
 
-            private val TAG = WebAuthnJsonUtil::class.simpleName.toString()
+    private val TAG = WebAuthnJsonUtil::class.simpleName.toString()
 
-        /**
-         * Takes applicable parameters and creates a string representation of
-         *  PublicKeyCredentialRequestOptionsJSON (https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptionsjson)
-         * @param challenge challenge string
-         * @param relyingPartyIdentifier rpId string
-         * @param allowedCredentials allowedCredentials string
-         * @param userVerificationPolicy yserVerificationPolicy string
-         * @return a string representation of PublicKeyCredentialRequestOptionsJSON.
-         */
-        fun createJsonAuthRequest(challenge: String,
-                                  relyingPartyIdentifier: String,
-                                  allowedCredentials: List<String>?,
-                                  userVerificationPolicy: String): String {
-            //Create classes
-            val publicKeyCredentialDescriptorList = ArrayList<PublicKeyCredentialDescriptor>()
-            allowedCredentials?.let {
-                for (id in allowedCredentials) {
-                    publicKeyCredentialDescriptorList.add(
-                        PublicKeyCredentialDescriptor("public-key", id)
-                    )
-                }
-            }
-            val options = PublicKeyCredentialRequestOptions(
-                challenge.base64UrlEncoded(),
-                relyingPartyIdentifier,
-                publicKeyCredentialDescriptorList,
-                userVerificationPolicy
-            )
-            return CommonMoshiJsonAdapter().toJson(options)
-        }
-
-        /**
-         * Extracts the AuthenticatorAssertionResponse from the overall AuthenticationResponse string received from the authenticator.
-         * @param fullResponseJson AuthenticationResponse Json string.
-         * @throws JSONException if a value is not present that should be.
-         */
-        fun extractAuthenticatorAssertionResponseJson(fullResponseJson : String): String {
-            val methodTag = "$TAG:extractAuthenticatorAssertionResponseJson"
-            val fullResponseJsonObject = JSONObject(fullResponseJson);
-            val authResponseJsonObject = fullResponseJsonObject
-                .getJSONObject(FidoConstants.WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY)
-            // ESTS expects a custom object with clientDataJSON, authenticatorData, signature, userHandle, and id.
-            val assertionResult = JSONObject();
-            assertionResult.put(WEBAUTHN_RESPONSE_ID_JSON_KEY, fullResponseJsonObject.get(
-                WEBAUTHN_RESPONSE_ID_JSON_KEY))
-            assertionResult.put(WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY, authResponseJsonObject.get(
-                WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY))
-            assertionResult.put(WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY, authResponseJsonObject.get(
-                WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY))
-            assertionResult.put(WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY, authResponseJsonObject.get(
-                WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY))
-            // UserHandle is optional if allowCredentials was provided in the request (username flow).
-            if (authResponseJsonObject.isNull(WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY)) {
-                Logger.info(methodTag, "UserHandle not found in assertion response.")
-            } else {
-                Logger.info(methodTag, "UserHandle was included in assertion response.")
-                assertionResult.put(
-                    WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY, authResponseJsonObject.get(
-                        WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY
-                    )
+    /**
+     * Takes applicable parameters and creates a string representation of
+     *  PublicKeyCredentialRequestOptionsJSON (https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptionsjson)
+     * @param challenge challenge string
+     * @param relyingPartyIdentifier rpId string
+     * @param allowedCredentials allowedCredentials string
+     * @param userVerificationPolicy yserVerificationPolicy string
+     * @return a string representation of PublicKeyCredentialRequestOptionsJSON.
+     */
+    fun createJsonAuthRequest(
+        challenge: String,
+        relyingPartyIdentifier: String,
+        allowedCredentials: List<String>?,
+        userVerificationPolicy: String
+    ): String {
+        //Create classes
+        val publicKeyCredentialDescriptorList = ArrayList<PublicKeyCredentialDescriptor>()
+        allowedCredentials?.let {
+            for (id in allowedCredentials) {
+                publicKeyCredentialDescriptorList.add(
+                    PublicKeyCredentialDescriptor("public-key", id)
                 )
             }
-            return assertionResult.toString()
         }
+        val options = PublicKeyCredentialRequestOptions(
+            challenge.base64UrlEncoded(),
+            relyingPartyIdentifier,
+            publicKeyCredentialDescriptorList,
+            userVerificationPolicy
+        )
+        return CommonMoshiJsonAdapter().toJson(options)
+    }
 
-        /**
-         * Given WebAuthn response values, create a string representation of the JSON assertion response that ESTS is expecting.
-         * @clientDataJson clientDataJson string
-         * @authenticatorData authenticatorData string
-         * @signature signature string
-         * @userHandle userHandle string
-         * @id id string
-         */
-        @JvmStatic
-        fun createAssertionString(clientDataJson: String,
-                                  authenticatorData: String,
-                                  signature: String,
-                                  userHandle: String,
-                                  id: String): String {
-            val assertionResult = JSONObject();
-            assertionResult.put(WEBAUTHN_RESPONSE_ID_JSON_KEY, id)
-            assertionResult.put(WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY, authenticatorData)
-            assertionResult.put(WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY, clientDataJson)
-            assertionResult.put(WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY, signature)
-            assertionResult.put(WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY, userHandle)
-            return assertionResult.toString()
+    /**
+     * Extracts the AuthenticatorAssertionResponse from the overall AuthenticationResponse string received from the authenticator.
+     * @param fullResponseJson AuthenticationResponse Json string.
+     * @throws JSONException if a value is not present that should be.
+     */
+    fun extractAuthenticatorAssertionResponseJson(fullResponseJson: String): String {
+        val methodTag = "$TAG:extractAuthenticatorAssertionResponseJson"
+        val fullResponseJsonObject = JSONObject(fullResponseJson)
+        val authResponseJsonObject = fullResponseJsonObject
+            .getJSONObject(WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY)
+        // ESTS expects a custom object with clientDataJSON, authenticatorData, signature, userHandle, and id.
+        val assertionResult = JSONObject()
+        assertionResult.put(
+            WEBAUTHN_RESPONSE_ID_JSON_KEY, fullResponseJsonObject.get(
+                WEBAUTHN_RESPONSE_ID_JSON_KEY
+            )
+        )
+        assertionResult.put(
+            WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY, authResponseJsonObject.get(
+                WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY
+            )
+        )
+        assertionResult.put(
+            WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY, authResponseJsonObject.get(
+                WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY
+            )
+        )
+        assertionResult.put(
+            WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY, authResponseJsonObject.get(
+                WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY
+            )
+        )
+        // UserHandle is optional if allowCredentials was provided in the request (username flow).
+        if (authResponseJsonObject.isNull(WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY)) {
+            Logger.info(methodTag, "UserHandle not found in assertion response.")
+        } else {
+            Logger.info(methodTag, "UserHandle was included in assertion response.")
+            assertionResult.put(
+                WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY, authResponseJsonObject.get(
+                    WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY
+                )
+            )
         }
+        return assertionResult.toString()
+    }
 
-        /**
-         * Returns a base64URL encoding of the string.
-         * @return String
-         */
-        fun String.base64UrlEncoded(): String {
-            val data: ByteArray = this.toByteArray(Charsets.UTF_8)
-            return Base64.encodeToString(data, (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING))
+    /**
+     * Given WebAuthn response values, create a string representation of the JSON assertion response that ESTS is expecting.
+     * @clientDataJson clientDataJson string
+     * @authenticatorData authenticatorData string
+     * @signature signature string
+     * @userHandle userHandle string
+     * @id id string
+     */
+    @JvmStatic
+    fun createAssertionString(
+        clientDataJson: String,
+        authenticatorData: String,
+        signature: String,
+        userHandle: String,
+        id: String
+    ): String {
+        val assertionResult = JSONObject()
+        assertionResult.put(WEBAUTHN_RESPONSE_ID_JSON_KEY, id)
+        assertionResult.put(WEBAUTHN_RESPONSE_AUTHENTICATOR_DATA_JSON_KEY, authenticatorData)
+        assertionResult.put(WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY, clientDataJson)
+        assertionResult.put(WEBAUTHN_RESPONSE_SIGNATURE_JSON_KEY, signature)
+        assertionResult.put(WEBAUTHN_RESPONSE_USER_HANDLE_JSON_KEY, userHandle)
+        return assertionResult.toString()
+    }
+
+    /**
+     * Returns a base64URL encoding of the string.
+     * @return String
+     */
+    fun String.base64UrlEncoded(): String {
+        val data: ByteArray = this.toByteArray(Charsets.UTF_8)
+        return Base64.encodeToString(
+            data,
+            (Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+        )
+    }
+
+    /**
+     * Extracts the origin from a WebAuthn passkey registration response JSON.
+     *
+     * Intended for use with the `registrationResponseJson` returned by
+     * `CredentialManagerHandler.createPasskey()`. Navigates to `response.clientDataJSON`,
+     * base64url-decodes it, parses it as JSON, and returns the `"origin"` field.
+     *
+     * @param registrationResponseJson The `registrationResponseJson` string from
+     *   `CreatePublicKeyCredentialResponse`.
+     * @return The origin string, or null if extraction fails.
+     */
+    fun extractOriginFromRegistrationResponse(registrationResponseJson: String): String? {
+        return try {
+            val responseObj = JSONObject(registrationResponseJson)
+                .getJSONObject(WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY)
+            val clientDataB64 = responseObj
+                .getString(WEBAUTHN_RESPONSE_CLIENT_DATA_JSON_KEY)
+            val decodedClientDataBytes = Base64.decode(clientDataB64, Base64.URL_SAFE)
+            val jsonString = String(decodedClientDataBytes, Charsets.UTF_8)
+            JSONObject(jsonString).getString(WEBAUTHN_REGISTRATION_ORIGIN_JSON_KEY)
+        } catch (e: Exception) {
+            Logger.warn(TAG, "Failed to extract origin from passkey registration response: ${e.message}")
+            null
         }
     }
+
+    /**
+     * Extracts the AAGUID from a WebAuthn passkey registration response JSON.
+     *
+     * Intended for use with the `registrationResponseJson` returned by
+     * `CredentialManagerHandler.createPasskey()`. Navigates to `response.attestationObject`,
+     * base64url-decodes it, parses the CBOR-encoded authenticator data, and returns the AAGUID
+     * as a formatted UUID string.
+     *
+     * @param registrationResponseJson The `registrationResponseJson` string from
+     *   `CreatePublicKeyCredentialResponse`.
+     * @return The AAGUID as a UUID string, or null if extraction fails.
+     */
+    fun extractAaguidFromRegistrationResponse(registrationResponseJson: String): String? {
+        return try {
+            val responseObj = JSONObject(registrationResponseJson)
+                .getJSONObject(WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY)
+            val attestationObject = responseObj
+                .getString(WEBAUTHN_REGISTRATION_ATTESTATION_OBJECT_JSON_KEY)
+            extractAaguidFromAttestationObject(attestationObject)
+        } catch (e: Exception) {
+            Logger.warn(TAG, "Failed to extract AAGUID from passkey registration response: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Parses a base64url-encoded CBOR attestation object and extracts the AAGUID.
+     *
+     * The AAGUID is located at byte offset 37 within the authenticator data (authData) field
+     * of the attestation object, and is 16 bytes long. It is returned as a formatted UUID string.
+     *
+     * @param attestationObjectB64 Base64url-encoded CBOR attestation object.
+     * @return The AAGUID as a UUID string.
+     * @throws Exception if the attestation object cannot be decoded or authData is not found.
+     */
+    fun extractAaguidFromAttestationObject(attestationObjectB64: String): String {
+        // 1. Decode Base64URL
+        val decoded = attestationObjectB64.decodeBase64()?.toByteArray()
+            ?: throw Exception("Failed to decode attestation object from Base64URL")
+        // 2. Find the "authData" key in the CBOR map
+        // The key "authData" is hex: 68 61 75 74 68 44 61 74 61
+        val authDataKey = "authData".toByteArray()
+        val keyIndex = indexOf(decoded, authDataKey)
+        if (keyIndex == -1) throw Exception("authData not found")
+
+        // 3. Skip the key and the CBOR byte string header
+        // In your string, it's followed by 0x58 (header) and 0x55 (length 85)
+        // So we skip the key length + 2 bytes for the CBOR header
+        val authDataStart = keyIndex + authDataKey.size + 2
+
+        // 4. AAGUID is at offset 37 within authData
+        val aaguidStart = authDataStart + WEBAUTHN_AUTHDATA_AAGUID_OFFSET
+        val aaguidBytes = decoded.copyOfRange(aaguidStart, aaguidStart + WEBAUTHN_AUTHDATA_AAGUID_LENGTH)
+
+        // 5. Convert to formatted UUID
+        return formatToUUID(aaguidBytes)
+    }
+
+    /**
+     * Returns the starting index of the first occurrence of [target] within [outer],
+     * or -1 if not found.
+     */
+    private fun indexOf(outer: ByteArray, target: ByteArray): Int {
+        for (i in 0 until outer.size - target.size + 1) {
+            if (outer.sliceArray(i until i + target.size).contentEquals(target)) return i
+        }
+        return -1
+    }
+
+    /**
+     * Converts a 16-byte AAGUID byte array into a formatted UUID string (e.g. "550e8400-e29b-41d4-a716-446655440000").
+     */
+    private fun formatToUUID(bytes: ByteArray): String {
+        val bb = ByteBuffer.wrap(bytes)
+        return UUID(bb.long, bb.long).toString()
+    }
+
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtil.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.fido
 
 import android.util.Base64
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
+import com.microsoft.identity.common.java.constants.CborConstants
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHENTICATION_ASSERTION_RESPONSE_JSON_KEY
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_LENGTH
 import com.microsoft.identity.common.java.constants.FidoConstants.Companion.WEBAUTHN_AUTHDATA_AAGUID_OFFSET
@@ -245,10 +246,10 @@ object WebAuthnJsonUtil {
             throw Exception("Attestation object truncated after 'authData' key (offset: $keyIndex, size: ${attestationObject.size} bytes).")
         }
 
-        val initialByte = attestationObject[valueOffset].toInt() and 0xFF
-        val majorType = (initialByte shr 5) and 0x07
-        if (majorType != 2) {
-            throw Exception("Invalid CBOR major type for 'authData': expected byte string (major type 2) but found $majorType at offset $valueOffset.")
+        val initialByte = attestationObject[valueOffset].toInt() and CborConstants.BYTE_UNSIGNED_MASK
+        val majorType = (initialByte shr 5) and CborConstants.MAJOR_TYPE_MASK
+        if (majorType != CborConstants.MAJOR_TYPE_BYTE_STRING) {
+            throw Exception("Invalid CBOR major type for 'authData': expected byte string (major type ${CborConstants.MAJOR_TYPE_BYTE_STRING}) but found $majorType at offset $valueOffset.")
         }
 
         val (headerSize, authDataLength) = parseCborByteStringHeader(attestationObject, valueOffset, initialByte)
@@ -291,27 +292,26 @@ object WebAuthnJsonUtil {
      * @throws Exception if the buffer is truncated or the length encoding is unsupported.
      */
     private fun parseCborByteStringHeader(buf: ByteArray, offset: Int, initialByte: Int): Pair<Int, Int> {
-        val additionalInfo = initialByte and 0x1F
-        return when (additionalInfo) {
+        return when (val additionalInfo = initialByte and CborConstants.ADDITIONAL_INFO_MASK) {
             in 0..23 -> 1 to additionalInfo
-            24 -> {
+            CborConstants.ADDITIONAL_INFO_ONE_BYTE_LENGTH -> {
                 val li = offset + 1
                 if (li >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 1 byte at offset $li, size: ${buf.size} bytes).")
-                2 to (buf[li].toInt() and 0xFF)
+                2 to (buf[li].toInt() and CborConstants.BYTE_UNSIGNED_MASK)
             }
-            25 -> {
+            CborConstants.ADDITIONAL_INFO_TWO_BYTE_LENGTH -> {
                 val li = offset + 1
                 if (li + 1 >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 2 bytes starting at offset $li, size: ${buf.size} bytes).")
-                val length = ((buf[li].toInt() and 0xFF) shl 8) or (buf[li + 1].toInt() and 0xFF)
+                val length = ((buf[li].toInt() and CborConstants.BYTE_UNSIGNED_MASK) shl 8) or (buf[li + 1].toInt() and CborConstants.BYTE_UNSIGNED_MASK)
                 3 to length
             }
-            26 -> {
+            CborConstants.ADDITIONAL_INFO_FOUR_BYTE_LENGTH -> {
                 val li = offset + 1
                 if (li + 3 >= buf.size) throw Exception("Attestation object truncated while reading 'authData' length (need 4 bytes starting at offset $li, size: ${buf.size} bytes).")
-                val length = ((buf[li].toInt() and 0xFF) shl 24) or
-                    ((buf[li + 1].toInt() and 0xFF) shl 16) or
-                    ((buf[li + 2].toInt() and 0xFF) shl 8) or
-                    (buf[li + 3].toInt() and 0xFF)
+                val length = ((buf[li].toInt() and CborConstants.BYTE_UNSIGNED_MASK) shl 24) or
+                    ((buf[li + 1].toInt() and CborConstants.BYTE_UNSIGNED_MASK) shl 16) or
+                    ((buf[li + 2].toInt() and CborConstants.BYTE_UNSIGNED_MASK) shl 8) or
+                    (buf[li + 3].toInt() and CborConstants.BYTE_UNSIGNED_MASK)
                 5 to length
             }
             else -> throw Exception("Unsupported CBOR length encoding for 'authData': initial byte 0x${initialByte.toString(16).uppercase()} at offset $offset.")

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivity.java
@@ -51,7 +51,7 @@ public class AuthorizationActivity extends DualScreenActivity {
     @Accessors(prefix = "m")
     private SpanContext mSpanContext;
 
-    @Getter
+
     @Accessors(prefix = "m")
     private Context mOtelContext;
 
@@ -97,5 +97,14 @@ public class AuthorizationActivity extends DualScreenActivity {
             Logger.error(methodTag, "Did not receive AuthorizationFragment from factory", ex);
         }
         setFragment(mFragment);
+    }
+
+    /**
+     * Returns the OpenTelemetry Context extracted from the Intent extras,
+     * or null if it was not provided or an error occurred during extraction.
+     * @return the OpenTelemetry Context, or null if not available.
+     */
+    public final Context getOtelContext() {
+        return mOtelContext;
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -24,6 +24,10 @@ package com.microsoft.identity.common.internal.providers.oauth2
 
 import android.annotation.SuppressLint
 import androidx.credentials.exceptions.CreateCredentialCancellationException
+import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import androidx.credentials.exceptions.CreateCredentialInterruptedException
 import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
 import androidx.credentials.exceptions.CreateCredentialUnknownException
@@ -50,11 +54,16 @@ import org.json.JSONObject
  *
  * @property replyProxy Proxy for sending messages to JavaScript.
  * @property requestType Type of WebAuthn request (e.g., "create", "get"). Defaults to "unknown".
+ * @property spanContext Parent span context for OpenTelemetry tracing.
+ * @property telemetryScope Coroutine scope used to record additional telemetry in a background
+ *   thread after the reply has already been posted, so callers are not blocked by telemetry work.
+ *   Defaults to a new [CoroutineScope] backed by [Dispatchers.IO].
  */
 class PasskeyReplyChannel(
     private val replyProxy: JavaScriptReplyProxy,
     private val requestType: String = "unknown",
-    private val spanContext: SpanContext? = null
+    private val spanContext: SpanContext? = null,
+    private val telemetryScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
     companion object {
         const val TAG = "PasskeyReplyChannel"
@@ -77,7 +86,6 @@ class PasskeyReplyChannel(
         const val DOM_EXCEPTION_ABORT_ERROR = "AbortError"
         const val DOM_EXCEPTION_NOT_SUPPORTED_ERROR = "NotSupportedError"
         const val DOM_EXCEPTION_UNKNOWN_ERROR = "UnknownError"
-
     }
 
     /**
@@ -137,39 +145,62 @@ class PasskeyReplyChannel(
     }
 
     /**
-     * Posts a success message with credential data.
+     * Posts a success message with credential data and returns immediately.
+     *
+     * The reply is sent to JavaScript right away. Additional telemetry attributes that require
+     * inspecting the response (e.g. passkey_origin) are recorded asynchronously
+     * on [telemetryScope] so that the caller is never blocked by telemetry work.
      *
      * @param json JSON string containing the credential response.
      */
     @SuppressLint("RequiresFeature", "Only called when feature is available")
-    fun postSuccess(json: String) {
+     fun postSuccess(json: String) {
         val methodTag = "$TAG:postSuccess"
         val span = OTelUtility.createSpanFromParent(
             SpanName.PasskeyWebListener.name,
             spanContext
         )
-
         try {
-            SpanExtension.makeCurrentSpan(span).use {
-                val successMessage = ReplyMessage.Success(json, requestType).toString()
-                replyProxy.postMessage(successMessage)
-                Logger.info(methodTag, "RequestType: $requestType was successful.")
-                span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
-                span.setStatus(StatusCode.OK)
-            }
+            // Send the reply to JS immediately — callers are not blocked after this point.
+            val successMessage = ReplyMessage.Success(json, requestType).toString()
+            replyProxy.postMessage(successMessage)
+            Logger.info(methodTag, "RequestType: $requestType was successful.")
         } catch (throwable: Throwable) {
             span.setStatus(StatusCode.ERROR)
             span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
             span.recordException(throwable)
+            span.end()
             Logger.error(methodTag, "Reply message failed", throwable)
             throw throwable
-        } finally {
-            span.end()
+        }
+
+        // Record telemetry in a background thread so we don't delay the response to the caller.
+        // We inspect the result JSON here to attach richer span attributes.
+        telemetryScope.launch {
+            try {
+                SpanExtension.makeCurrentSpan(span).use {
+                    span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
+
+                    if (requestType == PasskeyWebListener.CREATE_UNIQUE_KEY) {
+                        WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(json)?.let {
+                            span.setAttribute(AttributeName.passkey_aaguid.name, it)
+                        }
+                        WebAuthnJsonUtil.extractOriginFromRegistrationResponse(json)?.let {
+                            span.setAttribute(AttributeName.passkey_origin.name, it)
+                        }
+                    }
+
+                    span.setStatus(StatusCode.OK)
+                }
+            } catch (throwable: Throwable) {
+                span.setStatus(StatusCode.ERROR)
+                span.recordException(throwable)
+                Logger.error(methodTag, "Background telemetry recording failed", throwable)
+            } finally {
+                span.end()
+            }
         }
     }
-
-
-
 
     /**
      * Posts an error message based on a thrown exception.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -38,10 +38,12 @@ import androidx.credentials.exceptions.GetCredentialUnknownException
 import androidx.credentials.exceptions.NoCredentialException
 import androidx.webkit.JavaScriptReplyProxy
 import com.microsoft.identity.common.java.opentelemetry.AttributeName
+import com.microsoft.identity.common.java.opentelemetry.BaggageExtension
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.SpanName
 import com.microsoft.identity.common.logging.Logger
+import io.opentelemetry.api.baggage.Baggage
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
@@ -57,7 +59,7 @@ import org.json.JSONObject
  *
  * @property replyProxy Proxy for sending messages to JavaScript.
  * @property requestType Type of WebAuthn request (e.g., "create", "get"). Defaults to "unknown".
- * @property spanContext Parent span context for OpenTelemetry tracing.
+ * @property Context for OpenTelemetry span creation. Optional; if not provided, telemetry will be skipped with a warning.
  * @property telemetryScope Coroutine scope used to record additional telemetry in a background
  *   thread after the reply has already been posted, so callers are not blocked by telemetry work.
  *   Defaults to a new [CoroutineScope] backed by [Dispatchers.IO].
@@ -65,7 +67,7 @@ import org.json.JSONObject
 class PasskeyReplyChannel(
     private val replyProxy: JavaScriptReplyProxy,
     private val requestType: String = "unknown",
-    private val spanContext: SpanContext? = null,
+    private val otelContext: Context? = null,
     private val telemetryScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
     companion object {
@@ -89,6 +91,13 @@ class PasskeyReplyChannel(
         const val DOM_EXCEPTION_ABORT_ERROR = "AbortError"
         const val DOM_EXCEPTION_NOT_SUPPORTED_ERROR = "NotSupportedError"
         const val DOM_EXCEPTION_UNKNOWN_ERROR = "UnknownError"
+
+        private val parentAttributeNames = arrayListOf(
+            AttributeName.correlation_id,
+            AttributeName.tenant_id,
+            AttributeName.account_type,
+            AttributeName.calling_package_name
+        )
     }
 
     /**
@@ -148,6 +157,23 @@ class PasskeyReplyChannel(
     }
 
     /**
+     * Resolves the parent [SpanContext] from the provided [otelContext].
+     *
+     * Returns `null` and emits a warning if no OTel context was supplied, so callers can still
+     * create a root span rather than failing outright.
+     *
+     * @param methodTag Logging tag of the calling method, included in the warning message.
+     * @return The [SpanContext] extracted from [otelContext], or `null`.
+     */
+    private fun resolveParentSpanContext(methodTag: String): SpanContext? =
+        if (otelContext == null) {
+            Logger.warn(methodTag, "No OpenTelemetry context provided. Telemetry will not be recorded for this operation.")
+            null
+        } else {
+            SpanExtension.fromContext(otelContext).spanContext
+        }
+
+    /**
      * Posts a success message with credential data and returns immediately.
      *
      * The reply is sent to JavaScript right away. Additional telemetry attributes that require
@@ -161,7 +187,7 @@ class PasskeyReplyChannel(
         val methodTag = "$TAG:postSuccess"
         val span = OTelUtility.createSpanFromParent(
             SpanName.PasskeyWebListener.name,
-            spanContext
+            resolveParentSpanContext(methodTag)
         )
         // We use a flag or a structured try-catch to ensure span.end()
         // is called exactly once.
@@ -175,10 +201,11 @@ class PasskeyReplyChannel(
             span.setStatus(StatusCode.OK)
             span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
             val otelContext = Context.current().with(span)
+            val baggage = BaggageExtension.fromContext(otelContext)
 
             // 2. Hand off post-success telemetry to background worker
             val job = telemetryScope.launch(otelContext.asContextElement()) {
-                recordPostSuccessTelemetry(span, json)
+                recordPostSuccessTelemetry(span, json, baggage)
             }
             job.invokeOnCompletion {
                 span.end()
@@ -210,9 +237,15 @@ class PasskeyReplyChannel(
      * @param span The span created in [postSuccess], owned by the background task lifecycle.
      * @param json JSON payload returned from WebAuthn operation.
      */
-    private fun recordPostSuccessTelemetry(span: Span, json: String) {
+    private fun recordPostSuccessTelemetry(span: Span, json: String, baggage: Baggage? = null) {
         try {
             SpanExtension.makeCurrentSpan(span).use {
+                parentAttributeNames.forEach { attributeName ->
+                    baggage?.getEntryValue(attributeName.name)?.let { value ->
+                        span.setAttribute(attributeName.name, value)
+                    }
+                }
+
                 if (requestType == PasskeyWebListener.CREATE_UNIQUE_KEY) {
                     WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(json)?.let {
                         span.setAttribute(AttributeName.passkey_aaguid.name, it)
@@ -222,10 +255,10 @@ class PasskeyReplyChannel(
                     }
                 }
             }
-        } catch (e: Exception) {
+        } catch (exception: Exception) {
             Logger.warn(
                 TAG,
-                "Failed to record post-success passkey telemetry for requestType: $requestType"
+                "Failed to record post-success passkey telemetry for requestType: $requestType, ${exception.message}"
             )
         } finally {
             // The background worker owns span completion for the success path.
@@ -245,7 +278,7 @@ class PasskeyReplyChannel(
         val methodTag = "$TAG:postError"
         val span = OTelUtility.createSpanFromParent(
             SpanName.PasskeyWebListener.name,
-            spanContext
+            resolveParentSpanContext(methodTag)
         )
 
         try {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -200,11 +200,11 @@ class PasskeyReplyChannel(
 
             span.setStatus(StatusCode.OK)
             span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
-            val otelContext = Context.current().with(span)
+            val otelContextCurrentSpan = Context.current().with(span)
             val baggage = BaggageExtension.fromContext(otelContext)
 
             // 2. Hand off post-success telemetry to background worker
-            val job = telemetryScope.launch(otelContext.asContextElement()) {
+            val job = telemetryScope.launch(otelContextCurrentSpan.asContextElement()) {
                 recordPostSuccessTelemetry(span, json, baggage)
             }
             job.invokeOnCompletion {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -42,8 +42,11 @@ import com.microsoft.identity.common.java.opentelemetry.OTelUtility
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.SpanName
 import com.microsoft.identity.common.logging.Logger
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
 import org.json.JSONObject
 
 
@@ -154,51 +157,74 @@ class PasskeyReplyChannel(
      * @param json JSON string containing the credential response.
      */
     @SuppressLint("RequiresFeature", "Only called when feature is available")
-     fun postSuccess(json: String) {
+    fun postSuccess(json: String) {
         val methodTag = "$TAG:postSuccess"
         val span = OTelUtility.createSpanFromParent(
             SpanName.PasskeyWebListener.name,
             spanContext
         )
+        // We use a flag or a structured try-catch to ensure span.end()
+        // is called exactly once.
+        var handedOffToBackground = false
+
         try {
-            // Send the reply to JS immediately — callers are not blocked after this point.
+            // 1. Immediate Work
             val successMessage = ReplyMessage.Success(json, requestType).toString()
             replyProxy.postMessage(successMessage)
-            Logger.info(methodTag, "RequestType: $requestType was successful.")
-        } catch (throwable: Throwable) {
-            span.setStatus(StatusCode.ERROR)
+
+            span.setStatus(StatusCode.OK)
             span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
+            val otelContext = Context.current().with(span)
+
+            // 2. Hand off post-success telemetry to background worker
+            telemetryScope.launch(otelContext.asContextElement()) {
+                recordPostSuccessTelemetry(span, json)
+            }
+            handedOffToBackground = true
+
+        } catch (throwable: Throwable) {
+            // 3. Error Path: If postMessage fails OR launch fails
             span.recordException(throwable)
-            span.end()
-            Logger.error(methodTag, "Reply message failed", throwable)
+            span.setStatus(StatusCode.ERROR)
+            Logger.error(methodTag, "Immediate execution failed", throwable)
             throw throwable
-        }
-
-        // Record telemetry in a background thread so we don't delay the response to the caller.
-        // We inspect the result JSON here to attach richer span attributes.
-        telemetryScope.launch {
-            try {
-                SpanExtension.makeCurrentSpan(span).use {
-                    span.setAttribute(AttributeName.passkey_operation_type.name, requestType)
-
-                    if (requestType == PasskeyWebListener.CREATE_UNIQUE_KEY) {
-                        WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(json)?.let {
-                            span.setAttribute(AttributeName.passkey_aaguid.name, it)
-                        }
-                        WebAuthnJsonUtil.extractOriginFromRegistrationResponse(json)?.let {
-                            span.setAttribute(AttributeName.passkey_origin.name, it)
-                        }
-                    }
-
-                    span.setStatus(StatusCode.OK)
-                }
-            } catch (throwable: Throwable) {
-                span.setStatus(StatusCode.ERROR)
-                span.recordException(throwable)
-                Logger.error(methodTag, "Background telemetry recording failed", throwable)
-            } finally {
+        } finally {
+            // 4. Lifecycle Guard: Only end here if we didn't successfully
+            // start the background task.
+            if (!handedOffToBackground) {
                 span.end()
             }
+        }
+    }
+
+    /**
+     * Records additional post-success telemetry on a background thread.
+     *
+     * This method is invoked only after the success reply has already been posted to JavaScript.
+     * It must remain non-blocking for the caller path and should never prevent a successful
+     * response from being returned.
+     *
+     * @param span The span created in [postSuccess], owned by the background task lifecycle.
+     * @param json JSON payload returned from WebAuthn operation.
+     */
+    private fun recordPostSuccessTelemetry(span: Span, json: String) {
+        try {
+            SpanExtension.current().makeCurrent().use {
+                if (requestType == PasskeyWebListener.CREATE_UNIQUE_KEY) {
+                    WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(json)?.let {
+                        span.setAttribute(AttributeName.passkey_aaguid.name, it)
+                    }
+                    WebAuthnJsonUtil.extractOriginFromRegistrationResponse(json)?.let {
+                        span.setAttribute(AttributeName.passkey_origin.name, it)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            span.recordException(e)
+            span.setStatus(StatusCode.ERROR)
+        } finally {
+            // The background worker owns span completion for the success path.
+            span.end()
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -225,8 +225,7 @@ class PasskeyReplyChannel(
         } catch (e: Exception) {
             Logger.warn(
                 TAG,
-                "Failed to record post-success passkey telemetry for requestType: $requestType",
-                e
+                "Failed to record post-success passkey telemetry for requestType: $requestType"
             )
         } finally {
             // The background worker owns span completion for the success path.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -221,7 +221,6 @@ class PasskeyReplyChannel(
             }
         } catch (e: Exception) {
             span.recordException(e)
-            span.setStatus(StatusCode.ERROR)
         } finally {
             // The background worker owns span completion for the success path.
             span.end()

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyReplyChannel.kt
@@ -177,8 +177,11 @@ class PasskeyReplyChannel(
             val otelContext = Context.current().with(span)
 
             // 2. Hand off post-success telemetry to background worker
-            telemetryScope.launch(otelContext.asContextElement()) {
+            val job = telemetryScope.launch(otelContext.asContextElement()) {
                 recordPostSuccessTelemetry(span, json)
+            }
+            job.invokeOnCompletion {
+                span.end()
             }
             handedOffToBackground = true
 
@@ -209,7 +212,7 @@ class PasskeyReplyChannel(
      */
     private fun recordPostSuccessTelemetry(span: Span, json: String) {
         try {
-            SpanExtension.current().makeCurrent().use {
+            SpanExtension.makeCurrentSpan(span).use {
                 if (requestType == PasskeyWebListener.CREATE_UNIQUE_KEY) {
                     WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(json)?.let {
                         span.setAttribute(AttributeName.passkey_aaguid.name, it)
@@ -220,7 +223,11 @@ class PasskeyReplyChannel(
                 }
             }
         } catch (e: Exception) {
-            span.recordException(e)
+            Logger.warn(
+                TAG,
+                "Failed to record post-success passkey telemetry for requestType: $requestType",
+                e
+            )
         } finally {
             // The background worker owns span completion for the success path.
             span.end()

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyWebListener.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyWebListener.kt
@@ -49,7 +49,15 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Intercepts postMessage() calls from JavaScript to handle credential creation and retrieval
  * using the Android Credential Manager API. Only accepts requests from allowed origins.
  *
- * @property coroutineScope Scope for launching credential operations.
+ * ## Threading model
+ * - [onPostMessage] is always invoked on the **main thread** by the WebView framework.
+ * - Credential operations ([handleCreateFlow], [handleGetFlow]) are launched as coroutines on
+ *   [kotlinx.coroutines.Dispatchers.Main] because [androidx.credentials.CredentialManager]
+ *   must be called from the main thread in order to display its system UI.
+ * - The [coroutineScope] supplied at construction time **must** therefore be bound to
+ *   [kotlinx.coroutines.Dispatchers.Main] (see [hook] for the canonical way to create an instance).
+ *
+ * @property coroutineScope Scope for launching credential operations (must use [kotlinx.coroutines.Dispatchers.Main]).
  * @property credentialManagerHandler Handles passkey creation and retrieval.
  */
 class PasskeyWebListener(
@@ -329,7 +337,9 @@ class PasskeyWebListener(
                     INTERFACE_NAME,
                     PasskeyOriginRulesManager.getAllowedOriginRules(),
                     PasskeyWebListener(
-                        coroutineScope = CoroutineScope(Dispatchers.Default),
+                        // CredentialManager must be called on the main thread (it shows system UI),
+                        // so the coroutine scope must use Dispatchers.Main.
+                        coroutineScope = CoroutineScope(Dispatchers.Main),
                         credentialManagerHandler = CredentialManagerHandler(activity)
                     )
                 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyWebListener.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/PasskeyWebListener.kt
@@ -34,6 +34,7 @@ import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.microsoft.identity.common.BuildConfig
+import com.microsoft.identity.common.internal.providers.oauth2.PasskeyWebListener.Companion.hook
 import com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClient
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.logging.Logger
@@ -63,6 +64,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class PasskeyWebListener(
     private val coroutineScope: CoroutineScope,
     private val credentialManagerHandler: CredentialManagerHandler,
+    private val otelContext: io.opentelemetry.context.Context? = null
 ) : WebViewCompat.WebMessageListener {
 
     /** Tracks if a WebAuthN request is currently pending. Only one request is allowed at a time. */
@@ -114,7 +116,11 @@ class PasskeyWebListener(
             methodTag,
             "Received WebAuthN request of type: ${webAuthNMessage.type} from origin: $sourceOrigin"
         )
-        val passkeyReplyChannel = PasskeyReplyChannel(javaScriptReplyProxy, webAuthNMessage.type)
+        val passkeyReplyChannel = PasskeyReplyChannel(
+            replyProxy = javaScriptReplyProxy,
+            requestType = webAuthNMessage.type,
+            otelContext = otelContext
+        )
 
         // Only allow one request at a time.
         if (havePendingRequest.get()) {
@@ -236,7 +242,10 @@ class PasskeyWebListener(
         messageData: String?,
         javaScriptReplyProxy: JavaScriptReplyProxy
     ): WebAuthNMessage? {
-        val passkeyReplyChannel = PasskeyReplyChannel(javaScriptReplyProxy)
+        val passkeyReplyChannel = PasskeyReplyChannel(
+            replyProxy = javaScriptReplyProxy,
+            otelContext = otelContext
+        )
         return runCatching {
             if (messageData.isNullOrBlank()) {
                 throw ClientException(ClientException.MISSING_PARAMETER, "Message data is null or blank")
@@ -340,7 +349,8 @@ class PasskeyWebListener(
                         // CredentialManager must be called on the main thread (it shows system UI),
                         // so the coroutine scope must use Dispatchers.Main.
                         coroutineScope = CoroutineScope(Dispatchers.Main),
-                        credentialManagerHandler = CredentialManagerHandler(activity)
+                        credentialManagerHandler = CredentialManagerHandler(activity),
+                        otelContext = (activity as? AuthorizationActivity)?.otelContext
                     )
                 )
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtilTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/WebAuthnJsonUtilTest.kt
@@ -22,9 +22,10 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.common.internal.fido
 
-import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil.Companion.base64UrlEncoded
+import com.microsoft.identity.common.internal.fido.WebAuthnJsonUtil.base64UrlEncoded
 import org.json.JSONException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -150,5 +151,68 @@ class WebAuthnJsonUtilTest {
     @Test
     fun testBase64UrlEncoded_RandomString() {
         assertEquals(expectedEncodedRandomString, randomString.base64UrlEncoded())
+    }
+
+    // createCredentialResponse.json test data
+    // clientDataJSON decodes to:
+    // {"type":"webauthn.create","challenge":"...","origin":"android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU","androidPackageName":"com.microsoft.identity.testuserapp"}
+    val createCredentialResponseJson = """{"rawId":"_mqxqFyisYcQDo7sTf5Ggw","authenticatorAttachment":"platform","type":"public-key","id":"_mqxqFyisYcQDo7sTf5Ggw","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiTFVOeGMwZ3FXaXBwYTBacmRGTmpiMU5OUkc1UmNqaHZlRFUxWkVOUFZGWkZVbVJrV0hSNFFXSnRWbWN6Wld4UldGVkxZblpvUWpkalJrNXRaa2g1VkhNek9FUjNaM05pVG5oVFVtTnRjRzgwZVVSRVUzQk5SVlpuYzBKc2QxUnlNVkZ4TlhOcVFqSndTMnBSS2ciLCJvcmlnaW4iOiJhbmRyb2lkOmFway1rZXktaGFzaDpFOGxTWDF6Sk1QQlo5R196cG5meGZtZmgtZDBxMnFFWXotMmJnTmVVS0NVIiwiYW5kcm9pZFBhY2thZ2VOYW1lIjoiY29tLm1pY3Jvc29mdC5pZGVudGl0eS50ZXN0dXNlcmFwcCJ9","attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViUNWye1KCTIblpXx6vkYID8bVfaJ2mH7yWGEwVfdpoDIFdAAAAAOqbjWZNAR0hPOS2tIy1ddQAEP5qsahcorGHEA6O7E3-RoOlAQIDJiABIVgg2wYC7isQOus7OjKigGo_J37T42oJq0SROrLhqn-53AgiWCAN3Z596TH_Lh9BeAdZinza_vXPWfb90QzUcK-vpipqKQ","transports":["internal","hybrid"],"authenticatorData":"NWye1KCTIblpXx6vkYID8bVfaJ2mH7yWGEwVfdpoDIFdAAAAAOqbjWZNAR0hPOS2tIy1ddQAEP5qsahcorGHEA6O7E3-RoOlAQIDJiABIVgg2wYC7isQOus7OjKigGo_J37T42oJq0SROrLhqn-53AgiWCAN3Z596TH_Lh9BeAdZinza_vXPWfb90QzUcK-vpipqKQ","publicKeyAlgorithm":-7,"publicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2wYC7isQOus7OjKigGo_J37T42oJq0SROrLhqn-53AgN3Z596TH_Lh9BeAdZinza_vXPWfb90QzUcK-vpipqKQ"},"clientExtensionResults":{"credProps":{"rk":true}}}"""
+    val expectedOriginFromCreateCredentialResponse = "android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU"
+
+    // attestationObject from createCredentialResponseJson decodes to AAGUID ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4
+    val expectedAaguidFromCreateCredentialResponse = "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4"
+    val attestationObjectFromCreateCredential = "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViUNWye1KCTIblpXx6vkYID8bVfaJ2mH7yWGEwVfdpoDIFdAAAAAOqbjWZNAR0hPOS2tIy1ddQAEP5qsahcorGHEA6O7E3-RoOlAQIDJiABIVgg2wYC7isQOus7OjKigGo_J37T42oJq0SROrLhqn-53AgiWCAN3Z596TH_Lh9BeAdZinza_vXPWfb90QzUcK-vpipqKQ"
+
+    @Test
+    fun testExtractOriginFromRegistrationResponse_fromCreateCredentialResponse() {
+        val result = WebAuthnJsonUtil.extractOriginFromRegistrationResponse(createCredentialResponseJson)
+        assertEquals(expectedOriginFromCreateCredentialResponse, result)
+    }
+
+    @Test
+    fun testExtractOriginFromRegistrationResponse_invalidJson_returnsNull() {
+        val result = WebAuthnJsonUtil.extractOriginFromRegistrationResponse("not valid json")
+        assertNull(result)
+    }
+
+    @Test
+    fun testExtractOriginFromRegistrationResponse_missingResponseKey_returnsNull() {
+        val result = WebAuthnJsonUtil.extractOriginFromRegistrationResponse("""{"id":"abc","type":"public-key"}""")
+        assertNull(result)
+    }
+
+    @Test
+    fun testExtractAaguidFromRegistrationResponse_fromCreateCredentialResponse() {
+        val result = WebAuthnJsonUtil.extractAaguidFromRegistrationResponse(createCredentialResponseJson)
+        assertEquals(expectedAaguidFromCreateCredentialResponse, result)
+    }
+
+    @Test
+    fun testExtractAaguidFromRegistrationResponse_invalidJson_returnsNull() {
+        val result = WebAuthnJsonUtil.extractAaguidFromRegistrationResponse("not valid json")
+        assertNull(result)
+    }
+
+    @Test
+    fun testExtractAaguidFromRegistrationResponse_missingResponseKey_returnsNull() {
+        val result = WebAuthnJsonUtil.extractAaguidFromRegistrationResponse("""{"id":"abc","type":"public-key"}""")
+        assertNull(result)
+    }
+
+    @Test
+    fun testExtractAaguidFromAttestationObject_validAttestationObject_returnsExpectedAaguid() {
+        val result = WebAuthnJsonUtil.extractAaguidFromAttestationObject(attestationObjectFromCreateCredential)
+        assertEquals(expectedAaguidFromCreateCredentialResponse, result)
+    }
+
+    @Test(expected = Exception::class)
+    fun testExtractAaguidFromAttestationObject_invalidBase64_throws() {
+        WebAuthnJsonUtil.extractAaguidFromAttestationObject("!!!not-valid-base64!!!")
+    }
+
+    @Test(expected = Exception::class)
+    fun testExtractAaguidFromAttestationObject_missingAuthData_throws() {
+        // Valid base64url but CBOR with no authData key
+        WebAuthnJsonUtil.extractAaguidFromAttestationObject("oA")
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/constants/CborConstants.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/constants/CborConstants.kt
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.constants
+
+/**
+ * Constants for CBOR (Concise Binary Object Representation) parsing.
+ *
+ * CBOR is a binary data serialization format defined by RFC 7049 / RFC 8949.
+ * It is used, for example, to encode the `attestationObject` in WebAuthn
+ * registration responses.
+ */
+object CborConstants {
+
+    /**
+     * Bitmask used to convert a signed Kotlin/Java [Byte] to its unsigned integer representation
+     * (0–255) when parsing raw binary data.
+     *
+     * Because [Byte] is signed (-128..127), calling [Byte.toInt] on values ≥ 0x80 produces a
+     * negative number due to sign extension (e.g. `0x80.toByte().toInt() == -128`, not 128).
+     * ANDing with [BYTE_UNSIGNED_MASK] clears the upper 24 bits and yields the correct unsigned value.
+     */
+    const val BYTE_UNSIGNED_MASK = 0xFF
+
+    /**
+     * Bitmask to extract the major type from a CBOR initial byte.
+     *
+     * In CBOR encoding, the upper 3 bits of the initial byte encode the major type.
+     * Shifting the initial byte right by 5 and ANDing with this mask yields a value 0–7
+     * identifying the type (e.g. 0 = unsigned int, 2 = byte string, 3 = text string).
+     */
+    const val MAJOR_TYPE_MASK = 0x07
+
+    /**
+     * Mask for the additional info field in the lower 5 bits of a CBOR initial byte.
+     *
+     * Values 0–23 encode the length directly; values 24, 25, and 26 signal that the
+     * length follows in 1, 2, or 4 subsequent bytes respectively.
+     */
+    const val ADDITIONAL_INFO_MASK = 0x1F
+
+    /**
+     * CBOR major type value for a byte string (major type 2).
+     *
+     * Used to confirm a CBOR item is a byte string before reading its length.
+     * After extracting the major type with [MAJOR_TYPE_MASK], compare against this value.
+     */
+    const val MAJOR_TYPE_BYTE_STRING = 2
+
+    /**
+     * CBOR additional info value indicating the length follows in 1 byte (uint8).
+     */
+    const val ADDITIONAL_INFO_ONE_BYTE_LENGTH = 24
+
+    /**
+     * CBOR additional info value indicating the length follows in 2 bytes (uint16, big-endian).
+     */
+    const val ADDITIONAL_INFO_TWO_BYTE_LENGTH = 25
+
+    /**
+     * CBOR additional info value indicating the length follows in 4 bytes (uint32, big-endian).
+     */
+    const val ADDITIONAL_INFO_FOUR_BYTE_LENGTH = 26
+}
+

--- a/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
@@ -173,6 +173,16 @@ class FidoConstants {
         const val WEBAUTHN_REGISTRATION_ORIGIN_JSON_KEY = "origin"
 
         /**
+         * Byte offset of the flags byte within authenticator data (`authData`) as defined by WebAuthn.
+         */
+        const val WEBAUTHN_AUTHDATA_FLAGS_OFFSET = 32
+
+        /**
+         * Bit mask for the attested credential data flag (AT) in the authenticator data flags byte.
+         */
+        const val WEBAUTHN_AUTHDATA_ATTESTED_CREDENTIAL_DATA_FLAG = 0x40
+
+        /**
          * Byte offset of the AAGUID within the authenticator data (authData) of a WebAuthn
          * attestation object, as defined by the WebAuthn spec
          * (https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data).

--- a/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/constants/FidoConstants.kt
@@ -161,5 +161,28 @@ class FidoConstants {
          * JSON key value of id in response of Webauthn JSON object.
          */
         const val WEBAUTHN_RESPONSE_ID_JSON_KEY = "id"
+
+        /**
+         * JSON key value of attestationObject in WebAuthn registration response JSON object.
+         */
+        const val WEBAUTHN_REGISTRATION_ATTESTATION_OBJECT_JSON_KEY = "attestationObject"
+
+        /**
+         * JSON key value of origin in WebAuthn registration response JSON object.
+         */
+        const val WEBAUTHN_REGISTRATION_ORIGIN_JSON_KEY = "origin"
+
+        /**
+         * Byte offset of the AAGUID within the authenticator data (authData) of a WebAuthn
+         * attestation object, as defined by the WebAuthn spec
+         * (https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data).
+         */
+        const val WEBAUTHN_AUTHDATA_AAGUID_OFFSET = 37
+
+        /**
+         * Length in bytes of the AAGUID field within the authenticator data (authData),
+         * as defined by the WebAuthn spec.
+         */
+        const val WEBAUTHN_AUTHDATA_AAGUID_LENGTH = 16
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -496,6 +496,16 @@ public enum AttributeName {
     passkey_dom_exception_name,
 
     /**
+     * Origin extracted from the WebAuthn clientDataJSON response.
+     */
+    passkey_origin,
+
+    /**
+     * AAGUID of the authenticator, extracted from the attestation authenticatorData (create flow only).
+     */
+    passkey_aaguid,
+
+    /**
      *  Elapsed time (in milliseconds) spent in executing the save() method in BrokerOAuth2TokenCache.
      */
     elapsed_time_save_aggregated_account_data,


### PR DESCRIPTION

The purpose of this PR is to extract additional telemetry (passkey_aaguid and passkey_origin) from successful PasskeyWebListener scenarios. This will help us investigate an error observed in MSAL STS, where the origin is not in the expected format. We want to determine whether this issue is caused by our code or by a malicious app. If it originates from our side, we aim to identify the conditions under which it occurs, such as specific device models, OEMs, or passkey providers.

### WebAuthn Passkey Registration & Extraction Enhancements

* Added new methods to `WebAuthnJsonUtil` for extracting the origin and AAGUID from passkey registration responses, including robust parsing of CBOR-encoded attestation objects and error handling. These utilities help with downstream identity and device management.
* Refactored `WebAuthnJsonUtil` from a `class` with a `companion object` to a singleton `object`, and updated method signatures for improved clarity and usage. [[1]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL27-R50) [[2]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL51-R68) [[3]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL83-R118) [[4]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL119-R149)
* Updated imports and usage of constants in `WebAuthnJsonUtil` to reference individual fields from `FidoConstants.Companion`, improving code readability and maintainability.

### OpenTelemetry Integration

* Added the `opentelemetry-extension-kotlin` dependency, enabling better integration of OpenTelemetry with Kotlin coroutines and context propagation.
* Refactored `PasskeyReplyChannel` to accept an OpenTelemetry `Context` and a coroutine scope for telemetry, allowing asynchronous telemetry recording and improved tracing. [[1]](diffhunk://#diff-bb537edfab7cad219e40b22765c8dbc5628fb406b13116f4ca715d1c769724edR62-R71) [[2]](diffhunk://#diff-bb537edfab7cad219e40b22765c8dbc5628fb406b13116f4ca715d1c769724edR41-R51) [[3]](diffhunk://#diff-bb537edfab7cad219e40b22765c8dbc5628fb406b13116f4ca715d1c769724edR27-R30)
* Added a new `getOtelContext()` method to `AuthorizationActivity` for safe access to the OpenTelemetry context extracted from intent extras.

### Code Quality & Maintenance

* Improved formatting, parameter naming, and error handling throughout the updated files, including more descriptive documentation for new and existing methods. [[1]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL51-R68) [[2]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL83-R118) [[3]](diffhunk://#diff-3eccc9e10af08853b545937ac7feb125a07fd5e9409ae12893f069f429a9b7abL139-R337)
* Added parent attribute names for telemetry correlation in `PasskeyReplyChannel`, supporting more detailed trace and span metadata.



android_spans
| where span_name ==  "PasskeyWebListener"
| project calling_package_name, DeviceInfo_Model, active_broker_package_name, DeviceInfo_Make, account_type, passkey_aaguid, passkey_origin
|take 1000

| calling_package_name                          | DeviceInfo_Model | active_broker_package_name                | DeviceInfo_Make | account_type | passkey_aaguid                           | passkey_origin                                                                 |
|----------------------------------------------|------------------|-------------------------------------------|-----------------|--------------|------------------------------------------|--------------------------------------------------------------------------------|
|                                              | SM-F926U1        | com.microsoft.identity.testuserapp         | samsung         |              |                                          |                                                                                |
| com.msft.identity.client.sample.local         | SM-F926U1        | com.microsoft.identity.testuserapp         | samsung         | AAD          | 53414d53-554e-4700-0000-000000000000      | android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU                  |
|                                              | SM-F926U1        | com.microsoft.identity.testuserapp         | samsung         |              | 53414d53-554e-4700-0000-000000000000      | android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU                  |
|                                              | SM-F926U1        | com.microsoft.identity.testuserapp         | samsung         |              | 53414d53-554e-4700-0000-000000000000      | android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU                  |
|                                              | SM-F926U1        | com.microsoft.identity.testuserapp         | samsung         |              | 53414d53-554e-4700-0000-000000000000      | android:apk-key-hash:E8lSX1zJMPBZ9G_zpnfxfmfh-d0q2qEYz-2bgNeUKCU                  |

[AB#3540659](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3540659)

related PR: https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/107
