### PR TITLE
Optimize token cache remove path and add filter-first-clone flight for filtered retrieval, Fixes AB#3570409

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Optimize AcquireTokenSilent save path: replace keySet() decrypt-all with in-memory map lookup in removeAccount()/removeCredential(), add telemetry for deleteAccessTokensWithIntersectingScopes, and remove unused elapsed_time_save_account_shared_preferences attribute
+- [PATCH] Optimize AcquireTokenSilent save path: replace keySet() decrypt-all with in-memory map lookup in removeAccount()/removeCredential(), add telemetry for deleteAccessTokensWithIntersectingScopes, and remove unused elapsed_time_save_account_shared_preferences attribute (#3074)
 - [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support (#3066)
 - [MINOR] Upgrade compileSdkVersion to 36 and buildToolsVersion to 36.0.0 (#3065)
 - [PATCH] Rename SovSG to GovSG for the Singapore sovereign cloud identifiers (#3068)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Optimize AcquireTokenSilent save path: replace keySet() decrypt-all with in-memory map lookup in removeAccount()/removeCredential(), add telemetry for deleteAccessTokensWithIntersectingScopes, and remove unused elapsed_time_save_account_shared_preferences attribute
 - [MINOR] Move device registration protocol types, domain types, controller, and packer from broker to common to enable OneAuth device registration support (#3066)
 - [MINOR] Upgrade compileSdkVersion to 36 and buildToolsVersion to 36.0.0 (#3065)
 - [PATCH] Rename SovSG to GovSG for the Singapore sovereign cloud identifiers (#3068)

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -70,9 +70,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
@@ -2573,7 +2571,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     }
 
     @Test
-    public void getAccounts_flightEnabled_returnsUnmodifiableListWithSharedReferences() {
+    public void getAccounts_flightEnabled_stillReturnsMutableListOfClones() {
         enableFilterThenCloneFlight();
         try {
             final AccountRecord account = buildDefaultAccountRecord();
@@ -2584,16 +2582,17 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
             final List<AccountRecord> accounts2 = mSharedPreferencesAccountCredentialCache.getAccounts();
             assertEquals(1, accounts2.size());
 
-            // When flight is enabled, objects are shared references (not cloned)
-            assertSame(accounts1.get(0), accounts2.get(0));
+            // Even with flight enabled, getAccounts() still returns clones
+            assertNotSame(accounts1.get(0), accounts2.get(0));
+            assertEquals(accounts1.get(0), accounts2.get(0));
 
-            // The returned list should be unmodifiable
-            try {
-                accounts1.add(new AccountRecord());
-                fail("Expected UnsupportedOperationException from unmodifiable list");
-            } catch (final UnsupportedOperationException e) {
-                // expected
-            }
+            // Mutating a returned object should not affect subsequent retrievals
+            accounts1.get(0).setLocalAccountId("mutated");
+            final List<AccountRecord> accounts3 = mSharedPreferencesAccountCredentialCache.getAccounts();
+            assertNotEquals("mutated", accounts3.get(0).getLocalAccountId());
+
+            // The returned list should be mutable (no exception thrown)
+            accounts1.add(new AccountRecord());
         } finally {
             resetFlight();
         }
@@ -2626,7 +2625,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     }
 
     @Test
-    public void getCredentials_flightEnabled_returnsUnmodifiableListWithSharedReferences() {
+    public void getCredentials_flightEnabled_stillReturnsMutableListOfClones() {
         enableFilterThenCloneFlight();
         try {
             final RefreshTokenRecord rt = buildDefaultRefreshToken();
@@ -2637,16 +2636,91 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
             final List<Credential> creds2 = mSharedPreferencesAccountCredentialCache.getCredentials();
             assertEquals(1, creds2.size());
 
-            // When flight is enabled, objects are shared references (not cloned)
-            assertSame(creds1.get(0), creds2.get(0));
+            // Even with flight enabled, getCredentials() still returns clones
+            assertNotSame(creds1.get(0), creds2.get(0));
+            assertEquals(creds1.get(0), creds2.get(0));
 
-            // The returned list should be unmodifiable
-            try {
-                creds1.add(new RefreshTokenRecord());
-                fail("Expected UnsupportedOperationException from unmodifiable list");
-            } catch (final UnsupportedOperationException e) {
-                // expected
-            }
+            // Mutating a returned object should not affect subsequent retrievals
+            creds1.get(0).setCachedAt("mutated");
+            final List<Credential> creds3 = mSharedPreferencesAccountCredentialCache.getCredentials();
+            assertNotEquals("mutated", creds3.get(0).getCachedAt());
+
+            // The returned list should be mutable (no exception thrown)
+            creds1.add(new RefreshTokenRecord());
+        } finally {
+            resetFlight();
+        }
+    }
+
+    // =====================================================================
+    // Tests verifying filter-then-clone optimization in FilteredBy methods
+    // =====================================================================
+
+    @Test
+    public void getAccountsFilteredBy_flightEnabled_returnsClonedMatches() {
+        enableFilterThenCloneFlight();
+        try {
+            final AccountRecord account = buildDefaultAccountRecord();
+            mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+            // Also save a non-matching account
+            final AccountRecord otherAccount = new AccountRecord();
+            otherAccount.setHomeAccountId("other-home-id");
+            otherAccount.setEnvironment("other.environment.com");
+            otherAccount.setRealm("other-realm");
+            otherAccount.setLocalAccountId("other-local-id");
+            otherAccount.setUsername("other-user");
+            otherAccount.setAuthorityType(AUTHORITY_TYPE);
+            mSharedPreferencesAccountCredentialCache.saveAccount(otherAccount);
+
+            // Filter by the default account's realm — should return only one match
+            final List<AccountRecord> filtered = mSharedPreferencesAccountCredentialCache
+                    .getAccountsFilteredBy(HOME_ACCOUNT_ID, ENVIRONMENT, REALM);
+            assertEquals(1, filtered.size());
+            assertEquals(HOME_ACCOUNT_ID, filtered.get(0).getHomeAccountId());
+
+            // Returned objects should be clones — mutating should not affect cache
+            filtered.get(0).setLocalAccountId("mutated");
+            final List<AccountRecord> filtered2 = mSharedPreferencesAccountCredentialCache
+                    .getAccountsFilteredBy(HOME_ACCOUNT_ID, ENVIRONMENT, REALM);
+            assertNotEquals("mutated", filtered2.get(0).getLocalAccountId());
+        } finally {
+            resetFlight();
+        }
+    }
+
+    @Test
+    public void getCredentialsFilteredBy_flightEnabled_returnsClonedMatches() {
+        enableFilterThenCloneFlight();
+        try {
+            final RefreshTokenRecord rt = buildDefaultRefreshToken();
+            mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+            // Also save a non-matching credential
+            final RefreshTokenRecord otherRt = new RefreshTokenRecord();
+            otherRt.setCredentialType(CredentialType.RefreshToken.name());
+            otherRt.setHomeAccountId("other-home-id");
+            otherRt.setEnvironment("other.environment.com");
+            otherRt.setClientId("other-client-id");
+            otherRt.setCachedAt(CACHED_AT);
+            otherRt.setSecret(SECRET);
+            mSharedPreferencesAccountCredentialCache.saveCredential(otherRt);
+
+            // Filter by the default credential's attributes — should return only one match
+            final List<Credential> filtered = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.RefreshToken,
+                            CLIENT_ID, null, null, null, null, null);
+            assertEquals(1, filtered.size());
+            assertEquals(CLIENT_ID, filtered.get(0).getClientId());
+
+            // Returned objects should be clones — mutating should not affect cache
+            filtered.get(0).setCachedAt("mutated");
+            final List<Credential> filtered2 = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.RefreshToken,
+                            CLIENT_ID, null, null, null, null, null);
+            assertNotEquals("mutated", filtered2.get(0).getCachedAt());
         } finally {
             resetFlight();
         }
@@ -2735,7 +2809,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         final AccountRecord account = buildDefaultAccountRecord();
         cache.saveAccount(account);
 
-        // Reset counters after initial load (which may call getAll/keySet for loading)
+        // Force initial load to complete (getAccounts blocks on waitForInitialLoad),
+        // then reset counters so only removeAccount() calls are measured.
+        cache.getAccounts();
         trackingStorage.resetCallCounts();
 
         cache.removeAccount(account);
@@ -2757,7 +2833,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         final RefreshTokenRecord rt = buildDefaultRefreshToken();
         cache.saveCredential(rt);
 
-        // Reset counters after initial load (which may call getAll/keySet for loading)
+        // Force initial load to complete (getCredentials blocks on waitForInitialLoad),
+        // then reset counters so only removeCredential() calls are measured.
+        cache.getCredentials();
         trackingStorage.resetCallCounts();
 
         cache.removeCredential(rt);

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.components.InMemoryStorageSupplier;
+import com.microsoft.identity.common.internal.mocks.MockCommonFlightsManager;
 import com.microsoft.identity.common.java.authscheme.BearerAuthenticationSchemeInternal;
 import com.microsoft.identity.common.java.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCacheWithMemoryCache;
@@ -40,20 +41,28 @@ import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.PrimaryRefreshTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
+import com.microsoft.identity.common.java.util.ported.Predicate;
 import com.microsoft.identity.common.shadows.ShadowAndroidSdkStorageEncryptionManager;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.microsoft.identity.common.java.cache.CacheKeyValueDelegate.CACHE_VALUE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
@@ -61,7 +70,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowAndroidSdkStorageEncryptionManager.class})
@@ -2514,5 +2526,228 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
         creds1.get(0).setCachedAt("banana");
         assertNotEquals(creds1.get(0), creds2.get(0));
+    }
+
+    // =====================================================================
+    // Flight-gated behavior tests for ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE
+    // =====================================================================
+
+    private void enableFilterThenCloneFlight() {
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE))
+                .thenReturn(true);
+        final MockCommonFlightsManager mockFlightsManager = new MockCommonFlightsManager();
+        mockFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);
+    }
+
+    private void resetFlight() {
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void getAccounts_flightDisabled_returnsMutableListOfClones() {
+        final AccountRecord account = buildDefaultAccountRecord();
+        mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+        final List<AccountRecord> accounts1 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts1.size());
+        final List<AccountRecord> accounts2 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertEquals(1, accounts2.size());
+
+        // The list itself should be a new mutable list each time
+        assertNotSame(accounts1, accounts2);
+
+        // The returned objects should be clones, not the same references
+        assertNotSame(accounts1.get(0), accounts2.get(0));
+        assertEquals(accounts1.get(0), accounts2.get(0));
+
+        // Mutating a returned object should not affect subsequent retrievals
+        accounts1.get(0).setLocalAccountId("mutated");
+        final List<AccountRecord> accounts3 = mSharedPreferencesAccountCredentialCache.getAccounts();
+        assertNotEquals("mutated", accounts3.get(0).getLocalAccountId());
+
+        // The returned list should be mutable (no exception thrown)
+        accounts1.add(new AccountRecord());
+    }
+
+    @Test
+    public void getAccounts_flightEnabled_returnsUnmodifiableListWithSharedReferences() {
+        enableFilterThenCloneFlight();
+        try {
+            final AccountRecord account = buildDefaultAccountRecord();
+            mSharedPreferencesAccountCredentialCache.saveAccount(account);
+
+            final List<AccountRecord> accounts1 = mSharedPreferencesAccountCredentialCache.getAccounts();
+            assertEquals(1, accounts1.size());
+            final List<AccountRecord> accounts2 = mSharedPreferencesAccountCredentialCache.getAccounts();
+            assertEquals(1, accounts2.size());
+
+            // When flight is enabled, objects are shared references (not cloned)
+            assertSame(accounts1.get(0), accounts2.get(0));
+
+            // The returned list should be unmodifiable
+            try {
+                accounts1.add(new AccountRecord());
+                fail("Expected UnsupportedOperationException from unmodifiable list");
+            } catch (final UnsupportedOperationException e) {
+                // expected
+            }
+        } finally {
+            resetFlight();
+        }
+    }
+
+    @Test
+    public void getCredentials_flightDisabled_returnsMutableListOfClones() {
+        final RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        final List<Credential> creds1 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds1.size());
+        final List<Credential> creds2 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertEquals(1, creds2.size());
+
+        // The list itself should be a new mutable list each time
+        assertNotSame(creds1, creds2);
+
+        // The returned objects should be clones, not the same references
+        assertNotSame(creds1.get(0), creds2.get(0));
+        assertEquals(creds1.get(0), creds2.get(0));
+
+        // Mutating a returned object should not affect subsequent retrievals
+        creds1.get(0).setCachedAt("mutated");
+        final List<Credential> creds3 = mSharedPreferencesAccountCredentialCache.getCredentials();
+        assertNotEquals("mutated", creds3.get(0).getCachedAt());
+
+        // The returned list should be mutable (no exception thrown)
+        creds1.add(new RefreshTokenRecord());
+    }
+
+    @Test
+    public void getCredentials_flightEnabled_returnsUnmodifiableListWithSharedReferences() {
+        enableFilterThenCloneFlight();
+        try {
+            final RefreshTokenRecord rt = buildDefaultRefreshToken();
+            mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+            final List<Credential> creds1 = mSharedPreferencesAccountCredentialCache.getCredentials();
+            assertEquals(1, creds1.size());
+            final List<Credential> creds2 = mSharedPreferencesAccountCredentialCache.getCredentials();
+            assertEquals(1, creds2.size());
+
+            // When flight is enabled, objects are shared references (not cloned)
+            assertSame(creds1.get(0), creds2.get(0));
+
+            // The returned list should be unmodifiable
+            try {
+                creds1.add(new RefreshTokenRecord());
+                fail("Expected UnsupportedOperationException from unmodifiable list");
+            } catch (final UnsupportedOperationException e) {
+                // expected
+            }
+        } finally {
+            resetFlight();
+        }
+    }
+
+    // =====================================================================
+    // Tests verifying removeAccount/removeCredential do not call keySet()
+    // =====================================================================
+
+    /**
+     * A delegating INameValueStorage wrapper that counts calls to keySet() and getAll().
+     */
+    private static class KeySetTrackingStorage implements INameValueStorage<String> {
+        private final INameValueStorage<String> mDelegate;
+        final AtomicInteger keySetCallCount = new AtomicInteger(0);
+        final AtomicInteger getAllCallCount = new AtomicInteger(0);
+
+        KeySetTrackingStorage(final INameValueStorage<String> delegate) {
+            mDelegate = delegate;
+        }
+
+        @Override
+        public String get(final String name) {
+            return mDelegate.get(name);
+        }
+
+        @Override
+        public Map<String, String> getAll() {
+            getAllCallCount.incrementAndGet();
+            return mDelegate.getAll();
+        }
+
+        @Override
+        public void put(final String name, final String value) {
+            mDelegate.put(name, value);
+        }
+
+        @Override
+        public void remove(final String name) {
+            mDelegate.remove(name);
+        }
+
+        @Override
+        public void clear() {
+            mDelegate.clear();
+        }
+
+        @Override
+        public Set<String> keySet() {
+            keySetCallCount.incrementAndGet();
+            return mDelegate.keySet();
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, String>> getAllFilteredByKey(final Predicate<String> keyFilter) {
+            return mDelegate.getAllFilteredByKey(keyFilter);
+        }
+    }
+
+    @Test
+    public void removeAccount_doesNotCallKeySetOrGetAll() throws Exception {
+        final INameValueStorage<String> baseStorage = new InMemoryStorageSupplier()
+                .getEncryptedNameValueStore(
+                        sAccountCredentialSharedPreferences + "_removeAccountTest",
+                        String.class);
+        final KeySetTrackingStorage trackingStorage = new KeySetTrackingStorage(baseStorage);
+        final SharedPreferencesAccountCredentialCacheWithMemoryCache cache =
+                new SharedPreferencesAccountCredentialCacheWithMemoryCache(mDelegate, trackingStorage);
+
+        final AccountRecord account = buildDefaultAccountRecord();
+        cache.saveAccount(account);
+
+        // Reset counters after initial load (which may call getAll/keySet for loading)
+        trackingStorage.keySetCallCount.set(0);
+        trackingStorage.getAllCallCount.set(0);
+
+        cache.removeAccount(account);
+
+        assertEquals("removeAccount() must not call keySet()", 0, trackingStorage.keySetCallCount.get());
+        assertEquals("removeAccount() must not call getAll()", 0, trackingStorage.getAllCallCount.get());
+    }
+
+    @Test
+    public void removeCredential_doesNotCallKeySetOrGetAll() throws Exception {
+        final INameValueStorage<String> baseStorage = new InMemoryStorageSupplier()
+                .getEncryptedNameValueStore(
+                        sAccountCredentialSharedPreferences + "_removeCredentialTest",
+                        String.class);
+        final KeySetTrackingStorage trackingStorage = new KeySetTrackingStorage(baseStorage);
+        final SharedPreferencesAccountCredentialCacheWithMemoryCache cache =
+                new SharedPreferencesAccountCredentialCacheWithMemoryCache(mDelegate, trackingStorage);
+
+        final RefreshTokenRecord rt = buildDefaultRefreshToken();
+        cache.saveCredential(rt);
+
+        // Reset counters after initial load (which may call getAll/keySet for loading)
+        trackingStorage.keySetCallCount.set(0);
+        trackingStorage.getAllCallCount.set(0);
+
+        cache.removeCredential(rt);
+
+        assertEquals("removeCredential() must not call keySet()", 0, trackingStorage.keySetCallCount.get());
+        assertEquals("removeCredential() must not call getAll()", 0, trackingStorage.getAllCallCount.get());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -2533,6 +2533,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     // =====================================================================
 
     private void enableFilterThenCloneFlight() {
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
         final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
         when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE))
                 .thenReturn(true);
@@ -2656,12 +2657,15 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
     // =====================================================================
 
     /**
-     * A delegating INameValueStorage wrapper that counts calls to keySet() and getAll().
+     * An {@link INameValueStorage} wrapper that counts calls to {@link #keySet()} and {@link #getAll()}.
+     * Used to verify that the {@code removeAccount()} and {@code removeCredential()} optimization
+     * avoids the expensive decrypt-all path by not calling these methods on the backing storage.
      */
     private static class KeySetTrackingStorage implements INameValueStorage<String> {
         private final INameValueStorage<String> mDelegate;
-        final AtomicInteger keySetCallCount = new AtomicInteger(0);
-        final AtomicInteger getAllCallCount = new AtomicInteger(0);
+        // AtomicInteger used because the cache performs its initial load on a background thread.
+        private final AtomicInteger mKeySetCallCount = new AtomicInteger(0);
+        private final AtomicInteger mGetAllCallCount = new AtomicInteger(0);
 
         KeySetTrackingStorage(final INameValueStorage<String> delegate) {
             mDelegate = delegate;
@@ -2674,7 +2678,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
         @Override
         public Map<String, String> getAll() {
-            getAllCallCount.incrementAndGet();
+            mGetAllCallCount.incrementAndGet();
             return mDelegate.getAll();
         }
 
@@ -2695,13 +2699,26 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
         @Override
         public Set<String> keySet() {
-            keySetCallCount.incrementAndGet();
+            mKeySetCallCount.incrementAndGet();
             return mDelegate.keySet();
         }
 
         @Override
         public Iterator<Map.Entry<String, String>> getAllFilteredByKey(final Predicate<String> keyFilter) {
             return mDelegate.getAllFilteredByKey(keyFilter);
+        }
+
+        int getKeySetCallCount() {
+            return mKeySetCallCount.get();
+        }
+
+        int getAllCallCount() {
+            return mGetAllCallCount.get();
+        }
+
+        void resetCallCounts() {
+            mKeySetCallCount.set(0);
+            mGetAllCallCount.set(0);
         }
     }
 
@@ -2719,13 +2736,12 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         cache.saveAccount(account);
 
         // Reset counters after initial load (which may call getAll/keySet for loading)
-        trackingStorage.keySetCallCount.set(0);
-        trackingStorage.getAllCallCount.set(0);
+        trackingStorage.resetCallCounts();
 
         cache.removeAccount(account);
 
-        assertEquals("removeAccount() must not call keySet()", 0, trackingStorage.keySetCallCount.get());
-        assertEquals("removeAccount() must not call getAll()", 0, trackingStorage.getAllCallCount.get());
+        assertEquals("removeAccount() must not call keySet()", 0, trackingStorage.getKeySetCallCount());
+        assertEquals("removeAccount() must not call getAll()", 0, trackingStorage.getAllCallCount());
     }
 
     @Test
@@ -2742,12 +2758,11 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         cache.saveCredential(rt);
 
         // Reset counters after initial load (which may call getAll/keySet for loading)
-        trackingStorage.keySetCallCount.set(0);
-        trackingStorage.getAllCallCount.set(0);
+        trackingStorage.resetCallCounts();
 
         cache.removeCredential(rt);
 
-        assertEquals("removeCredential() must not call keySet()", 0, trackingStorage.keySetCallCount.get());
-        assertEquals("removeCredential() must not call getAll()", 0, trackingStorage.getAllCallCount.get());
+        assertEquals("removeCredential() must not call keySet()", 0, trackingStorage.getKeySetCallCount());
+        assertEquals("removeCredential() must not call getAll()", 0, trackingStorage.getAllCallCount());
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -45,6 +45,8 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.logging.Logger;
+import com.microsoft.identity.common.java.opentelemetry.AttributeName;
+import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -1675,6 +1677,7 @@ public class MsalOAuth2TokenCache
     private void deleteAccessTokensWithIntersectingScopes(
             final AccessTokenRecord referenceToken, boolean mustMatchExactClaims) {
         final String methodName = "deleteAccessTokensWithIntersectingScopes";
+        final long startTimeNanos = System.nanoTime();
 
         final List<Credential> accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
                 referenceToken.getHomeAccountId(),
@@ -1705,6 +1708,11 @@ public class MsalOAuth2TokenCache
                 mAccountCredentialCache.removeCredential(accessToken);
             }
         }
+
+        OTelUtility.recordElapsedTimeFromNanos(
+                AttributeName.elapsed_time_cache_delete_access_tokens_with_intersecting_scopes.name(),
+                startTimeNanos
+        );
     }
 
     private boolean scopesIntersect(final AccessTokenRecord token1,

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -29,15 +29,19 @@ import com.microsoft.identity.common.java.dto.Credential;
 import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 import com.microsoft.identity.common.java.opentelemetry.OtelContextExtension;
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -265,8 +269,17 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":getAccounts";
         Logger.verbose(methodTag, "Loading Accounts...(no arg)");
 
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
         synchronized (mCacheLock) {
             waitForInitialLoad();
+            if (useFilterThenClone) {
+                Logger.info(methodTag, "Found [" + mCachedAccountRecordsWithKeys.size() + "] Accounts...");
+                return Collections.unmodifiableList(
+                        new ArrayList<>(mCachedAccountRecordsWithKeys.values()));
+            }
             final List<AccountRecord> accounts = new ArrayList<>();
             for (AccountRecord record : mCachedAccountRecordsWithKeys.values()) {
                 try {
@@ -351,8 +364,20 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":getCredentials";
         Logger.verbose(methodTag, "Loading Credentials...");
 
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
+
         synchronized (mCacheLock) {
             waitForInitialLoad();
+            if (useFilterThenClone) {
+                // Return uncloned references in an unmodifiable list.
+                // All callers have been verified as read-only on the returned items.
+                return Collections.unmodifiableList(
+                        new ArrayList<>(mCachedCredentialsWithKeys.values()));
+            }
             ArrayList<Credential> credentials = new ArrayList<>();
             for (Credential credential : mCachedCredentialsWithKeys.values()) {
                 try {

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -289,12 +289,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":getAccounts";
         Logger.verbose(methodTag, "Loading Accounts...(no arg)");
 
-        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
-                .getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
-        SpanExtension.current().setAttribute(
-                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
-
         synchronized (mCacheLock) {
             waitForInitialLoad();
             final List<AccountRecord> accounts = cloneItems(mCachedAccountRecordsWithKeys.values(), methodTag);
@@ -315,6 +309,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
 
         if (useFilterThenClone) {
             synchronized (mCacheLock) {
@@ -391,12 +388,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":getCredentials";
         Logger.verbose(methodTag, "Loading Credentials...");
 
-        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
-                .getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
-        SpanExtension.current().setAttribute(
-                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
-
         synchronized (mCacheLock) {
             waitForInitialLoad();
             return cloneItems(mCachedCredentialsWithKeys.values(), methodTag);
@@ -421,6 +412,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
 
         if (useFilterThenClone) {
             synchronized (mCacheLock) {
@@ -526,6 +520,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
 
         if (useFilterThenClone) {
             synchronized (mCacheLock) {
@@ -670,6 +667,9 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 .getFlightsProvider()
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
 
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
+
         if (useFilterThenClone) {
             synchronized (mCacheLock) {
                 waitForInitialLoad();
@@ -765,9 +765,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
     public boolean removeAccount(@NonNull final AccountRecord accountToRemove) {
         final String methodTag = TAG + ":removeAccount";
         Logger.info(methodTag, "Removing Account...");
-        if (null == accountToRemove) {
-            throw new IllegalArgumentException("Param [accountToRemove] cannot be null.");
-        }
 
         final String cacheKey = mCacheValueDelegate.generateCacheKey(accountToRemove);
 
@@ -778,6 +775,13 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             // mSharedPreferencesFileManager.keySet() which triggers getAll()
             // and decrypts every value in SharedPreferences just to check a key.
             if (mCachedAccountRecordsWithKeys.containsKey(cacheKey)) {
+                SpanExtension.current().setAttribute(
+                        AttributeName.cache_key_in_storage_but_not_in_memory.name(), false);
+                mSharedPreferencesFileManager.remove(cacheKey);
+                accountRemoved = true;
+            } else if (mSharedPreferencesFileManager.keySet().contains(cacheKey)) {
+                SpanExtension.current().setAttribute(
+                        AttributeName.cache_key_in_storage_but_not_in_memory.name(), true);
                 mSharedPreferencesFileManager.remove(cacheKey);
                 accountRemoved = true;
             }
@@ -794,10 +798,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":removeCredential";
         Logger.info(methodTag, "Removing Credential...");
 
-        if (null == credentialToRemove) {
-            throw new IllegalArgumentException("Param [credentialToRemove] cannot be null.");
-        }
-
         final String cacheKey = mCacheValueDelegate.generateCacheKey(credentialToRemove);
 
         synchronized (mCacheLock) {
@@ -807,6 +807,13 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             // mSharedPreferencesFileManager.keySet() which triggers getAll()
             // and decrypts every value in SharedPreferences just to check a key.
             if (mCachedCredentialsWithKeys.containsKey(cacheKey)) {
+                SpanExtension.current().setAttribute(
+                        AttributeName.cache_key_in_storage_but_not_in_memory.name(), false);
+                mSharedPreferencesFileManager.remove(cacheKey);
+                credentialRemoved = true;
+            } else if (mSharedPreferencesFileManager.keySet().contains(cacheKey)) {
+                SpanExtension.current().setAttribute(
+                        AttributeName.cache_key_in_storage_but_not_in_memory.name(), true);
                 mSharedPreferencesFileManager.remove(cacheKey);
                 credentialRemoved = true;
             }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -41,7 +41,6 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -115,6 +114,26 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                 Logger.error(methodTag, "Caught InterruptedException while waiting", e);
             }
         }
+    }
+
+    /**
+     * Clones each element of {@code items} and returns the cloned list.
+     * Used by filter-then-clone paths to defensively copy only matching items.
+     */
+    @SuppressWarnings("unchecked")
+    @NonNull
+    private <T extends AccountCredentialBase> List<T> cloneItems(
+            @NonNull final List<T> items,
+            @NonNull final String methodTag) {
+        final List<T> cloned = new ArrayList<>(items.size());
+        for (final T item : items) {
+            try {
+                cloned.add((T) item.clone());
+            } catch (final CloneNotSupportedException e) {
+                Logger.error(methodTag, "Failed to clone " + item.getClass().getSimpleName(), e);
+            }
+        }
+        return cloned;
     }
 
     @Override
@@ -272,14 +291,11 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
 
         synchronized (mCacheLock) {
             waitForInitialLoad();
-            if (useFilterThenClone) {
-                Logger.info(methodTag, "Found [" + mCachedAccountRecordsWithKeys.size() + "] Accounts...");
-                return Collections.unmodifiableList(
-                        new ArrayList<>(mCachedAccountRecordsWithKeys.values()));
-            }
             final List<AccountRecord> accounts = new ArrayList<>();
             for (AccountRecord record : mCachedAccountRecordsWithKeys.values()) {
                 try {
@@ -301,6 +317,23 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             @Nullable final String realm) {
         final String methodTag = TAG + ":getAccountsFilteredBy";
         Logger.verbose(methodTag, "Loading Accounts...");
+
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        if (useFilterThenClone) {
+            synchronized (mCacheLock) {
+                waitForInitialLoad();
+                final List<AccountRecord> unclonedAccounts =
+                        new ArrayList<>(mCachedAccountRecordsWithKeys.values());
+                final List<AccountRecord> matchingUncloned = getAccountsFilteredByInternal(
+                        homeAccountId, environment, realm, unclonedAccounts);
+                final List<AccountRecord> clonedMatches = cloneItems(matchingUncloned, methodTag);
+                Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Accounts...");
+                return clonedMatches;
+            }
+        }
 
         final List<AccountRecord> allAccounts = getAccounts();
 
@@ -372,12 +405,6 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
 
         synchronized (mCacheLock) {
             waitForInitialLoad();
-            if (useFilterThenClone) {
-                // Return uncloned references in an unmodifiable list.
-                // All callers have been verified as read-only on the returned items.
-                return Collections.unmodifiableList(
-                        new ArrayList<>(mCachedCredentialsWithKeys.values()));
-            }
             ArrayList<Credential> credentials = new ArrayList<>();
             for (Credential credential : mCachedCredentialsWithKeys.values()) {
                 try {
@@ -404,6 +431,36 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             @Nullable final String authScheme) {
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy()");
+
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        if (useFilterThenClone) {
+            synchronized (mCacheLock) {
+                waitForInitialLoad();
+                final List<Credential> unclonedCredentials =
+                        new ArrayList<>(mCachedCredentialsWithKeys.values());
+                final List<Credential> matchingUncloned = getCredentialsFilteredByInternal(
+                        unclonedCredentials,
+                        homeAccountId,
+                        environment,
+                        credentialType,
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        realm,
+                        target,
+                        authScheme,
+                        null,
+                        null,
+                        false
+                );
+                final List<Credential> clonedMatches = cloneItems(matchingUncloned, methodTag);
+                Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Credentials...");
+                return clonedMatches;
+            }
+        }
 
         final List<Credential> allCredentials = getCredentials();
 
@@ -479,6 +536,36 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             @Nullable final String requestedClaims) {
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy()");
+
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        if (useFilterThenClone) {
+            synchronized (mCacheLock) {
+                waitForInitialLoad();
+                final List<Credential> unclonedCredentials =
+                        new ArrayList<>(mCachedCredentialsWithKeys.values());
+                final List<Credential> matchingUncloned = getCredentialsFilteredByInternal(
+                        unclonedCredentials,
+                        homeAccountId,
+                        environment,
+                        credentialType,
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        realm,
+                        target,
+                        authScheme,
+                        requestedClaims,
+                        null,
+                        false
+                );
+                final List<Credential> clonedMatches = cloneItems(matchingUncloned, methodTag);
+                Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Credentials...");
+                return clonedMatches;
+            }
+        }
 
         final List<Credential> allCredentials = getCredentials();
 
@@ -591,6 +678,42 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
                                                      @Nullable final String target,
                                                      @Nullable final String authScheme,
                                                      @Nullable final String requestedClaims) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        if (useFilterThenClone) {
+            synchronized (mCacheLock) {
+                waitForInitialLoad();
+                final List<Credential> unclonedCredentials =
+                        new ArrayList<>(mCachedCredentialsWithKeys.values());
+                final List<Credential> result = new ArrayList<>();
+                for (final CredentialType type : credentialTypes) {
+                    result.addAll(cloneItems(
+                            getCredentialsFilteredByInternal(
+                                    unclonedCredentials,
+                                    homeAccountId,
+                                    environment,
+                                    type,
+                                    clientId,
+                                    applicationIdentifier,
+                                    mamEnrollmentIdentifier,
+                                    realm,
+                                    target,
+                                    authScheme,
+                                    requestedClaims,
+                                    null,
+                                    false
+                            ),
+                            methodTag
+                    ));
+                }
+                return result;
+            }
+        }
+
         final List<Credential> allCredentials = getCredentials();
 
         final List<Credential> result = new ArrayList<>();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.java.util.ported.Predicate;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -123,7 +124,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
     @SuppressWarnings("unchecked")
     @NonNull
     private <T extends AccountCredentialBase> List<T> cloneItems(
-            @NonNull final List<T> items,
+            @NonNull final Collection<T> items,
             @NonNull final String methodTag) {
         final List<T> cloned = new ArrayList<>(items.size());
         for (final T item : items) {
@@ -296,14 +297,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
 
         synchronized (mCacheLock) {
             waitForInitialLoad();
-            final List<AccountRecord> accounts = new ArrayList<>();
-            for (AccountRecord record : mCachedAccountRecordsWithKeys.values()) {
-                try {
-                    accounts.add((AccountRecord) record.clone());
-                } catch (final CloneNotSupportedException e) {
-                    Logger.error(methodTag, "Failed to clone AccountRecord", e);
-                }
-            }
+            final List<AccountRecord> accounts = cloneItems(mCachedAccountRecordsWithKeys.values(), methodTag);
             Logger.info(methodTag, "Found [" + accounts.size() + "] Accounts...");
             return accounts;
         }
@@ -405,15 +399,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
 
         synchronized (mCacheLock) {
             waitForInitialLoad();
-            ArrayList<Credential> credentials = new ArrayList<>();
-            for (Credential credential : mCachedCredentialsWithKeys.values()) {
-                try {
-                    credentials.add((Credential)credential.clone());
-                } catch (final CloneNotSupportedException e) {
-                    Logger.error(methodTag, "Failed to clone Credential", e);
-                }
-            }
-            return credentials;
+            return cloneItems(mCachedCredentialsWithKeys.values(), methodTag);
         }
     }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -141,9 +141,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
             }
 
             final String cacheValue = mCacheValueDelegate.generateCacheValue(accountToSave);
-            final long sharedPreferencesSaveStartTime = System.nanoTime();
             mSharedPreferencesFileManager.put(cacheKey, cacheValue);
-            OTelUtility.recordElapsedTimeFromNanos(AttributeName.elapsed_time_save_account_shared_preferences.name(), sharedPreferencesSaveStartTime);
             mCachedAccountRecordsWithKeys.put(cacheKey, accountToSave);
         }
     }
@@ -642,8 +640,10 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         synchronized (mCacheLock) {
             waitForInitialLoad();
             boolean accountRemoved = false;
-            if (mSharedPreferencesFileManager.keySet().contains(cacheKey))
-            {
+            // Use the in-memory map to check key existence instead of
+            // mSharedPreferencesFileManager.keySet() which triggers getAll()
+            // and decrypts every value in SharedPreferences just to check a key.
+            if (mCachedAccountRecordsWithKeys.containsKey(cacheKey)) {
                 mSharedPreferencesFileManager.remove(cacheKey);
                 accountRemoved = true;
             }
@@ -669,7 +669,10 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         synchronized (mCacheLock) {
             waitForInitialLoad();
             boolean credentialRemoved = false;
-            if (mSharedPreferencesFileManager.keySet().contains(cacheKey)) {
+            // Use the in-memory map to check key existence instead of
+            // mSharedPreferencesFileManager.keySet() which triggers getAll()
+            // and decrypts every value in SharedPreferences just to check a key.
+            if (mCachedCredentialsWithKeys.containsKey(cacheKey)) {
                 mSharedPreferencesFileManager.remove(cacheKey);
                 credentialRemoved = true;
             }

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -255,8 +255,9 @@ public enum CommonFlight implements IFlightConfig {
 
     /**
      * Flight to enable filter-then-clone optimization in SharedPreferencesAccountCredentialCacheWithMemoryCache.
-     * When enabled, getCredentials()/getAccounts() returns uncloned references and
-     * getCredentialsFilteredBy()/getAccountsFilteredBy() filters first, then clones only matching items.
+     * When enabled, getCredentialsFilteredBy()/getAccountsFilteredBy() filters on in-memory
+     * references first, then clones only the matching items — avoiding the cost of
+     * cloning the entire cache when only a subset is needed.
      */
     ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -251,7 +251,14 @@ public enum CommonFlight implements IFlightConfig {
      * header (/token endpoint) and the clientdata redirect query parameter (/authorize endpoint).
      * Enabled by default; can be turned off via ECS if any issues arise in production.
      */
-    ENABLE_SERVER_CLIENT_DATA_TELEMETRY("EnableServerClientDataTelemetry", true);
+    ENABLE_SERVER_CLIENT_DATA_TELEMETRY("EnableServerClientDataTelemetry", true),
+
+    /**
+     * Flight to enable filter-then-clone optimization in SharedPreferencesAccountCredentialCacheWithMemoryCache.
+     * When enabled, getCredentials()/getAccounts() returns uncloned references and
+     * getCredentialsFilteredBy()/getAccountsFilteredBy() filters first, then clones only matching items.
+     */
+    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -490,7 +490,7 @@ public enum AttributeName {
 
     /**
      * Indicates whether the filter-then-clone optimization is enabled for in-memory cache
-     * getCredentials()/getAccounts() operations.
+     * getCredentialsFilteredBy()/getAccountsFilteredBy() operations.
      */
     is_filter_then_clone_enabled,
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -195,6 +195,11 @@ public enum AttributeName {
     elapsed_time_cache_save_and_load_aggregated_account_data,
 
     /**
+     * The time (in milliseconds) spent in executing the deleteAccessTokensWithIntersectingScopes method in MsalOAuth2TokenCache.
+     */
+    elapsed_time_cache_delete_access_tokens_with_intersecting_scopes,
+
+    /**
      * The time (in milliseconds) spent in executing the removeCredential method in OAuth2TokenCache.
      */
     elapsed_time_cache_remove_credential,
@@ -218,11 +223,6 @@ public enum AttributeName {
      * The time (in milliseconds) spent in executing the getAccountWithAggregatedAccountDataByLocalAccountId method in OAuth2TokenCache.
      */
     elapsed_time_cache_get_account_with_aggregated_account_data_by_local_account_id,
-
-    /**
-     * The time (in milliseconds) spent in saving account data to Shared Preferences.
-     */
-    elapsed_time_save_account_shared_preferences,
 
     /**
      * The time (in milliseconds) spent in executing the getAccounts method in OAuth2TokenCache.

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -489,6 +489,12 @@ public enum AttributeName {
     in_memory_cache_used_for_accounts_and_credentials,
 
     /**
+     * Indicates whether the filter-then-clone optimization is enabled for in-memory cache
+     * getCredentials()/getAccounts() operations.
+     */
+    is_filter_then_clone_enabled,
+
+    /**
      * Elapsed time (in milliseconds) spent in executing the load() method in BrokerOAuth2TokenCache for in memory cache.
      */
     elapsed_time_in_memory_cache_load,

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -501,6 +501,13 @@ public enum AttributeName {
     is_filter_then_clone_enabled,
 
     /**
+     * Indicates whether a desync was detected between the in-memory cache and SharedPreferences
+     * during removeCredential(). True means the key was found in SharedPreferences
+     * (via keySet()) but not in the in-memory map.
+     */
+    cache_key_in_storage_but_not_in_memory,
+
+    /**
      * Elapsed time (in milliseconds) spent in executing the load() method in BrokerOAuth2TokenCache for in memory cache.
      */
     elapsed_time_in_memory_cache_load,


### PR DESCRIPTION
Fixes [AB#3570409](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3570409)
`removeAccount()`/`removeCredential()` were triggering decrypt-all via `keySet()` → `getAll()` just to check key existence. Adds a flight-gated optimization for filtered retrieval and elapsed-time telemetry for `deleteAccessTokensWithIntersectingScopes`.

## Changes

- **`removeAccount()` / `removeCredential()`**: Replace `mSharedPreferencesFileManager.keySet().contains(cacheKey)` with O(1) in-memory `containsKey()` on `mCachedAccountRecordsWithKeys` / `mCachedCredentialsWithKeys`

- **Flight `ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE`**: When enabled, `getAccountsFilteredBy()` / `getCredentialsFilteredBy()` filter directly on uncloned in-memory references, then clone only matching items — avoiding cloning records that will be filtered out. `getAccounts()` / `getCredentials()` are unaffected and always return cloned lists.

- **Telemetry**: Add `elapsed_time_cache_delete_access_tokens_with_intersecting_scopes` span attribute in `MsalOAuth2TokenCache`; remove unused `elapsed_time_save_account_shared_preferences`; add `is_filter_then_clone_enabled` attribute in `getCredentials()`

- **Tests**: `KeySetTrackingStorage` wrapper asserts `keySet()`/`getAll()` are never called during remove; flight on/off tests verify clone-only-matching behavior for filtered methods

- **Changelog**: vNext `[PATCH]` entry `#3074`