### PR TITLE
Replace MSSecurity-1ES pool with Microsoft-hosted agents in common-cd pipeline, Fixes AB#3549891

### DIFF
--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -15,9 +15,7 @@ variables:
     versionNumber: ${{ variables.customVersion }}
 
 pool:
-  name: MSSecurity-1ES-Build-Agents-Pool
-  image: MSSecurity-1ES-Windows-2022
-  os: windows
+  vmImage: 'windows-latest'
 jobs:
 # Key Vault
 - job: keyvault_phase

--- a/azure-pipelines/continuous-delivery/common-cd.yml
+++ b/azure-pipelines/continuous-delivery/common-cd.yml
@@ -15,7 +15,7 @@ variables:
     versionNumber: ${{ variables.customVersion }}
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 jobs:
 # Key Vault
 - job: keyvault_phase


### PR DESCRIPTION
## Summary
Replace `MSSecurity-1ES-Build-Agents-Pool` with Microsoft-hosted `vmImage: 'windows-2022'` in the `common-cd.yml` pipeline.

## Changes
- **File:** `azure-pipelines/continuous-delivery/common-cd.yml`
- **Before:** `pool: { name: MSSecurity-1ES-Build-Agents-Pool, image: MSSecurity-1ES-Windows-2022, os: windows }`
- **After:** `pool: { vmImage: 'windows-2022' }`

## Affected Jobs
All 5 CD jobs now run on Microsoft-hosted agents:
- keyvault_phase
- labapi_phase
- labapiutilities_phase
- testutils_phase
- uiautomationutilities_phase

None of these jobs build Broker or require self-hosted agent capabilities.

## Not Changed
- `build-consumers.yml` - brokerValidation job stays on MSSecurity-1ES (builds Broker)
- `vsts-release-template.yml` - stays on 1ES-AndroidPool-EOC

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1609024&view=results
[AB#3549891](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3549891)