### PR TITLE
Set default value for the flight for open-id vc handling in webview redirect, Fixes AB#3541420

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -110,6 +110,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PLAY_STORE_INSTALL_PREFIX;
 import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP_LINK_KEY;
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_ERROR;
+import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_OPEN_ID_VC_REDIRECT;
 import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_PLAYSTORE_URL_LAUNCH;
 
 import io.opentelemetry.api.baggage.Baggage;
@@ -338,8 +339,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (isAmazonAppRedirect(formattedURL)) {
                 Logger.info(methodTag, "It is an Amazon app request");
                 processAmazonAppUri(url);
-            } else if (isOpenIdVcUrl(formattedURL)) {
-                // TO-DO : Decide whether flight is needed in this case. https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3541420
+            } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(ENABLE_OPEN_ID_VC_REDIRECT) && isOpenIdVcUrl(formattedURL)) {
                 Logger.info(methodTag, "It is an OpenID Verifiable Credentials request.");
                 processOpenIdVcRequest(view, url);
             } else if (isInvalidRedirectUri(url)) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -231,6 +231,45 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     @Test
+    public void testUrlOverrideHandlesOpenIdVcUrl_FlightDisabled() {
+        // When the flight is disabled, the openid-vc:// URL bypasses the VC handler
+        // and is caught by the SSL protection check instead (non-https URL).
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor = ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        final AzureActiveDirectoryWebViewClient webViewClient = new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                mockCallback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                false
+        );
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_OPEN_ID_VC_REDIRECT)).thenReturn(false);
+
+        final MockCommonFlightsManager mockCommonFlightsManager = new MockCommonFlightsManager();
+        mockCommonFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockCommonFlightsManager);
+
+        final boolean result = webViewClient.shouldOverrideUrlLoading(mockWebView, TEST_OPENID_VC_URL);
+
+        assertTrue("shouldOverrideUrlLoading must return true (intercepted by SSL check)", result);
+        Mockito.verify(mockWebView).stopLoading();
+
+        // Verify the error is SSL protection, NOT the VC-specific ACTIVITY_NOT_FOUND.
+        Mockito.verify(mockCallback).onChallengeResponseReceived(resultCaptor.capture());
+        final RawAuthorizationResult capturedResult = resultCaptor.getValue();
+        assertEquals("Expected SSL protection error, not VC handler error",
+                ErrorStrings.WEBVIEW_REDIRECTURL_NOT_SSL_PROTECTED,
+                ((ClientException) capturedResult.getException()).getErrorCode());
+
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
     @Config(shadows = {
             ShadowProcessUtil.class})
     public void testUrlOverrideHandlesHttpsDeviceCARequestUrl() {

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -223,7 +223,12 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable file upload support in the embedded WebView.
      * When enabled, the WebView will handle file chooser requests from web pages.
      */
-    ENABLE_WEBVIEW_FILE_UPLOAD("EnableWebViewFileUpload", false);
+    ENABLE_WEBVIEW_FILE_UPLOAD("EnableWebViewFileUpload", false),
+
+    /**
+     * Flight to enable open-id vc redirect handling in webview.
+     */
+    ENABLE_OPEN_ID_VC_REDIRECT("EnableOpenIdVcRedirect", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -228,7 +228,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable open-id vc redirect handling in webview.
      */
-    ENABLE_OPEN_ID_VC_REDIRECT("EnableOpenIdVcRedirect", true);
+    ENABLE_OPENID_VC_REDIRECT("EnableOpenIdVcRedirect", true);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
Previously in this PR https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3013, we added support for handling open-id vc urls in webview. 
This PR adds a flight to disable the feature in brokered flows in case something goes wrong. 
This may not be needed as it is a completely new redirect handling that is not used in any of the existing eSTS scenarios but just adding it to be on the safe side.

Fixes [AB#3541420](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3541420)