### PR TITLE
Add support for Authenticator app activation links in WebView., Fixes AB#3556494

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Add support for Authenticator app activation links in WebView, enabling account pairing/MFA flows to launch Microsoft Authenticator directly instead of redirecting to the Play Store (#3090)
 - [PATCH] Fix: WPJ's BrokerDiscovery cache crash due to shared predefined encryption key with MSAL (#3081)
 - [PATCH] Fix ABBA deadlock between AzureActiveDirectory and AzureActiveDirectoryAuthority class monitors by extracting polymorphic getAuthorityURL() calls outside synchronized scopes and removing unnecessary synchronized from ConcurrentHashMap read-only methods (#3082)
 - [PATCH] Optimize AcquireTokenSilent save path: replace keySet() decrypt-all with in-memory map lookup in removeAccount()/removeCredential(), add telemetry for deleteAccessTokensWithIntersectingScopes, and remove unused elapsed_time_save_account_shared_preferences attribute (#3074)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -1325,6 +1325,13 @@ public final class AuthenticationConstants {
         public static final String AUTHENTICATOR_MFA_LINKING_PREFIX = "microsoft-authenticator://activatemfa";
 
         /**
+         * Path for the Authenticator app activation Android App Link.
+         * This is the HTTPS-based app link used by eSTS to launch the Authenticator app
+         * for MFA account pairing (e.g., https://login.microsoftonline.com/authenticatorApp/activateAccount).
+         */
+        public static final String AUTHENTICATOR_APP_LINK_ACTIVATION_PATH = "/authenticatorapp/activateaccount";
+
+        /**
          * Redirect URL from WebCP that should launch the Intune Company Portal app.
          */
         public static final String WEBCP_LAUNCH_COMPANY_PORTAL_URL = BROWSER_EXT_WEB_CP + "enrollment";

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -951,10 +951,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                 Logger.info(methodTag, "Launched Authenticator via activation app link.");
             } else {
                 Logger.warn(methodTag, "No application found to handle activation app link. Opening in browser.");
+                // Browser automatically redirects user to playstore.
                 openLinkInBrowser(url);
             }
         } catch (final ActivityNotFoundException e) {
             Logger.error(methodTag, "Failed to launch Authenticator via activation app link.", e);
+            // Browser automatically redirects user to playstore.
             openLinkInBrowser(url);
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -417,7 +417,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
      * @return true if the URL is an Authenticator activation app link.
      */
     boolean isAuthenticatorActivationAppLink(@NonNull final String url) {
-        if (!url.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)) {
+        if (!isUriSSLProtected(url)) {
             return false;
         }
         final Uri uri = Uri.parse(url);

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -112,6 +112,9 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_ERROR;
 import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_OPEN_ID_VC_REDIRECT;
 import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_PLAYSTORE_URL_LAUNCH;
+import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.CHINA_CLOUD_HOST;
+import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.PUBLIC_CLOUD_HOST;
+import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.US_GOV_CLOUD_HOST;
 
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
@@ -336,6 +339,9 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             } else if (isAuthAppMFAUrl(formattedURL)) {
                 Logger.info(methodTag,"Request to link account with Authenticator.");
                 processAuthAppMFAUrl(url);
+            } else if (isAuthenticatorActivationAppLink(formattedURL)) {
+                Logger.info(methodTag,"Request to open Authenticator via activation app link.");
+                processAuthenticatorActivationAppLink(view, url);
             } else if (isAmazonAppRedirect(formattedURL)) {
                 Logger.info(methodTag, "It is an Amazon app request");
                 processAmazonAppUri(url);
@@ -397,6 +403,37 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
 
     private boolean isAuthAppMFAUrl(@NonNull final String url) {
         return url.startsWith(AuthenticationConstants.Broker.AUTHENTICATOR_MFA_LINKING_PREFIX);
+    }
+
+    /**
+     * Checks if the URL is an Authenticator app activation Android App Link.
+     * These are HTTPS URLs from trusted AAD hosts with the activation path,
+     * e.g., https://login.microsoftonline.com/authenticatorApp/activateAccount?...
+     *
+     * Unlike Chrome, WebView does not resolve Android App Links automatically.
+     * We must intercept them and dispatch via Intent.ACTION_VIEW.
+     *
+     * @param url The lowercased URL to check.
+     * @return true if the URL is an Authenticator activation app link.
+     */
+    boolean isAuthenticatorActivationAppLink(@NonNull final String url) {
+        if (!url.startsWith(AuthenticationConstants.Broker.REDIRECT_SSL_PREFIX)) {
+            return false;
+        }
+        final Uri uri = Uri.parse(url);
+        final String host = uri.getHost();
+        final String path = uri.getPath();
+        // For 21Vianet cloud identity environment.
+        final String china_cloud_legacy_host = "login.chinacloudapi.cn";
+        if (host == null || path == null) {
+            return false;
+        }
+        final boolean isTrustedHost = host.equalsIgnoreCase(PUBLIC_CLOUD_HOST)
+                || host.equalsIgnoreCase(US_GOV_CLOUD_HOST)
+                || host.equalsIgnoreCase(china_cloud_legacy_host);
+        final boolean isActivationPath = path.equalsIgnoreCase(
+                AuthenticationConstants.Broker.AUTHENTICATOR_APP_LINK_ACTIVATION_PATH);
+        return isTrustedHost && isActivationPath;
     }
 
     private boolean isPlayStoreUrl(@NonNull final String url) {
@@ -892,6 +929,35 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             getActivity().startActivity(intent);
         } catch (android.content.ActivityNotFoundException e) {
             Logger.error(methodTag,"Failed to open the Authenticator application.", e);
+        }
+    }
+
+    /**
+     * Handles Authenticator activation Android App Links.
+     * WebView does not resolve Android App Links automatically (unlike Chrome).
+     * This method intercepts the HTTPS activation URL and dispatches it via
+     * Intent.ACTION_VIEW so the system can route it to the Authenticator app.
+     *
+     * @param view The WebView that intercepted the navigation.
+     * @param url  The original (non-lowercased) activation URL.
+     */
+    void processAuthenticatorActivationAppLink(@NonNull final WebView view,
+                                               @NonNull final String url) {
+        final String methodTag = TAG + ":processAuthenticatorActivationAppLink";
+        view.stopLoading();
+        try {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
+                getActivity().startActivity(intent);
+                Logger.info(methodTag, "Launched Authenticator via activation app link.");
+            } else {
+                Logger.warn(methodTag, "No application found to handle activation app link. Opening in browser.");
+                openLinkInBrowser(url);
+            }
+        } catch (final ActivityNotFoundException e) {
+            Logger.error(methodTag, "Failed to launch Authenticator via activation app link.", e);
+            openLinkInBrowser(url);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -424,13 +424,13 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final String host = uri.getHost();
         final String path = uri.getPath();
         // For 21Vianet cloud identity environment.
-        final String china_cloud_legacy_host = "login.chinacloudapi.cn";
+        final String chinaCloudLegacyHost = "login.chinacloudapi.cn";
         if (host == null || path == null) {
             return false;
         }
         final boolean isTrustedHost = host.equalsIgnoreCase(PUBLIC_CLOUD_HOST)
                 || host.equalsIgnoreCase(US_GOV_CLOUD_HOST)
-                || host.equalsIgnoreCase(china_cloud_legacy_host);
+                || host.equalsIgnoreCase(chinaCloudLegacyHost);
         final boolean isActivationPath = path.equalsIgnoreCase(
                 AuthenticationConstants.Broker.AUTHENTICATOR_APP_LINK_ACTIVATION_PATH);
         return isTrustedHost && isActivationPath;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -137,6 +137,8 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
     private static final String DEVICE_CERT_ISSUER = "CN=MS-Organization-Access";
+    // For 21Vianet cloud identity environment.
+    private static final String CHINA_CLOUD_LEGACY_HOST = "login.chinacloudapi.cn";
     // 3 secs wait for the intent to be launched and the current flow is killed for smooth transition.
     private static final int THREAD_SLEEP_FOR_INTENT_LAUNCH_MS = 3;
     private final String mRedirectUrl;
@@ -423,14 +425,12 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
         final Uri uri = Uri.parse(url);
         final String host = uri.getHost();
         final String path = uri.getPath();
-        // For 21Vianet cloud identity environment.
-        final String chinaCloudLegacyHost = "login.chinacloudapi.cn";
         if (host == null || path == null) {
             return false;
         }
         final boolean isTrustedHost = host.equalsIgnoreCase(PUBLIC_CLOUD_HOST)
                 || host.equalsIgnoreCase(US_GOV_CLOUD_HOST)
-                || host.equalsIgnoreCase(chinaCloudLegacyHost);
+                || host.equalsIgnoreCase(CHINA_CLOUD_LEGACY_HOST);
         final boolean isActivationPath = path.equalsIgnoreCase(
                 AuthenticationConstants.Broker.AUTHENTICATOR_APP_LINK_ACTIVATION_PATH);
         return isTrustedHost && isActivationPath;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -112,7 +112,7 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.AAD.APP
 import static com.microsoft.identity.common.java.exception.ClientException.UNKNOWN_ERROR;
 import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_OPEN_ID_VC_REDIRECT;
 import static com.microsoft.identity.common.java.flighting.CommonFlight.ENABLE_PLAYSTORE_URL_LAUNCH;
-import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.CHINA_CLOUD_HOST;
+import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.CHINA_CLOUD_LEGACY_HOST;
 import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.PUBLIC_CLOUD_HOST;
 import static com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectoryCloud.US_GOV_CLOUD_HOST;
 
@@ -137,8 +137,6 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public static final String ERROR = "error";
     public static final String ERROR_DESCRIPTION = "error_description";
     private static final String DEVICE_CERT_ISSUER = "CN=MS-Organization-Access";
-    // For 21Vianet cloud identity environment.
-    private static final String CHINA_CLOUD_LEGACY_HOST = "login.chinacloudapi.cn";
     // 3 secs wait for the intent to be launched and the current flow is killed for smooth transition.
     private static final int THREAD_SLEEP_FOR_INTENT_LAUNCH_MS = 3;
     private final String mRedirectUrl;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -39,6 +39,10 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
 import android.net.http.SslError;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceError;
@@ -74,8 +78,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
-
+import org.robolectric.shadows.ShadowPackageManager;
 import java.util.HashMap;
 
 import io.opentelemetry.api.trace.Span;
@@ -127,6 +132,18 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     private static final String TEST_PLAYSTORE_REDIRECT_WITH_BROWSER_PROTOCOL = "browser://play.app.goo.gl/?link=https://play.google.com/store/apps/details?id=com.microsoft.windowsintune.companyportal";
     private static final String TEST_OPENID_VC_URL = "openid-vc://credential-offer?credential_issuer=https%3A%2F%2Fexample.com&credential_configuration_ids=VerifiedEmployee";
+
+    // Authenticator activation app link test URLs
+    private static final String TEST_AUTHENTICATOR_ACTIVATION_GLOBAL =
+            "https://login.microsoftonline.com/authenticatorApp/activateAccount?accountType=mfa&source=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
+    private static final String TEST_AUTHENTICATOR_ACTIVATION_CHINA =
+            "https://login.chinacloudapi.cn/authenticatorApp/activateAccount?accountType=mfa&source=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
+    private static final String TEST_AUTHENTICATOR_ACTIVATION_US_GOV =
+            "https://login.microsoftonline.us/authenticatorApp/activateAccount?accountType=mfa&ssource=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
+    private static final String TEST_AUTHENTICATOR_ACTIVATION_INVALID_HOST =
+            "https://login.evil.com/authenticatorApp/activateAccount?accountType=mfa&code=123";
+    private static final String TEST_AUTHENTICATOR_ACTIVATION_INVALID_PATH =
+            "https://login.microsoftonline.com/some/other/path?accountType=mfa&code=123";
 
     @Before
     public void setup() throws ClientException {
@@ -921,5 +938,161 @@ public class AzureActiveDirectoryWebViewClientTest {
         client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
 
         Mockito.verify(mockTracker, never()).updateLatestUrlStatus(any(), any());
+    }
+
+    // ===== Authenticator activation app link tests =====
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_globalHost_shouldReturnTrue() {
+        assertTrue(mWebViewClient.isAuthenticatorActivationAppLink(
+                TEST_AUTHENTICATOR_ACTIVATION_GLOBAL.toLowerCase()));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_chinaHost_shouldReturnTrue() {
+        assertTrue(mWebViewClient.isAuthenticatorActivationAppLink(
+                TEST_AUTHENTICATOR_ACTIVATION_CHINA.toLowerCase()));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_usGovHost_shouldReturnTrue() {
+        assertTrue(mWebViewClient.isAuthenticatorActivationAppLink(
+                TEST_AUTHENTICATOR_ACTIVATION_US_GOV.toLowerCase()));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_invalidHost_shouldReturnFalse() {
+        assertFalse(mWebViewClient.isAuthenticatorActivationAppLink(
+                TEST_AUTHENTICATOR_ACTIVATION_INVALID_HOST.toLowerCase()));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_invalidPath_shouldReturnFalse() {
+        assertFalse(mWebViewClient.isAuthenticatorActivationAppLink(
+                TEST_AUTHENTICATOR_ACTIVATION_INVALID_PATH.toLowerCase()));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_nonHttpsScheme_shouldReturnFalse() {
+        assertFalse(mWebViewClient.isAuthenticatorActivationAppLink(
+                "http://login.microsoftonline.com/authenticatorapp/activateaccount"));
+    }
+
+    @Test
+    public void testIsAuthenticatorActivationAppLink_legacyMfaScheme_shouldReturnFalse() {
+        assertFalse(mWebViewClient.isAuthenticatorActivationAppLink(
+                AUTHENTICATOR_MFA_LINKING_PREFIX.toLowerCase()));
+    }
+
+    /**
+     * Registers a fake handler on the given activity's PackageManager so that
+     * {@code intent.resolveActivity(...)} returns non-null for ACTION_VIEW + the given Uri.
+     * This lets us exercise the "handler present" branch of
+     * processAuthenticatorActivationAppLink in a Robolectric test.
+     */
+    private void registerActivationHandler(@NonNull final Activity activity,
+                                           @NonNull final Uri uri,
+                                           @NonNull final String packageName,
+                                           @NonNull final String activityClass) {
+        final ShadowPackageManager shadowPm = Shadows.shadowOf(activity.getPackageManager());
+        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        final ResolveInfo info = new ResolveInfo();
+        info.activityInfo = new ActivityInfo();
+        info.activityInfo.packageName = packageName;
+        info.activityInfo.name = activityClass;
+        shadowPm.addResolveInfoForIntent(intent, info);
+    }
+
+    @Test
+    public void testAuthenticatorActivationAppLink_launchesIntent_whenHandlerPresent() {
+        // Arrange: register a handler so resolveActivity(...) returns non-null.
+        registerActivationHandler(
+                mActivity,
+                Uri.parse(TEST_AUTHENTICATOR_ACTIVATION_GLOBAL),
+                "com.azure.authenticator",
+                "com.azure.authenticator.ui.MainActivity");
+
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Act
+        final boolean handled = mWebViewClient.shouldOverrideUrlLoading(
+                mockWebView, TEST_AUTHENTICATOR_ACTIVATION_GLOBAL);
+
+        // Assert: URL was intercepted, WebView stopped, and an ACTION_VIEW intent was launched.
+        assertTrue(handled);
+        Mockito.verify(mockWebView).stopLoading();
+
+        final Intent launched = Shadows.shadowOf(mActivity).getNextStartedActivity();
+        Assert.assertNotNull("Expected an intent to be launched for the activation link", launched);
+        assertEquals(Intent.ACTION_VIEW, launched.getAction());
+        assertEquals(TEST_AUTHENTICATOR_ACTIVATION_GLOBAL, launched.getData().toString());
+        assertTrue("Expected FLAG_ACTIVITY_NEW_TASK on activation intent",
+                (launched.getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0);
+    }
+
+    @Test
+    public void testAuthenticatorActivationAppLink_noHandler_stopsLoading_andDoesNotCrash() {
+        // Arrange: no handler registered -> intent.resolveActivity() returns null in both
+        // the Authenticator launch path and the openLinkInBrowser fallback path.
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        // Act
+        final boolean handled = mWebViewClient.shouldOverrideUrlLoading(
+                mockWebView, TEST_AUTHENTICATOR_ACTIVATION_GLOBAL);
+
+        // Assert: handled=true, WebView stopped, no activity started (no crash, no error callback).
+        assertTrue(handled);
+        Mockito.verify(mockWebView).stopLoading();
+        Assert.assertNull("Expected NO intent to be launched when no handler is installed",
+                Shadows.shadowOf(mActivity).getNextStartedActivity());
+    }
+
+    @Test
+    public void testAuthenticatorActivationAppLink_preservesOriginalCasing() {
+        // The activation link carries case-sensitive query values (e.g. base64 codes).
+        // shouldOverrideUrlLoading lowercases the URL for matching but must dispatch the
+        // *original* URL to the Authenticator.
+        final String mixedCaseUrl =
+                "https://login.microsoftonline.com/authenticatorApp/activateAccount"
+                        + "?accountType=mfa&source=QrCode&code=AbCdEf123XYZ&url=https://Service";
+        registerActivationHandler(
+                mActivity,
+                Uri.parse(mixedCaseUrl),
+                "com.azure.authenticator",
+                "com.azure.authenticator.ui.MainActivity");
+
+        final WebView mockWebView = Mockito.mock(WebView.class);
+
+        final boolean handled = mWebViewClient.shouldOverrideUrlLoading(mockWebView, mixedCaseUrl);
+
+        assertTrue(handled);
+        final Intent launched = Shadows.shadowOf(mActivity).getNextStartedActivity();
+        Assert.assertNotNull(launched);
+        assertEquals("Authenticator activation intent must carry the original-cased URL",
+                mixedCaseUrl, launched.getData().toString());
+    }
+
+    @Test
+    public void testProcessAuthAppMFAUrl_startsViewIntentWithNewTaskFlag() {
+        // microsoft-authenticator://activatemfa/... is handed to processAuthAppMFAUrl,
+        // which dispatches an ACTION_VIEW intent with FLAG_ACTIVITY_NEW_TASK.
+        final String mfaUrl = AUTHENTICATOR_MFA_LINKING_PREFIX + "/?x=1";
+        // Make the intent resolvable so the OS would accept the launch. (Robolectric
+        // records the started activity regardless, but this documents the expectation.)
+        registerActivationHandler(
+                mActivity,
+                Uri.parse(mfaUrl),
+                "com.azure.authenticator",
+                "com.azure.authenticator.ui.MainActivity");
+
+        final boolean handled = mWebViewClient.shouldOverrideUrlLoading(mMockWebView, mfaUrl);
+
+        assertTrue(handled);
+        final Intent launched = Shadows.shadowOf(mActivity).getNextStartedActivity();
+        Assert.assertNotNull(launched);
+        assertEquals(Intent.ACTION_VIEW, launched.getAction());
+        assertEquals(mfaUrl, launched.getDataString());
+        assertTrue("MFA activation intent must carry FLAG_ACTIVITY_NEW_TASK",
+                (launched.getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0);
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -139,7 +139,7 @@ public class AzureActiveDirectoryWebViewClientTest {
     private static final String TEST_AUTHENTICATOR_ACTIVATION_CHINA =
             "https://login.chinacloudapi.cn/authenticatorApp/activateAccount?accountType=mfa&source=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
     private static final String TEST_AUTHENTICATOR_ACTIVATION_US_GOV =
-            "https://login.microsoftonline.us/authenticatorApp/activateAccount?accountType=mfa&ssource=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
+            "https://login.microsoftonline.us/authenticatorApp/activateAccount?accountType=mfa&source=qrCode&accountType=msa&code=demo&uaid=0022d4c4141444b484dd38026d312794&expires=3971458484";
     private static final String TEST_AUTHENTICATOR_ACTIVATION_INVALID_HOST =
             "https://login.evil.com/authenticatorApp/activateAccount?accountType=mfa&code=123";
     private static final String TEST_AUTHENTICATOR_ACTIVATION_INVALID_PATH =

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryCloud.java
@@ -121,6 +121,8 @@ public class AzureActiveDirectoryCloud {
     public static final String PUBLIC_CLOUD_HOST = "login.microsoftonline.com";
     public static final String PPE_CLOUD_HOST = "login.windows-ppe.net";
     public static final String CHINA_CLOUD_HOST = "login.partner.microsoftonline.cn";
+    // Legacy host for the 21Vianet cloud identity environment.
+    public static final String CHINA_CLOUD_LEGACY_HOST = "login.chinacloudapi.cn";
     public static final String US_GOV_CLOUD_HOST = "login.microsoftonline.us";
     public static final String BLEU_CLOUD_HOST = "login.sovcloud-identity.fr";
     public static final String DELOS_CLOUD_HOST = "login.sovcloud-identity.de";


### PR DESCRIPTION


<a href="https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3556494
">[[AB#3556494](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3556494)](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3556494
</a>

Add support for user using "Pair your account functionality" in webview.

* Previously the Android Applink was taking user to Playstore directly.
* After fix --> the user is taken to authenticator app where MFA is completed and user is brought back to webview to complete the setup.

[Check this fix video out - You can skip to half the video](https://microsoft.sharepoint.com/:v:/t/aad/cQpS7w5j-RjGTIwPARqjhpcjEgUC1m9f8sjVib1RAlSQ9S09Zw)