### PR TITLE
Enabled opening of TLR URLs in browser by default by enabling the flight ENABLE_WEBVIEW_MULTIPLE_WINDOWS, Fixes AB#3541043

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ vNext
 - [MINOR] Handle openid-vc urls in webview (#3013)
 - [MINOR] Add WebView file upload support (#3022)
 - [MINOR] Enhance WebAuthn telemetry for passkey registration (#3018)
+- [MINOR] Enabled opening of TLR URLs in browser by default by enabling the flight ENABLE_WEBVIEW_MULTIPLE_WINDOWS (#3042)
 
 Version 24.0.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -217,7 +217,7 @@ public enum CommonFlight implements IFlightConfig {
      * Flight to enable multiple window support in WebView, which allows target="_blank" links
      * to be intercepted via onCreateWindow and opened in an external browser.
      */
-    ENABLE_WEBVIEW_MULTIPLE_WINDOWS("EnableWebViewMultipleWindows", false),
+    ENABLE_WEBVIEW_MULTIPLE_WINDOWS("EnableWebViewMultipleWindows", true),
 
     /**
      * Flight to enable file upload support in the embedded WebView.


### PR DESCRIPTION
We are enabling the flight for opening TLR URLs in browser by default in this PR, the actual code change to support this was added in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3010

Fixes [AB#3541043](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3541043)
