### PR TITLE
Phase 2 - Add DeviceRegistrationClientApplication in Common For OneAuth, Fixes AB#3450073

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add DeviceRegistrationClientApplication as public API for OneAuth device registration with mandatory correlationId, DeviceState and DrsDiscoveryEndpoint enums (#3073)
 - [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support (#3066)
 - [MINOR] Upgrade compileSdkVersion to 36 and buildToolsVersion to 36.0.0 (#3065)
 - [PATCH] Rename SovSG to GovSG for the Singapore sovereign cloud identifiers (#3068)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IInstallCertCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IInstallCertCallback.java
@@ -27,13 +27,14 @@ import android.app.Activity;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.deviceregistration.api.DeviceRegistrationClientApplication;
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
 
 import java.util.UUID;
 
 /**
  * Interface for the callback
- * {@link com.microsoft.identity.deviceregistration.DeviceRegistrationClientApplication#installCert(IDeviceRegistrationRecord, Activity, IInstallCertCallback, UUID)}
+ * {@link DeviceRegistrationClientApplication#installCert(IDeviceRegistrationRecord, Activity, IInstallCertCallback, UUID)}
  * If certificate is installed successfully, it will be returned through onSuccess.
  * Otherwise, a {@link BaseException} will be returned through onError.
  */

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/IInstallCertCallback.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/IInstallCertCallback.java
@@ -27,10 +27,13 @@ import android.app.Activity;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
+
+import java.util.UUID;
 
 /**
  * Interface for the callback
- * {@link DeviceRegistrationClientApplication#installCert(IDeviceRegistrationRecord, Activity, InstallCertCallback)}.
+ * {@link com.microsoft.identity.deviceregistration.DeviceRegistrationClientApplication#installCert(IDeviceRegistrationRecord, Activity, IInstallCertCallback, UUID)}
  * If certificate is installed successfully, it will be returned through onSuccess.
  * Otherwise, a {@link BaseException} will be returned through onError.
  */

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/DeviceRegistrationClientApplication.kt
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/DeviceRegistrationClientApplication.kt
@@ -1,0 +1,420 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory
+import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClientFactory
+import com.microsoft.identity.common.internal.activebrokerdiscovery.IBrokerDiscoveryClient
+import com.microsoft.identity.common.internal.broker.IInstallCertCallback
+import com.microsoft.identity.common.internal.broker.InstallCertActivityLauncher
+import com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater
+import com.microsoft.identity.common.internal.cache.ClientActiveBrokerCache
+import com.microsoft.identity.common.java.exception.BaseException
+import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import com.microsoft.identity.common.logging.Logger
+import com.microsoft.identity.deviceregistration.java.DeviceState
+import com.microsoft.identity.deviceregistration.java.DrsDiscoveryEndpoint
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord
+import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.DeviceRegistrationPreAuthorizedV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.DeviceRegistrationWithTokensV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.GetDeviceRegistrationRecordV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.GetDeviceRegistrationRecordsV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.GetDeviceTokenV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.GetInstallWpjCertificateIntentRequestV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.GetRegistrationStateV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.InstallCertificateSilentlyV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.PreProvisionedBlobV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.UnregisterDeviceV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.response.DeviceRegistrationPreAuthorizedV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.DeviceRegistrationWithTokensV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceRegistrationRecordV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceRegistrationRecordsV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceTokenV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetInstallWpjCertificateIntentRequestV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetRegistrationStateV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.InstallCertificateSilentlyV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.PreProvisionedBlobV0Response
+import java.util.UUID
+
+/**
+ * Performs device registration operations via IPC to the broker.
+ *
+ * Strategy construction is delegated to [DeviceRegistrationIpcStrategiesProvider].
+ * Default provider supplies ContentProvider + BoundService.
+ * Broker supplies its own provider that adds WpjLegacyAccountAuthenticatorStrategy.
+ *
+ * All public methods require a [UUID] correlationId for IPC request tracing.
+ */
+class DeviceRegistrationClientApplication {
+
+    private val mController: AndroidDeviceRegistrationClientController
+
+    /**
+     * Simple constructor — creates defaults from context.
+     * Used by OneAuth consumers.
+     *
+     * @throws ClientException if no valid broker is found.
+     */
+    @Throws(ClientException::class)
+    constructor(context: Context) {
+        val components = AndroidPlatformComponentsFactory.createFromContext(context)
+        mController = buildController(
+            context,
+            components,
+            BrokerDiscoveryClientFactory.getInstanceForClientSdk(context, components),
+            DeviceRegistrationIpcStrategiesProvider()
+        )
+    }
+
+    /**
+     * Full constructor — accepts all dependencies explicitly.
+     * Used by broker's DRCA and for testing.
+     *
+     * @throws ClientException if no valid broker is found.
+     */
+    @Throws(ClientException::class)
+    constructor(
+        context: Context,
+        components: IPlatformComponents,
+        discoveryClient: IBrokerDiscoveryClient,
+        strategiesProvider: DeviceRegistrationIpcStrategiesProvider
+    ) {
+        mController = buildController(context, components, discoveryClient, strategiesProvider)
+    }
+
+    companion object {
+        private val TAG = DeviceRegistrationClientApplication::class.java.simpleName
+
+        private fun buildController(
+            context: Context,
+            components: IPlatformComponents,
+            discoveryClient: IBrokerDiscoveryClient,
+            strategiesProvider: DeviceRegistrationIpcStrategiesProvider
+        ): AndroidDeviceRegistrationClientController {
+            val cacheUpdater = ActiveBrokerCacheUpdater(
+                context,
+                ClientActiveBrokerCache.getBrokerSdkCache(components.storageSupplier)
+            )
+            return AndroidDeviceRegistrationClientController(
+                context,
+                components,
+                discoveryClient,
+                strategiesProvider,
+                cacheUpdater
+            )
+        }
+    }
+
+    /**
+     * Performs Device Registration with Access Token.
+     *
+     * @param idToken               (JWT) with an ID Token.
+     * @param accessToken           accessToken obtained from OAuth.
+     * @param refreshToken          token used to set up the PRT.
+     * @param registerAsSharedDevice whether to register as shared device.
+     * @param drsDiscoveryEndpoint     discovery endpoint name. Default is "PROD".
+     * @param correlationId         correlation ID for request tracing.
+     */
+    @JvmOverloads
+    @Throws(BaseException::class)
+    fun deviceRegistrationWithTokens(
+        idToken: String,
+        accessToken: String,
+        refreshToken: String,
+        registerAsSharedDevice: Boolean,
+        correlationId: UUID,
+        drsDiscoveryEndpoint: DrsDiscoveryEndpoint = DrsDiscoveryEndpoint.PROD
+    ): IDeviceRegistrationRecord {
+        val methodTag = "$TAG:deviceRegistrationWithTokens"
+        Logger.info(methodTag, "Registration started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            DeviceRegistrationWithTokensV0Parameters(
+                correlationId,
+                idToken,
+                accessToken,
+                refreshToken,
+                registerAsSharedDevice,
+                drsDiscoveryEndpoint.name
+            )
+        )
+        val result = DeviceRegistrationWithTokensV0Response.create(responseSerialized)
+            .deviceRegistrationRecord
+        Logger.info(methodTag, "Registration ended successfully.")
+        return result
+    }
+
+    /**
+     * Unregisters/leaves the device registration.
+     *
+     * @param deviceRegistrationRecord record to unregister.
+     * @param correlationId            correlation ID for request tracing.
+     */
+    @Throws(BaseException::class)
+    fun leave(deviceRegistrationRecord: IDeviceRegistrationRecord, correlationId: UUID) {
+        val methodTag = "$TAG:leave"
+        Logger.info(methodTag, "Leave started. CorrelationId: $correlationId")
+        mController.execute(UnregisterDeviceV0Parameters(correlationId, deviceRegistrationRecord))
+        Logger.info(methodTag, "Leave ended successfully.")
+    }
+
+    /**
+     * Returns a signed pre-provisioned blob (JWS) containing the nonce from ADRS.
+     *
+     * @param tenantId      tenant ID for device registration.
+     * @param correlationId correlation ID for request tracing.
+     */
+    @Throws(BaseException::class)
+    fun getPreProvisionedBlob(tenantId: String, correlationId: UUID): String {
+        val methodTag = "$TAG:getPreProvisionedBlob"
+        Logger.info(methodTag, "GetPreProvisionedBlob started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(PreProvisionedBlobV0Parameters(correlationId, tenantId))
+        val result = PreProvisionedBlobV0Response.create(responseSerialized).jws
+        Logger.info(methodTag, "Blob returned successfully.")
+        return result
+    }
+
+    /**
+     * Gets the registration state from ADRS.
+     *
+     * @param deviceRegistrationRecord record to query state for.
+     * @param correlationId            correlation ID for request tracing.
+     * @return [DeviceState] representing the device state.
+     */
+    @Throws(BaseException::class)
+    fun getRegistrationState(
+        deviceRegistrationRecord: IDeviceRegistrationRecord,
+        correlationId: UUID
+    ): DeviceState {
+        val methodTag = "$TAG:getRegistrationState"
+        Logger.info(methodTag, "GetRegistrationState started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            GetRegistrationStateV0Parameters(correlationId, deviceRegistrationRecord)
+        )
+        val result = DeviceState.fromString(
+            GetRegistrationStateV0Response.create(responseSerialized).deviceState
+        )
+        Logger.info(methodTag, "Get state ended successfully.")
+        return result
+    }
+
+    /**
+     * Registers device with encrypted preAuthorizedJoinChallenge.
+     *
+     * @param tenantId                    tenant to register to.
+     * @param encryptedPreAuthorizedToken encrypted token (JWE).
+     * @param registerAsSharedDevice      whether to register as shared.
+     * @param drsDiscoveryEndpoint           discovery endpoint name.
+     * @param correlationId               correlation ID for request tracing.
+     */
+    @JvmOverloads
+    @Throws(BaseException::class)
+    fun registerWithEncryptedPreAuthorizedToken(
+        tenantId: String,
+        encryptedPreAuthorizedToken: String,
+        registerAsSharedDevice: Boolean,
+        correlationId: UUID,
+        drsDiscoveryEndpoint: DrsDiscoveryEndpoint = DrsDiscoveryEndpoint.PROD
+    ): IDeviceRegistrationRecord {
+        return registerWithPreAuthorizedTokenInternal(
+            tenantId, encryptedPreAuthorizedToken, registerAsSharedDevice, true, drsDiscoveryEndpoint, correlationId
+        )
+    }
+
+    /**
+     * Registers device with preAuthorizedJoinChallenge.
+     *
+     * @param tenantId               tenant to register to.
+     * @param preAuthorizedToken     challenge blob.
+     * @param registerAsSharedDevice whether to register as shared.
+     * @param correlationId          correlation ID for request tracing.
+     * @param drsDiscoveryEndpoint      discovery endpoint name.
+     */
+    @JvmOverloads
+    @Throws(BaseException::class)
+    fun registerWithPreAuthorizedToken(
+        tenantId: String,
+        preAuthorizedToken: String,
+        registerAsSharedDevice: Boolean,
+        correlationId: UUID,
+        drsDiscoveryEndpoint: DrsDiscoveryEndpoint = DrsDiscoveryEndpoint.PROD
+    ): IDeviceRegistrationRecord {
+        return registerWithPreAuthorizedTokenInternal(
+            tenantId, preAuthorizedToken, registerAsSharedDevice, false, drsDiscoveryEndpoint, correlationId
+        )
+    }
+
+    @Throws(BaseException::class)
+    private fun registerWithPreAuthorizedTokenInternal(
+        tenantId: String,
+        preAuthorizedToken: String,
+        registerAsSharedDevice: Boolean,
+        isEncrypted: Boolean,
+        drsDiscoveryEndpoint: DrsDiscoveryEndpoint,
+        correlationId: UUID
+    ): IDeviceRegistrationRecord {
+        val methodTag = "$TAG:registerWithPreAuthorizedTokenInternal"
+        Logger.info(methodTag, "Registration started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            DeviceRegistrationPreAuthorizedV0Parameters(
+                correlationId, tenantId, preAuthorizedToken,
+                isEncrypted, registerAsSharedDevice, drsDiscoveryEndpoint.name
+            )
+        )
+        val result = DeviceRegistrationPreAuthorizedV0Response.create(responseSerialized)
+            .deviceRegistrationRecord
+        Logger.info(methodTag, "Registration ended successfully.")
+        return result
+    }
+
+    /**
+     * Gets the device token for a device registration record.
+     *
+     * @param deviceRegistrationRecord record to get token for.
+     * @param resources                resource requiring device token.
+     * @param correlationId            correlation ID for request tracing.
+     * @param scope                    optional scope.
+     */
+    @Throws(BaseException::class)
+    @JvmOverloads
+    fun getDeviceToken(
+        deviceRegistrationRecord: IDeviceRegistrationRecord,
+        resources: String,
+        correlationId: UUID,
+        scope: String? = null
+    ): String {
+        val methodTag = "$TAG:getDeviceToken"
+        Logger.info(methodTag, "GetDeviceToken started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            GetDeviceTokenV0Parameters(correlationId, deviceRegistrationRecord, resources, scope)
+        )
+        Logger.info(methodTag, "Get device token ended successfully.")
+        return GetDeviceTokenV0Response.create(responseSerialized).deviceToken
+    }
+
+    /**
+     * Installs device registration certificate on device.
+     *
+     * @param deviceRegistrationRecord record to install cert for.
+     * @param activity                 Activity for cert install UI.
+     * @param callback                 callback for result.
+     * @param correlationId            correlation ID for request tracing.
+     */
+    fun installCert(
+        deviceRegistrationRecord: IDeviceRegistrationRecord,
+        activity: Activity,
+        callback: IInstallCertCallback,
+        correlationId: UUID
+    ) {
+        val methodTag = "$TAG:installCert"
+        Logger.info(methodTag, "InstallCert started. CorrelationId: $correlationId")
+        try {
+            val responseSerialized = mController.execute(
+                GetInstallWpjCertificateIntentRequestV0Parameters(correlationId, deviceRegistrationRecord)
+            )
+            val response = GetInstallWpjCertificateIntentRequestV0Response.create(responseSerialized)
+            Logger.info(methodTag, "Response from broker received")
+            InstallCertActivityLauncher.installCertificate(
+                activity,
+                createInstallCertIntent(response),
+                callback,
+                response.installCertActivityResultKey,
+                response.installCertActivityErrorKey
+            )
+        } catch (exception: BaseException) {
+            callback.onError(exception)
+        }
+    }
+
+    private fun createInstallCertIntent(response: GetInstallWpjCertificateIntentRequestV0Response): Intent {
+        val intent = Intent()
+        intent.setPackage(response.brokerPackageName)
+        intent.setClassName(response.brokerPackageName, response.activityClassName)
+        for (key in response.extras.keys) {
+            intent.putExtra(key, response.extras[key])
+        }
+        return intent
+    }
+
+    /**
+     * Installs certificate silently.
+     *
+     * @param deviceRegistrationRecord record to install cert for.
+     * @param correlationId            correlation ID for request tracing.
+     */
+    @Throws(DeviceRegistrationException::class, ClientException::class)
+    fun installCertSilently(
+        deviceRegistrationRecord: IDeviceRegistrationRecord,
+        correlationId: UUID
+    ): Boolean {
+        val methodTag = "$TAG:installCertSilently"
+        Logger.info(methodTag, "InstallCertSilently started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            InstallCertificateSilentlyV0Parameters(correlationId, deviceRegistrationRecord)
+        )
+        Logger.info(methodTag, "Install cert silently ended successfully.")
+        return InstallCertificateSilentlyV0Response.create(responseSerialized).isCertificateInstalled
+    }
+
+    /**
+     * Gets all device registration records.
+     *
+     * @param correlationId correlation ID for request tracing.
+     * @return list of device registration records.
+     */
+    @Throws(BaseException::class)
+    fun getAllEntries(correlationId: UUID): List<IDeviceRegistrationRecord> {
+        val methodTag = "$TAG:getAllEntries"
+        Logger.info(methodTag, "GetAllEntries started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(GetDeviceRegistrationRecordsV0Parameters(correlationId))
+        Logger.info(methodTag, "Return all device registration records.")
+        return GetDeviceRegistrationRecordsV0Response.create(responseSerialized)
+            .deviceRegistrationRecords
+    }
+
+    /**
+     * Gets the device registration record matching the supplied identifier.
+     *
+     * @param identifier    tenant ID or UPN.
+     * @param correlationId correlation ID for request tracing.
+     * @return matching record, or null.
+     */
+    @Throws(BaseException::class)
+    fun getDeviceRegistrationRecord(
+        identifier: String,
+        correlationId: UUID
+    ): IDeviceRegistrationRecord? {
+        val methodTag = "$TAG:getDeviceRegistrationRecord"
+        Logger.info(methodTag, "GetDeviceRegistrationRecord started. CorrelationId: $correlationId")
+        val responseSerialized = mController.execute(
+            GetDeviceRegistrationRecordV0Parameters(correlationId, identifier)
+        )
+        Logger.info(methodTag, "Return a device registration record.")
+        return GetDeviceRegistrationRecordV0Response.create(responseSerialized)
+            .deviceRegistrationRecord
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/deviceregistration/api/DeviceRegistrationClientApplication.kt
+++ b/common/src/main/java/com/microsoft/identity/deviceregistration/api/DeviceRegistrationClientApplication.kt
@@ -20,7 +20,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.deviceregistration
+
+package com.microsoft.identity.deviceregistration.api
 
 import android.app.Activity
 import android.content.Context
@@ -36,6 +37,8 @@ import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.logging.Logger
+import com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationClientController
+import com.microsoft.identity.deviceregistration.DeviceRegistrationIpcStrategiesProvider
 import com.microsoft.identity.deviceregistration.java.DeviceState
 import com.microsoft.identity.deviceregistration.java.DrsDiscoveryEndpoint
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord
@@ -64,11 +67,11 @@ import java.util.UUID
 /**
  * Performs device registration operations via IPC to the broker.
  *
- * Strategy construction is delegated to [DeviceRegistrationIpcStrategiesProvider].
+ * Strategy construction is delegated to [com.microsoft.identity.deviceregistration.DeviceRegistrationIpcStrategiesProvider].
  * Default provider supplies ContentProvider + BoundService.
  * Broker supplies its own provider that adds WpjLegacyAccountAuthenticatorStrategy.
  *
- * All public methods require a [UUID] correlationId for IPC request tracing.
+ * All public methods require a [java.util.UUID] correlationId for IPC request tracing.
  */
 class DeviceRegistrationClientApplication {
 
@@ -78,7 +81,7 @@ class DeviceRegistrationClientApplication {
      * Simple constructor — creates defaults from context.
      * Used by OneAuth consumers.
      *
-     * @throws ClientException if no valid broker is found.
+     * @throws com.microsoft.identity.common.java.exception.ClientException if no valid broker is found.
      */
     @Throws(ClientException::class)
     constructor(context: Context) {
@@ -86,7 +89,7 @@ class DeviceRegistrationClientApplication {
         mController = buildController(
             context,
             components,
-            BrokerDiscoveryClientFactory.getInstanceForClientSdk(context, components),
+            BrokerDiscoveryClientFactory.Companion.getInstanceForClientSdk(context, components),
             DeviceRegistrationIpcStrategiesProvider()
         )
     }
@@ -118,7 +121,7 @@ class DeviceRegistrationClientApplication {
         ): AndroidDeviceRegistrationClientController {
             val cacheUpdater = ActiveBrokerCacheUpdater(
                 context,
-                ClientActiveBrokerCache.getBrokerSdkCache(components.storageSupplier)
+                ClientActiveBrokerCache.Companion.getBrokerSdkCache(components.storageSupplier)
             )
             return AndroidDeviceRegistrationClientController(
                 context,
@@ -192,7 +195,12 @@ class DeviceRegistrationClientApplication {
     fun getPreProvisionedBlob(tenantId: String, correlationId: UUID): String {
         val methodTag = "$TAG:getPreProvisionedBlob"
         Logger.info(methodTag, "GetPreProvisionedBlob started. CorrelationId: $correlationId")
-        val responseSerialized = mController.execute(PreProvisionedBlobV0Parameters(correlationId, tenantId))
+        val responseSerialized = mController.execute(
+            PreProvisionedBlobV0Parameters(
+                correlationId,
+                tenantId
+            )
+        )
         val result = PreProvisionedBlobV0Response.create(responseSerialized).jws
         Logger.info(methodTag, "Blob returned successfully.")
         return result
@@ -203,7 +211,7 @@ class DeviceRegistrationClientApplication {
      *
      * @param deviceRegistrationRecord record to query state for.
      * @param correlationId            correlation ID for request tracing.
-     * @return [DeviceState] representing the device state.
+     * @return [com.microsoft.identity.deviceregistration.java.DeviceState] representing the device state.
      */
     @Throws(BaseException::class)
     fun getRegistrationState(
@@ -215,7 +223,7 @@ class DeviceRegistrationClientApplication {
         val responseSerialized = mController.execute(
             GetRegistrationStateV0Parameters(correlationId, deviceRegistrationRecord)
         )
-        val result = DeviceState.fromString(
+        val result = DeviceState.Companion.fromString(
             GetRegistrationStateV0Response.create(responseSerialized).deviceState
         )
         Logger.info(methodTag, "Get state ended successfully.")
@@ -334,7 +342,10 @@ class DeviceRegistrationClientApplication {
         Logger.info(methodTag, "InstallCert started. CorrelationId: $correlationId")
         try {
             val responseSerialized = mController.execute(
-                GetInstallWpjCertificateIntentRequestV0Parameters(correlationId, deviceRegistrationRecord)
+                GetInstallWpjCertificateIntentRequestV0Parameters(
+                    correlationId,
+                    deviceRegistrationRecord
+                )
             )
             val response = GetInstallWpjCertificateIntentRequestV0Response.create(responseSerialized)
             Logger.info(methodTag, "Response from broker received")
@@ -390,7 +401,11 @@ class DeviceRegistrationClientApplication {
     fun getAllEntries(correlationId: UUID): List<IDeviceRegistrationRecord> {
         val methodTag = "$TAG:getAllEntries"
         Logger.info(methodTag, "GetAllEntries started. CorrelationId: $correlationId")
-        val responseSerialized = mController.execute(GetDeviceRegistrationRecordsV0Parameters(correlationId))
+        val responseSerialized = mController.execute(
+            GetDeviceRegistrationRecordsV0Parameters(
+                correlationId
+            )
+        )
         Logger.info(methodTag, "Return all device registration records.")
         return GetDeviceRegistrationRecordsV0Response.create(responseSerialized)
             .deviceRegistrationRecords

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationClientControllerTest.kt
@@ -101,7 +101,7 @@ class AndroidDeviceRegistrationClientControllerTest {
     private val testRecordWithAccount = DeviceRegistrationRecordWithAccount("account", "tenant", "upn", "deviceId", false, false)
 
     private fun testParams() = TestHappyPathV0Parameters(
-        "hello ", "world", true, false, 1.4f, 3.7f, testRecord, testRecordWithAccount
+        UUID.randomUUID(), "hello ", "world", true, false, 1.4f, 3.7f, testRecord, testRecordWithAccount
     )
 
     private fun testResponse() = TestHappyPathV0Response(

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPackerTest.java
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/AndroidDeviceRegistrationProtocolPackerTest.java
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.deviceregistration;
 
-import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INTERNAL_ERROR_CODE;
-import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INVALID_PACKAGE_ERROR_CODE;
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.CORRELATION_ID;
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_DATA;
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_ERROR_CAUSE_MESSAGE;
@@ -31,23 +29,23 @@ import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistratio
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_ERROR_MESSAGE;
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_EXCEPTION_STACK_TRACE_STRING;
 import static com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker.PROTOCOL_NAME;
-
+import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INTERNAL_ERROR_CODE;
+import static com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException.INVALID_PACKAGE_ERROR_CODE;
 
 import android.os.Bundle;
 
-import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Parameters;
+import com.microsoft.identity.common.java.exception.BaseException;
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord;
 import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecordWithAccount;
 import com.microsoft.identity.deviceregistration.java.exception.DeviceRegistrationException;
 import com.microsoft.identity.deviceregistration.java.exception.DrsErrorResponseException;
-import com.microsoft.identity.common.java.exception.BaseException;
-import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.deviceregistration.testprotocols.TestHappyPathV0Parameters;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-
 
 import java.util.UUID;
 
@@ -72,6 +70,7 @@ public class AndroidDeviceRegistrationProtocolPackerTest {
 
 
     private static final TestHappyPathV0Parameters TEST_PROTOCOL = new TestHappyPathV0Parameters(
+            UUID.randomUUID(),
             TEST_DATA,
             TEST_DATA,
             true,

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/DeviceRegistrationClientApplicationTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/DeviceRegistrationClientApplicationTest.kt
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.deviceregistration
+
+import android.content.Context
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import com.microsoft.identity.common.internal.activebrokerdiscovery.IBrokerDiscoveryClient
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import com.microsoft.identity.deviceregistration.java.DeviceState
+import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord
+import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord
+import com.microsoft.identity.deviceregistration.java.protocol.parameters.PreProvisionedBlobV0Parameters
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceRegistrationRecordV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceRegistrationRecordsV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.GetRegistrationStateV0Response
+import com.microsoft.identity.deviceregistration.java.protocol.response.PreProvisionedBlobV0Response
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import java.util.UUID
+
+/**
+ * Unit tests for [DeviceRegistrationClientApplication].
+ * Uses mock IPC strategy to verify DRCA methods call the controller
+ * with correct V0 params and return correctly parsed responses.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DeviceRegistrationClientApplicationTest {
+
+    private lateinit var context: Context
+    private val packer = AndroidDeviceRegistrationProtocolPacker()
+    private val testBrokerPkg = "com.microsoft.test.broker"
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    private fun createDrca(strategy: IIpcStrategy): DeviceRegistrationClientApplication {
+        val storageSupplier: com.microsoft.identity.common.java.interfaces.IStorageSupplier = mock(defaultAnswer = org.mockito.Mockito.RETURNS_DEEP_STUBS)
+        val components: IPlatformComponents = mock {
+            whenever(it.storageSupplier).thenReturn(storageSupplier)
+        }
+        val discoveryClient: IBrokerDiscoveryClient = mock {
+            whenever(it.getActiveBroker(false)).thenReturn(BrokerData(testBrokerPkg, "sig"))
+        }
+        val provider = object : DeviceRegistrationIpcStrategiesProvider(false) {
+            override fun getStrategies(
+                context: Context,
+                components: IPlatformComponents,
+                activeBrokerPackageName: String
+            ): MutableList<IIpcStrategy> = mutableListOf(strategy)
+        }
+        return DeviceRegistrationClientApplication(context, components, discoveryClient, provider)
+    }
+
+    private fun successStrategy(responseBundle: Bundle): IIpcStrategy {
+        val strategy: IIpcStrategy = mock()
+        whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(strategy.communicateToBroker(any())).thenReturn(responseBundle)
+        return strategy
+    }
+
+    @Test
+    fun getPreProvisionedBlob_returnsJws() {
+        val expectedJws = "test.jws.blob"
+        val response = PreProvisionedBlobV0Response(UUID.randomUUID(), expectedJws)
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getPreProvisionedBlob("test-tenant", UUID.randomUUID())
+
+
+        assertEquals(expectedJws, result)
+    }
+
+    @Test
+    fun getRegistrationState_returnsDeviceState() {
+        val response = GetRegistrationStateV0Response(UUID.randomUUID(), "DEVICE_VALID")
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getRegistrationState(
+            DeviceRegistrationRecord("tenant", "upn", "device", false, false),
+            UUID.randomUUID()
+        )
+
+        assertEquals(DeviceState.DEVICE_VALID, result)
+    }
+
+    @Test
+    fun getRegistrationState_unknownState_returnsUnknown() {
+        val response = GetRegistrationStateV0Response(UUID.randomUUID(), "SOME_NEW_STATE")
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getRegistrationState(
+            DeviceRegistrationRecord("tenant", "upn", "device", false, false),
+            UUID.randomUUID()
+        )
+
+        assertEquals(DeviceState.UNKNOWN, result)
+    }
+
+    @Test
+    fun getDeviceRegistrationRecord_returnsRecord() {
+        val record = DeviceRegistrationRecord("test-tenant", "user@test.com", "device-123", false, true)
+        val response = GetDeviceRegistrationRecordV0Response(UUID.randomUUID(), record)
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getDeviceRegistrationRecord("test-tenant", UUID.randomUUID())
+
+
+        assertNotNull(result)
+        assertEquals("test-tenant", result!!.tenantId)
+        assertEquals("user@test.com", result.upn)
+        assertEquals("device-123", result.deviceId)
+    }
+
+    @Test
+    fun getDeviceRegistrationRecord_notFound_returnsNull() {
+        val response = GetDeviceRegistrationRecordV0Response(UUID.randomUUID(), null)
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getDeviceRegistrationRecord("unknown-tenant", UUID.randomUUID())
+
+
+        assertNull(result)
+    }
+
+    @Test
+    fun getAllEntries_returnsList() {
+        val records = listOf<IDeviceRegistrationRecord>(
+            DeviceRegistrationRecord("tenant1", "upn1", "dev1", false, false),
+            DeviceRegistrationRecord("tenant2", "upn2", "dev2", true, false)
+        )
+        val response = GetDeviceRegistrationRecordsV0Response(UUID.randomUUID(), records)
+        val drca = createDrca(successStrategy(packer.pack(response)))
+
+        val result = drca.getAllEntries(UUID.randomUUID())
+
+
+        assertEquals(2, result.size)
+        assertEquals("tenant1", result[0].tenantId)
+        assertEquals("tenant2", result[1].tenantId)
+    }
+
+    @Test
+    fun correlationId_isPassedToParameters() {
+        val correlationId = UUID.randomUUID()
+        val response = PreProvisionedBlobV0Response(UUID.randomUUID(), "jws")
+        val strategy: IIpcStrategy = mock()
+        whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
+        whenever(strategy.communicateToBroker(any())).thenAnswer { invocation ->
+            val bundle = (invocation.arguments[0] as com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle).bundle
+            val protocolData = bundle?.getByteArray(AndroidDeviceRegistrationProtocolPacker.PROTOCOL_DATA)
+            assertNotNull(protocolData)
+            val parameters = PreProvisionedBlobV0Parameters.create(protocolData)
+            assertEquals(correlationId, parameters.correlationId)
+            // Return the packed response
+            packer.pack(response)
+        }
+
+        val drca = createDrca(strategy)
+
+        drca.getPreProvisionedBlob("test-tenant", correlationId)
+        // If we get here without exception, the correlationId was accepted and the flow completed
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/deviceregistration/api/DeviceRegistrationClientApplicationTest.kt
+++ b/common/src/test/java/com/microsoft/identity/deviceregistration/api/DeviceRegistrationClientApplicationTest.kt
@@ -20,15 +20,19 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.deviceregistration
+package com.microsoft.identity.deviceregistration.api
 
 import android.content.Context
 import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import com.microsoft.identity.common.internal.activebrokerdiscovery.IBrokerDiscoveryClient
 import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle
 import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents
+import com.microsoft.identity.common.java.interfaces.IStorageSupplier
+import com.microsoft.identity.deviceregistration.AndroidDeviceRegistrationProtocolPacker
+import com.microsoft.identity.deviceregistration.DeviceRegistrationIpcStrategiesProvider
 import com.microsoft.identity.deviceregistration.java.DeviceState
 import com.microsoft.identity.deviceregistration.java.api.DeviceRegistrationRecord
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord
@@ -37,12 +41,11 @@ import com.microsoft.identity.deviceregistration.java.protocol.response.GetDevic
 import com.microsoft.identity.deviceregistration.java.protocol.response.GetDeviceRegistrationRecordsV0Response
 import com.microsoft.identity.deviceregistration.java.protocol.response.GetRegistrationStateV0Response
 import com.microsoft.identity.deviceregistration.java.protocol.response.PreProvisionedBlobV0Response
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -67,7 +70,7 @@ class DeviceRegistrationClientApplicationTest {
     }
 
     private fun createDrca(strategy: IIpcStrategy): DeviceRegistrationClientApplication {
-        val storageSupplier: com.microsoft.identity.common.java.interfaces.IStorageSupplier = mock(defaultAnswer = org.mockito.Mockito.RETURNS_DEEP_STUBS)
+        val storageSupplier: IStorageSupplier = mock(defaultAnswer = Mockito.RETURNS_DEEP_STUBS)
         val components: IPlatformComponents = mock {
             whenever(it.storageSupplier).thenReturn(storageSupplier)
         }
@@ -100,7 +103,7 @@ class DeviceRegistrationClientApplicationTest {
         val result = drca.getPreProvisionedBlob("test-tenant", UUID.randomUUID())
 
 
-        assertEquals(expectedJws, result)
+        Assert.assertEquals(expectedJws, result)
     }
 
     @Test
@@ -113,7 +116,7 @@ class DeviceRegistrationClientApplicationTest {
             UUID.randomUUID()
         )
 
-        assertEquals(DeviceState.DEVICE_VALID, result)
+        Assert.assertEquals(DeviceState.DEVICE_VALID, result)
     }
 
     @Test
@@ -126,22 +129,23 @@ class DeviceRegistrationClientApplicationTest {
             UUID.randomUUID()
         )
 
-        assertEquals(DeviceState.UNKNOWN, result)
+        Assert.assertEquals(DeviceState.UNKNOWN, result)
     }
 
     @Test
     fun getDeviceRegistrationRecord_returnsRecord() {
-        val record = DeviceRegistrationRecord("test-tenant", "user@test.com", "device-123", false, true)
+        val record =
+            DeviceRegistrationRecord("test-tenant", "user@test.com", "device-123", false, true)
         val response = GetDeviceRegistrationRecordV0Response(UUID.randomUUID(), record)
         val drca = createDrca(successStrategy(packer.pack(response)))
 
         val result = drca.getDeviceRegistrationRecord("test-tenant", UUID.randomUUID())
 
 
-        assertNotNull(result)
-        assertEquals("test-tenant", result!!.tenantId)
-        assertEquals("user@test.com", result.upn)
-        assertEquals("device-123", result.deviceId)
+        Assert.assertNotNull(result)
+        Assert.assertEquals("test-tenant", result!!.tenantId)
+        Assert.assertEquals("user@test.com", result.upn)
+        Assert.assertEquals("device-123", result.deviceId)
     }
 
     @Test
@@ -152,7 +156,7 @@ class DeviceRegistrationClientApplicationTest {
         val result = drca.getDeviceRegistrationRecord("unknown-tenant", UUID.randomUUID())
 
 
-        assertNull(result)
+        Assert.assertNull(result)
     }
 
     @Test
@@ -167,9 +171,9 @@ class DeviceRegistrationClientApplicationTest {
         val result = drca.getAllEntries(UUID.randomUUID())
 
 
-        assertEquals(2, result.size)
-        assertEquals("tenant1", result[0].tenantId)
-        assertEquals("tenant2", result[1].tenantId)
+        Assert.assertEquals(2, result.size)
+        Assert.assertEquals("tenant1", result[0].tenantId)
+        Assert.assertEquals("tenant2", result[1].tenantId)
     }
 
     @Test
@@ -179,11 +183,11 @@ class DeviceRegistrationClientApplicationTest {
         val strategy: IIpcStrategy = mock()
         whenever(strategy.getType()).thenReturn(IIpcStrategy.Type.CONTENT_PROVIDER)
         whenever(strategy.communicateToBroker(any())).thenAnswer { invocation ->
-            val bundle = (invocation.arguments[0] as com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle).bundle
-            val protocolData = bundle?.getByteArray(AndroidDeviceRegistrationProtocolPacker.PROTOCOL_DATA)
-            assertNotNull(protocolData)
+            val bundle = (invocation.arguments[0] as BrokerOperationBundle).bundle
+            val protocolData = bundle?.getByteArray("protocol.data")
+            Assert.assertNotNull(protocolData)
             val parameters = PreProvisionedBlobV0Parameters.create(protocolData)
-            assertEquals(correlationId, parameters.correlationId)
+            Assert.assertEquals(correlationId, parameters.correlationId)
             // Return the packed response
             packer.pack(response)
         }

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/DeviceState.kt
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/DeviceState.kt
@@ -20,25 +20,33 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.deviceregistration.java.protocol.parameters;
-
-import java.util.UUID;
-
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.experimental.Accessors;
+package com.microsoft.identity.deviceregistration.java
 
 /**
- * Abstract base class for all IDeviceRegistrationProtocolParameters.
+ * Represents the WPJ device state as queried from ADRS.
  */
-@Accessors(prefix = "m")
-public abstract class AbstractDeviceRegistrationProtocolParameters implements IDeviceRegistrationProtocolParameters {
+enum class DeviceState {
+    /** Device is found and valid. */
+    DEVICE_VALID,
+    /** Device was not found. */
+    DEVICE_NOT_FOUND,
+    /** Device was disabled (e.g. by the admin). */
+    DEVICE_DISABLED,
+    /** Unexpected state. */
+    UNKNOWN;
 
-    @Getter
-    @NonNull
-    protected final UUID mCorrelationId;
-
-    protected AbstractDeviceRegistrationProtocolParameters(@NonNull final UUID correlationId) {
-        mCorrelationId = correlationId;
+    companion object {
+        /**
+         * Converts a raw state string (from V0 protocol response) to a [DeviceState].
+         * Returns [UNKNOWN] if the string doesn't match any known state.
+         */
+        @JvmStatic
+        fun fromString(state: String): DeviceState {
+            return try {
+                valueOf(state)
+            } catch (e: IllegalArgumentException) {
+                UNKNOWN
+            }
+        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/DrsDiscoveryEndpoint.kt
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/DrsDiscoveryEndpoint.kt
@@ -20,25 +20,32 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.microsoft.identity.deviceregistration.java.protocol.parameters;
-
-import java.util.UUID;
-
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.experimental.Accessors;
+package com.microsoft.identity.deviceregistration.java
 
 /**
- * Abstract base class for all IDeviceRegistrationProtocolParameters.
+ * Discovery endpoint flags to indicate the instance for device registration.
  */
-@Accessors(prefix = "m")
-public abstract class AbstractDeviceRegistrationProtocolParameters implements IDeviceRegistrationProtocolParameters {
+enum class DrsDiscoveryEndpoint {
+    /** Production instance. */
+    PROD,
+    /** PPE instance. */
+    PPE,
+    /** Int instance. */
+    INT;
 
-    @Getter
-    @NonNull
-    protected final UUID mCorrelationId;
-
-    protected AbstractDeviceRegistrationProtocolParameters(@NonNull final UUID correlationId) {
-        mCorrelationId = correlationId;
+    companion object {
+        /**
+         * Converts a string into [DrsDiscoveryEndpoint].
+         * Returns [PROD] by default if not recognizable.
+         */
+        @JvmStatic
+        fun fromString(value: String?): DrsDiscoveryEndpoint {
+            if (value.isNullOrEmpty()) return PROD
+            return try {
+                valueOf(value)
+            } catch (e: IllegalArgumentException) {
+                PROD
+            }
+        }
     }
 }

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationPreAuthorizedV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationPreAuthorizedV0Parameters.java
@@ -24,8 +24,9 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
+import java.util.UUID;
+
 import edu.umd.cs.findbugs.annotations.Nullable;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -37,7 +38,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 /**
  * Implements a protocol parameters for a device registration with a pre authorized challenge.
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class DeviceRegistrationPreAuthorizedV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -51,6 +51,20 @@ public class DeviceRegistrationPreAuthorizedV0Parameters extends AbstractDeviceR
      */
     public static DeviceRegistrationPreAuthorizedV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public DeviceRegistrationPreAuthorizedV0Parameters(@NonNull final UUID correlationId,
+                                                       @NonNull final String tenantId,
+                                                       @NonNull final String preAuthorizedJoinChallenge,
+                                                       final boolean challengeEncrypted,
+                                                       final boolean registerAsSharedDevice,
+                                                       @Nullable final String discoveryEndpointName) {
+        super(correlationId);
+        mTenantId = tenantId;
+        mPreAuthorizedJoinChallenge = preAuthorizedJoinChallenge;
+        mChallengeEncrypted = challengeEncrypted;
+        mRegisterAsSharedDevice = registerAsSharedDevice;
+        mDiscoveryEndpointName = discoveryEndpointName;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationWithTokensV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/DeviceRegistrationWithTokensV0Parameters.java
@@ -22,21 +22,21 @@
 // THE SOFTWARE.
 package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
+import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
-import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
-import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
-import com.microsoft.identity.common.java.exception.ClientException;
-
 /**
  * Implements a protocol parameters for a device registration with tokens.
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class DeviceRegistrationWithTokensV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -50,6 +50,20 @@ public class DeviceRegistrationWithTokensV0Parameters extends AbstractDeviceRegi
      */
     public static DeviceRegistrationWithTokensV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public DeviceRegistrationWithTokensV0Parameters(@NonNull final UUID correlationId,
+                                                    @NonNull final String idToken,
+                                                    @NonNull final String accessToken,
+                                                    @NonNull final String refreshToken,
+                                                    final boolean registerAsSharedDevice,
+                                                    @Nullable final String discoveryEndpointName) {
+        super(correlationId);
+        mIdToken = idToken;
+        mAccessToken = accessToken;
+        mRefreshToken = refreshToken;
+        mRegisterAsSharedDevice = registerAsSharedDevice;
+        mDiscoveryEndpointName = discoveryEndpointName;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordV0Parameters.java
@@ -24,7 +24,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -33,7 +34,6 @@ import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegi
 import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class GetDeviceRegistrationRecordV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -47,6 +47,12 @@ public class GetDeviceRegistrationRecordV0Parameters extends AbstractDeviceRegis
      */
     public static GetDeviceRegistrationRecordV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public GetDeviceRegistrationRecordV0Parameters(@NonNull final UUID correlationId,
+                                                   @NonNull final String identifier) {
+        super(correlationId);
+        mIdentifier = identifier;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordsV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceRegistrationRecordsV0Parameters.java
@@ -23,16 +23,15 @@
 package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
-
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.experimental.Accessors;
-
 import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegistrationProtocolMoshiSerializer;
 import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-@NoArgsConstructor
+import java.util.UUID;
+
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
 @Accessors(prefix = "m")
 public class GetDeviceRegistrationRecordsV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -46,6 +45,10 @@ public class GetDeviceRegistrationRecordsV0Parameters extends AbstractDeviceRegi
      */
     public static GetDeviceRegistrationRecordsV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public GetDeviceRegistrationRecordsV0Parameters(@NonNull final UUID correlationId) {
+        super(correlationId);
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceTokenV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetDeviceTokenV0Parameters.java
@@ -28,7 +28,6 @@ import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistratio
 import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -37,9 +36,8 @@ import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegi
 import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-@AllArgsConstructor
 @Accessors(prefix = "m")
-public class GetDeviceTokenV0Parameters implements IDeviceRegistrationProtocolParameters {
+public class GetDeviceTokenV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
     private static final IDeviceRegistrationProtocolSerializer<GetDeviceTokenV0Parameters> serializer
             = new DeviceRegistrationProtocolMoshiSerializer<>(GetDeviceTokenV0Parameters.class);
@@ -53,15 +51,23 @@ public class GetDeviceTokenV0Parameters implements IDeviceRegistrationProtocolPa
         return serializer.deserialize(serializedData);
     }
 
+    public GetDeviceTokenV0Parameters(@NonNull final UUID correlationId,
+                                     @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord,
+                                     @NonNull final String resources,
+                                     @Nullable final String scope) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
+        mResources = resources;
+        mScope = scope;
+    }
+
     @Getter
     @NonNull
     private final IDeviceRegistrationRecord mDeviceRegistrationRecord;
     @Getter
     @NonNull
     private final String mResources;
-    @Getter
-    @NonNull
-    private final UUID mCorrelationId;
+
     @Getter
     @Nullable
     private final String mScope;

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetInstallWpjCertificateIntentRequestV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetInstallWpjCertificateIntentRequestV0Parameters.java
@@ -25,7 +25,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -37,7 +38,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 /**
  * Implements a protocol parameters to install a certificate
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class GetInstallWpjCertificateIntentRequestV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -51,6 +51,12 @@ public class GetInstallWpjCertificateIntentRequestV0Parameters extends AbstractD
      */
     public static GetInstallWpjCertificateIntentRequestV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public GetInstallWpjCertificateIntentRequestV0Parameters(@NonNull final UUID correlationId,
+                                                             @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetRegistrationStateV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/GetRegistrationStateV0Parameters.java
@@ -25,7 +25,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -34,7 +35,6 @@ import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegi
 import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class GetRegistrationStateV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -48,6 +48,12 @@ public class GetRegistrationStateV0Parameters extends AbstractDeviceRegistration
      */
     public static GetRegistrationStateV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public GetRegistrationStateV0Parameters(@NonNull final UUID correlationId,
+                                            @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/InstallCertificateSilentlyV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/InstallCertificateSilentlyV0Parameters.java
@@ -25,7 +25,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -37,7 +38,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 /**
  * Implements a protocol parameters to install a certificate silently
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class InstallCertificateSilentlyV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -51,6 +51,12 @@ public class InstallCertificateSilentlyV0Parameters extends AbstractDeviceRegist
      */
     public static InstallCertificateSilentlyV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public InstallCertificateSilentlyV0Parameters(@NonNull final UUID correlationId,
+                                                  @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/PreProvisionedBlobV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/PreProvisionedBlobV0Parameters.java
@@ -24,7 +24,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -33,7 +34,6 @@ import com.microsoft.identity.deviceregistration.java.protocol.packer.DeviceRegi
 import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceRegistrationProtocolSerializer;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class PreProvisionedBlobV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -47,6 +47,12 @@ public class PreProvisionedBlobV0Parameters extends AbstractDeviceRegistrationPr
      */
     public static PreProvisionedBlobV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public PreProvisionedBlobV0Parameters(@NonNull final UUID correlationId,
+                                          @NonNull final String tenantId) {
+        super(correlationId);
+        mTenantId = tenantId;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/ProvisionResourceAccountV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/ProvisionResourceAccountV0Parameters.java
@@ -24,7 +24,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -36,7 +37,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 /**
  * Implements a protocol parameters for provisioning a resource account.
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class ProvisionResourceAccountV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -50,6 +50,14 @@ public class ProvisionResourceAccountV0Parameters extends AbstractDeviceRegistra
      */
     public static ProvisionResourceAccountV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public ProvisionResourceAccountV0Parameters(@NonNull final UUID correlationId,
+                                                @NonNull final String tenantId,
+                                                @NonNull final String raObjectId) {
+        super(correlationId);
+        mTenantId = tenantId;
+        mRaObjectId = raObjectId;
     }
 
     @Getter

--- a/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/UnregisterDeviceV0Parameters.java
+++ b/common4j/src/main/com/microsoft/identity/deviceregistration/java/protocol/parameters/UnregisterDeviceV0Parameters.java
@@ -25,7 +25,8 @@ package com.microsoft.identity.deviceregistration.java.protocol.parameters;
 import com.microsoft.identity.deviceregistration.java.api.IDeviceRegistrationRecord;
 import com.microsoft.identity.deviceregistration.java.protocol.DeviceRegistrationProtocolConstants;
 
-import lombok.AllArgsConstructor;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -37,7 +38,6 @@ import com.microsoft.identity.common.java.exception.ClientException;
 /**
  * Implements a protocol parameters to unregister.
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class UnregisterDeviceV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -51,6 +51,12 @@ public class UnregisterDeviceV0Parameters extends AbstractDeviceRegistrationProt
      */
     public static UnregisterDeviceV0Parameters create(final byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public UnregisterDeviceV0Parameters(@NonNull final UUID correlationId,
+                                        @NonNull final IDeviceRegistrationRecord deviceRegistrationRecord) {
+        super(correlationId);
+        mDeviceRegistrationRecord = deviceRegistrationRecord;
     }
 
     @Getter

--- a/common4j/src/test/com/microsoft/identity/deviceregistration/java/packer/DeviceRegistrationProtocolSerializerParameterizedTest.java
+++ b/common4j/src/test/com/microsoft/identity/deviceregistration/java/packer/DeviceRegistrationProtocolSerializerParameterizedTest.java
@@ -37,6 +37,7 @@ import org.junit.runners.Parameterized;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import lombok.SneakyThrows;
 
@@ -60,6 +61,7 @@ public class DeviceRegistrationProtocolSerializerParameterizedTest {
 
 
     private static final TestHappyPathV0Parameters TEST_PROTOCOL = new TestHappyPathV0Parameters(
+            UUID.randomUUID(),
             TEST_STRING_1,
             TEST_STRING_2,
             true,

--- a/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Parameters.java
+++ b/common4j/src/testFixtures/java/com/microsoft/identity/deviceregistration/testprotocols/TestHappyPathV0Parameters.java
@@ -28,15 +28,15 @@ import com.microsoft.identity.deviceregistration.java.protocol.packer.IDeviceReg
 import com.microsoft.identity.deviceregistration.java.protocol.parameters.AbstractDeviceRegistrationProtocolParameters;
 import com.microsoft.identity.common.java.exception.ClientException;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
+import java.util.UUID;
+
 /**
  * Implements a protocol parameters, for testing.
  */
-@AllArgsConstructor
 @Accessors(prefix = "m")
 public class TestHappyPathV0Parameters extends AbstractDeviceRegistrationProtocolParameters {
 
@@ -50,6 +50,27 @@ public class TestHappyPathV0Parameters extends AbstractDeviceRegistrationProtoco
      */
     static public TestHappyPathV0Parameters create(byte[] serializedData) throws ClientException {
         return serializer.deserialize(serializedData);
+    }
+
+    public TestHappyPathV0Parameters(
+            @NonNull final UUID correlationId,
+            @NonNull final String string1,
+            @NonNull final String string2,
+            final boolean boolean1,
+            final boolean boolean2,
+            final float float1,
+            final float float2,
+            @NonNull final IDeviceRegistrationRecord record,
+            @NonNull final IDeviceRegistrationRecord recordWithAccount) {
+        super(correlationId);
+        mString1 = string1;
+        mString2 = string2;
+        mBoolean1 = boolean1;
+        mBoolean2 = boolean2;
+        mFloat1 = float1;
+        mFloat2 = float2;
+        mRecord = record;
+        mRecordWithAccount = recordWithAccount;
     }
 
     @Getter


### PR DESCRIPTION
## Summary
Introduce `DeviceRegistrationClientApplication` as a public API for OneAuth consumers to perform device registration operations via IPC. Add `DeviceState` and `DiscoveryEndpoint` enums in common4j.

## Changes

### common4j
- `DeviceState` enum — `DEVICE_VALID`, `DEVICE_NOT_FOUND`, `DEVICE_DISABLED`, `UNKNOWN` with `fromString()` factory
- `DiscoveryEndpoint` enum — `PROD`, `PPE`, `INT` with `fromString()` factory
- `AbstractDeviceRegistrationProtocolParameters` — removed no-arg constructor, added `(UUID correlationId)` constructor. All V0 param subclasses updated with explicit `(correlationId, ...fields)` constructors, `@AllArgsConstructor` removed.
- `TestHappyPathV0Parameters` (testFixtures) — updated constructor for correlationId

### common (Android)
- `DeviceRegistrationClientApplication` — new public API with two constructors:
  - Simple: `(Context)` — creates defaults for OneAuth consumers
  - Full: `(Context, IPlatformComponents, IBrokerDiscoveryClient, DeviceRegistrationIpcStrategiesProvider)` — for broker/testing
- All methods require mandatory `correlationId: UUID` for IPC request tracing
- `correlationId` passed to V0 protocol parameters via constructor

### Tests
- `DeviceRegistrationClientApplicationTest` (7 tests) — getPreProvisionedBlob, getRegistrationState (valid + unknown), getDeviceRegistrationRecord (found + null), getAllEntries, correlationId propagation
- Updated serializer and packer tests for new constructor signatures

## Companion PR
Broker: https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/144

Fixes [AB#3450073](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3450073)