### PR TITLE
Edge TB: getSupportedContracts fix, Fixes AB#3553348

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ vNext
 - [MINOR] Add WebView file upload support (#3022)
 - [MINOR] Enhance WebAuthn telemetry for passkey registration (#3018)
 - [MINOR] Enabled opening of TLR URLs in browser by default by enabling the flight ENABLE_WEBVIEW_MULTIPLE_WINDOWS (#3042)
+- [PATCH] Edge TB: getSupportedContracts fix (#3050)
 
 Version 24.0.1
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppsSupportedContracts.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppsSupportedContracts.kt
@@ -40,6 +40,7 @@ data class WebAppsSupportedContracts(
         return contracts.joinToString(
             separator = ", ",
             prefix = "[",
-            postfix = "]")
+            postfix = "]",
+            transform = { "\"$it\"" })
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppsSupportedContracts.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppsSupportedContracts.kt
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.commands.webapps
 
+import com.microsoft.identity.common.java.util.ObjectMapper
 import java.io.Serializable
 
 /**
@@ -37,10 +38,6 @@ data class WebAppsSupportedContracts(
     }
 
     override fun toString(): String {
-        return contracts.joinToString(
-            separator = ", ",
-            prefix = "[",
-            postfix = "]",
-            transform = { "\"$it\"" })
+        return ObjectMapper.serializeObjectToJsonString(contracts)
     }
 }


### PR DESCRIPTION
### Summary
The string from getSupportedContracts fix needs to a viable JSON array. Such that we return:
[\"GetToken\", \"SignOut\", \"GetCookies\"] and not "[GetToken, SignOut, GetCookies]"

The unit test is in broker: 

[AB#3553348](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3553348)