### PR TITLE
 Move device registration protocol infrastructure to common, Fixes AB#3512895

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support.
 
 Version 24.1.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support.
+- [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support (#3066)
 
 Version 24.1.0
 ----------

--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -25,6 +25,8 @@
 -keep class * extends com.microsoft.identity.common.java.cache.ITokenCacheItem { *; }
 -keep class * extends com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme { *; }
 -keep class com.microsoft.identity.common.internal.broker.AuthUxJsonPayload { *; }
+-keep class * extends com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol { *; }
+-keep class * extends com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord { *; }
 
 # Keep WebView JS bridge methods annotated with @JavascriptInterface
 -keepclassmembers class com.microsoft.identity.** {

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration;
+
+import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle.Operation.DEVICE_REGISTRATION_OPERATIONS;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
+import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.LEGACY_ACCOUNT_AUTHENTICATOR_FOR_WPJ_API;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.activebrokerdiscovery.IBrokerDiscoveryClient;
+import com.microsoft.identity.common.internal.broker.BrokerData;
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater;
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationClientController;
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException;
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.IDeviceRegistrationProtocolParameters;
+import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
+import com.microsoft.identity.common.java.opentelemetry.SpanName;
+import com.microsoft.identity.common.logging.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Android specific device registration controller to communicate protocols to the broker.
+ * Moved from AADAuthenticator to common module to allow OneAuth consumers to use it.
+ */
+public class AndroidDeviceRegistrationClientController implements IDeviceRegistrationClientController {
+    private static final String TAG = AndroidDeviceRegistrationClientController.class.getSimpleName();
+
+    // OTel attribute name constants (mirrored from broker4j's AttributeName enum).
+    private static final String ATTR_DEVICE_REGISTRATION_PROTOCOL_NAME = "device_registration_protocol_name";
+    private static final String ATTR_CALLING_PACKAGE_NAME = "calling_package_name";
+    private static final String ATTR_ACTIVE_BROKER_PACKAGE_NAME = "active_broker_package_name";
+    private static final String ATTR_CONTENT_PROVIDER_STATUS = "content_provider_status";
+    private static final String ATTR_BOUND_SERVICE_STATUS = "bound_service_status";
+    private static final String ATTR_LEGACY_ACCOUNT_MANAGER_STATUS = "legacy_account_manager_status";
+
+    @NonNull
+    private final String mActiveBrokerPackageName;
+    @NonNull
+    private final List<IIpcStrategy> mIpcStrategies;
+    @NonNull
+    private static final AndroidDeviceRegistrationProtocolPacker mProtocolPacker
+            = new AndroidDeviceRegistrationProtocolPacker();
+
+    private final boolean mSupportsBoundService;
+
+    @NonNull
+    private final ActiveBrokerCacheUpdater mCacheUpdater;
+
+    @NonNull
+    private final String mCallerPackageName;
+
+    /**
+     * Creates a new controller.
+     *
+     * @param context              application context.
+     * @param components           platform components.
+     * @param discoveryClient      broker discovery client for resolving active broker.
+     * @param strategiesProvider   provides the IPC strategies and supportsBoundService flag.
+     * @param cacheUpdater         cache updater for active broker cache.
+     */
+    public AndroidDeviceRegistrationClientController(
+            @NonNull final Context context,
+            @NonNull final IPlatformComponents components,
+            @NonNull final IBrokerDiscoveryClient discoveryClient,
+            @NonNull final DeviceRegistrationIpcStrategiesProvider strategiesProvider,
+            @NonNull final ActiveBrokerCacheUpdater cacheUpdater
+    ) throws ClientException {
+        mCallerPackageName = context.getPackageName();
+        mActiveBrokerPackageName = getActiveBrokerPackageName(discoveryClient);
+        mIpcStrategies = strategiesProvider.getStrategies(context, components, mActiveBrokerPackageName);
+        mCacheUpdater = cacheUpdater;
+        mSupportsBoundService = strategiesProvider.getSupportsBoundService();
+    }
+
+    private static String getActiveBrokerPackageName(
+            @NonNull final IBrokerDiscoveryClient discoveryClient) throws ClientException {
+        final BrokerData activeBroker = discoveryClient.getActiveBroker(false);
+        if (activeBroker == null) {
+            throw new ClientException(ClientException.NOT_VALID_BROKER_FOUND,
+                    "Broker should not be null when invoked from Broker API.");
+        }
+        return activeBroker.getPackageName();
+    }
+
+    /**
+     * Communicates the protocol associated with the given parameters using the available strategies.
+     *
+     * @param protocolParameters protocol parameters to execute.
+     * @return a serialized protocol response.
+     * @throws BaseException if all strategies to execute the protocol fail.
+     */
+    @Override
+    @NonNull
+    public final byte[] execute(@NonNull final IDeviceRegistrationProtocolParameters protocolParameters)
+            throws BaseException {
+        final String methodTag = TAG + ":execute";
+
+        if (mSupportsBoundService && (Thread.currentThread() == Looper.getMainLooper().getThread())) {
+            throw new ClientException(ClientException.CALLED_ON_MAIN_THREAD,
+                    protocolParameters.getProtocolName() + " must not be called from the main thread.");
+        }
+
+        final Queue<BrokerCommunicationException> communicationExceptionQueue = new LinkedList<>();
+        final Span span = OTelUtility.createSpan(SpanName.DeviceRegistrationIpc.name());
+        try (final Scope ignored = SpanExtension.makeCurrentSpan(span)) {
+            span.setAttribute(ATTR_DEVICE_REGISTRATION_PROTOCOL_NAME, protocolParameters.getProtocolName());
+            span.setAttribute(ATTR_CALLING_PACKAGE_NAME, mCallerPackageName);
+            span.setAttribute(ATTR_ACTIVE_BROKER_PACKAGE_NAME, mActiveBrokerPackageName);
+            for (final IIpcStrategy strategy : mIpcStrategies) {
+                try {
+                    byte[] protocolResult = communicateProtocolWithStrategy(protocolParameters, strategy);
+                    setIpcStrategyTelemetryAttributes(strategy.getType(), "OK");
+                    span.setStatus(StatusCode.OK);
+                    return protocolResult;
+                } catch (final BrokerCommunicationException communicationException) {
+                    setIpcStrategyTelemetryAttributes(strategy.getType(), communicationException.getMessage());
+                    // Fails to communicate to the broker. Try next strategy in list.
+                    communicationExceptionQueue.add(communicationException);
+                }
+            }
+            // If we reach this section We've tried all the strategies...
+            Logger.error(methodTag, "All IPC strategies to communicate with the broker have failed.", null);
+            for (final BrokerCommunicationException e : communicationExceptionQueue) {
+                Logger.error(methodTag, e.getMessage(), e);
+            }
+            throw new DeviceRegistrationException(
+                    DeviceRegistrationException.FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_CODE,
+                    DeviceRegistrationException.FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_MESSAGE
+            );
+        } catch (final Throwable throwable) {
+            span.recordException(throwable);
+            span.setStatus(StatusCode.ERROR);
+            throw throwable;
+        } finally {
+            span.end();
+        }
+    }
+
+    /**
+     * Communicates the protocol associated with the given parameters using the provided strategy.
+     *
+     * @param protocolParameters protocol parameters to execute.
+     * @param ipcStrategy        strategy to be invoked.
+     * @return a serialized protocol response.
+     * @throws BrokerCommunicationException if the strategy fails.
+     */
+    @NonNull
+    private byte[] communicateProtocolWithStrategy(
+            @NonNull final IDeviceRegistrationProtocolParameters protocolParameters,
+            @NonNull final IIpcStrategy ipcStrategy) throws BaseException {
+        final String methodTag = TAG + ":executeProtocolWithStrategy";
+        Logger.info(methodTag, "Executing " + protocolParameters.getProtocolName()
+                + " with strategy: " + ipcStrategy.getType());
+        final Bundle protocolParametersBundle;
+        try {
+            protocolParametersBundle = mProtocolPacker.pack(protocolParameters);
+        } catch (final Throwable throwable) {
+            Logger.error(methodTag, "Serialization error while packing the protocol", throwable);
+            throw new DeviceRegistrationException(
+                    DeviceRegistrationException.INTERNAL_ERROR_CODE,
+                    DeviceRegistrationException.SERIALIZATION_ERROR_MESSAGE);
+        }
+        final Bundle protocolResultBundle = ipcStrategy.communicateToBroker(
+                new BrokerOperationBundle(
+                        DEVICE_REGISTRATION_OPERATIONS,
+                        mActiveBrokerPackageName,
+                        protocolParametersBundle
+                )
+        );
+
+        mCacheUpdater.updateCachedActiveBrokerFromResultBundle(protocolResultBundle);
+
+        return mProtocolPacker.unpackData(protocolResultBundle);
+    }
+
+    /**
+     * Records IPC strategy telemetry attributes on the current span for device registration.
+     * <p>
+     * Maps the strategy type to its corresponding status attribute and sets a human-readable
+     * status message. If no attribute is mapped for the strategy type, a warning is logged and no
+     * attribute is set. Callers should avoid passing sensitive data in the status message.
+     * </p>
+     *
+     * @param strategyType  {@link IIpcStrategy.Type} being evaluated.
+     * @param statusMessage Status text describing the outcome; a fallback message is used when null.
+     */
+    private void setIpcStrategyTelemetryAttributes(
+            @NonNull final IIpcStrategy.Type strategyType,
+            @Nullable final String statusMessage) {
+        final String methodTag = TAG + ":setIpcStrategyTelemetryAttributes";
+        final String attributeName;
+        if (CONTENT_PROVIDER.equals(strategyType)) {
+            attributeName = ATTR_CONTENT_PROVIDER_STATUS;
+        } else if (BOUND_SERVICE.equals(strategyType)) {
+            attributeName = ATTR_BOUND_SERVICE_STATUS;
+        } else if (LEGACY_ACCOUNT_AUTHENTICATOR_FOR_WPJ_API.equals(strategyType)) {
+            attributeName = ATTR_LEGACY_ACCOUNT_MANAGER_STATUS;
+        } else {
+            attributeName = null;
+        }
+        if (attributeName == null) {
+            Logger.warn(methodTag, "No attribute name mapped for strategy: " + strategyType.name());
+        } else {
+            final String message = statusMessage == null ? "No status message" : statusMessage;
+            SpanExtension.current().setAttribute(attributeName, message);
+        }
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.internal.broker.ipc.BrokerOperationB
 import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.BOUND_SERVICE;
 import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.CONTENT_PROVIDER;
 import static com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy.Type.LEGACY_ACCOUNT_AUTHENTICATOR_FOR_WPJ_API;
+import static com.microsoft.identity.common.java.exception.ClientException.INVALID_BROKER_BUNDLE;
 
 import android.content.Context;
 import android.os.Bundle;
@@ -208,6 +209,10 @@ public class AndroidDeviceRegistrationClientController implements IDeviceRegistr
                         protocolParametersBundle
                 )
         );
+
+        if (protocolResultBundle == null) {
+            throw new ClientException(INVALID_BROKER_BUNDLE, "Broker Result not returned from Broker.");
+        }
 
         mCacheUpdater.updateCachedActiveBrokerFromResultBundle(protocolResultBundle);
 

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientController.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.deviceregistration.java.protocol.parameters.IDevic
 import com.microsoft.identity.common.java.exception.BaseException;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.opentelemetry.SpanName;
@@ -66,14 +67,6 @@ import io.opentelemetry.context.Scope;
  */
 public class AndroidDeviceRegistrationClientController implements IDeviceRegistrationClientController {
     private static final String TAG = AndroidDeviceRegistrationClientController.class.getSimpleName();
-
-    // OTel attribute name constants (mirrored from broker4j's AttributeName enum).
-    private static final String ATTR_DEVICE_REGISTRATION_PROTOCOL_NAME = "device_registration_protocol_name";
-    private static final String ATTR_CALLING_PACKAGE_NAME = "calling_package_name";
-    private static final String ATTR_ACTIVE_BROKER_PACKAGE_NAME = "active_broker_package_name";
-    private static final String ATTR_CONTENT_PROVIDER_STATUS = "content_provider_status";
-    private static final String ATTR_BOUND_SERVICE_STATUS = "bound_service_status";
-    private static final String ATTR_LEGACY_ACCOUNT_MANAGER_STATUS = "legacy_account_manager_status";
 
     @NonNull
     private final String mActiveBrokerPackageName;
@@ -145,9 +138,9 @@ public class AndroidDeviceRegistrationClientController implements IDeviceRegistr
         final Queue<BrokerCommunicationException> communicationExceptionQueue = new LinkedList<>();
         final Span span = OTelUtility.createSpan(SpanName.DeviceRegistrationIpc.name());
         try (final Scope ignored = SpanExtension.makeCurrentSpan(span)) {
-            span.setAttribute(ATTR_DEVICE_REGISTRATION_PROTOCOL_NAME, protocolParameters.getProtocolName());
-            span.setAttribute(ATTR_CALLING_PACKAGE_NAME, mCallerPackageName);
-            span.setAttribute(ATTR_ACTIVE_BROKER_PACKAGE_NAME, mActiveBrokerPackageName);
+            span.setAttribute(AttributeName.device_registration_protocol_name.name(), protocolParameters.getProtocolName());
+            span.setAttribute(AttributeName.calling_package_name.name(), mCallerPackageName);
+            span.setAttribute(AttributeName.active_broker_package_name.name(), mActiveBrokerPackageName);
             for (final IIpcStrategy strategy : mIpcStrategies) {
                 try {
                     byte[] protocolResult = communicateProtocolWithStrategy(protocolParameters, strategy);
@@ -200,7 +193,9 @@ public class AndroidDeviceRegistrationClientController implements IDeviceRegistr
             Logger.error(methodTag, "Serialization error while packing the protocol", throwable);
             throw new DeviceRegistrationException(
                     DeviceRegistrationException.INTERNAL_ERROR_CODE,
-                    DeviceRegistrationException.SERIALIZATION_ERROR_MESSAGE);
+                    DeviceRegistrationException.SERIALIZATION_ERROR_MESSAGE,
+                    throwable
+            );
         }
         final Bundle protocolResultBundle = ipcStrategy.communicateToBroker(
                 new BrokerOperationBundle(
@@ -236,11 +231,11 @@ public class AndroidDeviceRegistrationClientController implements IDeviceRegistr
         final String methodTag = TAG + ":setIpcStrategyTelemetryAttributes";
         final String attributeName;
         if (CONTENT_PROVIDER.equals(strategyType)) {
-            attributeName = ATTR_CONTENT_PROVIDER_STATUS;
+            attributeName = AttributeName.content_provider_status.name();
         } else if (BOUND_SERVICE.equals(strategyType)) {
-            attributeName = ATTR_BOUND_SERVICE_STATUS;
+            attributeName = AttributeName.bound_service_status.name();
         } else if (LEGACY_ACCOUNT_AUTHENTICATOR_FOR_WPJ_API.equals(strategyType)) {
-            attributeName = ATTR_LEGACY_ACCOUNT_MANAGER_STATUS;
+            attributeName = AttributeName.legacy_account_manager_status.name();
         } else {
             attributeName = null;
         }

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPacker.java
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPacker.java
@@ -50,16 +50,15 @@ public class AndroidDeviceRegistrationProtocolPacker implements IDeviceRegistrat
 
     private static final String TAG = AndroidDeviceRegistrationProtocolPacker.class.getSimpleName();
 
-    // Bundle keys — must match the broker-side packer for wire compatibility.
-    public static final String PROTOCOL_DATA = "protocol.data";
-    public static final String PROTOCOL_NAME = "protocol.name";
-    public static final String CORRELATION_ID = "correlation.id";
-    public static final String PROTOCOL_EXCEPTION_ERROR_CODE = "protocol.exception.error.code";
-    public static final String PROTOCOL_EXCEPTION_ERROR_MESSAGE = "protocol.exception.error.message";
-    public static final String PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE = "protocol.exception.error.cause";
-    public static final String PROTOCOL_EXCEPTION_STACK_TRACE_STRING = "protocol.exception.stack.trace.string";
-    private static final String PROTOCOL_EXCEPTION_CALLING_PACKAGE_NAME = "protocol.exception.api.to.update";
-    private static final String PROTOCOL_EXCEPTION_BROKER_PACKAGE_NAME = "protocol.exception.broker.to.update";
+    static final String PROTOCOL_DATA = "protocol.data";
+    static final String PROTOCOL_NAME = "protocol.name";
+    static final String CORRELATION_ID = "correlation.id";
+    static final String PROTOCOL_EXCEPTION_ERROR_CODE = "protocol.exception.error.code";
+    static final String PROTOCOL_EXCEPTION_ERROR_MESSAGE = "protocol.exception.error.message";
+    static final String PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE = "protocol.exception.error.cause";
+    static final String PROTOCOL_EXCEPTION_STACK_TRACE_STRING = "protocol.exception.stack.trace.string";
+    static final String PROTOCOL_EXCEPTION_CALLING_PACKAGE_NAME = "protocol.exception.api.to.update";
+    static final String PROTOCOL_EXCEPTION_BROKER_PACKAGE_NAME = "protocol.exception.broker.to.update";
 
     @NonNull
     @Override

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPacker.java
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPacker.java
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration;
+
+import android.os.Bundle;
+
+import com.microsoft.identity.deviceregistration.java.exception.ApiUpdateRequiredException;
+import com.microsoft.identity.deviceregistration.java.exception.BrokerUpdateRequiredException;
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException;
+import com.microsoft.identity.deviceregistration.java.exception.DrsErrorResponseException;
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolPacker;
+import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.exception.IErrorInformation;
+import com.microsoft.identity.common.java.util.StringUtil;
+import com.microsoft.identity.common.java.util.ThrowableUtil;
+import com.microsoft.identity.common.java.logging.Logger;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import lombok.NonNull;
+
+/**
+ * Android-specific packer for the device registration protocol.
+ * Packs/unpacks {@link IDeviceRegistrationProtocol} objects into/from {@link Bundle}.
+ */
+public class AndroidDeviceRegistrationProtocolPacker implements IDeviceRegistrationProtocolPacker<Bundle> {
+
+    private static final String TAG = AndroidDeviceRegistrationProtocolPacker.class.getSimpleName();
+
+    // Bundle keys — must match the broker-side packer for wire compatibility.
+    public static final String PROTOCOL_DATA = "protocol.data";
+    public static final String PROTOCOL_NAME = "protocol.name";
+    public static final String CORRELATION_ID = "correlation.id";
+    public static final String PROTOCOL_EXCEPTION_ERROR_CODE = "protocol.exception.error.code";
+    public static final String PROTOCOL_EXCEPTION_ERROR_MESSAGE = "protocol.exception.error.message";
+    public static final String PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE = "protocol.exception.error.cause";
+    public static final String PROTOCOL_EXCEPTION_STACK_TRACE_STRING = "protocol.exception.stack.trace.string";
+    private static final String PROTOCOL_EXCEPTION_CALLING_PACKAGE_NAME = "protocol.exception.api.to.update";
+    private static final String PROTOCOL_EXCEPTION_BROKER_PACKAGE_NAME = "protocol.exception.broker.to.update";
+
+    @NonNull
+    @Override
+    public final Bundle pack(@NonNull final IDeviceRegistrationProtocol protocol) {
+        final Bundle bundle = new Bundle();
+        bundle.putString(PROTOCOL_NAME, protocol.getProtocolName());
+        bundle.putByteArray(PROTOCOL_DATA, protocol.serialize());
+        if (protocol.getCorrelationId() != null) {
+            bundle.putString(CORRELATION_ID, protocol.getCorrelationId().toString());
+        }
+        return bundle;
+    }
+
+    @NonNull
+    @Override
+    public final String unpackName(@NonNull final Bundle packedData) throws DeviceRegistrationException {
+        final String methodTag = TAG + ":unpackName";
+        final String name = packedData.getString(PROTOCOL_NAME, null);
+        if (StringUtil.isNullOrEmpty(name)) {
+            final String errorMessage = "Bundle does not contain " + PROTOCOL_NAME + " key or is empty.";
+            Logger.error(methodTag, errorMessage, null);
+            throw new DeviceRegistrationException(
+                    DeviceRegistrationException.INVALID_PACKAGE_ERROR_CODE, errorMessage);
+        }
+        return name;
+    }
+
+    @NonNull
+    @Override
+    public final String unpackCorrelationId(@NonNull final Bundle packedData) {
+        final String methodTag = TAG + ":unpackCorrelationId";
+        final String correlationId = packedData.getString(CORRELATION_ID, null);
+        if (StringUtil.isNullOrEmpty(correlationId)) {
+            final String warningMessage = "Bundle does not contain " + CORRELATION_ID +
+                    " key or is empty. Generating a new one";
+            Logger.warn(methodTag, warningMessage);
+            return UUID.randomUUID().toString();
+        }
+        return correlationId;
+    }
+
+    @Override
+    public final byte[] unpackData(@NonNull final Bundle packedData) throws BaseException {
+        final String methodTag = TAG + ":unpackData";
+        throwIfBundleContainsException(packedData);
+        final byte[] data = packedData.getByteArray(PROTOCOL_DATA);
+        if (data == null || data.length == 0) {
+            final String errorMessage = "Bundle does not contain " + PROTOCOL_DATA + " key or is empty.";
+            Logger.error(methodTag, errorMessage, null);
+            throw new DeviceRegistrationException(
+                    DeviceRegistrationException.INVALID_PACKAGE_ERROR_CODE, errorMessage);
+        }
+        Logger.info(methodTag, "Data unpacked successfully");
+        return data;
+    }
+
+    @NonNull
+    @Override
+    public final Bundle packThrowable(@NonNull final Throwable throwable) {
+        final Bundle bundle = new Bundle();
+        final Throwable rootCause;
+        if (throwable instanceof ExecutionException && throwable.getCause() != null) {
+            rootCause = throwable.getCause();
+        } else {
+            rootCause = throwable;
+        }
+        final String errorCode;
+        if (rootCause instanceof IErrorInformation) {
+            errorCode = ((IErrorInformation) rootCause).getErrorCode();
+        } else {
+            errorCode = ClientException.UNKNOWN_ERROR;
+        }
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_CODE, errorCode);
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_MESSAGE, rootCause.getMessage());
+        if (rootCause.getCause() != null) {
+            bundle.putString(PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE, rootCause.getCause().getMessage());
+        }
+        final String stackTraceString = ThrowableUtil.getStackTraceAsString(rootCause);
+        bundle.putString(PROTOCOL_EXCEPTION_STACK_TRACE_STRING, stackTraceString);
+        if (rootCause instanceof ApiUpdateRequiredException) {
+            bundle.putString(
+                    PROTOCOL_EXCEPTION_CALLING_PACKAGE_NAME,
+                    ((ApiUpdateRequiredException) rootCause).getCallingPackageName());
+        }
+        if (rootCause instanceof BrokerUpdateRequiredException) {
+            bundle.putString(
+                    PROTOCOL_EXCEPTION_BROKER_PACKAGE_NAME,
+                    ((BrokerUpdateRequiredException) rootCause).getBrokerPackageName());
+        }
+        return bundle;
+    }
+
+    /**
+     * Throws a {@link DeviceRegistrationException} if the bundle contains a packed exception.
+     */
+    private void throwIfBundleContainsException(@NonNull final Bundle protocolBundle)
+            throws DeviceRegistrationException, DrsErrorResponseException {
+        final String methodTag = TAG + ":throwIfBundleContainsException";
+        final String errorCode = protocolBundle.getString(PROTOCOL_EXCEPTION_ERROR_CODE, null);
+        if (StringUtil.isNullOrEmpty(errorCode)) {
+            return;
+        }
+        final String errorMessage = protocolBundle.getString(PROTOCOL_EXCEPTION_ERROR_MESSAGE, errorCode);
+        final String causeMessage = protocolBundle.getString(PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE);
+        final String stackTraceString = protocolBundle.getString(PROTOCOL_EXCEPTION_STACK_TRACE_STRING);
+        final Throwable cause;
+        if (StringUtil.isNullOrEmpty(causeMessage)) {
+            cause = null;
+        } else {
+            cause = new Exception(causeMessage);
+        }
+        Logger.info(methodTag, "Bundle contains exception " + errorCode);
+        if (DeviceRegistrationException.UPDATE_API_ERROR_CODE.equalsIgnoreCase(errorCode)) {
+            final String callingPackageName = protocolBundle.getString(PROTOCOL_EXCEPTION_CALLING_PACKAGE_NAME);
+            throw new ApiUpdateRequiredException(callingPackageName, cause);
+        }
+        if (DeviceRegistrationException.UPDATE_BROKER_ERROR_CODE.equalsIgnoreCase(errorCode)) {
+            final String brokerPackageName = protocolBundle.getString(PROTOCOL_EXCEPTION_BROKER_PACKAGE_NAME);
+            throw new BrokerUpdateRequiredException(brokerPackageName, cause);
+        }
+        final DrsErrorResponseException drsException =
+                DrsErrorResponseException.getFromErrorResponse(errorMessage);
+        if (!DrsErrorResponseException.DEFAULT_ERROR_CODE.equalsIgnoreCase(drsException.getErrorCode())) {
+            throw drsException;
+        }
+        throw new DeviceRegistrationException(errorCode, errorMessage, cause, stackTraceString);
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/DeviceRegistrationIpcStrategiesProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/DeviceRegistrationIpcStrategiesProvider.kt
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration
+
+import android.content.Context
+import com.microsoft.identity.client.IDeviceRegistrationService
+import com.microsoft.identity.common.internal.broker.ipc.BoundServiceStrategy
+import com.microsoft.identity.common.internal.broker.ipc.ContentProviderStrategy
+import com.microsoft.identity.common.internal.broker.ipc.DeviceRegistrationServiceClient
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * Provides IPC strategies for device registration communication.
+ *
+ * Default implementation supplies ContentProvider + BoundService strategies.
+ * Broker subclass overrides [getStrategies] to add WpjLegacyAccountAuthenticatorStrategy.
+ *
+ * @param supportsBoundService whether to include the BoundService IPC strategy.
+ */
+open class DeviceRegistrationIpcStrategiesProvider @JvmOverloads constructor(
+    val supportsBoundService: Boolean = true
+) {
+    companion object {
+        private val TAG = DeviceRegistrationIpcStrategiesProvider::class.java.simpleName
+    }
+
+    /**
+     * Returns the list of IPC strategies to use for device registration.
+     * Default: ContentProvider + BoundService (if supported).
+     *
+     * Broker overrides this to append legacy strategy after calling super.
+     *
+     * @param context                  application context.
+     * @param components               platform components for the active broker.
+     * @param activeBrokerPackageName  package name of the active broker.
+     * @return ordered list of IPC strategies.
+     */
+    open fun getStrategies(
+        context: Context,
+        components: IPlatformComponents,
+        activeBrokerPackageName: String
+    ): MutableList<IIpcStrategy> {
+        val methodTag = "$TAG:getStrategies"
+        val strategies = mutableListOf<IIpcStrategy>()
+
+        val contentProviderStrategy = ContentProviderStrategy(context, components)
+        if (contentProviderStrategy.isSupportedByTargetedBroker(activeBrokerPackageName)) {
+            Logger.info(methodTag, "Adding primary strategy: ${ContentProviderStrategy::class.java.simpleName}")
+            strategies.add(contentProviderStrategy)
+        }
+
+        val boundServiceStrategy = BoundServiceStrategy<IDeviceRegistrationService>(
+            DeviceRegistrationServiceClient(context)
+        )
+        if (boundServiceStrategy.isSupportedByTargetedBroker(activeBrokerPackageName) && supportsBoundService) {
+            Logger.info(methodTag, "Adding fallback strategy: ${BoundServiceStrategy::class.java.simpleName}")
+            strategies.add(boundServiceStrategy)
+        }
+
+        return strategies
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
@@ -48,6 +48,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -112,7 +113,11 @@ class AndroidDeviceRegistrationClientControllerTest {
 
     private fun <T> runOnBackground(operation: () -> T): T {
         val future = backgroundExecutor.submit(operation)
-        return future.get(5, TimeUnit.SECONDS)
+        try {
+            return future.get(5, TimeUnit.SECONDS)
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
     }
 
     private fun successStrategy(responseBundle: Bundle): IIpcStrategy = mock {

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration
+
+import android.content.Context
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Parameters
+import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Response
+import com.microsoft.identity.common.exception.BrokerCommunicationException
+import com.microsoft.identity.common.internal.activebrokerdiscovery.IBrokerDiscoveryClient
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
+import com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecordWithAccount
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException
+import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Unit tests for [AndroidDeviceRegistrationClientController] in the common module.
+ * Uses mock IPC strategies to verify controller behavior without broker dependencies.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AndroidDeviceRegistrationClientControllerTest {
+
+    private lateinit var context: Context
+    private val backgroundExecutor = Executors.newSingleThreadExecutor()
+    private val testBrokerPackageName = "com.microsoft.test.broker"
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    private fun createController(
+        strategies: List<IIpcStrategy>,
+        supportsBoundService: Boolean = false
+    ): AndroidDeviceRegistrationClientController {
+        val provider = object : DeviceRegistrationIpcStrategiesProvider(supportsBoundService) {
+            override fun getStrategies(
+                context: Context,
+                components: IPlatformComponents,
+                activeBrokerPackageName: String
+            ): MutableList<IIpcStrategy> = strategies.toMutableList()
+        }
+        val components: IPlatformComponents = mock()
+        val discoveryClient: IBrokerDiscoveryClient = mock {
+            whenever(it.getActiveBroker(false)).thenReturn(
+                BrokerData(testBrokerPackageName, "test_sig")
+            )
+        }
+        val cacheUpdater: ActiveBrokerCacheUpdater = mock()
+        return AndroidDeviceRegistrationClientController(
+            context,
+            components,
+            discoveryClient,
+            provider,
+            cacheUpdater
+        )
+    }
+
+    private val packer = AndroidDeviceRegistrationProtocolPacker()
+
+    private val testRecord = DeviceRegistrationRecord("tenant", "upn", "deviceId", false, false)
+    private val testRecordWithAccount = DeviceRegistrationRecordWithAccount("account", "tenant", "upn", "deviceId", false, false)
+
+    private fun testParams() = TestHappyPathV0Parameters(
+        "hello ", "world", true, false, 1.4f, 3.7f, testRecord, testRecordWithAccount
+    )
+
+    private fun testResponse() = TestHappyPathV0Response(
+        UUID.randomUUID(), "hello world", 1.4f * 3.7f, true,
+        DeviceRegistrationRecord("tenantX", "upnX", "deviceIdX", false, false)
+    )
+
+    private fun packTestResponse(): Bundle = packer.pack(testResponse())
+
+    private fun <T> runOnBackground(operation: () -> T): T {
+        val future = backgroundExecutor.submit(operation)
+        return future.get(5, TimeUnit.SECONDS)
+    }
+
+    private fun successStrategy(responseBundle: Bundle): IIpcStrategy = mock {
+        whenever(it.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(it.communicateToBroker(any())).thenReturn(responseBundle)
+    }
+
+    private fun failingStrategy(): IIpcStrategy = mock {
+        whenever(it.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(it.communicateToBroker(any())).thenThrow(
+            BrokerCommunicationException(
+                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
+                IIpcStrategy.Type.CONTENT_PROVIDER,
+                null,
+                null
+            )
+        )
+    }
+
+    @Test
+    fun testExecuteSucceedsWithFirstStrategy() {
+        val controller = createController(listOf(successStrategy(packTestResponse())))
+
+        val result = runOnBackground { controller.execute(testParams()) }
+
+        val response = TestHappyPathV0Response.create(result)
+        assertEquals("hello world", response.concatenatedStrings)
+        assertEquals(1.4f * 3.7f, response.multiplicationResult, 0.001f)
+        assertTrue(response.isLogicalOr)
+        assertEquals("tenantX", response.sameRecordWithConcatenatedX.tenantId)
+    }
+
+    @Test
+    fun testExecuteFallsBackToSecondStrategy() {
+        val controller = createController(
+            listOf(failingStrategy(), successStrategy(packTestResponse()))
+        )
+
+        val result = runOnBackground { controller.execute(testParams()) }
+
+        val response = TestHappyPathV0Response.create(result)
+        assertEquals("hello world", response.concatenatedStrings)
+    }
+
+    @Test
+    fun testExecuteThrowsWhenAllStrategiesFail() {
+        val controller = createController(listOf(failingStrategy(), failingStrategy()))
+
+        val exception = assertThrows(DeviceRegistrationException::class.java) {
+            runOnBackground { controller.execute(testParams()) }
+        }
+
+        assertEquals(DeviceRegistrationException.FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_CODE, exception.errorCode)
+    }
+
+    @Test
+    fun testExecuteThrowsWhenNoStrategies() {
+        val controller = createController(emptyList())
+
+        val exception = assertThrows(DeviceRegistrationException::class.java) {
+            runOnBackground { controller.execute(testParams()) }
+        }
+
+        assertEquals(DeviceRegistrationException.FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_CODE, exception.errorCode)
+    }
+
+    @Test
+    fun testExecuteThrowsOnMainThreadWhenBoundServiceSupported() {
+        val controller = createController(
+            listOf(successStrategy(packTestResponse())),
+            supportsBoundService = true
+        )
+
+        val exception = assertThrows(ClientException::class.java) {
+            controller.execute(testParams())
+        }
+
+        assertEquals(ClientException.CALLED_ON_MAIN_THREAD, exception.errorCode)
+    }
+
+    @Test
+    fun testExecuteAllowsMainThreadWhenBoundServiceNotSupported() {
+        val controller = createController(
+            listOf(successStrategy(packTestResponse())),
+            supportsBoundService = false
+        )
+
+        val result = controller.execute(testParams())
+
+        val response = TestHappyPathV0Response.create(result)
+        assertEquals("hello world", response.concatenatedStrings)
+    }
+
+    @Test
+    fun testExecuteWithRecordsSerialization() {
+        val controller = createController(listOf(successStrategy(packTestResponse())))
+
+        val result = runOnBackground { controller.execute(testParams()) }
+
+        val response = TestHappyPathV0Response.create(result)
+        assertEquals("tenantX", response.sameRecordWithConcatenatedX.tenantId)
+        assertEquals("upnX", response.sameRecordWithConcatenatedX.upn)
+        assertEquals("deviceIdX", response.sameRecordWithConcatenatedX.deviceId)
+    }
+
+    @Test
+    fun testConstructorThrowsWhenNoBrokerFound() {
+        val discoveryClient: IBrokerDiscoveryClient = mock {
+            whenever(it.getActiveBroker(false)).thenReturn(null)
+        }
+        val components: IPlatformComponents = mock()
+        val provider = DeviceRegistrationIpcStrategiesProvider()
+        val cacheUpdater: ActiveBrokerCacheUpdater = mock()
+
+        val exception = assertThrows(ClientException::class.java) {
+            AndroidDeviceRegistrationClientController(
+                context, components, discoveryClient, provider, cacheUpdater
+            )
+        }
+
+        assertEquals(ClientException.NOT_VALID_BROKER_FOUND, exception.errorCode)
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
@@ -120,14 +120,17 @@ class AndroidDeviceRegistrationClientControllerTest {
         }
     }
 
-    private fun successStrategy(responseBundle: Bundle): IIpcStrategy = mock {
-        whenever(it.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
-        whenever(it.communicateToBroker(any())).thenReturn(responseBundle)
+    private fun successStrategy(responseBundle: Bundle): IIpcStrategy {
+        val strategy: IIpcStrategy = mock()
+        whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(strategy.communicateToBroker(any())).thenReturn(responseBundle)
+        return strategy
     }
 
-    private fun failingStrategy(): IIpcStrategy = mock {
-        whenever(it.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
-        whenever(it.communicateToBroker(any())).thenThrow(
+    private fun failingStrategy(): IIpcStrategy {
+        val strategy: IIpcStrategy = mock()
+        whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(strategy.communicateToBroker(any())).thenThrow(
             BrokerCommunicationException(
                 BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
                 IIpcStrategy.Type.CONTENT_PROVIDER,
@@ -135,6 +138,7 @@ class AndroidDeviceRegistrationClientControllerTest {
                 null
             )
         )
+        return strategy
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
@@ -128,16 +128,15 @@ class AndroidDeviceRegistrationClientControllerTest {
     }
 
     private fun failingStrategy(): IIpcStrategy {
+        val brokerCommunicationException = BrokerCommunicationException(
+            BrokerCommunicationException.Category.CONNECTION_ERROR,
+            IIpcStrategy.Type.CONTENT_PROVIDER,
+            "Failed to communicate with broker",
+            null
+        )
         val strategy: IIpcStrategy = mock()
         whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
-        whenever(strategy.communicateToBroker(any())).thenThrow(
-            BrokerCommunicationException(
-                BrokerCommunicationException.Category.OPERATION_NOT_SUPPORTED_ON_SERVER_SIDE,
-                IIpcStrategy.Type.CONTENT_PROVIDER,
-                null,
-                null
-            )
-        )
+        whenever(strategy.communicateToBroker(any())).thenThrow(brokerCommunicationException)
         return strategy
     }
 

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPackerTest.java
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPackerTest.java
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration;
+
+import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INTERNAL_ERROR_CODE;
+import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INVALID_PACKAGE_ERROR_CODE;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.CORRELATION_ID;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_DATA;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_ERROR_CODE;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_ERROR_MESSAGE;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_STACK_TRACE_STRING;
+import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_NAME;
+
+
+import android.os.Bundle;
+
+import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Parameters;
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecordWithAccount;
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException;
+import com.microsoft.identity.deviceregistration.java.exception.DrsErrorResponseException;
+import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+
+import java.util.UUID;
+
+import lombok.SneakyThrows;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidDeviceRegistrationProtocolPackerTest {
+
+    private static final String TEST_CORRELATION_ID = UUID.randomUUID().toString();
+    private static final String TEST_PROTOCOL_NAME = "fake.protocol.name";
+    private static final String TEST_DATA = "data.sample.1";
+    private static final String TEST_TENANT = "test.tenant.id";
+    private static final String TEST_UPN = "test.upn";
+    private static final String TEST_DEVICE_ID = "test.device.id";
+    private static final String TEST_ACCOUNT_NAME = "test.account.name";
+
+    private static final DeviceRegistrationRecord DEVICE_REGISTRATION_RECORD
+            = new DeviceRegistrationRecord(TEST_TENANT, TEST_UPN, TEST_DEVICE_ID, false, false);
+
+    private static final DeviceRegistrationRecordWithAccount DEVICE_REGISTRATION_RECORD_WITH_ACCOUNT
+            = new DeviceRegistrationRecordWithAccount(TEST_ACCOUNT_NAME, TEST_TENANT, TEST_UPN, TEST_DEVICE_ID, false, false);
+
+
+    private static final TestHappyPathV0Parameters TEST_PROTOCOL = new TestHappyPathV0Parameters(
+            TEST_DATA,
+            TEST_DATA,
+            true,
+            false,
+            123.456f,
+            9f,
+            DEVICE_REGISTRATION_RECORD,
+            DEVICE_REGISTRATION_RECORD_WITH_ACCOUNT
+    );
+
+    private static final String TEST_ERROR_MESSAGE = "Test error message";
+    private static final String TEST_ERROR_CAUSE_MESSAGE = "Fake cause";
+    private static final NullPointerException NULL_POINTER_EXCEPTION = new NullPointerException(TEST_ERROR_CAUSE_MESSAGE);
+    private static final DeviceRegistrationException DEVICE_REGISTRATION_EXCEPTION =
+            new DeviceRegistrationException(INTERNAL_ERROR_CODE, TEST_ERROR_MESSAGE, NULL_POINTER_EXCEPTION);
+
+    private static final AndroidDeviceRegistrationProtocolPacker packer = new AndroidDeviceRegistrationProtocolPacker();
+
+    @Test
+    public void testPackingNull() {
+        Assert.assertThrows(NullPointerException.class, () -> {
+            packer.pack(null);
+        });
+    }
+
+    @Test
+    public void testPackExceptionNull() {
+        Assert.assertThrows(NullPointerException.class, () -> {
+            packer.packThrowable(null);
+        });
+    }
+
+    @Test
+    public void testUnpackNameNull() {
+        Assert.assertThrows(NullPointerException.class, () -> {
+            packer.unpackName(null);
+        });
+    }
+
+    @Test
+    public void testUnpackDataNull() {
+        Assert.assertThrows(NullPointerException.class, () -> {
+            packer.unpackData(null);
+        });
+    }
+
+    @Test
+    public void testUnpackNameWithEmptyBundle() {
+        final DeviceRegistrationException deviceRegistrationException
+                = Assert.assertThrows(DeviceRegistrationException.class, () -> {
+            packer.unpackName(new Bundle());
+        });
+        Assert.assertEquals(
+                INVALID_PACKAGE_ERROR_CODE,
+                deviceRegistrationException.getErrorCode()
+        );
+        Assert.assertEquals(
+                "Bundle does not contain " + PROTOCOL_NAME + " key or is empty.",
+                deviceRegistrationException.getMessage()
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    public void testUnpackDataWithEmptyBundle() {
+        final DeviceRegistrationException deviceRegistrationException
+                = Assert.assertThrows(DeviceRegistrationException.class, () -> {
+            packer.unpackData(new Bundle());
+        });
+        Assert.assertEquals(
+                INVALID_PACKAGE_ERROR_CODE,
+                deviceRegistrationException.getErrorCode()
+        );
+        Assert.assertEquals(
+                "Bundle does not contain " + PROTOCOL_DATA + " key or is empty.",
+                deviceRegistrationException.getMessage()
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    public void testUnpackDataWithEmptyData() {
+        final DeviceRegistrationException deviceRegistrationException =
+                Assert.assertThrows(DeviceRegistrationException.class, () -> {
+                    final Bundle bundle = new Bundle();
+                    bundle.putString(PROTOCOL_NAME, TEST_PROTOCOL.getProtocolName());
+                    packer.unpackData(bundle);
+                });
+        Assert.assertEquals(
+                INVALID_PACKAGE_ERROR_CODE,
+                deviceRegistrationException.getErrorCode()
+        );
+        Assert.assertEquals(
+                "Bundle does not contain " + PROTOCOL_DATA + " key or is empty.",
+                deviceRegistrationException.getMessage()
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    public void testUnpackData() {
+        final Bundle bundle = new Bundle();
+        bundle.putString(PROTOCOL_NAME, PROTOCOL_NAME);
+        bundle.putByteArray(PROTOCOL_DATA, TEST_DATA.getBytes());
+        Assert.assertArrayEquals(
+                TEST_DATA.getBytes(),
+                packer.unpackData(bundle)
+        );
+    }
+
+    @SneakyThrows
+    @Test
+    public void testUnpackDataWithException() {
+
+        final DeviceRegistrationException deviceRegistrationException =
+                Assert.assertThrows(DeviceRegistrationException.class, () -> {
+                    final Bundle bundle = packer.packThrowable(DEVICE_REGISTRATION_EXCEPTION);
+                    packer.unpackData(bundle);
+                });
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getMessage(),
+                deviceRegistrationException.getMessage())
+        ;
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getErrorCode(),
+                deviceRegistrationException.getErrorCode()
+        );
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getCause().getMessage(),
+                deviceRegistrationException.getCause().getMessage()
+        );
+        Assert.assertNotNull(deviceRegistrationException.getStackTraceString());
+    }
+
+    @SneakyThrows
+    @Test
+    public void testUnpackName() {
+        final Bundle bundle = new Bundle();
+        bundle.putString(PROTOCOL_NAME, TEST_PROTOCOL_NAME);
+        Assert.assertEquals(
+                TEST_PROTOCOL_NAME,
+                packer.unpackName(bundle)
+        );
+    }
+
+    @Test
+    public void testUnpackCorrelationId() {
+        final Bundle bundle = new Bundle();
+        bundle.putString(CORRELATION_ID, TEST_CORRELATION_ID);
+        Assert.assertEquals(
+                TEST_CORRELATION_ID,
+                packer.unpackCorrelationId(bundle)
+        );
+    }
+
+    @Test
+    public void testUnpackCorrelationIdNull() {
+        final Bundle bundle = new Bundle();
+        Assert.assertNotNull(
+                packer.unpackCorrelationId(bundle)
+        );
+    }
+
+    @Test
+    public void testPackingProtocol() {
+        final Bundle protocolBundle = packer.pack(TEST_PROTOCOL);
+        Assert.assertEquals(
+                TEST_PROTOCOL.getProtocolName(),
+                protocolBundle.getString(PROTOCOL_NAME)
+        );
+        Assert.assertArrayEquals(
+                TEST_PROTOCOL.serialize(),
+                protocolBundle.getByteArray(PROTOCOL_DATA)
+
+        );
+    }
+
+    @Test
+    public void testPackBaseException() {
+
+        final Bundle bundle = packer.packThrowable(
+                DEVICE_REGISTRATION_EXCEPTION
+        );
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getErrorCode(),
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_CODE)
+        );
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getMessage(),
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_MESSAGE)
+        );
+        Assert.assertEquals(
+                DEVICE_REGISTRATION_EXCEPTION.getCause().getMessage(),
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE)
+        );
+        Assert.assertNotNull(bundle.getString(PROTOCOL_EXCEPTION_STACK_TRACE_STRING));
+
+    }
+
+    @Test
+    public void testPackThrowable() {
+        final String errorMessage = "UnexpectedError";
+        final Bundle bundle = packer.packThrowable(
+                new Throwable(errorMessage)
+        );
+        Assert.assertEquals(
+                ClientException.UNKNOWN_ERROR,
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_CODE)
+        );
+        Assert.assertEquals(
+                errorMessage,
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_MESSAGE)
+        );
+        Assert.assertNotNull(bundle.getString(PROTOCOL_EXCEPTION_STACK_TRACE_STRING));
+    }
+
+    @Test
+    public void testUnPackThrowable() {
+        final Bundle bundle = new Bundle();
+        final String errorCode = "errorCode";
+        final String errorMessage = "errorMessage";
+        final String errorCause = "errorCause";
+
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_CODE, errorCode);
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_MESSAGE, errorMessage);
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE, errorCause);
+
+        final BaseException exception = Assert.assertThrows(BaseException.class, () -> {
+            packer.unpackData(bundle);
+        });
+
+        Assert.assertEquals(errorMessage, exception.getMessage());
+        Assert.assertEquals(errorCode, exception.getErrorCode());
+        Assert.assertEquals(errorCause, exception.getCause().getMessage());
+    }
+
+    @Test
+    public void testPackDRSException() {
+        final String drsError = "{\"code\": \"invalid_request\", \"message\": \"Error: 'invalid_tenant' Description: 'Tenant 'rapong.onmicrosoft.com' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator'\", \"operation\": \"Discovery\", \"requestid\": \"07171fdd-1059-41af-97b1-8e6ca61a02a7\", \"subcode\": \"invalid_tenant\", \"time\": \"08-25-2020 20:38:52Z\"}";
+        final Bundle bundle = packer.packThrowable(
+                DrsErrorResponseException.getFromErrorResponse(drsError)
+        );
+        Assert.assertEquals(
+                "invalid_request",
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_CODE)
+        );
+        Assert.assertEquals(
+                drsError,
+                bundle.getString(PROTOCOL_EXCEPTION_ERROR_MESSAGE)
+        );
+        Assert.assertNotNull(bundle.getString(PROTOCOL_EXCEPTION_STACK_TRACE_STRING));
+
+    }
+
+    @Test
+    public void testUnPackDRSException() {
+        final Bundle bundle = new Bundle();
+        final String errorMessage = "{\"code\": \"invalid_request\", \"message\": \"Error: 'invalid_tenant' Description: 'Tenant 'rapong.onmicrosoft.com' not found. This may happen if there are no active subscriptions for the tenant. Check to make sure you have the correct tenant ID. Check with your subscription administrator'\", \"operation\": \"Discovery\", \"requestid\": \"07171fdd-1059-41af-97b1-8e6ca61a02a7\", \"subcode\": \"invalid_tenant\", \"time\": \"08-25-2020 20:38:52Z\"}";
+
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_CODE, DrsErrorResponseException.DEFAULT_ERROR_CODE);
+        bundle.putString(PROTOCOL_EXCEPTION_ERROR_MESSAGE, errorMessage);
+
+        final DrsErrorResponseException exception = Assert.assertThrows(DrsErrorResponseException.class, () -> {
+            packer.unpackData(bundle);
+        });
+
+        Assert.assertEquals(errorMessage, exception.getMessage());
+        Assert.assertEquals("invalid_request", exception.getErrorCode());
+        Assert.assertNull(exception.getCause());
+    }
+}

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -303,6 +303,8 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     implementation "com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
+    implementation "com.squareup.moshi:moshi:$rootProject.ext.moshiVersion"
+    implementation "com.squareup.moshi:moshi-adapters:$rootProject.ext.moshiAdaptersVersion"
     implementation "org.json:json:$rootProject.ext.jsonVersion"
     implementation "com.github.stephenc.jcip:jcip-annotations:$rootProject.ext.jcipAnnotationVersion"
     implementation 'org.apache.httpcomponents.core5:httpcore5:5.3'

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecord.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecord.java
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.api;
+
+import javax.annotation.Nullable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * This class represents a device registration entry, where each record has a unique tenant ID.
+ * Note: A device registration record is shared by all the accounts in that tenant.
+ */
+@AllArgsConstructor
+@Getter
+@Accessors(prefix = "m")
+public class DeviceRegistrationRecord implements IDeviceRegistrationRecord {
+    public static final String TAG = DeviceRegistrationRecord.class.getSimpleName();
+
+    /**
+     * Tenant Id to which the device is registered.
+     */
+    @NonNull
+    private final String mTenantId;
+
+    /**
+     * UPN associated to this device registration entry.
+     * Could be null if the device is registered without user.
+     */
+    @Nullable
+    private final String mUpn;
+
+    /**
+     * Device Id associated to this device registration entry.
+     */
+    @NonNull
+    private final String mDeviceId;
+
+    /**
+     * True if the device is shared.
+     */
+    @Getter
+    private final boolean mSharedDevice;
+
+    /**
+     * True if WPJ is registered with strong key.
+     * (Meaning that installCert would not work for this entry).
+     */
+    @Getter
+    private final boolean mIsRegisteredWithStrongKeys;
+
+    @Override
+    public String toString() {
+        return "TenantId: " + mTenantId + "\n" + "Upn:" + mUpn + "\n" +
+                "DeviceId:" + mDeviceId + "\n" + "isShared:" + mSharedDevice + "\n" +
+                "isRegisteredWithStrongKeys:" + mIsRegisteredWithStrongKeys;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecord.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecord.java
@@ -70,11 +70,4 @@ public class DeviceRegistrationRecord implements IDeviceRegistrationRecord {
      */
     @Getter
     private final boolean mIsRegisteredWithStrongKeys;
-
-    @Override
-    public String toString() {
-        return "TenantId: " + mTenantId + "\n" + "Upn:" + mUpn + "\n" +
-                "DeviceId:" + mDeviceId + "\n" + "isShared:" + mSharedDevice + "\n" +
-                "isRegisteredWithStrongKeys:" + mIsRegisteredWithStrongKeys;
-    }
 }

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecordWithAccount.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecordWithAccount.java
@@ -52,13 +52,4 @@ public class DeviceRegistrationRecordWithAccount extends DeviceRegistrationRecor
         super(tenantId, upn, deviceId, sharedDevice, isRegisteredWithStrongKeys);
         mAccountName = accountName;
     }
-
-    @NonNull
-    @Override
-    public String toString() {
-        return "TenantId: " + getTenantId() + "\n" + "Upn:" + getUpn() + "\n" +
-                "DeviceId:" + getDeviceId() + "\n" + "isShared:" + isSharedDevice() + "\n" +
-                "isRegisteredWithStrongKeys:" + isRegisteredWithStrongKeys() + "\n" +
-                "Account Name:" + mAccountName;
-    }
 }

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecordWithAccount.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/DeviceRegistrationRecordWithAccount.java
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.api;
+
+import javax.annotation.Nullable;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * This class extends the {@link DeviceRegistrationRecord} class adding the account name as private member.
+ * This to improve the performance of LegacyExecutors that use an Account for most of the legacy
+ * WorkplaceJoin operations.
+ */
+@Getter
+@Accessors(prefix = "m")
+public class DeviceRegistrationRecordWithAccount extends DeviceRegistrationRecord {
+
+    /**
+     * Account name of the device registration record.
+     */
+    @NonNull
+    private final String mAccountName;
+
+    public DeviceRegistrationRecordWithAccount(@NonNull final String accountName,
+                                               @NonNull final String tenantId,
+                                               @Nullable final String upn,
+                                               @NonNull String deviceId,
+                                               final boolean sharedDevice,
+                                               final boolean isRegisteredWithStrongKeys) {
+        super(tenantId, upn, deviceId, sharedDevice, isRegisteredWithStrongKeys);
+        mAccountName = accountName;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "TenantId: " + getTenantId() + "\n" + "Upn:" + getUpn() + "\n" +
+                "DeviceId:" + getDeviceId() + "\n" + "isShared:" + isSharedDevice() + "\n" +
+                "isRegisteredWithStrongKeys:" + isRegisteredWithStrongKeys() + "\n" +
+                "Account Name:" + mAccountName;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/IDeviceRegistrationClientController.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/IDeviceRegistrationClientController.java
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.api;
+
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.IDeviceRegistrationProtocolParameters;
+import com.microsoft.identity.common.java.exception.BaseException;
+
+import lombok.NonNull;
+
+/**
+ * An interface that represents a platform device registration controller to communicate protocols to the broker.
+ */
+public interface IDeviceRegistrationClientController {
+    /**
+     * Communicates the protocol associated with the given parameters using the available strategies.
+     *
+     * @param protocolParameters {@link IDeviceRegistrationProtocolParameters} protocol parameters.
+     * @return a serialized protocol response.
+     * @throws BaseException if all strategies to execute the protocol fail.
+     */
+    byte[] execute(@NonNull final IDeviceRegistrationProtocolParameters protocolParameters)
+            throws BaseException;
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/IDeviceRegistrationRecord.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/api/IDeviceRegistrationRecord.java
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.api;
+
+import javax.annotation.Nullable;
+
+import lombok.NonNull;
+
+/**
+ * Interface describing a device registration entry, where each record has a unique tenant ID.
+ * Note: A device registration record is shared by all the accounts in that tenant.
+ */
+public interface IDeviceRegistrationRecord {
+
+    /**
+     * Gets the tenant Id to which the device is registered.
+     */
+    @NonNull
+    String getTenantId();
+
+    /**
+     * Gets the UPN associated to this device registration entry.
+     * Could be null if the device is registered without user.
+     */
+    @Nullable
+    String getUpn();
+
+    /**
+     * Gets Device Id associated to this device registration entry.
+     */
+    @NonNull
+    String getDeviceId();
+
+    /**
+     * Returns true if the device registration entry is on shared device mode, otherwise false.
+     */
+    boolean isSharedDevice();
+
+    /**
+     * True if WPJ is registered with strong key.
+     * (Meaning that installCert would not work for this entry).
+     */
+    boolean isRegisteredWithStrongKeys();
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/ApiUpdateRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/ApiUpdateRequiredException.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.exception;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Representing exceptions that occur when the device registration API needs to be updated.
+ */
+public class ApiUpdateRequiredException extends DeviceRegistrationException {
+    //@VisibleForTesting
+    public static final String UPDATE_API_ERROR_MESSAGE = "Upgrade is required, please update device registration calling app";
+
+    @NonNull
+    @Getter
+    @Accessors(prefix = "m")
+    private final String mCallingPackageName;
+
+    public ApiUpdateRequiredException(@NonNull final String callingPackageName, @Nullable final Throwable cause) {
+        super(UPDATE_API_ERROR_CODE, UPDATE_API_ERROR_MESSAGE, cause);
+        mCallingPackageName = callingPackageName;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/BrokerUpdateRequiredException.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/BrokerUpdateRequiredException.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.exception;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Representing exceptions that occur when the active broker needs to be updated.
+ */
+public class BrokerUpdateRequiredException extends DeviceRegistrationException {
+    //@VisibleForTesting
+    public static final String UPDATE_BROKER_ERROR_MESSAGE = "Upgrade is required, please update broker";
+
+    @NonNull
+    @Getter
+    @Accessors(prefix = "m")
+    private final String mBrokerPackageName;
+
+    public BrokerUpdateRequiredException(@NonNull final String brokerPackageName, @Nullable final Throwable cause) {
+        super(UPDATE_BROKER_ERROR_CODE, UPDATE_BROKER_ERROR_MESSAGE, cause);
+        mBrokerPackageName = brokerPackageName;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/DeviceRegistrationException.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/DeviceRegistrationException.java
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.exception;
+
+import com.microsoft.identity.common.java.exception.BaseException;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Base class for all device registration exceptions.
+ */
+@Accessors(prefix = "m")
+@Getter
+public class DeviceRegistrationException extends BaseException {
+    private static final String TAG = DeviceRegistrationException.class.getSimpleName();
+
+    @Nullable
+    private final String mStackTraceString;
+
+    /**
+     * Device registration error codes
+     **/
+    // Thrown to indicate that the active broker needs to be updated.
+    public static final String UPDATE_BROKER_ERROR_CODE = "update_broker";
+
+    // Thrown to indicate the device registration API needs to be updated.
+    public static final String UPDATE_API_ERROR_CODE = "update_device_registration_api";
+
+    // Thrown when an unexpected error occurs during the execution of a device registration protocol.
+    public static final String INTERNAL_ERROR_CODE = "internal_error";
+
+    // Thrown when invalid package is provided to the protocol packer
+    public static final String INVALID_PACKAGE_ERROR_CODE = "invalid_package";
+
+    // Thrown when the API failed to communicate with the broker.
+    public static final String FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_CODE = "failed_to_communicate_with_broker";
+
+    // Thrown when the expected device registration entry is null.
+    public static final String NO_SUCH_DEVICE_REGISTRATION_ERROR_CODE = "no_such_device_registration";
+
+    // Thrown to indicate that the proportionate device registration record
+    // does not match with the returned record in the fallback strategy.
+    public static final String NOT_MATCHING_RECORD_FOUND_ERROR_CODE = "no_matching_record_found";
+
+    /**
+     * Device registration messages
+     **/
+    public static final String FAILED_TO_COMMUNICATE_WITH_BROKER_ERROR_MESSAGE
+            = "All the strategies to communicate with the broker have failed.";
+
+    public static final String SERIALIZATION_ERROR_MESSAGE
+        = "The protocol can not be serialized ";
+
+    public static final String NO_SUCH_DEVICE_REGISTRATION_ERROR_MESSAGE
+            = "The device registration record requested does not exist";
+
+    public static final String NOT_MATCHING_RECORD_FOUND_ERROR_MESSAGE
+            = "A record matching the proportionate device id was not found";
+
+    public DeviceRegistrationException(@NonNull final String deviceRegistrationErrorCode,
+                                       @NonNull final String errorMessage) {
+        super(deviceRegistrationErrorCode, errorMessage);
+        mStackTraceString = null;
+    }
+
+    public DeviceRegistrationException(@NonNull final String deviceRegistrationErrorCode,
+                                       @NonNull final String errorMessage,
+                                       @Nullable final Throwable cause) {
+        super(deviceRegistrationErrorCode, errorMessage, cause);
+        mStackTraceString = null;
+    }
+
+    public DeviceRegistrationException(@NonNull final String deviceRegistrationErrorCode,
+                                       @NonNull final String errorMessage,
+                                       @Nullable final Throwable cause,
+                                       @Nullable final String stackTraceString) {
+        super(deviceRegistrationErrorCode, errorMessage, cause);
+        mStackTraceString = stackTraceString;
+    }
+
+    /**
+     * Return a BrokerUpdateRequiredException.
+     *
+     * @param brokerPackageName The package name of the active broker.
+     * @param cause             The {@link Throwable} contains the cause for the exception.
+     * @return BrokerUpdateRequiredException
+     */
+    public static BrokerUpdateRequiredException getBrokerUpdateNeededException(
+            @NonNull final String brokerPackageName,
+            @Nullable final Throwable cause) {
+        return new BrokerUpdateRequiredException(brokerPackageName, cause);
+    }
+
+    /**
+     * Return a ApiUpdateRequiredException.
+     *
+     * @param callingPackageName The package name of app calling the device registration API.
+     * @param cause              The {@link Throwable} contains the cause for the exception.
+     * @return ApiUpdateRequiredException
+     */
+    public static ApiUpdateRequiredException getApiUpdateNeededException(
+            @NonNull final String callingPackageName,
+            @Nullable final Throwable cause) {
+        return new ApiUpdateRequiredException(callingPackageName, cause);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/DrsErrorResponseException.kt
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/exception/DrsErrorResponseException.kt
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.exception
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.microsoft.identity.common.java.exception.BaseException
+import com.microsoft.identity.common.java.logging.Logger
+import java.net.HttpURLConnection
+
+/**
+ * DRS could return errors in 2 different formats.
+ * (Newer endpoint versions would return an error under odata.error).
+ * This class will handle both and parse accordingly.
+ *
+ * Its exception message might contain a response from DRS (JSON string) or a basic error string.
+ *
+ * @param httpErrorCode             HTTP Error code of this DRS request.
+ * @param errorCode                 Error code from DRS (extracted from fullErrorResponse).
+ * @param fullErrorResponse         Full error response (could be a JSON from DRS,
+ *                                      or a regular string if the error occurs on the client side - i.e. response parsing failure.)
+ * @param extractedErrorMessage     Error message from DRS (extracted from fullErrorResponse).
+ * @param operation                 Type of this DRS request, i.e. DeviceJoin.
+ * @param time                      Timestamp of the request.
+ */
+open class DrsErrorResponseException(
+    val httpErrorCode: Int,
+    errorCode: String,
+    fullErrorResponse: String?,
+    val extractedErrorMessage: String?,
+    val operation: String?,
+    val time: String?) : BaseException(errorCode, fullErrorResponse) {
+    companion object {
+        private val TAG = DrsErrorResponseException::class.simpleName
+        private const val CODE = "code"
+        private const val SUB_CODE = "subcode"
+        private const val MESSAGE = "message"
+        private const val OPERATION = "operation"
+        private const val TIME = "time"
+        private const val REQUEST_ID = "requestid"
+        private const val ODATA_ERROR = "odata.error"
+        private const val VALUE = "value"
+        private const val VALUES = "values"
+        private const val ITEM = "item"
+        private const val DATE = "date"
+        const val DEFAULT_ERROR_CODE = "wpj_unknown_error"
+
+        @JvmStatic
+        fun getFromErrorResponse(drsErrorResponse: String?):
+                DrsErrorResponseException {
+            return getFromErrorResponse(HttpURLConnection.HTTP_OK, drsErrorResponse)
+        }
+
+        @JvmStatic
+        fun getFromErrorResponse(httpErrorCode: Int, drsErrorResponse: String?):
+                DrsErrorResponseException {
+            val jsonResponse = getJsonObject(drsErrorResponse)
+
+            return if (jsonResponse.get(ODATA_ERROR) != null) {
+                // with odata, the error is formatted differently.
+                val odataError = jsonResponse.getAsJsonObject(ODATA_ERROR)
+                val valuesJsonArray = odataError.getAsJsonArray(VALUES)
+
+                val exception = DrsErrorResponseException(
+                    httpErrorCode = httpErrorCode,
+                    errorCode = getFromJsonObject(odataError, CODE, DEFAULT_ERROR_CODE),
+                    fullErrorResponse = drsErrorResponse,
+                    extractedErrorMessage = getFromJsonObject(odataError.getAsJsonObject(MESSAGE), VALUE),
+                    operation = null,
+                    time = valuesJsonArray?.let { getFromJsonArray(it, DATE) }
+                )
+
+                exception.correlationId = valuesJsonArray?.let { getFromJsonArray(it, REQUEST_ID) }
+                exception.subErrorCode = valuesJsonArray?.let { getFromJsonArray(it, SUB_CODE) }
+                exception
+            } else {
+                val exception = DrsErrorResponseException(
+                    httpErrorCode = httpErrorCode,
+                    errorCode = getFromJsonObject(jsonResponse, CODE, DEFAULT_ERROR_CODE),
+                    fullErrorResponse = drsErrorResponse,
+                    extractedErrorMessage = getFromJsonObject(jsonResponse, MESSAGE),
+                    operation = getFromJsonObject(jsonResponse, OPERATION),
+                    time = getFromJsonObject(jsonResponse, TIME)
+                )
+                exception.subErrorCode = getFromJsonObject(jsonResponse, SUB_CODE)
+                exception.correlationId = getFromJsonObject(jsonResponse, REQUEST_ID)
+                exception
+            }
+        }
+
+        private fun getFromJsonObject(obj: JsonObject, key: String, defaultString: String): String {
+            val result = obj.get(key)
+            if (result == null || result is JsonNull){
+                return defaultString
+            }
+
+            return result.asString
+        }
+
+        private fun getFromJsonObject(obj: JsonObject, key: String): String? {
+            val result = obj.get(key)
+            if (result == null || result is JsonNull){
+                return null
+            }
+
+            return result.asString
+        }
+
+        private fun getFromJsonArray(array: JsonArray, key: String): String? {
+            val element = array.find { jsonElement ->
+                jsonElement.asJsonObject.get(ITEM)?.asString.equals(key, ignoreCase = true)
+            }
+
+            if (element !is JsonObject){
+                return null
+            }
+
+            return getFromJsonObject(element.asJsonObject, VALUE)
+        }
+
+        /**
+         * Parse the error response from DRS and return a JsonObject.
+         * If the error response cannot be parsed, return an empty JsonObject.
+         */
+        private fun getJsonObject(drsErrorResponse: String?): JsonObject {
+            val methodTag = "$TAG:getJsonObject"
+            return try {
+                JsonParser.parseString(drsErrorResponse).asJsonObject
+            } catch (e: Throwable) {
+                Logger.error(methodTag, "Failed to parse DRS error response", e)
+                JsonParser.parseString("{}").asJsonObject
+            }
+        }
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/DeviceRegistrationProtocolConstants.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/DeviceRegistrationProtocolConstants.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol;
+
+/**
+ * Contains all the constant values for device registration protocols.
+ */
+public final class DeviceRegistrationProtocolConstants {
+    public static final String DEVICE_REGISTRATION_WITH_TOKENS_V0 = "protocol.device.registration.with.tokens.v0";
+    public static final String DEVICE_REGISTRATION_PREAUTHORIZED_V0 = "protocol.device.registration.preauthorized.v0";
+    public static final String GET_PRE_PROVISIONED_BLOB_V0 = "protocol.get.pre.provisioned.blob.v0";;
+    public static final String GET_REGISTRATION_STATE_V0 = "protocol.get.state.v0";
+    public static final String GET_DEVICE_TOKEN_V0 = "protocol.get.device.token.v0";
+    public static final String INSTALL_CERTIFICATE_V0 = "protocol.install.certificate.v0";
+    public static final String GET_ALL_DEVICE_REGISTRATION_RECORDS_VO = "get.all.device.registration.records.v0";
+    public static final String UNREGISTER_DEVICE_V0 = "protocol.unregister.v0";
+    public static final String INSTALL_CERTIFICATE_SILENTLY_V0 = "protocol.install.certificate.silently.v0";
+    public static final String GET_DEVICE_REGISTRATION_RECORD_VO = "get.device.registration.record.v0";
+    public static final String PROVISION_RESOURCE_ACCOUNT_V0 = "protocol.provision.resource.account.v0";
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/DeviceRegistrationProtocolConstants.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/DeviceRegistrationProtocolConstants.java
@@ -28,7 +28,7 @@ package com.microsoft.identity.deviceregistration.java.protocol;
 public final class DeviceRegistrationProtocolConstants {
     public static final String DEVICE_REGISTRATION_WITH_TOKENS_V0 = "protocol.device.registration.with.tokens.v0";
     public static final String DEVICE_REGISTRATION_PREAUTHORIZED_V0 = "protocol.device.registration.preauthorized.v0";
-    public static final String GET_PRE_PROVISIONED_BLOB_V0 = "protocol.get.pre.provisioned.blob.v0";;
+    public static final String GET_PRE_PROVISIONED_BLOB_V0 = "protocol.get.pre.provisioned.blob.v0";
     public static final String GET_REGISTRATION_STATE_V0 = "protocol.get.state.v0";
     public static final String GET_DEVICE_TOKEN_V0 = "protocol.get.device.token.v0";
     public static final String INSTALL_CERTIFICATE_V0 = "protocol.install.certificate.v0";

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/IDeviceRegistrationProtocol.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/IDeviceRegistrationProtocol.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol;
+
+import java.util.UUID;
+
+import lombok.NonNull;
+
+/**
+ * Interface describing a device registration protocol,
+ * a protocol refers to a set of fixed, negotiated request parameters or results for an operation.
+ */
+public interface IDeviceRegistrationProtocol {
+    /**
+     * Returns the name of the protocol.
+     */
+    @NonNull
+    String getProtocolName();
+
+    /**
+     * return the serialized protocol.
+     */
+    byte[] serialize();
+
+    /**
+     * return the correlationId.
+     */
+    @NonNull
+    UUID getCorrelationId();
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/DeviceRegistrationProtocolMoshiSerializer.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/DeviceRegistrationProtocolMoshiSerializer.java
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.packer;
+
+import static com.microsoft.identity.common.java.AuthenticationConstants.CHARSET_UTF8;
+import static com.microsoft.identity.common.java.exception.ClientException.JSON_PARSE_FAILURE;
+
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecordWithAccount;
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.logging.Logger;
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.ToJson;
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import lombok.NonNull;
+
+/**
+ * Moshi-based serializer for device registration protocol types in common4j.
+ * Uses hardcoded broker4j FQCNs as polymorphic discriminator labels to ensure
+ * wire compatibility between common4j (client-side) and broker4j (server-side).
+ *
+ * <p>Moshi serializes/deserializes {@link IDeviceRegistrationRecord} using common4j types
+ * ({@link DeviceRegistrationRecord}, {@link DeviceRegistrationRecordWithAccount}).
+ * Broker callers should convert broker4j records to common4j records before serialization,
+ * and convert common4j records back to broker4j after deserialization.
+ * The wire format (JSON discriminator labels) uses hardcoded broker4j FQCNs for
+ * backward compatibility.</p>
+ */
+public class DeviceRegistrationProtocolMoshiSerializer<DeviceRegistrationProtocol extends IDeviceRegistrationProtocol>
+        implements IDeviceRegistrationProtocolSerializer<DeviceRegistrationProtocol> {
+
+    public static final String TAG = DeviceRegistrationProtocolMoshiSerializer.class.getSimpleName();
+    public static final String RECORD_TYPE_KEY = "record_type";
+
+    // Hardcoded broker4j FQCNs for wire compatibility with existing broker serialization.
+    public static final String RECORD_WITHOUT_ACCOUNT =
+            "com.microsoft.identity.broker4j.workplacejoin.api.DeviceRegistrationRecord";
+    public static final String RECORD_WITH_ACCOUNT =
+            "com.microsoft.identity.broker4j.workplacejoin.api.DeviceRegistrationRecordWithAccount";
+
+    private static final Moshi moshi = new Moshi.Builder()
+            .add(PolymorphicJsonAdapterFactory.of(IDeviceRegistrationRecord.class, RECORD_TYPE_KEY)
+                    .withSubtype(DeviceRegistrationRecord.class, RECORD_WITHOUT_ACCOUNT)
+                    .withSubtype(DeviceRegistrationRecordWithAccount.class, RECORD_WITH_ACCOUNT))
+            .add(new UUIDAdapter())
+            .build();
+
+    private static final class UUIDAdapter {
+        @ToJson
+        public String toJson(final UUID uuid) {
+            return uuid.toString();
+        }
+
+        @FromJson
+        public UUID fromJson(final String json) {
+            return UUID.fromString(json);
+        }
+    }
+
+    private final JsonAdapter<DeviceRegistrationProtocol> deviceRegistrationProtocolJsonAdapter;
+
+    public DeviceRegistrationProtocolMoshiSerializer(
+            final Class<DeviceRegistrationProtocol> deviceRegistrationProtocolType) {
+        deviceRegistrationProtocolJsonAdapter = moshi.adapter(deviceRegistrationProtocolType);
+    }
+
+    /**
+     * Serialize a {@link DeviceRegistrationProtocol protocol} into a byte array.
+     *
+     * @param protocol to serialize
+     * @return a byte array with the serialized protocol.
+     */
+    @Override
+    public byte[] serialize(@NonNull final DeviceRegistrationProtocol protocol) {
+        return deviceRegistrationProtocolJsonAdapter.toJson(protocol).getBytes(CHARSET_UTF8);
+    }
+
+    /**
+     * Deserializes a byte array into a {@link DeviceRegistrationProtocol protocol} object.
+     *
+     * @param serializedProtocol byte array with the serialized object.
+     * @return a {@link DeviceRegistrationProtocol protocol} based on provided byte array.
+     */
+    @NonNull
+    @Override
+    public DeviceRegistrationProtocol deserialize(@NonNull final byte[] serializedProtocol) throws ClientException {
+        final String methodTag = TAG + ":deserialize";
+        final String jsonString = new String(serializedProtocol, CHARSET_UTF8);
+        final DeviceRegistrationProtocol protocol;
+        try {
+            protocol = deviceRegistrationProtocolJsonAdapter.fromJson(jsonString);
+        } catch (final IOException e) {
+            Logger.error(methodTag, "Failed to convert json to DeviceRegistrationProtocol", e);
+            throw new ClientException(JSON_PARSE_FAILURE, e.getMessage(), e);
+        }
+        if (protocol == null) {
+            Logger.error(methodTag, "The protocol cannot be unpacked", null);
+            throw new ClientException(JSON_PARSE_FAILURE, "Protocol is null");
+        }
+        return protocol;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/IDeviceRegistrationProtocolPacker.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/IDeviceRegistrationProtocolPacker.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.packer;
+
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException;
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+import com.microsoft.identity.common.java.exception.BaseException;
+
+import lombok.NonNull;
+
+/**
+ * A generic interface for packing and unpacking {@link IDeviceRegistrationProtocol protocols}.
+ */
+public interface IDeviceRegistrationProtocolPacker<PackageType> {
+
+    /**
+     * Returns the protocol name contained in the provided package.
+     *
+     * @param packedData Generic protocol package.
+     * @return name of the protocol.
+     * @throws DeviceRegistrationException if the protocol bundle contains a packed exception.
+     */
+    String unpackName(@NonNull final PackageType packedData) throws DeviceRegistrationException;
+
+    /**
+     * Returns the correlation id contained in the provided package.
+     * If the correlation id is not present, generates a new one.
+     *
+     * @param packedData Generic protocol package.
+     * @return correlationId.
+     */
+    String unpackCorrelationId(@NonNull final PackageType packedData);
+
+    /**
+     * Unpacks a packed protocol into a serialized protocol.
+     *
+     * @param packedData Generic protocol package to unpack.
+     * @return a byte array with the protocol data.
+     * @throws BaseException if the protocol bundle contains a packed exception.
+     */
+    byte[] unpackData(@NonNull final PackageType packedData) throws BaseException;
+
+    /**
+     * Packs a {@link IDeviceRegistrationProtocol protocol} into a generic object.
+     *
+     * @param protocol {@link IDeviceRegistrationProtocol protocol} to pack.
+     * @return a packed protocol.
+     */
+    PackageType pack(@NonNull final IDeviceRegistrationProtocol protocol);
+
+    /**
+     * Packs a Throwable into a package.
+     *
+     * @param throwable to pack.
+     * @return package with all the exception data.
+     */
+    PackageType packThrowable(@NonNull final Throwable throwable);
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/IDeviceRegistrationProtocolSerializer.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/packer/IDeviceRegistrationProtocolSerializer.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.packer;
+
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import lombok.NonNull;
+
+/**
+ * A generic interface for serializing/deserializing {@link IDeviceRegistrationProtocol protocols}.
+ */
+public interface IDeviceRegistrationProtocolSerializer<DeviceRegistrationProtocol extends IDeviceRegistrationProtocol> {
+
+    /**
+     * Serialize a {@link DeviceRegistrationProtocol protocol} into a byte array object.
+     *
+     * @param protocol to serialize
+     * @return a byte array with the serialized protocol.
+     */
+    byte[] serialize(@NonNull final DeviceRegistrationProtocol protocol);
+
+    /**
+     * Deserializes a byte array into a {@link DeviceRegistrationProtocol protocol} object.
+     *
+     * @param serializedProtocol byte array with the serialized object.
+     * @return a {@link DeviceRegistrationProtocol protocol} based on provided byte array.
+     */
+    DeviceRegistrationProtocol deserialize(@NonNull final byte[] serializedProtocol) throws ClientException;
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/AbstractDeviceRegistrationProtocolParameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/AbstractDeviceRegistrationProtocolParameters.java
@@ -30,8 +30,6 @@ import lombok.experimental.Accessors;
 
 /**
  * Abstract base class for all IDeviceRegistrationProtocolParameters.
- * Every time a ProtocolParameters object is instantiated it will generate a correlation Id
- * that will be used for all the requests used by this protocol.
  */
 @Accessors(prefix = "m")
 public abstract class AbstractDeviceRegistrationProtocolParameters implements IDeviceRegistrationProtocolParameters {

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/AbstractDeviceRegistrationProtocolParameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/AbstractDeviceRegistrationProtocolParameters.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Abstract base class for all IDeviceRegistrationProtocolParameters.
+ * Every time a ProtocolParameters object is instantiated it will generate a correlation Id
+ * that will be used for all the requests used by this protocol.
+ */
+@Accessors(prefix = "m")
+public abstract class AbstractDeviceRegistrationProtocolParameters implements IDeviceRegistrationProtocolParameters {
+
+    @Getter
+    @NonNull
+    protected final UUID mCorrelationId = UUID.randomUUID();
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationPreAuthorizedV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationPreAuthorizedV0Parameters.java
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters for a device registration with a pre authorized challenge.
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class DeviceRegistrationPreAuthorizedV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<DeviceRegistrationPreAuthorizedV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(DeviceRegistrationPreAuthorizedV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static DeviceRegistrationPreAuthorizedV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    /**
+     * ID of the tenant the device will be registered to.
+     */
+    @Getter
+    @NonNull
+    private final String mTenantId;
+
+    /**
+     * A challenge blob to perform pre-authorized registration, it can be encrypted.
+     */
+    @Getter
+    @NonNull
+    private final String mPreAuthorizedJoinChallenge;
+
+    /**
+     * Determines if the preAuthorizedToken is encrypted.
+     */
+    @Getter
+    private final boolean mChallengeEncrypted;
+
+    /**
+     * Determines if the device should be registered as a shared device.
+     */
+    @Getter
+    private final boolean mRegisterAsSharedDevice;
+
+    @Getter
+    @Nullable
+    private final String mDiscoveryEndpointName;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.DEVICE_REGISTRATION_PREAUTHORIZED_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationWithTokensV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationWithTokensV0Parameters.java
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters for a device registration with tokens.
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class DeviceRegistrationWithTokensV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<DeviceRegistrationWithTokensV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(DeviceRegistrationWithTokensV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static DeviceRegistrationWithTokensV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mIdToken;
+
+    @Getter
+    @NonNull
+    private final String mAccessToken;
+
+    @Getter
+    @NonNull
+    private final String mRefreshToken;
+
+    @Getter
+    private final boolean mRegisterAsSharedDevice;
+
+    @Getter
+    private final String mDiscoveryEndpointName;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.DEVICE_REGISTRATION_WITH_TOKENS_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordV0Parameters.java
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class GetDeviceRegistrationRecordV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceRegistrationRecordV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceRegistrationRecordV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceRegistrationRecordV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mIdentifier;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_DEVICE_REGISTRATION_RECORD_VO;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordsV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordsV0Parameters.java
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@NoArgsConstructor
+@Accessors(prefix = "m")
+public class GetDeviceRegistrationRecordsV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceRegistrationRecordsV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceRegistrationRecordsV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceRegistrationRecordsV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_ALL_DEVICE_REGISTRATION_RECORDS_VO;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceTokenV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceTokenV0Parameters.java
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class GetDeviceTokenV0Parameters implements IDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceTokenV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceTokenV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceTokenV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+    @Getter
+    @NonNull
+    private final String mResources;
+    @Getter
+    @NonNull
+    private final UUID mCorrelationId;
+    @Getter
+    @Nullable
+    private final String mScope;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_DEVICE_TOKEN_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetInstallWpjCertificateIntentRequestV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetInstallWpjCertificateIntentRequestV0Parameters.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters to install a certificate
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class GetInstallWpjCertificateIntentRequestV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetInstallWpjCertificateIntentRequestV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetInstallWpjCertificateIntentRequestV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetInstallWpjCertificateIntentRequestV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.INSTALL_CERTIFICATE_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetRegistrationStateV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetRegistrationStateV0Parameters.java
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class GetRegistrationStateV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetRegistrationStateV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetRegistrationStateV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetRegistrationStateV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_REGISTRATION_STATE_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/IDeviceRegistrationProtocolParameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/IDeviceRegistrationProtocolParameters.java
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+
+/**
+ * Interface describing a device registration protocol parameters.
+ */
+public interface IDeviceRegistrationProtocolParameters extends IDeviceRegistrationProtocol {
+
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/InstallCertificateSilentlyV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/InstallCertificateSilentlyV0Parameters.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters to install a certificate silently
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class InstallCertificateSilentlyV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<InstallCertificateSilentlyV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(InstallCertificateSilentlyV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static InstallCertificateSilentlyV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.INSTALL_CERTIFICATE_SILENTLY_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/PreProvisionedBlobV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/PreProvisionedBlobV0Parameters.java
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class PreProvisionedBlobV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<PreProvisionedBlobV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(PreProvisionedBlobV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static PreProvisionedBlobV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mTenantId;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_PRE_PROVISIONED_BLOB_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/ProvisionResourceAccountV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/ProvisionResourceAccountV0Parameters.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters for provisioning a resource account.
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class ProvisionResourceAccountV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<ProvisionResourceAccountV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(ProvisionResourceAccountV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static ProvisionResourceAccountV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mTenantId;
+
+    @Getter
+    @NonNull
+    private final String mRaObjectId;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.PROVISION_RESOURCE_ACCOUNT_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/UnregisterDeviceV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/UnregisterDeviceV0Parameters.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.parameters;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol parameters to unregister.
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class UnregisterDeviceV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    private static final IDeviceRegistrationProtocolSerializer<UnregisterDeviceV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(UnregisterDeviceV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static UnregisterDeviceV0Parameters create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    @Override
+    @NonNull
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.UNREGISTER_DEVICE_V0;
+    }
+
+    /**
+     * Serialization is handled by the packer layer.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/AbstractDeviceRegistrationProtocolResponse.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/AbstractDeviceRegistrationProtocolResponse.java
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Abstract base class for all IDeviceRegistrationProtocolResponse.
+ */
+@Accessors(prefix = "m")
+public abstract class AbstractDeviceRegistrationProtocolResponse implements IDeviceRegistrationProtocolResponse {
+
+    @Getter
+    @NonNull
+    protected final UUID mCorrelationId;
+
+    protected AbstractDeviceRegistrationProtocolResponse(@NonNull final UUID correlationId) {
+        mCorrelationId = correlationId;
+    }
+
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/DeviceRegistrationPreAuthorizedV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/DeviceRegistrationPreAuthorizedV0Response.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class DeviceRegistrationPreAuthorizedV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<DeviceRegistrationPreAuthorizedV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(DeviceRegistrationPreAuthorizedV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static DeviceRegistrationPreAuthorizedV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public DeviceRegistrationPreAuthorizedV0Response(@NonNull final UUID correlationId,
+                                                     @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.DEVICE_REGISTRATION_PREAUTHORIZED_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/DeviceRegistrationWithTokensV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/DeviceRegistrationWithTokensV0Response.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class DeviceRegistrationWithTokensV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<DeviceRegistrationWithTokensV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(DeviceRegistrationWithTokensV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static DeviceRegistrationWithTokensV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public DeviceRegistrationWithTokensV0Response(@NonNull final UUID correlationId,
+                                                  @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
+    }
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.DEVICE_REGISTRATION_WITH_TOKENS_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceRegistrationRecordV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceRegistrationRecordV0Response.java
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class GetDeviceRegistrationRecordV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceRegistrationRecordV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceRegistrationRecordV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceRegistrationRecordV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public GetDeviceRegistrationRecordV0Response(@NonNull final UUID correlationId,
+                                                 @Nullable final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
+    }
+
+    @Getter
+    @Nullable
+    private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_DEVICE_REGISTRATION_RECORD_VO;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceRegistrationRecordsV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceRegistrationRecordsV0Response.java
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class GetDeviceRegistrationRecordsV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceRegistrationRecordsV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceRegistrationRecordsV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceRegistrationRecordsV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public GetDeviceRegistrationRecordsV0Response(@NonNull final UUID correlationId,
+                                                  @NonNull final List<IDeviceRegistrationRecord> deviceRegistrationRecordList) {
+        super(correlationId);
+        mDeviceRegistrationRecords = deviceRegistrationRecordList;
+    }
+
+    @Getter
+    @NonNull
+    private final List<IDeviceRegistrationRecord> mDeviceRegistrationRecords;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_ALL_DEVICE_REGISTRATION_RECORDS_VO;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceTokenV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetDeviceTokenV0Response.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class GetDeviceTokenV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetDeviceTokenV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceTokenV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetDeviceTokenV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public GetDeviceTokenV0Response(@NonNull final UUID correlationId, @NonNull final String deviceToken) {
+        super(correlationId);
+        mDeviceToken = deviceToken;
+    }
+
+    @Getter
+    @NonNull
+    private final String mDeviceToken;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_DEVICE_TOKEN_V0;
+    }
+
+    /**
+     * return the serialized protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetInstallWpjCertificateIntentRequestV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetInstallWpjCertificateIntentRequestV0Response.java
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+/**
+ * Implements a protocol response with the information necessary to launch
+ * a install WPJ certificate intent and get the result or error message from the activity.
+ */
+@Accessors(prefix = "m")
+public class GetInstallWpjCertificateIntentRequestV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetInstallWpjCertificateIntentRequestV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetInstallWpjCertificateIntentRequestV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetInstallWpjCertificateIntentRequestV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public GetInstallWpjCertificateIntentRequestV0Response(@NonNull final UUID correlationId,
+                                                           @NonNull final String activityClassName,
+                                                           @NonNull final String brokerPackageName,
+                                                           @NonNull final String installCertActivityResultKey,
+                                                           @NonNull final String installCertActivityErrorKey,
+                                                           @NonNull final Map<String, String> extras) {
+        super(correlationId);
+        mActivityClassName = activityClassName;
+        mBrokerPackageName = brokerPackageName;
+        mInstallCertActivityResultKey = installCertActivityResultKey;
+        mInstallCertActivityErrorKey = installCertActivityErrorKey;
+        mExtras = extras;
+    }
+
+    /**
+     * Class name of the Activity that will install the WPJ certificate (InstallCertActivity).
+     */
+    @NonNull
+    @Getter
+    private final String mActivityClassName;
+
+    /**
+     * The package name of the active broker.
+     */
+    @NonNull
+    @Getter
+    private final String mBrokerPackageName;
+
+    /**
+     * key used to extract the result from the InstallCertActivity.
+     */
+    @NonNull
+    @Getter
+    private final String mInstallCertActivityResultKey;
+
+    /**
+     * key used to extract the error message from the InstallCertActivity.
+     */
+    @NonNull
+    @Getter
+    private final String mInstallCertActivityErrorKey;
+
+    /**
+     * HashMap with the variables we will send to the InstallCertActivity.
+     */
+    @NonNull
+    @Getter
+    private final Map<String, String> mExtras;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.DEVICE_REGISTRATION_WITH_TOKENS_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetRegistrationStateV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/GetRegistrationStateV0Response.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class GetRegistrationStateV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<GetRegistrationStateV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(GetRegistrationStateV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static GetRegistrationStateV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public GetRegistrationStateV0Response(@NonNull final UUID correlationId, @NonNull final String deviceState) {
+        super(correlationId);
+        mDeviceState = deviceState;
+    }
+
+    @Getter
+    @NonNull
+    private final String mDeviceState;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_REGISTRATION_STATE_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/IDeviceRegistrationProtocolResponse.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/IDeviceRegistrationProtocolResponse.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.IDeviceRegistrationProtocol;
+
+/**
+ * Interface describing a device registration protocol response.
+ */
+public interface IDeviceRegistrationProtocolResponse extends IDeviceRegistrationProtocol {
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/InstallCertificateSilentlyV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/InstallCertificateSilentlyV0Response.java
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class InstallCertificateSilentlyV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<InstallCertificateSilentlyV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(InstallCertificateSilentlyV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static InstallCertificateSilentlyV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public InstallCertificateSilentlyV0Response(@NonNull final UUID correlationId,
+                                                final boolean isCertificateInstalled) {
+        super(correlationId);
+        mCertificateInstalled = isCertificateInstalled;
+    }
+
+    @Getter
+    @NonNull
+    private final boolean mCertificateInstalled;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.INSTALL_CERTIFICATE_SILENTLY_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/PreProvisionedBlobV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/PreProvisionedBlobV0Response.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class PreProvisionedBlobV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<PreProvisionedBlobV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(PreProvisionedBlobV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static PreProvisionedBlobV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public PreProvisionedBlobV0Response(@NonNull final UUID correlationId, @NonNull final String jws) {
+        super(correlationId);
+        mJws = jws;
+    }
+
+    @Getter
+    @NonNull
+    private final String mJws;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.GET_PRE_PROVISIONED_BLOB_V0;
+    }
+
+    /**
+     * return the serialized protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/ProvisionResourceAccountV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/ProvisionResourceAccountV0Response.java
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class ProvisionResourceAccountV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<ProvisionResourceAccountV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(ProvisionResourceAccountV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static ProvisionResourceAccountV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public ProvisionResourceAccountV0Response(@NonNull final UUID correlationId,
+                                              @NonNull final String result) {
+        super(correlationId);
+        mResult = result;
+    }
+
+    @Getter
+    @NonNull
+    private final String mResult;
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.PROVISION_RESOURCE_ACCOUNT_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/UnregisterDeviceV0Response.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/response/UnregisterDeviceV0Response.java
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.protocol.response;
+
+import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+
+import java.util.UUID;
+
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+@Accessors(prefix = "m")
+public class UnregisterDeviceV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    private static final IDeviceRegistrationProtocolSerializer<UnregisterDeviceV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(UnregisterDeviceV0Response.class);
+
+    /**
+     * Creates a protocol object from a byte array (serialized protocol).
+     *
+     * @param serializedData protocol data serialized
+     */
+    public static UnregisterDeviceV0Response create(final byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    public UnregisterDeviceV0Response(@NonNull final UUID correlationId) {
+        super(correlationId);
+    }
+
+    /**
+     * Returns the name of the protocol.
+     */
+    @Override
+    public String getProtocolName() {
+        return DeviceRegistrationProtocolConstants.UNREGISTER_DEVICE_V0;
+    }
+
+    /**
+     * return the serialized the protocol.
+     */
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/deviceregistration/java/exception/DrsErrorResponseExceptionTest.kt
+++ b/common4j/src/test/com/microsoft/identity/deviceregistration/java/exception/DrsErrorResponseExceptionTest.kt
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.exception
+
+import com.microsoft.identity.deviceregistration.java.exception.DrsErrorResponseException
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class
+DrsErrorResponseExceptionTest {
+
+    companion object {
+        private const val CODE = "invalid_request"
+        private const val SUB_CODE = "error_directory_quota_exceeded"
+        private const val MESSAGE = "User '0c95131f-020b-48e0-999f-2553604a2bd0' is not eligible to enroll a device of type 'Android'. Reason 'DeviceCapReached'."
+        private const val OPERATION = "DeviceJoin"
+        private const val TIME = "12-30-2023 17:00:40Z"
+        private const val REQUEST_ID = "1083df47-c860-48c8-b2b9-caf93288058f"
+        private const val ERROR_RESPONSE = "{\"code\":\"${CODE}\"," +
+                "\"subcode\":\"${SUB_CODE}\"," +
+                "\"message\":\"${MESSAGE}\"," +
+                "\"operation\":\"${OPERATION}\"," +
+                "\"requestid\":\"${REQUEST_ID}\"," +
+                "\"time\":\"${TIME}\"}"
+
+        private const val ODATA_CODE = "directory_error"
+        private const val ODATA_SUB_CODE = "error_user_not_registered_device_owner"
+        private const val ODATA_MESSAGE = "User '0c95131f-020b-48e0-999f-2553604a2bd0' is not eligible to enroll a device of type 'Android'. Reason 'DeviceCapReached'."
+        private const val ODATA_TIME = "05-30-2025 22:52:53Z"
+        private const val ODATA_REQUEST_ID = "44abc15a-9a48-48ba-b4f0-f4d547847801"
+        private const val ODATA_ERROR_RESPONSE = "{\"odata.error\":" +
+                "{\"code\":\"$ODATA_CODE\"," +
+                "\"message\":{\"lang\":\"en\"," +
+                "\"value\":\"$ODATA_MESSAGE\"}," +
+                "\"values\":[{\"item\":\"subCode\"," +
+                "\"value\":\"$ODATA_SUB_CODE\"}," +
+                "{\"item\":\"requestId\",\"value\":\"$ODATA_REQUEST_ID\"}," +
+                "{\"item\":\"date\",\"value\":\"$ODATA_TIME\"}]}}"
+    }
+
+    @Test
+    fun testWithInvalidErrorMessage() {
+        val drsErrorResponseException = DrsErrorResponseException.getFromErrorResponse(400, "invalid_error_message")
+        Assert.assertEquals(400, drsErrorResponseException.httpErrorCode)
+        Assert.assertEquals("invalid_error_message", drsErrorResponseException.message)
+        Assert.assertEquals(DrsErrorResponseException.DEFAULT_ERROR_CODE, drsErrorResponseException.errorCode)
+        Assert.assertNull(drsErrorResponseException.subErrorCode)
+        Assert.assertNull(drsErrorResponseException.extractedErrorMessage)
+        Assert.assertNull(drsErrorResponseException.operation)
+        Assert.assertNull(drsErrorResponseException.time)
+        Assert.assertNull(drsErrorResponseException.correlationId)
+    }
+
+    @Test
+    fun testWithNullErrorMessage() {
+        val drsErrorResponseException = DrsErrorResponseException.getFromErrorResponse(400, null)
+        Assert.assertEquals(400, drsErrorResponseException.httpErrorCode)
+        Assert.assertEquals(DrsErrorResponseException.DEFAULT_ERROR_CODE, drsErrorResponseException.errorCode)
+        Assert.assertNull(drsErrorResponseException.message)
+        Assert.assertNull(drsErrorResponseException.subErrorCode)
+        Assert.assertNull(drsErrorResponseException.extractedErrorMessage)
+        Assert.assertNull(drsErrorResponseException.operation)
+        Assert.assertNull(drsErrorResponseException.time)
+        Assert.assertNull(drsErrorResponseException.correlationId)
+    }
+
+    @Test
+    fun testValidErrorMessage() {
+        val drsErrorResponseException = DrsErrorResponseException.getFromErrorResponse(400, ERROR_RESPONSE)
+        Assert.assertEquals(400, drsErrorResponseException.httpErrorCode)
+        Assert.assertEquals(ERROR_RESPONSE, drsErrorResponseException.message)
+        Assert.assertEquals(CODE, drsErrorResponseException.errorCode)
+        Assert.assertEquals(SUB_CODE, drsErrorResponseException.subErrorCode)
+        Assert.assertEquals(MESSAGE, drsErrorResponseException.extractedErrorMessage)
+        Assert.assertEquals(OPERATION, drsErrorResponseException.operation)
+        Assert.assertEquals(TIME, drsErrorResponseException.time)
+        Assert.assertEquals(REQUEST_ID, drsErrorResponseException.correlationId)
+    }
+
+    @Test
+    fun testODataErrorMessage(){
+        val drsErrorResponseException = DrsErrorResponseException.getFromErrorResponse(400, ODATA_ERROR_RESPONSE)
+        Assert.assertEquals(400, drsErrorResponseException.httpErrorCode)
+        Assert.assertEquals(ODATA_ERROR_RESPONSE, drsErrorResponseException.message)
+        Assert.assertEquals(ODATA_CODE, drsErrorResponseException.errorCode)
+        Assert.assertEquals(ODATA_SUB_CODE, drsErrorResponseException.subErrorCode)
+        Assert.assertEquals(ODATA_MESSAGE, drsErrorResponseException.extractedErrorMessage)
+        Assert.assertNull(drsErrorResponseException.operation)
+        Assert.assertEquals(ODATA_TIME, drsErrorResponseException.time)
+        Assert.assertEquals(ODATA_REQUEST_ID, drsErrorResponseException.correlationId)
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/deviceregistration/java/packer/DeviceRegistrationProtocolSerializerParameterizedTest.java
+++ b/common4j/src/test/com/microsoft/identity/deviceregistration/java/packer/DeviceRegistrationProtocolSerializerParameterizedTest.java
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.java.packer;
+
+import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Parameters;
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecordWithAccount;
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.SneakyThrows;
+
+@RunWith(Parameterized.class)
+public class DeviceRegistrationProtocolSerializerParameterizedTest {
+
+    private static final String TEST_STRING_1 = "TEST1";
+    private static final String TEST_STRING_2 = "TEST2";
+    private static final float TEST_FLOAT_1 = 123.456f;
+    private static final float TEST_FLOAT_2 = 9f;
+    private static final String TEST_TENANT = "test.tenant.id";
+    private static final String TEST_UPN = "test.upn";
+    private static final String TEST_DEVICE_ID = "test.device.id";
+    private static final String TEST_ACCOUNT_NAME = "test.account.name";
+
+    private static final IDeviceRegistrationRecord DEVICE_REGISTRATION_RECORD
+            = new DeviceRegistrationRecord(TEST_TENANT, TEST_UPN, TEST_DEVICE_ID, false, false);
+
+    private static final IDeviceRegistrationRecord DEVICE_REGISTRATION_RECORD_WITH_ACCOUNT
+            = new DeviceRegistrationRecordWithAccount(TEST_ACCOUNT_NAME, TEST_TENANT, TEST_UPN, TEST_DEVICE_ID, false, false);
+
+
+    private static final TestHappyPathV0Parameters TEST_PROTOCOL = new TestHappyPathV0Parameters(
+            TEST_STRING_1,
+            TEST_STRING_2,
+            true,
+            false,
+            TEST_FLOAT_1,
+            TEST_FLOAT_2,
+            DEVICE_REGISTRATION_RECORD,
+            DEVICE_REGISTRATION_RECORD_WITH_ACCOUNT
+    );
+
+    private final IDeviceRegistrationProtocolSerializer<TestHappyPathV0Parameters> serializer;
+
+    public DeviceRegistrationProtocolSerializerParameterizedTest(IDeviceRegistrationProtocolSerializer<TestHappyPathV0Parameters> serializer) {
+        this.serializer = serializer;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<IDeviceRegistrationProtocolSerializer<TestHappyPathV0Parameters>> testData() {
+        return new ArrayList<>(Collections.singletonList(
+                new DeviceRegistrationProtocolMoshiSerializer<>(TestHappyPathV0Parameters.class)
+        ));
+    }
+
+
+    @SneakyThrows
+    @Test
+    public void testSerializeProtocol() {
+        // Serialize/deserialize protocol
+        final byte[] serializedData = serializer.serialize(TEST_PROTOCOL);
+        final TestHappyPathV0Parameters protocol = serializer.deserialize(serializedData);
+        // Validate
+        Assert.assertEquals(TEST_PROTOCOL.getProtocolName(), protocol.getProtocolName());
+        Assert.assertEquals(TEST_PROTOCOL.getString1(), protocol.getString1());
+        Assert.assertEquals(TEST_PROTOCOL.getString2(), protocol.getString2());
+        Assert.assertEquals(TEST_PROTOCOL.getFloat1(), protocol.getFloat1(), 0);
+        Assert.assertEquals(TEST_PROTOCOL.getFloat2(), protocol.getFloat2(), 0);
+        Assert.assertTrue(protocol.isBoolean1());
+        Assert.assertFalse(protocol.isBoolean2());
+        Assert.assertEquals(TEST_TENANT, protocol.getRecord().getTenantId());
+        Assert.assertEquals(TEST_UPN, protocol.getRecord().getUpn());
+        Assert.assertEquals(TEST_DEVICE_ID, protocol.getRecord().getDeviceId());
+        final DeviceRegistrationRecordWithAccount recordWithAccount =
+                (DeviceRegistrationRecordWithAccount) protocol.getRecordWithAccount();
+        Assert.assertEquals(TEST_ACCOUNT_NAME, recordWithAccount.getAccountName());
+        Assert.assertEquals(TEST_TENANT, recordWithAccount.getTenantId());
+        Assert.assertEquals(TEST_UPN, recordWithAccount.getUpn());
+        Assert.assertEquals(TEST_DEVICE_ID, recordWithAccount.getDeviceId());
+        Assert.assertEquals(TEST_PROTOCOL.getCorrelationId(), protocol.getCorrelationId());
+    }
+}

--- a/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/DeviceRegistrationTestProtocolConstants.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/DeviceRegistrationTestProtocolConstants.java
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.testprotocols;
+
+/**
+ * Contains all the constant values for device registration test protocols.
+ */
+public final class DeviceRegistrationTestProtocolConstants {
+    public final static String TEST_HAPPY_PATH_V0_PROTOCOL = "protocol.happy.path.v0";
+    public final static String TEST_RETIRED_V0_PROTOCOL = "protocol.retired.v0";
+    public final static String TEST_UNREGISTER_V0_PROTOCOL = "protocol.unregistered.v0";
+    public final static String TEST_LEGACY_ADAPTER_V0_PROTOCOL = "protocol.legacy.adapter.v0";
+    public final static String TEST_SERIALIZATION_ERROR_V0_PROTOCOL = "protocol.serialization.error.v0";
+}

--- a/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Parameters.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Parameters.java
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.testprotocols;
+
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.AbstractDeviceRegistrationProtocolParameters;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Implements a protocol parameters, for testing.
+ */
+@AllArgsConstructor
+@Accessors(prefix = "m")
+public class TestHappyPathV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
+
+    public final static String TEST_HAPPY_PATH_V0_PROTOCOL = "protocol.happy.path.v0";
+
+    private static final IDeviceRegistrationProtocolSerializer<TestHappyPathV0Parameters> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(TestHappyPathV0Parameters.class);
+
+    /**
+     * Creates a protocol object from a bytes array (serialized protocol).
+     */
+    static public TestHappyPathV0Parameters create(byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mString1;
+
+    @Getter
+    @NonNull
+    private final String mString2;
+
+    @Getter
+    private final boolean mBoolean1;
+
+    @Getter
+    private final boolean mBoolean2;
+    @Getter
+    private final float mFloat1;
+
+    @Getter
+    private final float mFloat2;
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mRecord;
+
+    @Getter
+    @NonNull
+    private final IDeviceRegistrationRecord mRecordWithAccount;
+
+    @Override
+    public final String getProtocolName() {
+        return TEST_HAPPY_PATH_V0_PROTOCOL;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}

--- a/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Response.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Response.java
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration.testprotocols;
+
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.response.AbstractDeviceRegistrationProtocolResponse;
+import com.microsoft.identity.common.java.exception.ClientException;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Implements a protocol result, for testing.
+ */
+@Accessors(prefix = "m")
+public class TestHappyPathV0Response extends AbstractDeviceRegistrationProtocolResponse {
+
+    public static final IDeviceRegistrationProtocolSerializer<TestHappyPathV0Response> serializer
+            = new DeviceRegistrationProtocolMoshiSerializer<>(TestHappyPathV0Response.class);
+
+    public TestHappyPathV0Response(@NonNull final UUID correlationId,
+                                   @NonNull final String concatenatedStrings,
+                                   @NonNull final float multiplicationResult,
+                                   final boolean logicalOr,
+                                   @NonNull final DeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mConcatenatedStrings = concatenatedStrings;
+        mMultiplicationResult = multiplicationResult;
+        mLogicalOr = logicalOr;
+        mSameRecordWithConcatenatedX = deviceRegistrationRecord;
+    }
+
+    /**
+     * Creates a protocol object from a bytes array (serialized protocol).
+     */
+    static public TestHappyPathV0Response create(byte[] serializedData) throws ClientException {
+        return serializer.deserialize(serializedData);
+    }
+
+    @Getter
+    @NonNull
+    private final String mConcatenatedStrings;
+
+    @Getter
+    private final float mMultiplicationResult;
+
+    @Getter
+    private final boolean mLogicalOr;
+
+    @Getter
+    @NonNull
+    private final DeviceRegistrationRecord mSameRecordWithConcatenatedX;
+
+    @Override
+    public final String getProtocolName() {
+        return DeviceRegistrationTestProtocolConstants.TEST_HAPPY_PATH_V0_PROTOCOL;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return serializer.serialize(this);
+    }
+}


### PR DESCRIPTION
  Move device registration protocol types, domain types, controller, packer, and IPC strategies provider from broker to common to enable OneAuth device registration support.

  Changes

  common4j

   - Protocol types: V0 params, responses, interfaces, serializer, constants
   - Domain types: IDeviceRegistrationRecord, DeviceRegistrationRecord, DeviceRegistrationRecordWithAccount, exceptions (same simple names as broker4j — broker4j's become thin subclasses)
   - Moshi dependency added to build.gradle
   - testFixtures: TestHappyPathV0Parameters, TestHappyPathV0Response, DeviceRegistrationTestProtocolConstants

  common (Android)

   - AndroidDeviceRegistrationClientController — moved from broker, takes DeviceRegistrationIpcStrategiesProvider + IBrokerDiscoveryClient
   - AndroidDeviceRegistrationProtocolPacker — moved from broker
   - DeviceRegistrationIpcStrategiesProvider — open class providing ContentProvider + BoundService strategies. Broker subclasses to add legacy WPJ strategy.

  Tests moved/added

   - DeviceRegistrationProtocolSerializerParameterizedTest → common4j (JUnit parameterized, no Robolectric)
   - AndroidDeviceRegistrationProtocolPackerTest → common
   - DrsErrorResponseExceptionTest → common4j
   - AndroidDeviceRegistrationClientControllerTest — new in common (mock-based, 8 tests)

  Companion PR

  Broker: https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/138

Fixes [AB#3512895](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3512895)