### PR TITLE
Revert "Remove NativeAuthTeam ownership from CODEOWNERS"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,17 @@
 #---------------------
 changelog.txt @AzureAD/androididentity @AzureAD/NativeAuthTeam
 
+# Area Owners
+#---------------------
+# @AzureAD/NativeAuthTeam owns any files related to CIAM native authentication.
+/common/src/main/java/com/microsoft/identity/common/nativeauth/ @AzureAD/NativeAuthTeam
+/common/src/test/java/com/microsoft/identity/common/nativeauth/ @AzureAD/NativeAuthTeam
+
+/common4j/src/main/com/microsoft/identity/common/java/nativeauth/ @AzureAD/NativeAuthTeam
+/common4j/src/test/com/microsoft/identity/common/java/nativeauth/ @AzureAD/NativeAuthTeam
+/common4j/src/testFixtures/java/com/microsoft/identity/common/nativeauth/ @AzureAD/NativeAuthTeam
+
+
 # If you are interested in reviewing or getting notified of changes in a particular area
 # Please add your alias against that specific path below
 # Example:


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-common-for-android#3046