### PR TITLE
Add WebView file upload support, Fixes AB#3545256

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ vNext
 - [MINOR] Edge TB: PoP support (#3006)
 - [MINOR] Handle target="_blank" links in authorization WebView (#3010)
 - [MINOR] Handle openid-vc urls in webview (#3013)
+- [MINOR] Add WebView file upload support (#3022)
 
 Version 24.0.1
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -440,8 +440,9 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     final WebView webView,
                     final ValueCallback<Uri[]> filePathCallback,
                     final FileChooserParams fileChooserParams) {
-                final SpanContext parentSpanContext = requireActivity() instanceof AuthorizationActivity
-                        ? ((AuthorizationActivity) requireActivity()).getSpanContext() : null;
+                final FragmentActivity host = getActivity();
+                final SpanContext parentSpanContext = host instanceof AuthorizationActivity
+                        ? ((AuthorizationActivity) host).getSpanContext() : null;
                 return handleFileUploadRequest(filePathCallback, fileChooserParams, parentSpanContext);
             }
 
@@ -598,28 +599,45 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         final Span span = OTelUtility.createSpanFromParent(
                 SpanName.WebViewFileUpload.name(), parentSpanContext);
 
-        // Cancel any existing callback to avoid a dangling reference.
-        if (mFileUploadCallback != null) {
-            mFileUploadCallback.onReceiveValue(null);
-        }
-        mFileUploadCallback = filePathCallback;
+        try (final Scope scope = SpanExtension.makeCurrentSpan(span)) {
+            // Cancel any existing callback to avoid a dangling reference.
+            if (mFileUploadCallback != null) {
+                mFileUploadCallback.onReceiveValue(null);
+            }
+            // Clear any previous callback reference before handling the new request.
+            mFileUploadCallback = null;
 
-        try {
+            // Ensure the file chooser launcher is initialized before attempting to launch.
+            if (mFileChooserLauncher == null) {
+                Logger.error(methodTag,
+                        "File chooser launcher is not initialized. Cannot handle file upload request.",
+                        null);
+                // Notify the caller that no file was selected/returned.
+                filePathCallback.onReceiveValue(null);
+                span.setStatus(StatusCode.ERROR);
+                return false;
+            }
+
+            // At this point we have a valid launcher; store the callback for the result.
+            mFileUploadCallback = filePathCallback;
+
             final Intent intent = fileChooserParams.createIntent();
             Logger.info(methodTag, "Launching file chooser for WebView file upload.");
             mFileChooserLauncher.launch(intent);
             span.setStatus(StatusCode.OK);
+            return true;
         } catch (final Exception e) {
             Logger.error(methodTag, "Failed to launch file chooser.", e);
             span.recordException(e);
             span.setStatus(StatusCode.ERROR);
-            mFileUploadCallback.onReceiveValue(null);
-            mFileUploadCallback = null;
+            if (mFileUploadCallback != null) {
+                mFileUploadCallback.onReceiveValue(null);
+                mFileUploadCallback = null;
+            }
             return false;
         } finally {
             span.end();
         }
-        return true;
     }
 
     @VisibleForTesting

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -440,30 +440,9 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     final WebView webView,
                     final ValueCallback<Uri[]> filePathCallback,
                     final FileChooserParams fileChooserParams) {
-                if (!CommonFlightsManager.INSTANCE.getFlightsProvider()
-                        .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)) {
-                    Logger.warn(methodTag, "File upload is not enabled. Ignoring file chooser request.");
-                    filePathCallback.onReceiveValue(null);
-                    return true;
-                }
-
-                // Cancel any existing callback to avoid a dangling reference.
-                if (mFileUploadCallback != null) {
-                    mFileUploadCallback.onReceiveValue(null);
-                }
-                mFileUploadCallback = filePathCallback;
-
-                try {
-                    final Intent intent = fileChooserParams.createIntent();
-                    Logger.info(methodTag, "Launching file chooser for WebView file upload.");
-                    mFileChooserLauncher.launch(intent);
-                } catch (final Exception e) {
-                    Logger.error(methodTag, "Failed to launch file chooser.", e);
-                    mFileUploadCallback.onReceiveValue(null);
-                    mFileUploadCallback = null;
-                    return false;
-                }
-                return true;
+                final SpanContext parentSpanContext = requireActivity() instanceof AuthorizationActivity
+                        ? ((AuthorizationActivity) requireActivity()).getSpanContext() : null;
+                return handleFileUploadRequest(filePathCallback, fileChooserParams, parentSpanContext);
             }
 
             @Override
@@ -592,6 +571,70 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
         final String lowerUrl = url.toLowerCase();
         return lowerUrl.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)
                 && lowerUrl.contains(AuthenticationConstants.Broker.TLR_START_PATH);
+    }
+
+    /**
+     * Handles a file chooser request from the WebView. Creates a telemetry span,
+     * manages the file upload callback, and launches the system file picker.
+     *
+     * @param filePathCallback  The callback to deliver file selection results to the WebView.
+     * @param fileChooserParams Parameters describing the file chooser request.
+     * @param parentSpanContext The parent span context for telemetry, or null.
+     * @return {@code true} if the file chooser was launched, {@code false} otherwise.
+     */
+    @VisibleForTesting
+    boolean handleFileUploadRequest(
+            @NonNull final ValueCallback<Uri[]> filePathCallback,
+            @NonNull final WebChromeClient.FileChooserParams fileChooserParams,
+            @Nullable final SpanContext parentSpanContext) {
+        final String methodTag = TAG + ":handleFileUploadRequest";
+
+        if (!CommonFlightsManager.INSTANCE.getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)) {
+            Logger.info(methodTag, "ENABLE_WEBVIEW_FILE_UPLOAD flight is disabled.");
+            return false;
+        }
+
+        final Span span = OTelUtility.createSpanFromParent(
+                SpanName.WebViewFileUpload.name(), parentSpanContext);
+
+        // Cancel any existing callback to avoid a dangling reference.
+        if (mFileUploadCallback != null) {
+            mFileUploadCallback.onReceiveValue(null);
+        }
+        mFileUploadCallback = filePathCallback;
+
+        try {
+            final Intent intent = fileChooserParams.createIntent();
+            Logger.info(methodTag, "Launching file chooser for WebView file upload.");
+            mFileChooserLauncher.launch(intent);
+            span.setStatus(StatusCode.OK);
+        } catch (final Exception e) {
+            Logger.error(methodTag, "Failed to launch file chooser.", e);
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR);
+            mFileUploadCallback.onReceiveValue(null);
+            mFileUploadCallback = null;
+            return false;
+        } finally {
+            span.end();
+        }
+        return true;
+    }
+
+    @VisibleForTesting
+    void setFileUploadCallback(@Nullable final ValueCallback<Uri[]> callback) {
+        mFileUploadCallback = callback;
+    }
+
+    @VisibleForTesting
+    ValueCallback<Uri[]> getFileUploadCallback() {
+        return mFileUploadCallback;
+    }
+
+    @VisibleForTesting
+    void setFileChooserLauncher(@Nullable final ActivityResultLauncher<Intent> launcher) {
+        mFileChooserLauncher = launcher;
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -46,6 +46,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.PermissionRequest;
+import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
@@ -54,6 +55,7 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -139,6 +141,19 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
 
     private final CameraPermissionRequestHandler mCameraPermissionRequestHandler = new CameraPermissionRequestHandler(this);
 
+    /**
+     * Callback for file chooser requests from the WebView.
+     * This is set when {@link WebChromeClient#onShowFileChooser} is invoked and
+     * must be called back with the selected file URI(s) or null if cancelled.
+     */
+    private ValueCallback<Uri[]> mFileUploadCallback;
+
+    /**
+     * Launcher for the file chooser activity, registered in {@link #onCreate}.
+     * Handles the result of the file selection and passes it back to the WebView.
+     */
+    private ActivityResultLauncher<Intent> mFileChooserLauncher;
+
     // This is used by LegacyFido2ApiManager to launch a PendingIntent received by the legacy API.
     private ActivityResultLauncher<LegacyFido2ApiObject> mFidoLauncher;
     // This is used by the switch browser protocol to handle the resume of the flow.
@@ -158,6 +173,39 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             WebViewUtil.setDataDirectorySuffix(activity.getApplicationContext());
         }
 
+        // Register file chooser launcher for WebView file upload support.
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)) {
+            mFileChooserLauncher = registerForActivityResult(
+                    new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        if (mFileUploadCallback == null) {
+                            Logger.warn(methodTag, "File upload callback is null, ignoring result.");
+                            return;
+                        }
+                        Uri[] resultUris = null;
+                        if (result.getResultCode() == FragmentActivity.RESULT_OK && result.getData() != null) {
+                            final Intent data = result.getData();
+                            if (data.getClipData() != null) {
+                                // Multiple files selected
+                                final int count = data.getClipData().getItemCount();
+                                resultUris = new Uri[count];
+                                for (int i = 0; i < count; i++) {
+                                    resultUris[i] = data.getClipData().getItemAt(i).getUri();
+                                }
+                            } else if (data.getData() != null) {
+                                // Single file selected
+                                resultUris = new Uri[]{data.getData()};
+                            }
+                            Logger.info(methodTag, "File chooser returned "
+                                    + (resultUris != null ? resultUris.length : 0) + " file(s).");
+                        } else {
+                            Logger.info(methodTag, "File chooser cancelled or returned no data.");
+                        }
+                        mFileUploadCallback.onReceiveValue(resultUris);
+                        mFileUploadCallback = null;
+                    }
+            );
+        }
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_LEGACY_FIDO_SECURITY_KEY_LOGIC)
                 && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             mFidoLauncher = registerForActivityResult(
@@ -388,6 +436,37 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             }
 
             @Override
+            public boolean onShowFileChooser(
+                    final WebView webView,
+                    final ValueCallback<Uri[]> filePathCallback,
+                    final FileChooserParams fileChooserParams) {
+                if (!CommonFlightsManager.INSTANCE.getFlightsProvider()
+                        .isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)) {
+                    Logger.warn(methodTag, "File upload is not enabled. Ignoring file chooser request.");
+                    filePathCallback.onReceiveValue(null);
+                    return true;
+                }
+
+                // Cancel any existing callback to avoid a dangling reference.
+                if (mFileUploadCallback != null) {
+                    mFileUploadCallback.onReceiveValue(null);
+                }
+                mFileUploadCallback = filePathCallback;
+
+                try {
+                    final Intent intent = fileChooserParams.createIntent();
+                    Logger.info(methodTag, "Launching file chooser for WebView file upload.");
+                    mFileChooserLauncher.launch(intent);
+                } catch (final Exception e) {
+                    Logger.error(methodTag, "Failed to launch file chooser.", e);
+                    mFileUploadCallback.onReceiveValue(null);
+                    mFileUploadCallback = null;
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
             public Bitmap getDefaultVideoPoster() {
                 // When not playing, video elements are represented by a 'poster' image.
                 // The image to use can be specified by the poster attribute of the video tag in HTML.
@@ -556,6 +635,14 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
             // Note: mFidoLauncher shouldn't be null (based on the OS version check),
             // but we should still have a check here just to be safe.
             mFidoLauncher.unregister();
+        }
+        // Clean up file upload callback to prevent memory leaks.
+        if (mFileUploadCallback != null) {
+            mFileUploadCallback.onReceiveValue(null);
+            mFileUploadCallback = null;
+        }
+        if (mFileChooserLauncher != null) {
+            mFileChooserLauncher.unregister();
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentFileUploadTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragmentFileUploadTest.java
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.providers.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+
+import androidx.activity.result.ActivityResultLauncher;
+
+import com.microsoft.identity.common.internal.mocks.MockCommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Tests for the WebView file upload feature in {@link WebViewAuthorizationFragment}.
+ * Covers {@link WebViewAuthorizationFragment#handleFileUploadRequest} flight gating,
+ * launch behavior, error handling, and the {@code @VisibleForTesting} accessors
+ * used for cleanup verification.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class WebViewAuthorizationFragmentFileUploadTest {
+
+    private WebViewAuthorizationFragment mFragment;
+    private IFlightsProvider mMockFlightsProvider;
+    private ActivityResultLauncher<Intent> mMockLauncher;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        mMockFlightsProvider = mock(IFlightsProvider.class);
+        when(mMockFlightsProvider.isFlightEnabled(any(CommonFlight.class))).thenReturn(false);
+        when(mMockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)).thenReturn(true);
+
+        final MockCommonFlightsManager mgr = new MockCommonFlightsManager();
+        mgr.setMockCommonFlightsProvider(mMockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mgr);
+
+        mFragment = new WebViewAuthorizationFragment();
+
+        mMockLauncher = mock(ActivityResultLauncher.class);
+        mFragment.setFileChooserLauncher(mMockLauncher);
+    }
+
+    @After
+    public void tearDown() {
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private ValueCallback<Uri[]> mockFilePathCallback() {
+        return mock(ValueCallback.class);
+    }
+
+    private WebChromeClient.FileChooserParams mockFileChooserParams() {
+        final WebChromeClient.FileChooserParams params = mock(WebChromeClient.FileChooserParams.class);
+        when(params.createIntent()).thenReturn(new Intent(Intent.ACTION_GET_CONTENT));
+        return params;
+    }
+
+    // -----------------------------------------------------------------------
+    // handleFileUploadRequest — flight gating
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHandleFileUploadRequest_flightDisabled_returnsFalse() {
+        when(mMockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD)).thenReturn(false);
+
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        final boolean result = mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertFalse(result);
+        verify(callback, never()).onReceiveValue(any());
+        verify(mMockLauncher, never()).launch(any());
+    }
+
+    // -----------------------------------------------------------------------
+    // handleFileUploadRequest — launch success
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHandleFileUploadRequest_launchSucceeds_returnsTrue() {
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        final boolean result = mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertTrue(result);
+        verify(mMockLauncher).launch(any(Intent.class));
+    }
+
+    @Test
+    public void testHandleFileUploadRequest_storesCallback() {
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertEquals(callback, mFragment.getFileUploadCallback());
+    }
+
+    // -----------------------------------------------------------------------
+    // handleFileUploadRequest — cancels existing callback
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHandleFileUploadRequest_cancelsExistingCallback() {
+        final ValueCallback<Uri[]> existingCallback = mockFilePathCallback();
+        mFragment.setFileUploadCallback(existingCallback);
+
+        final ValueCallback<Uri[]> newCallback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        mFragment.handleFileUploadRequest(newCallback, params, null);
+
+        verify(existingCallback).onReceiveValue(null);
+    }
+
+    // -----------------------------------------------------------------------
+    // handleFileUploadRequest — launch failure
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHandleFileUploadRequest_createIntentThrows_returnsFalse() {
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mock(WebChromeClient.FileChooserParams.class);
+        when(params.createIntent()).thenThrow(new RuntimeException("No activity found"));
+
+        final boolean result = mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertFalse(result);
+        verify(callback).onReceiveValue(null);
+    }
+
+    @Test
+    public void testHandleFileUploadRequest_createIntentThrows_clearsCallback() {
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mock(WebChromeClient.FileChooserParams.class);
+        when(params.createIntent()).thenThrow(new RuntimeException("No activity found"));
+
+        mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertNull(mFragment.getFileUploadCallback());
+    }
+
+    @Test
+    public void testHandleFileUploadRequest_launcherThrows_returnsFalse() {
+        doThrow(new IllegalStateException("Launcher not initialized"))
+                .when(mMockLauncher).launch(any(Intent.class));
+
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        final boolean result = mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertFalse(result);
+        verify(callback).onReceiveValue(null);
+    }
+
+    @Test
+    public void testHandleFileUploadRequest_launcherThrows_clearsCallback() {
+        doThrow(new IllegalStateException("Launcher not initialized"))
+                .when(mMockLauncher).launch(any(Intent.class));
+
+        final ValueCallback<Uri[]> callback = mockFilePathCallback();
+        final WebChromeClient.FileChooserParams params = mockFileChooserParams();
+
+        mFragment.handleFileUploadRequest(callback, params, null);
+
+        assertNull(mFragment.getFileUploadCallback());
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -212,8 +212,7 @@ public enum CommonFlight implements IFlightConfig {
      * When true, uses 12 threads. When false, uses legacy 5 threads.
      */
     USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", false),
-
-    /**
+    
     /**
      * Flight to enable multiple window support in WebView, which allows target="_blank" links
      * to be intercepted via onCreateWindow and opened in an external browser.

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -224,7 +224,7 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable file upload support in the embedded WebView.
      * When enabled, the WebView will handle file chooser requests from web pages.
      */
-    ENABLE_WEBVIEW_FILE_UPLOAD("EnableWebViewFileUpload", true);
+    ENABLE_WEBVIEW_FILE_UPLOAD("EnableWebViewFileUpload", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -214,10 +214,17 @@ public enum CommonFlight implements IFlightConfig {
     USE_INCREASED_DEFAULT_SILENT_REQUEST_THREAD_POOL_SIZE("UseIncreasedSilentRequestThreadPoolSize", false),
 
     /**
+    /**
      * Flight to enable multiple window support in WebView, which allows target="_blank" links
      * to be intercepted via onCreateWindow and opened in an external browser.
      */
-    ENABLE_WEBVIEW_MULTIPLE_WINDOWS("EnableWebViewMultipleWindows", false);
+    ENABLE_WEBVIEW_MULTIPLE_WINDOWS("EnableWebViewMultipleWindows", false),
+
+    /**
+     * Flight to enable file upload support in the embedded WebView.
+     * When enabled, the WebView will handle file chooser requests from web pages.
+     */
+    ENABLE_WEBVIEW_FILE_UPLOAD("EnableWebViewFileUpload", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -648,4 +648,18 @@ public enum AttributeName {
     target_blank_navigation_route,
 
     //endregion
+
+    //region WebView file upload
+
+    /**
+     * The number of files selected by the user in the file chooser.
+     */
+    file_upload_file_count,
+
+    /**
+     * Indicates whether the file chooser was cancelled by the user.
+     */
+    is_file_upload_cancelled,
+
+    //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -648,18 +648,4 @@ public enum AttributeName {
     target_blank_navigation_route,
 
     //endregion
-
-    //region WebView file upload
-
-    /**
-     * The number of files selected by the user in the file chooser.
-     */
-    file_upload_file_count,
-
-    /**
-     * Indicates whether the file chooser was cancelled by the user.
-     */
-    is_file_upload_cancelled,
-
-    //endregion
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -107,5 +107,9 @@ public enum SpanName {
     /**
      * Span name for WebView target="_blank" navigation interception.
      */
-    WebViewTargetBlankNavigation
+    WebViewTargetBlankNavigation,
+    /**
+     * Span name for WebView file upload (onShowFileChooser) operations.
+     */
+    WebViewFileUpload
 }


### PR DESCRIPTION
**Summary**
Adds file upload support to the embedded WebView used during interactive authentication flows. When a web page (e.g., eSTS) presents a file chooser (<input type="file">), the WebView now handles it by launching the system file picker.

**Why** : This is needed for verfied id flows where eSTS redirects the user to some identity verification website which may ask the user to upload a profile picture.

**Changes**

- Implemented onShowFileChooser in the WebChromeClient to handle file upload requests

- Registered an ActivityResultLauncher in onCreate to receive file picker results (single file, multi-file, or cancellation)

- Extracted handleFileUploadRequest() as a @VisibleForTesting method for testability

- Added cleanup in onDestroy (cancel pending callback, unregister launcher)

- Entire feature gated behind CommonFlight.ENABLE_WEBVIEW_FILE_UPLOAD (default: off)

-  Added WebViewFileUpload span for telemetry

Fixes [AB#3545256](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3545256)

