### PR TITLE
Fix TestCase2519809 , Fixes AB#3577207

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
@@ -60,6 +60,10 @@ public class MultipleWpjApiFragment extends AbstractBrokerHost {
     private static final String GET_DEVICE_STATE_BUTTON_ID = "button_mwpj_get_state";
     private static final String GET_DEVICE_TOKEN_BUTTON_ID = "button_mwpj_get_device_token";
     private static final String GET_BLOB_BUTTON_ID = "button_mwpj_get_blob";
+
+    /**
+     * This must matches the message shown when getAllRecords is called but there are no device registration records in BrokerHost app.
+     */
     private static final String NO_DEVICE_REGISTRATION_RECORDS_MESSAGE = "There are no device registration records.";
 
     private final BrokerHost brokerHost;

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
@@ -62,7 +62,7 @@ public class MultipleWpjApiFragment extends AbstractBrokerHost {
     private static final String GET_BLOB_BUTTON_ID = "button_mwpj_get_blob";
 
     /**
-     * This must matches the message shown when getAllRecords is called but there are no device registration records in BrokerHost app.
+     * This must match the message shown when getAllRecords is called but there are no device registration records in BrokerHost app.
      */
     private static final String NO_DEVICE_REGISTRATION_RECORDS_MESSAGE = "There are no device registration records.";
 
@@ -108,7 +108,7 @@ public class MultipleWpjApiFragment extends AbstractBrokerHost {
         final List<Map<String, String>> records = new ArrayList<>();
         clickButton(GET_ALL_RECORDS_BUTTON_ID);
         final String dialogBoxText = dismissDialogBoxAndGetText();
-        if (dialogBoxText.equals(NO_DEVICE_REGISTRATION_RECORDS_MESSAGE)) {
+        if (NO_DEVICE_REGISTRATION_RECORDS_MESSAGE.equals(dialogBoxText)) {
             return records;
         }
         final String dialogBoxTextNoBrackets = dialogBoxText

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/MultipleWpjApiFragment.java
@@ -60,6 +60,7 @@ public class MultipleWpjApiFragment extends AbstractBrokerHost {
     private static final String GET_DEVICE_STATE_BUTTON_ID = "button_mwpj_get_state";
     private static final String GET_DEVICE_TOKEN_BUTTON_ID = "button_mwpj_get_device_token";
     private static final String GET_BLOB_BUTTON_ID = "button_mwpj_get_blob";
+    private static final String NO_DEVICE_REGISTRATION_RECORDS_MESSAGE = "There are no device registration records.";
 
     private final BrokerHost brokerHost;
 
@@ -103,6 +104,9 @@ public class MultipleWpjApiFragment extends AbstractBrokerHost {
         final List<Map<String, String>> records = new ArrayList<>();
         clickButton(GET_ALL_RECORDS_BUTTON_ID);
         final String dialogBoxText = dismissDialogBoxAndGetText();
+        if (dialogBoxText.equals(NO_DEVICE_REGISTRATION_RECORDS_MESSAGE)) {
+            return records;
+        }
         final String dialogBoxTextNoBrackets = dialogBoxText
                 .replace("[", "")
                 .replace("]", "");


### PR DESCRIPTION
Fixes [AB#3577207](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3577207)

The failure is due to change ([Refactor device registration to use protocol types and controller from common, Fixes AB#3512895 by mchand_microsoft · Pull Request #138 · identity-authnz-teams/ad-accounts-for-android](https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/138)) made in BrokerHost app as part of change done to create device registration APIs in common.

In the change I changed showing no device registration records from "[]" to "There are no device registration records."

UI automation expects "[]", hence the test failed.

Fixing it by updating UI test case step to verify the string "There are no device registration records." instead of "[]". This is better than reverting to "[]", given the message is more friendly for manual testing