### PR TITLE
[Hotfix 24.1.1] Fix ABBA deadlock between AzureActiveDirectory and AzureActiveDirectoryAuthority, Fixes AB#3578299

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
-vNext
+Version 24.1.1-RC1
+----------
+- [PATCH] Fix ABBA deadlock between AzureActiveDirectory and AzureActiveDirectoryAuthority class monitors by extracting polymorphic getAuthorityURL() calls outside synchronized scopes and removing unnecessary synchronized from ConcurrentHashMap read-only methods (#3082)
+
+Version 24.1.0
 ----------
 - [MINOR] Add sovereign cloud (Bleu/Delos/SovSG) instance discovery support with pre-seeded cloud metadata, cache-aware discovery routing, and ensureCloudDiscoveryForAuthority API (#3027)
 - [PATCH] Fix bug in Authority.getKnownAuthorityResult where cloud discovery failure would skip knownAuthorities check and fix thread safety in Authority.isKnownAuthority and getEquivalentConfiguredAuthority with synchronized block (#3027)

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -318,40 +318,52 @@ public abstract class Authority {
     }
 
     /**
-     * Authorities are either known by the developer and communicated to the library via configuration or they
-     * are known to Microsoft based on the list of clouds returned from:
+     * Clears all known authorities. For test use only.
+     */
+    // Visible for testing
+    static void clearKnownAuthorities() {
+        synchronized (sLock) {
+            knownAuthorities.clear();
+        }
+    }
+
+    /**
+     * Authorities are either known by the developer and communicated to the library via
+     * configuration, or they are known to Microsoft based on the cloud discovery metadata cache.
      *
      * @param authority Authority to check against.
      * @return True if the authority is known to Microsoft or defined in the configuration.
      */
     public static boolean isKnownAuthority(Authority authority) {
-        final String methodName = ":isKnownAuthority";
+        final String methodTag = TAG + ":isKnownAuthority";
         boolean knownToDeveloper = false;
         boolean knownToMicrosoft;
 
         if (authority == null) {
-            Logger.warn(
-                    TAG + methodName,
-                    "Authority is null"
-            );
+            Logger.warn(methodTag, "Authority is null");
             return false;
         }
 
-        if (BuildConfig.ALLOW_ONEBOX_AUTHORITIES && AzureActiveDirectoryEnvironment.ONEBOX_AUTHORITY.equals(authority.getAuthorityURL().getAuthority())) {
+        // Resolve the authority URL outside any lock to avoid calling a potentially-
+        // synchronized polymorphic method (e.g. AzureActiveDirectoryAuthority.getAuthorityURL())
+        // while holding sLock, which could create a lock-ordering inversion.
+        final URL authorityUrl = authority.getAuthorityURL();
+
+        if (authorityUrl == null) {
+            Logger.warn(methodTag, "Authority URL is null");
+            return false;
+        }
+
+        if (BuildConfig.ALLOW_ONEBOX_AUTHORITIES && AzureActiveDirectoryEnvironment.ONEBOX_AUTHORITY.equals(authorityUrl.getAuthority())) {
             return true; // onebox authorities are always considered to be known.
         }
 
-        //Check if authority was added to configuration
         synchronized (sLock) {
             for (final Authority currentAuthority : knownAuthorities) {
                 if (currentAuthority.mAuthorityUrlString != null &&
-                        authority.getAuthorityURL() != null &&
-                        authority.getAuthorityURL().getAuthority() != null &&
+                        authorityUrl.getAuthority() != null &&
                         currentAuthority.mAuthorityUrlString.toLowerCase(Locale.ROOT).contains(
-                                authority
-                                        .getAuthorityURL()
-                                        .getAuthority()
-                                        .toLowerCase(Locale.ROOT))) {
+                                authorityUrl.getAuthority().toLowerCase(Locale.ROOT))) {
                     knownToDeveloper = true;
                     break;
                 }
@@ -360,19 +372,14 @@ public abstract class Authority {
 
         // Check whether the authority is known to Microsoft or not.  Microsoft can recognize authorities that exist within public clouds.
         // Microsoft does not maintain a list of B2C authorities or a list of ADFS or 3rd party authorities (issuers).
-        knownToMicrosoft = AzureActiveDirectory.hasCloudHost(authority.getAuthorityURL());
+        knownToMicrosoft = AzureActiveDirectory.hasCloudHost(authorityUrl);
 
         final boolean isKnown = (knownToDeveloper || knownToMicrosoft);
 
-        Logger.verbose(
-                TAG + methodName,
-                "Authority is known to developer? [" + knownToDeveloper + "]"
-        );
-
-        Logger.verbose(
-                TAG + methodName,
-                "Authority is known to Microsoft? [" + knownToMicrosoft + "]"
-        );
+        Logger.verbose(methodTag,
+                "Authority is known to developer? [" + knownToDeveloper + "]");
+        Logger.verbose(methodTag,
+                "Authority is known to Microsoft? [" + knownToMicrosoft + "]");
 
         return isKnown;
     }
@@ -383,9 +390,8 @@ public abstract class Authority {
                 methodTag,
                 "Getting known authority result..."
         );
-        ClientException clientException = null;
-        boolean known = false;
 
+        ClientException discoveryException = null;
         try {
             AzureActiveDirectory.ensureCloudDiscoveryForAuthority(authority);
             Logger.info(methodTag, "Cloud discovery complete.");
@@ -393,27 +399,34 @@ public abstract class Authority {
             // Cloud discovery failed (e.g. network error).
             // Log but continue — the authority may still be known via hardcoded
             // metadata or developer configuration.
+            discoveryException = ex;
             Logger.warn(methodTag,
                     "Cloud discovery failed, will check hardcoded/configured authorities. Error: "
                             + ex.getErrorCode());
         }
 
-        if (!isKnownAuthority(authority)) {
-            clientException = new ClientException(
+        if (isKnownAuthority(authority)) {
+            Logger.info(methodTag, "Authority is known.");
+            return new KnownAuthorityResult(true, null);
+        }
+
+        // Authority is not known via any source.
+        if (discoveryException != null) {
+            // Discovery failed — propagate the original error
+            return new KnownAuthorityResult(false, discoveryException);
+        } else {
+            // Discovery succeeded but authority is not in any known list.
+            final ClientException clientException = new ClientException(
                     ClientException.UNKNOWN_AUTHORITY,
                     "Provided authority is not known.  MSAL will only make requests to known authorities"
             );
-        } else {
-            Logger.info(methodTag, "Cloud is known.");
-            known = true;
+            return new KnownAuthorityResult(false, clientException);
         }
-
-        return new KnownAuthorityResult(known, clientException);
     }
 
     public static class KnownAuthorityResult {
-        private boolean mKnown;
-        private ClientException mClientException;
+        private final boolean mKnown;
+        private final ClientException mClientException;
 
         KnownAuthorityResult(boolean known, ClientException exception) {
             mKnown = known;

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/AzureActiveDirectoryAuthority.java
@@ -71,7 +71,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
 
     /** Gets {@link AzureActiveDirectoryCloud}, if the cloud metadata is already initialized. */
     @Nullable
-    private static synchronized AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(
+    private static AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(
             @NonNull final AzureActiveDirectoryAudience audience) {
         final String methodName = ":getAzureActiveDirectoryCloud";
 
@@ -175,7 +175,7 @@ public class AzureActiveDirectoryAuthority extends Authority {
      * @return true if both authorities belong to same cloud, otherwise false.
      */
     //@WorkerThread
-    public synchronized boolean isSameCloudAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck)
+    public boolean isSameCloudAsAuthority(@NonNull final AzureActiveDirectoryAuthority authorityToCheck)
             throws ClientException {
         // Cloud discovery is needed to make sure that we have preferred_network_host_name to cloud aliases mappings
         AzureActiveDirectory.ensureCloudDiscoveryForAuthority(this);

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -164,12 +164,13 @@ public class AzureActiveDirectory
         return new AzureActiveDirectoryOAuth2Strategy(config, parameters);
     }
 
-    public static synchronized boolean hasCloudHost(@NonNull final URL authorityUrl) {
+    public static boolean hasCloudHost(@NonNull final URL authorityUrl) {
         return sAadClouds.containsKey(authorityUrl.getHost().toLowerCase(Locale.US));
     }
 
-    public static synchronized boolean isValidCloudHost(@NonNull final URL authorityUrl) {
-        return hasCloudHost(authorityUrl) && getAzureActiveDirectoryCloud(authorityUrl).isValidated();
+    public static boolean isValidCloudHost(@NonNull final URL authorityUrl) {
+        final AzureActiveDirectoryCloud cloud = getAzureActiveDirectoryCloud(authorityUrl);
+        return cloud != null && cloud.isValidated();
     }
 
     public static synchronized void setEnvironment(@NonNull final Environment environment) {
@@ -191,7 +192,7 @@ public class AzureActiveDirectory
      * @param authorityUrl URL
      * @return AzureActiveDirectoryCloud
      */
-    public static synchronized AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(@NonNull final URL authorityUrl) {
+    public static AzureActiveDirectoryCloud getAzureActiveDirectoryCloud(@NonNull final URL authorityUrl) {
         return sAadClouds.get(authorityUrl.getHost().toLowerCase(Locale.US));
     }
 
@@ -199,7 +200,7 @@ public class AzureActiveDirectory
      * @param preferredCacheHostName String
      * @return AzureActiveDirectoryCloud
      */
-    public static synchronized AzureActiveDirectoryCloud getAzureActiveDirectoryCloudFromHostName(@NonNull final String preferredCacheHostName) {
+    public static AzureActiveDirectoryCloud getAzureActiveDirectoryCloudFromHostName(@NonNull final String preferredCacheHostName) {
         return sAadClouds.get(preferredCacheHostName.toLowerCase(Locale.US));
     }
 
@@ -368,11 +369,16 @@ public class AzureActiveDirectory
      *
      * @param authority The authority whose URL determines the discovery endpoint, or null to use the default.
      */
-    public static synchronized void ensureCloudDiscoveryForAuthority(@Nullable final Authority authority)
+    public static void ensureCloudDiscoveryForAuthority(@Nullable final Authority authority)
             throws ClientException {
-        ensureCloudDiscoveryForAuthority(
-                authority != null ? authority.getAuthorityURL() : null
-        );
+        // Resolve the URL outside the synchronized scope to avoid deadlock:
+        // getAuthorityURL() on AzureActiveDirectoryAuthority acquires
+        // AzureActiveDirectoryAuthority.class then AzureActiveDirectory.class,
+        // while ensureCloudDiscoveryForAuthority(URL) acquires AzureActiveDirectory.class.
+        // Calling getAuthorityURL() while holding AzureActiveDirectory.class would
+        // create a lock-ordering inversion with any concurrent getAuthorityURL() caller.
+        final URL authorityUrl = authority != null ? authority.getAuthorityURL() : null;
+        ensureCloudDiscoveryForAuthority(authorityUrl);
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownAuthorityTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownAuthorityTest.kt
@@ -22,20 +22,49 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.java.authorities
 
+import com.google.gson.Gson
+import com.microsoft.identity.common.java.exception.ClientException
+import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud
-import org.junit.Assert.*
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
- * Tests for [Authority.isKnownAuthority] and [Authority.getKnownAuthorityResult]
- * focusing on sovereign cloud recognition via pre-seeded cloud metadata.
+ * Tests for [Authority.isKnownAuthority] and [Authority.getKnownAuthorityResult].
  */
 class AuthorityKnownAuthorityTest {
 
-    /**
-     * Verifies that a sovereign cloud authority (Bleu) is recognized as known
-     * through the pre-seeded cloud metadata, without requiring a network call.
-     */
+    @Before
+    fun setUp() {
+        unmockkAll()
+        // Re-seed sovereign cloud metadata in case a previous test's mockkStatic
+        // on AzureActiveDirectory cleared the static map.
+        AzureActiveDirectory.setEnvironment(Environment.Production)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        AzureActiveDirectory.setEnvironment(Environment.Production)
+        // Clear any authorities added during tests to prevent leaking state.
+        Authority.clearKnownAuthorities()
+    }
+
+    // ---- isKnownAuthority tests ----
+
     @Test
     fun testIsKnownAuthority_bleuSovereignCloud() {
         val authority = Authority.getAuthorityFromAuthorityUrl(
@@ -44,9 +73,6 @@ class AuthorityKnownAuthorityTest {
         assertTrue(Authority.isKnownAuthority(authority))
     }
 
-    /**
-     * Verifies that a sovereign cloud authority (Delos) is recognized as known.
-     */
     @Test
     fun testIsKnownAuthority_delosSovereignCloud() {
         val authority = Authority.getAuthorityFromAuthorityUrl(
@@ -55,9 +81,6 @@ class AuthorityKnownAuthorityTest {
         assertTrue(Authority.isKnownAuthority(authority))
     }
 
-    /**
-     * Verifies that a sovereign cloud authority (SovSG) is recognized as known.
-     */
     @Test
     fun testIsKnownAuthority_sovsgSovereignCloud() {
         val authority = Authority.getAuthorityFromAuthorityUrl(
@@ -66,12 +89,25 @@ class AuthorityKnownAuthorityTest {
         assertTrue(Authority.isKnownAuthority(authority))
     }
 
-    /**
-     * Verifies getKnownAuthorityResult returns known=true for a sovereign cloud
-     * authority. This exercises the showstopper fix: even if cloud discovery
-     * throws (no network), the pre-seeded metadata ensures the authority is
-     * still recognized as known.
-     */
+    @Test
+    fun testIsKnownAuthority_unknownAuthority() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.unknown-test.example/common"
+        )
+        assertFalse(Authority.isKnownAuthority(authority))
+    }
+
+    @Test
+    fun testIsKnownAuthority_nullAuthorityUrl_returnsFalse() {
+        val authority = spyk(Authority.getAuthorityFromAuthorityUrl(
+            "https://login.microsoftonline.com/common"
+        ))
+        every { authority.authorityURL } returns null
+        assertFalse(Authority.isKnownAuthority(authority))
+    }
+
+    // ---- getKnownAuthorityResult tests ----
+
     @Test
     fun testGetKnownAuthorityResult_bleuSovereignCloud_isKnown() {
         val authority = Authority.getAuthorityFromAuthorityUrl(
@@ -81,15 +117,167 @@ class AuthorityKnownAuthorityTest {
         assertTrue(result.known)
     }
 
+    @Test
+    fun testIsKnownAuthority_nullAuthority_returnsFalse() {
+        assertFalse(Authority.isKnownAuthority(null))
+    }
+
     /**
-     * A completely unknown authority should NOT be recognized as known
-     * (assumes no developer-configured knownAuthorities match).
+     * Developer-configured authority should be recognized even if discovery fails.
+     * Registers the authority in knownAuthorities so isKnownAuthority finds it.
      */
     @Test
-    fun testIsKnownAuthority_unknownAuthority() {
+    fun testGetKnownAuthorityResult_developerConfigured_discoveryFails_stillKnown() {
+        // Simulate a GSON-deserialized authority by constructing from JSON,
+        // which populates mAuthorityUrlString (used by isKnownAuthority matching).
+        val json = """{"type":"AAD","authority_url":"https://login.developer-configured.example/common"}"""
+        val configuredAuthority = Gson().fromJson(json, AzureActiveDirectoryAuthority::class.java)
+        Authority.addKnownAuthorities(listOf(configuredAuthority))
+
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.developer-configured.example/common"
+        )
+
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } throws ClientException(ClientException.IO_ERROR, "Network unavailable")
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns false
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertTrue(result.known)
+        assertNull(result.clientException)
+    }
+
+    /**
+     * When discovery fails and the authority is NOT known via any source,
+     * the original discovery exception should be propagated.
+     */
+    @Test
+    fun testGetKnownAuthorityResult_discoveryFails_unknownAuthority_propagatesDiscoveryError() {
         val authority = Authority.getAuthorityFromAuthorityUrl(
             "https://login.unknown-test.example/common"
         )
-        assertFalse(Authority.isKnownAuthority(authority))
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } throws ClientException(ClientException.IO_ERROR, "Network unavailable")
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns false
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertFalse(result.known)
+        assertNotNull(result.clientException)
+        assertEquals(
+            "Should propagate IO_ERROR, not UNKNOWN_AUTHORITY",
+            ClientException.IO_ERROR,
+            result.clientException.errorCode
+        )
+    }
+
+    /**
+     * When discovery succeeds but the authority is genuinely not known,
+     * should report UNKNOWN_AUTHORITY.
+     */
+    @Test
+    fun testGetKnownAuthorityResult_discoverySucceeds_unknownAuthority_reportsUnknownAuthority() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.unknown-test.example/common"
+        )
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } just Runs
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns false
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertFalse(result.known)
+        assertNotNull(result.clientException)
+        assertEquals(
+            ClientException.UNKNOWN_AUTHORITY,
+            result.clientException.errorCode
+        )
+    }
+
+    /**
+     * When discovery fails but the authority IS in pre-seeded metadata,
+     * it should still be known (isKnownAuthority falls back to cache).
+     */
+    @Test
+    fun testGetKnownAuthorityResult_discoveryFails_preSeededAuthority_stillKnown() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://${AzureActiveDirectoryCloud.BLEU_CLOUD_HOST}/common"
+        )
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } throws ClientException(ClientException.IO_ERROR, "Network unavailable")
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns true
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertTrue(result.known)
+        assertNull(result.clientException)
+    }
+
+    /**
+     * When discovery succeeds and the authority is known, result should be known.
+     */
+    @Test
+    fun testGetKnownAuthorityResult_discoverySucceeds_knownAuthority_isKnown() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://${AzureActiveDirectoryCloud.BLEU_CLOUD_HOST}/common"
+        )
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } just Runs
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns true
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertTrue(result.known)
+        assertNull(result.clientException)
+        // Verify discovery was called
+        verify(exactly = 1) {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        }
+    }
+
+    /**
+     * MALFORMED_URL error from discovery should be propagated as-is.
+     */
+    @Test
+    fun testGetKnownAuthorityResult_discoveryFails_malformedUrl_propagatesOriginalError() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.unknown-test.example/common"
+        )
+        mockkStatic(AzureActiveDirectory::class)
+        every {
+            AzureActiveDirectory.ensureCloudDiscoveryForAuthority(any<Authority>())
+        } throws ClientException(ClientException.MALFORMED_URL, "Bad URL")
+        every {
+            AzureActiveDirectory.hasCloudHost(any())
+        } returns false
+
+        val result = Authority.getKnownAuthorityResult(authority)
+
+        assertFalse(result.known)
+        assertEquals(
+            ClientException.MALFORMED_URL,
+            result.clientException.errorCode
+        )
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
@@ -23,16 +23,26 @@
 package com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory
 
 import com.microsoft.identity.common.java.authorities.Authority
+import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority
 import com.microsoft.identity.common.java.authorities.Environment
 import com.microsoft.identity.common.java.flighting.CommonFlight
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager
 import com.microsoft.identity.common.java.flighting.MockFlightsManager
 import com.microsoft.identity.common.java.flighting.MockFlightsProvider
 import org.junit.After
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Tests for sovereign cloud discovery support in [AzureActiveDirectory].
@@ -285,5 +295,243 @@ class AzureActiveDirectoryTest {
         AzureActiveDirectory.ensureCloudDiscoveryForAuthority(bleuUrl)
         assertTrue(AzureActiveDirectory.hasCloudHost(bleuUrl))
         assertTrue(AzureActiveDirectory.isValidCloudHost(bleuUrl))
+    }
+
+    // --- Concurrency tests ---
+    // Verify the fix for the ABBA deadlock between AzureActiveDirectory.class and
+    // AzureActiveDirectoryAuthority.class monitors, and the lock convoy where
+    // synchronized read-only methods blocked behind network I/O.
+
+    /**
+     * Regression test for the ABBA deadlock between AzureActiveDirectory.class and
+     * AzureActiveDirectoryAuthority.class monitors.
+     *
+     * Thread 1: isKnownAuthority → sLock → getAuthorityURL → AADAuthority.class → AAD.class
+     * Thread 2: ensureCloudDiscoveryForAuthority → AAD.class → getAuthorityURL → AADAuthority.class
+     *
+     * If the deadlock still existed, this test would hang and be killed by the timeout.
+     */
+    @Test(timeout = 10_000)
+    fun testNoDeadlock_isKnownAuthority_vs_ensureCloudDiscovery() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.microsoftonline.com/common"
+        ) as AzureActiveDirectoryAuthority
+
+        val barrier = CyclicBarrier(2)
+        val completedLatch = CountDownLatch(2)
+        val thread1Error = AtomicReference<Throwable?>(null)
+        val thread2Error = AtomicReference<Throwable?>(null)
+
+        val t1 = Thread {
+            try {
+                repeat(500) {
+                    if (it == 0) barrier.await(5, TimeUnit.SECONDS)
+                    Authority.isKnownAuthority(authority)
+                }
+            } catch (e: Throwable) {
+                thread1Error.set(e)
+            } finally {
+                completedLatch.countDown()
+            }
+        }.apply { isDaemon = true }
+
+        val t2 = Thread {
+            try {
+                repeat(500) {
+                    if (it == 0) barrier.await(5, TimeUnit.SECONDS)
+                    try {
+                        AzureActiveDirectory.ensureCloudDiscoveryForAuthority(authority)
+                    } catch (_: Exception) { }
+                }
+            } catch (e: Throwable) {
+                thread2Error.set(e)
+            } finally {
+                completedLatch.countDown()
+            }
+        }.apply { isDaemon = true }
+
+        t1.start()
+        t2.start()
+
+        assertTrue(
+            "Both threads should complete within timeout (deadlock detected if this fails)",
+            completedLatch.await(9, TimeUnit.SECONDS)
+        )
+        assertNull("Thread 1 should not throw", thread1Error.get())
+        assertNull("Thread 2 should not throw", thread2Error.get())
+    }
+
+    /**
+     * Verifies that concurrent reads to hasCloudHost / getAzureActiveDirectoryCloud
+     * do not block each other now that synchronized has been removed from read-only methods.
+     */
+    @Test(timeout = 10_000)
+    fun testConcurrentReads_doNotBlock() {
+        val threadCount = 8
+        val barrier = CyclicBarrier(threadCount)
+        val completedLatch = CountDownLatch(threadCount)
+        val anyError = AtomicBoolean(false)
+        val url = URL("https://login.microsoftonline.com/common")
+
+        val threads = (1..threadCount).map { index ->
+            Thread {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    repeat(1_000) {
+                        when (index % 4) {
+                            0 -> AzureActiveDirectory.hasCloudHost(url)
+                            1 -> AzureActiveDirectory.getAzureActiveDirectoryCloud(url)
+                            2 -> AzureActiveDirectory.getAzureActiveDirectoryCloudFromHostName("login.microsoftonline.com")
+                            3 -> AzureActiveDirectory.isValidCloudHost(url)
+                        }
+                    }
+                } catch (_: Throwable) {
+                    anyError.set(true)
+                } finally {
+                    completedLatch.countDown()
+                }
+            }.apply { isDaemon = true }
+        }
+
+        threads.forEach { it.start() }
+        assertTrue(
+            "All reader threads should complete quickly",
+            completedLatch.await(9, TimeUnit.SECONDS)
+        )
+        assertFalse("No reader should throw an exception", anyError.get())
+    }
+
+    /**
+     * Verifies that concurrent getAuthorityURL() calls on AzureActiveDirectoryAuthority
+     * do not deadlock or throw.
+     */
+    @Test(timeout = 10_000)
+    fun testConcurrentGetAuthorityURL_doesNotDeadlock() {
+        val authority = Authority.getAuthorityFromAuthorityUrl(
+            "https://login.microsoftonline.com/common"
+        ) as AzureActiveDirectoryAuthority
+
+        val threadCount = 4
+        val barrier = CyclicBarrier(threadCount)
+        val completedLatch = CountDownLatch(threadCount)
+        val anyError = AtomicBoolean(false)
+
+        val threads = (1..threadCount).map {
+            Thread {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS)
+                    repeat(1_000) {
+                        authority.authorityURL
+                    }
+                } catch (_: Throwable) {
+                    anyError.set(true)
+                } finally {
+                    completedLatch.countDown()
+                }
+            }.apply { isDaemon = true }
+        }
+
+        threads.forEach { it.start() }
+        assertTrue(
+            "All threads calling getAuthorityURL should complete",
+            completedLatch.await(9, TimeUnit.SECONDS)
+        )
+        assertFalse("No thread should throw", anyError.get())
+    }
+
+    /**
+     * Verifies that a writer (putCloud) and concurrent readers (hasCloudHost)
+     * can run simultaneously without errors, validating ConcurrentHashMap safety.
+     */
+    @Test(timeout = 10_000)
+    fun testConcurrentReadsAndWrites_noErrors() {
+        val completedLatch = CountDownLatch(2)
+        val anyError = AtomicBoolean(false)
+        val barrier = CyclicBarrier(2)
+
+        val writer = Thread {
+            try {
+                barrier.await(5, TimeUnit.SECONDS)
+                repeat(500) { i ->
+                    val host = "login.test$i.com"
+                    AzureActiveDirectory.putCloud(host, AzureActiveDirectoryCloud(host, host))
+                }
+            } catch (_: Throwable) {
+                anyError.set(true)
+            } finally {
+                completedLatch.countDown()
+            }
+        }.apply { isDaemon = true }
+
+        val reader = Thread {
+            try {
+                barrier.await(5, TimeUnit.SECONDS)
+                repeat(500) { i ->
+                    val host = "login.test$i.com"
+                    AzureActiveDirectory.hasCloudHost(URL("https://$host/common"))
+                    AzureActiveDirectory.getAzureActiveDirectoryCloudFromHostName(host)
+                }
+            } catch (_: Throwable) {
+                anyError.set(true)
+            } finally {
+                completedLatch.countDown()
+            }
+        }.apply { isDaemon = true }
+
+        writer.start()
+        reader.start()
+        assertTrue(
+            "Reader and writer should both complete",
+            completedLatch.await(9, TimeUnit.SECONDS)
+        )
+        assertFalse("No exception should occur during concurrent read/write", anyError.get())
+    }
+
+    /**
+     * Stress test: simulates the ANR scenario where multiple apps call
+     * isKnownAuthority and ensureCloudDiscovery simultaneously on different authorities.
+     */
+    @Test(timeout = 15_000)
+    fun testHighConcurrency_multipleAuthorities_noDeadlock() {
+        val hosts = listOf(
+            "login.microsoftonline.com",
+            "login.sovcloud-identity.fr",
+            "login.sovcloud-identity.de",
+            "login.sovcloud-identity.sg"
+        )
+        val authorities = hosts.map { Authority.getAuthorityFromAuthorityUrl("https://$it/common") }
+        val threadCount = authorities.size * 2
+        val barrier = CyclicBarrier(threadCount)
+        val completedLatch = CountDownLatch(threadCount)
+        val anyError = AtomicBoolean(false)
+
+        val threads = authorities.flatMap { authority ->
+            listOf(
+                Thread {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS)
+                        repeat(200) { Authority.isKnownAuthority(authority) }
+                    } catch (_: Throwable) { anyError.set(true) }
+                    finally { completedLatch.countDown() }
+                }.apply { isDaemon = true },
+                Thread {
+                    try {
+                        barrier.await(5, TimeUnit.SECONDS)
+                        repeat(200) {
+                            try { AzureActiveDirectory.ensureCloudDiscoveryForAuthority(authority) }
+                            catch (_: Exception) { }
+                        }
+                    } catch (_: Throwable) { anyError.set(true) }
+                    finally { completedLatch.countDown() }
+                }.apply { isDaemon = true }
+            )
+        }
+
+        threads.forEach { it.start() }
+        assertTrue(
+            "All $threadCount threads should complete (deadlock detected if this fails)",
+            completedLatch.await(14, TimeUnit.SECONDS)
+        )
+        assertFalse("No thread should throw an unexpected exception", anyError.get())
     }
 }


### PR DESCRIPTION
## Hotfix for release/24.1.1

Cherry-pick of PR #3082 (dev branch fix) onto \working/release/24.1.1\.

### Problem

ABBA deadlock between \AzureActiveDirectory.class\ and \AzureActiveDirectoryAuthority.class\ monitors under high concurrency (multiple apps calling into Broker simultaneously), causing ANR in Microsoft Authenticator.

### Changes

- Extract \uthority.getAuthorityURL()\ outside synchronized scopes
- Remove \synchronized\ from read-only \ConcurrentHashMap\ methods
- Remove \synchronized\ from \AzureActiveDirectoryAuthority.getAzureActiveDirectoryCloud()\ and \isSameCloudAsAuthority()\
- Fix race in \isValidCloudHost()\ (null-check before \isValidated()\)
- Improve error handling in \getKnownAuthorityResult()\
- Add concurrency regression tests

### Testing

All \common4j\ tests pass on this branch.

[AB#3578299](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3578299)
