### PR TITLE
Add handleButtonClickForObjectWithTextSafely overload to fix build, Fixes AB#3586240

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -565,7 +565,8 @@ public class UiAutomatorUtils {
         try {
             button.click();
         } catch (final UiObjectNotFoundException e) {
-            Logger.w(TAG, "Button with text \"" + text + "\" was not found: " + e.getMessage());
+            Logger.w(TAG, "Button with text \"" + text + "\" was not found after waiting "
+                    + existsTimeout + " ms: " + e.getMessage());
         }
     }
 

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -558,6 +558,8 @@ public class UiAutomatorUtils {
      * and logging a warning.
      *
      * @param text the text on the button to click
+     * @param existsTimeout the maximum time to wait, in milliseconds, for the button
+     *                      to exist before giving up and logging a warning
      */
     public static void handleButtonClickForObjectWithTextSafely(@NonNull final String text, final long existsTimeout) {
         final UiObject button = obtainUiObjectWithText(text, existsTimeout);

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/utils/UiAutomatorUtils.java
@@ -550,6 +550,25 @@ public class UiAutomatorUtils {
         }
     }
 
+
+    /**
+     * Clicks the button element that contains the supplied text.
+     * Do not throw an exception if the button is not found. Waits
+     * for the button to exist with the supplied timeout before giving up
+     * and logging a warning.
+     *
+     * @param text the text on the button to click
+     */
+    public static void handleButtonClickForObjectWithTextSafely(@NonNull final String text, final long existsTimeout) {
+        final UiObject button = obtainUiObjectWithText(text, existsTimeout);
+
+        try {
+            button.click();
+        } catch (final UiObjectNotFoundException e) {
+            Logger.w(TAG, "Button with text \"" + text + "\" was not found: " + e.getMessage());
+        }
+    }
+
     /**
      * Clicks the button element that contains text matching the supplied regex
      */


### PR DESCRIPTION
As seen here
https://identitydivision.visualstudio.com/Engineering/ISP%20-%20ID%20Risk%20for%20Passkey%20Registration%20and%20Recovery/_build/results?buildId=1626465&view=logs&s=ff4555a9-e895-5c04-ab14-88c3aa79b4da&j=9a146641-6417-5767-ad44-2e332adab356

Seems to have happened after https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2502 

  /mnt/vss/_work/1/s/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java:107: error: method handleButtonClickForObjectWithTextSafely in class UiAutomatorUtils cannot be applied to given types;
          UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("Close", CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);


Fixes [AB#3586240](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3586240)

