### PR TITLE
Fixes AB#3588022 Optimize load() and getIdTokensForAccountRecord() with filter-then-clone

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Extend filter-then-clone optimization to load() and getIdTokensForAccountRecord() in MsalOAuth2TokenCache: when ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight is enabled, skip clone-all preload and call direct flight-gated overloads that clone only matching credentials; add new getCredentialsFilteredBy overload with kid support (#TBD)
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)
 - [PATCH] Add support for Authenticator app activation links in WebView, enabling account pairing/MFA flows to launch Microsoft Authenticator directly instead of redirecting to the Play Store (#3090)
 - [PATCH] Fix: WPJ's BrokerDiscovery cache crash due to shared predefined encryption key with MSAL (#3081)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Extend filter-then-clone optimization to load() and getIdTokensForAccountRecord() in MsalOAuth2TokenCache: when ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight is enabled, skip clone-all preload and call direct flight-gated overloads that clone only matching credentials; add new getCredentialsFilteredBy overload with kid support (#TBD)
+- [PATCH] Extend filter-then-clone optimization to load() and getIdTokensForAccountRecord() in MsalOAuth2TokenCache: when ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight is enabled, skip clone-all preload and call direct flight-gated overloads that clone only matching credentials; add new getCredentialsFilteredBy overload with kid support (#3100)
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)
 - [PATCH] Add support for Authenticator app activation links in WebView, enabling account pairing/MFA flows to launch Microsoft Authenticator directly instead of redirecting to the Play Store (#3090)
 - [PATCH] Fix: WPJ's BrokerDiscovery cache crash due to shared predefined encryption key with MSAL (#3081)

--- a/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -29,6 +29,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.components.MockPlatformComponentsFactory;
+import com.microsoft.identity.common.internal.mocks.MockCommonFlightsManager;
 import com.microsoft.identity.common.internal.platform.AndroidPlatformUtil;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsOAuth2Strategy;
@@ -40,6 +41,7 @@ import com.microsoft.identity.common.java.cache.ICacheKeyValueDelegate;
 import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCache;
+import com.microsoft.identity.common.java.cache.SharedPreferencesAccountCredentialCacheWithMemoryCache;
 import com.microsoft.identity.common.java.dto.AccessTokenRecord;
 import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.common.java.dto.Credential;
@@ -47,6 +49,9 @@ import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.PrimaryRefreshTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftRefreshToken;
@@ -59,6 +64,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -1606,5 +1612,156 @@ public class MsalOAuth2TokenCacheTest {
         final RefreshTokenRecord refreshTokenRecord = mOauth2TokenCache.
                 getFamilyRefreshTokenForHomeAccountId("26685724-1f8e-4b97-a0ca-1863e33b9fb1"); // different home account id
         assertNull(refreshTokenRecord);
+    }
+
+    // =====================================================================
+    // Flight-gated tests for filter-then-clone optimization in load() and getIdTokensForAccountRecord()
+    // =====================================================================
+
+    private MsalOAuth2TokenCache<MicrosoftStsOAuth2Strategy, MicrosoftStsAuthorizationRequest,
+            MicrosoftStsTokenResponse, MicrosoftAccount, MicrosoftRefreshToken>
+            createCacheWithMemoryCache(final IPlatformComponents components) {
+        final ICacheKeyValueDelegate keyValueDelegate = new CacheKeyValueDelegate();
+        final INameValueStorage<String> storage = components.getStorageSupplier().getEncryptedNameValueStore(
+                "test_prefs_memory_cache",
+                String.class
+        );
+        final IAccountCredentialCache memoryCache = new SharedPreferencesAccountCredentialCacheWithMemoryCache(
+                keyValueDelegate,
+                storage
+        );
+        return new MsalOAuth2TokenCache<>(
+                components,
+                memoryCache,
+                mockCredentialAdapter
+        );
+    }
+
+    private void enableFilterThenCloneFlight() {
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE))
+                .thenReturn(true);
+        final MockCommonFlightsManager mockFlightsManager = new MockCommonFlightsManager();
+        mockFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);
+    }
+
+    private void resetFlight() {
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void loadTokens_flightEnabled_returnsCorrectCacheRecord() throws ClientException {
+        enableFilterThenCloneFlight();
+        try {
+            final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
+            final MsalOAuth2TokenCache<MicrosoftStsOAuth2Strategy, MicrosoftStsAuthorizationRequest,
+                    MicrosoftStsTokenResponse, MicrosoftAccount, MicrosoftRefreshToken>
+                    memoryCacheTokenCache = createCacheWithMemoryCache(components);
+
+            configureMocksForTestBundle(defaultTestBundleV2);
+            final ICacheRecord result = memoryCacheTokenCache.save(
+                    mockStrategy,
+                    mockRequest,
+                    mockResponse
+            );
+
+            final ICacheRecord secondaryLoad = memoryCacheTokenCache.load(
+                    CLIENT_ID,
+                    APPLICATION_IDENTIFIER_SHA512,
+                    MAM_ENROLLMENT_IDENTIFIER,
+                    TARGET,
+                    defaultTestBundleV2.mGeneratedAccount,
+                    BEARER_AUTHENTICATION_SCHEME
+            );
+
+            assertEquals(result.getAccount(), secondaryLoad.getAccount());
+            assertEquals(result.getAccessToken(), secondaryLoad.getAccessToken());
+            assertEquals(result.getRefreshToken(), secondaryLoad.getRefreshToken());
+            assertEquals(result.getIdToken(), secondaryLoad.getIdToken());
+        } finally {
+            resetFlight();
+        }
+    }
+
+    @Test
+    public void loadTokensV1Compat_flightEnabled_returnsCorrectCacheRecord() throws ClientException {
+        enableFilterThenCloneFlight();
+        try {
+            final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
+            final MsalOAuth2TokenCache<MicrosoftStsOAuth2Strategy, MicrosoftStsAuthorizationRequest,
+                    MicrosoftStsTokenResponse, MicrosoftAccount, MicrosoftRefreshToken>
+                    memoryCacheTokenCache = createCacheWithMemoryCache(components);
+
+            configureMocksForTestBundle(defaultTestBundleV1);
+            final ICacheRecord result = memoryCacheTokenCache.save(
+                    mockStrategy,
+                    mockRequest,
+                    mockResponse
+            );
+
+            final ICacheRecord secondaryLoad = memoryCacheTokenCache.load(
+                    CLIENT_ID,
+                    APPLICATION_IDENTIFIER_SHA512,
+                    MAM_ENROLLMENT_IDENTIFIER,
+                    TARGET,
+                    defaultTestBundleV1.mGeneratedAccount,
+                    BEARER_AUTHENTICATION_SCHEME
+            );
+
+            assertEquals(result.getAccount(), secondaryLoad.getAccount());
+            assertEquals(result.getAccessToken(), secondaryLoad.getAccessToken());
+            assertEquals(result.getRefreshToken(), secondaryLoad.getRefreshToken());
+            assertEquals(result.getV1IdToken(), secondaryLoad.getV1IdToken());
+        } finally {
+            resetFlight();
+        }
+    }
+
+    @Test
+    public void getIdTokensForAccountRecord_flightEnabled_returnsCorrectIdTokens() throws ClientException {
+        enableFilterThenCloneFlight();
+        try {
+            final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
+            final MsalOAuth2TokenCache<MicrosoftStsOAuth2Strategy, MicrosoftStsAuthorizationRequest,
+                    MicrosoftStsTokenResponse, MicrosoftAccount, MicrosoftRefreshToken>
+                    memoryCacheTokenCache = createCacheWithMemoryCache(components);
+
+            configureMocksForTestBundle(defaultTestBundleV2);
+            memoryCacheTokenCache.save(
+                    mockStrategy,
+                    mockRequest,
+                    mockResponse
+            );
+
+            final List<IdTokenRecord> idTokens = memoryCacheTokenCache.getIdTokensForAccountRecord(
+                    CLIENT_ID,
+                    defaultTestBundleV2.mGeneratedAccount
+            );
+
+            assertEquals(1, idTokens.size());
+            assertEquals(defaultTestBundleV2.mGeneratedIdToken, idTokens.get(0));
+        } finally {
+            resetFlight();
+        }
+    }
+
+    @Test
+    public void getIdTokensForAccountRecord_flightDisabled_returnsCorrectIdTokens() throws ClientException {
+        // Ensure the existing non-flighted path works unchanged
+        final ICacheRecord result = mOauth2TokenCache.save(
+                mockStrategy,
+                mockRequest,
+                mockResponse
+        );
+
+        final List<IdTokenRecord> idTokens = mOauth2TokenCache.getIdTokensForAccountRecord(
+                CLIENT_ID,
+                defaultTestBundleV2.mGeneratedAccount
+        );
+
+        assertEquals(1, idTokens.size());
+        assertEquals(defaultTestBundleV2.mGeneratedIdToken, idTokens.get(0));
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -2850,7 +2850,7 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
 
     @Test
     public void getCredentialsFilteredByWithKid_flightDisabled_returnsClonesFromAllCredentials() {
-        // Save an access token with a specific kid-like attribute
+        // Save an access token with kid = "kid1"
         final AccessTokenRecord at = new AccessTokenRecord();
         at.setCredentialType(CredentialType.AccessToken.name());
         at.setHomeAccountId(HOME_ACCOUNT_ID);
@@ -2861,37 +2861,54 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         at.setCachedAt(CACHED_AT);
         at.setExpiresOn(EXPIRES_ON);
         at.setSecret(SECRET);
+        at.setKid("kid1");
         mSharedPreferencesAccountCredentialCache.saveCredential(at);
 
-        // Also save a non-matching credential
+        // Also save a non-matching credential type
         final RefreshTokenRecord rt = buildDefaultRefreshToken();
         mSharedPreferencesAccountCredentialCache.saveCredential(rt);
 
-        // Call the new overload with kid = null (should match the AT)
-        final List<Credential> filtered = mSharedPreferencesAccountCredentialCache
+        // Matching kid = "kid1" should return the AT
+        final List<Credential> matchingKid = mSharedPreferencesAccountCredentialCache
+                .getCredentialsFilteredBy(
+                        HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                        CLIENT_ID, null, null, REALM, TARGET,
+                        null, null, "kid1");
+        assertEquals(1, matchingKid.size());
+        assertEquals(CredentialType.AccessToken.name(), matchingKid.get(0).getCredentialType());
+
+        // Non-matching kid = "kid2" should return nothing
+        final List<Credential> nonMatchingKid = mSharedPreferencesAccountCredentialCache
+                .getCredentialsFilteredBy(
+                        HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                        CLIENT_ID, null, null, REALM, TARGET,
+                        null, null, "kid2");
+        assertEquals(0, nonMatchingKid.size());
+
+        // kid = null should return the AT (no kid filter applied)
+        final List<Credential> nullKid = mSharedPreferencesAccountCredentialCache
                 .getCredentialsFilteredBy(
                         HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
                         CLIENT_ID, null, null, REALM, TARGET,
                         null, null, (String) null);
-
-        assertEquals(1, filtered.size());
-        assertEquals(CredentialType.AccessToken.name(), filtered.get(0).getCredentialType());
+        assertEquals(1, nullKid.size());
+        assertEquals(CredentialType.AccessToken.name(), nullKid.get(0).getCredentialType());
 
         // Returned objects should be clones — mutating should not affect cache
-        filtered.get(0).setCachedAt("mutated");
-        final List<Credential> filtered2 = mSharedPreferencesAccountCredentialCache
+        matchingKid.get(0).setCachedAt("mutated");
+        final List<Credential> afterMutation = mSharedPreferencesAccountCredentialCache
                 .getCredentialsFilteredBy(
                         HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
                         CLIENT_ID, null, null, REALM, TARGET,
-                        null, null, (String) null);
-        assertNotEquals("mutated", filtered2.get(0).getCachedAt());
+                        null, null, "kid1");
+        assertNotEquals("mutated", afterMutation.get(0).getCachedAt());
     }
 
     @Test
     public void getCredentialsFilteredByWithKid_flightEnabled_returnsClonedMatchesOnly() {
         enableFilterThenCloneFlight();
         try {
-            // Save an access token
+            // Save an access token with kid = "kid1"
             final AccessTokenRecord at = new AccessTokenRecord();
             at.setCredentialType(CredentialType.AccessToken.name());
             at.setHomeAccountId(HOME_ACCOUNT_ID);
@@ -2902,30 +2919,47 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
             at.setCachedAt(CACHED_AT);
             at.setExpiresOn(EXPIRES_ON);
             at.setSecret(SECRET);
+            at.setKid("kid1");
             mSharedPreferencesAccountCredentialCache.saveCredential(at);
 
-            // Also save a non-matching credential
+            // Also save a non-matching credential type
             final RefreshTokenRecord rt = buildDefaultRefreshToken();
             mSharedPreferencesAccountCredentialCache.saveCredential(rt);
 
-            // Call the new overload with kid = null (should match the AT)
-            final List<Credential> filtered = mSharedPreferencesAccountCredentialCache
+            // Matching kid = "kid1" should return the AT
+            final List<Credential> matchingKid = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                            CLIENT_ID, null, null, REALM, TARGET,
+                            null, null, "kid1");
+            assertEquals(1, matchingKid.size());
+            assertEquals(CredentialType.AccessToken.name(), matchingKid.get(0).getCredentialType());
+
+            // Non-matching kid = "kid2" should return nothing
+            final List<Credential> nonMatchingKid = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                            CLIENT_ID, null, null, REALM, TARGET,
+                            null, null, "kid2");
+            assertEquals(0, nonMatchingKid.size());
+
+            // kid = null should return the AT (no kid filter applied)
+            final List<Credential> nullKid = mSharedPreferencesAccountCredentialCache
                     .getCredentialsFilteredBy(
                             HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
                             CLIENT_ID, null, null, REALM, TARGET,
                             null, null, (String) null);
-
-            assertEquals(1, filtered.size());
-            assertEquals(CredentialType.AccessToken.name(), filtered.get(0).getCredentialType());
+            assertEquals(1, nullKid.size());
+            assertEquals(CredentialType.AccessToken.name(), nullKid.get(0).getCredentialType());
 
             // Returned objects should be clones — mutating should not affect cache
-            filtered.get(0).setCachedAt("mutated");
-            final List<Credential> filtered2 = mSharedPreferencesAccountCredentialCache
+            matchingKid.get(0).setCachedAt("mutated");
+            final List<Credential> afterMutation = mSharedPreferencesAccountCredentialCache
                     .getCredentialsFilteredBy(
                             HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
                             CLIENT_ID, null, null, REALM, TARGET,
-                            null, null, (String) null);
-            assertNotEquals("mutated", filtered2.get(0).getCachedAt());
+                            null, null, "kid1");
+            assertNotEquals("mutated", afterMutation.get(0).getCachedAt());
         } finally {
             resetFlight();
         }

--- a/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/SharedPreferencesAccountCredentialCacheWithMemoryCacheTest.java
@@ -2843,4 +2843,91 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCacheTest {
         assertEquals("removeCredential() must not call keySet()", 0, trackingStorage.getKeySetCallCount());
         assertEquals("removeCredential() must not call getAll()", 0, trackingStorage.getAllCallCount());
     }
+
+    // =====================================================================
+    // Tests for new getCredentialsFilteredBy overload with kid (no input list)
+    // =====================================================================
+
+    @Test
+    public void getCredentialsFilteredByWithKid_flightDisabled_returnsClonesFromAllCredentials() {
+        // Save an access token with a specific kid-like attribute
+        final AccessTokenRecord at = new AccessTokenRecord();
+        at.setCredentialType(CredentialType.AccessToken.name());
+        at.setHomeAccountId(HOME_ACCOUNT_ID);
+        at.setEnvironment(ENVIRONMENT);
+        at.setClientId(CLIENT_ID);
+        at.setRealm(REALM);
+        at.setTarget(TARGET);
+        at.setCachedAt(CACHED_AT);
+        at.setExpiresOn(EXPIRES_ON);
+        at.setSecret(SECRET);
+        mSharedPreferencesAccountCredentialCache.saveCredential(at);
+
+        // Also save a non-matching credential
+        final RefreshTokenRecord rt = buildDefaultRefreshToken();
+        mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+        // Call the new overload with kid = null (should match the AT)
+        final List<Credential> filtered = mSharedPreferencesAccountCredentialCache
+                .getCredentialsFilteredBy(
+                        HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                        CLIENT_ID, null, null, REALM, TARGET,
+                        null, null, (String) null);
+
+        assertEquals(1, filtered.size());
+        assertEquals(CredentialType.AccessToken.name(), filtered.get(0).getCredentialType());
+
+        // Returned objects should be clones — mutating should not affect cache
+        filtered.get(0).setCachedAt("mutated");
+        final List<Credential> filtered2 = mSharedPreferencesAccountCredentialCache
+                .getCredentialsFilteredBy(
+                        HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                        CLIENT_ID, null, null, REALM, TARGET,
+                        null, null, (String) null);
+        assertNotEquals("mutated", filtered2.get(0).getCachedAt());
+    }
+
+    @Test
+    public void getCredentialsFilteredByWithKid_flightEnabled_returnsClonedMatchesOnly() {
+        enableFilterThenCloneFlight();
+        try {
+            // Save an access token
+            final AccessTokenRecord at = new AccessTokenRecord();
+            at.setCredentialType(CredentialType.AccessToken.name());
+            at.setHomeAccountId(HOME_ACCOUNT_ID);
+            at.setEnvironment(ENVIRONMENT);
+            at.setClientId(CLIENT_ID);
+            at.setRealm(REALM);
+            at.setTarget(TARGET);
+            at.setCachedAt(CACHED_AT);
+            at.setExpiresOn(EXPIRES_ON);
+            at.setSecret(SECRET);
+            mSharedPreferencesAccountCredentialCache.saveCredential(at);
+
+            // Also save a non-matching credential
+            final RefreshTokenRecord rt = buildDefaultRefreshToken();
+            mSharedPreferencesAccountCredentialCache.saveCredential(rt);
+
+            // Call the new overload with kid = null (should match the AT)
+            final List<Credential> filtered = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                            CLIENT_ID, null, null, REALM, TARGET,
+                            null, null, (String) null);
+
+            assertEquals(1, filtered.size());
+            assertEquals(CredentialType.AccessToken.name(), filtered.get(0).getCredentialType());
+
+            // Returned objects should be clones — mutating should not affect cache
+            filtered.get(0).setCachedAt("mutated");
+            final List<Credential> filtered2 = mSharedPreferencesAccountCredentialCache
+                    .getCredentialsFilteredBy(
+                            HOME_ACCOUNT_ID, ENVIRONMENT, CredentialType.AccessToken,
+                            CLIENT_ID, null, null, REALM, TARGET,
+                            null, null, (String) null);
+            assertNotEquals("mutated", filtered2.get(0).getCachedAt());
+        } finally {
+            resetFlight();
+        }
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/IAccountCredentialCache.java
@@ -291,6 +291,38 @@ public interface IAccountCredentialCache {
     );
 
     /**
+     * Returns all of the Credentials matching the supplied criteria, including kid filtering.
+     * Unlike the input-list overload, this method reads directly from the cache and
+     * benefits from filter-then-clone optimization when the corresponding flight is enabled.
+     *
+     * @param homeAccountId   The homeAccountId used to match Credential cache keys.
+     * @param environment     The environment used to match Credential cache keys.
+     * @param credentialType  The sought CredentialType.
+     * @param clientId        The clientId used to match Credential cache keys.
+     * @param applicationIdentifier The physical identifier of the application (Android: packageName/signature)
+     * @param mamEnrollmentIdentifier The Mobile Application Management or Intune App Protection enrollment identifier (Android Only)
+     * @param realm           The realm used to match Credential cache keys.
+     * @param target          The target used to match Credential cache keys.
+     * @param authScheme      The auth scheme used to match Credential cache keys.
+     * @param requestedClaims The requested claims used to match Credential cache keys.
+     * @param kid             Kid value used to match access token record.
+     * @return A mutable List of Credentials matching the supplied criteria.
+     */
+    List<Credential> getCredentialsFilteredBy(
+            final String homeAccountId,
+            final String environment,
+            final CredentialType credentialType,
+            final String clientId,
+            final String applicationIdentifier,
+            final String mamEnrollmentIdentifier,
+            final String realm,
+            final String target,
+            final String authScheme,
+            final String requestedClaims,
+            final String kid
+    );
+
+    /**
      * Removes the supplied Account from the cache.
      *
      * @param accountToRemove The Account to delete.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -665,7 +665,10 @@ public class MsalOAuth2TokenCache
 
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE)
+                && CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS);
 
         final List<Credential> accessTokens;
         final List<Credential> idTokens;
@@ -673,61 +676,67 @@ public class MsalOAuth2TokenCache
         List<Credential> refreshTokens;
 
         if (useFilterThenClone) {
-            // When filter-then-clone is enabled, call direct (non-input-list) overloads
-            // so each call filters on uncloned in-memory references, cloning only matches.
-            accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                    account.getHomeAccountId(),
-                    account.getEnvironment(),
-                    getAccessTokenCredentialTypeForAuthenticationScheme(authScheme),
-                    clientId,
-                    applicationIdentifier,
-                    mamEnrollmentIdentifier,
-                    account.getRealm(),
-                    target,
-                    authScheme.getName(),
-                    null,
-                    kid
-            );
+            // Wrap all reads under one lock to ensure a consistent snapshot and prevent
+            // a concurrent removal from causing partial/inconsistent cache records.
+            // Safe to cast — USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS guarantees
+            // mAccountCredentialCache is SharedPreferencesAccountCredentialCacheWithMemoryCache.
+            final Object cacheLock = ((SharedPreferencesAccountCredentialCacheWithMemoryCache)
+                    mAccountCredentialCache).getCacheLock();
+            synchronized (cacheLock) {
+                accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                        account.getHomeAccountId(),
+                        account.getEnvironment(),
+                        getAccessTokenCredentialTypeForAuthenticationScheme(authScheme),
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        account.getRealm(),
+                        target,
+                        authScheme.getName(),
+                        null,
+                        kid
+                );
 
-            refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                    account.getHomeAccountId(),
-                    account.getEnvironment(),
-                    CredentialType.RefreshToken,
-                    clientId,
-                    null, //wildcard (*)
-                    null, //wildcard (*)
-                    isMultiResourceCapable
-                            ? null // wildcard (*)
-                            : account.getRealm(),
-                    isMultiResourceCapable
-                            ? null // wildcard (*)
-                            : target,
-                    null // not applicable
-            );
+                refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                        account.getHomeAccountId(),
+                        account.getEnvironment(),
+                        CredentialType.RefreshToken,
+                        clientId,
+                        null, //wildcard (*)
+                        null, //wildcard (*)
+                        isMultiResourceCapable
+                                ? null // wildcard (*)
+                                : account.getRealm(),
+                        isMultiResourceCapable
+                                ? null // wildcard (*)
+                                : target,
+                        null // not applicable
+                );
 
-            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                    account.getHomeAccountId(),
-                    account.getEnvironment(),
-                    IdToken,
-                    clientId,
-                    null, //wildcard (*)
-                    null, //wildcard (*)
-                    account.getRealm(),
-                    null, // wildcard (*),
-                    null // not applicable
-            );
+                idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                        account.getHomeAccountId(),
+                        account.getEnvironment(),
+                        IdToken,
+                        clientId,
+                        null, //wildcard (*)
+                        null, //wildcard (*)
+                        account.getRealm(),
+                        null, // wildcard (*),
+                        null // not applicable
+                );
 
-            v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                    account.getHomeAccountId(),
-                    account.getEnvironment(),
-                    CredentialType.V1IdToken,
-                    clientId,
-                    null, //wildcard (*)
-                    null, //wildcard (*)
-                    account.getRealm(),
-                    null, // wildcard (*)
-                    null // not applicable
-            );
+                v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                        account.getHomeAccountId(),
+                        account.getEnvironment(),
+                        CredentialType.V1IdToken,
+                        clientId,
+                        null, //wildcard (*)
+                        null, //wildcard (*)
+                        account.getRealm(),
+                        null, // wildcard (*)
+                        null // not applicable
+                );
+            }
         } else {
             // Legacy path: preload all credentials (clone-all) once,
             // then filter the pre-cloned list multiple times.
@@ -949,36 +958,42 @@ public class MsalOAuth2TokenCache
 
         final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
                 .getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE)
+                && CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS);
 
         final List<Credential> idTokens;
 
         if (useFilterThenClone) {
-            // When filter-then-clone is enabled, call direct (non-input-list) overloads
-            // so each call filters on uncloned in-memory references, cloning only matches.
-            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                    accountRecord.getHomeAccountId(),
-                    accountRecord.getEnvironment(),
-                    IdToken,
-                    clientId, // If null, behaves as wildcard
-                    null,
-                    null,
-                    accountRecord.getRealm(),
-                    null, // wildcard (*),
-                    null // not applicable
-            );
+            // Wrap under one lock for snapshot consistency (same rationale as load()).
+            final Object cacheLock = ((SharedPreferencesAccountCredentialCacheWithMemoryCache)
+                    mAccountCredentialCache).getCacheLock();
+            synchronized (cacheLock) {
+                idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                        accountRecord.getHomeAccountId(),
+                        accountRecord.getEnvironment(),
+                        IdToken,
+                        clientId, // If null, behaves as wildcard
+                        null,
+                        null,
+                        accountRecord.getRealm(),
+                        null, // wildcard (*),
+                        null // not applicable
+                );
 
-            idTokens.addAll(mAccountCredentialCache.getCredentialsFilteredBy(
-                    accountRecord.getHomeAccountId(),
-                    accountRecord.getEnvironment(),
-                    CredentialType.V1IdToken,
-                    clientId,
-                    null, //wildcard (*)
-                    null, //wildcard (*)
-                    accountRecord.getRealm(),
-                    null, // wildcard (*)
-                    null // not applicable
-            ));
+                idTokens.addAll(mAccountCredentialCache.getCredentialsFilteredBy(
+                        accountRecord.getHomeAccountId(),
+                        accountRecord.getEnvironment(),
+                        CredentialType.V1IdToken,
+                        clientId,
+                        null, //wildcard (*)
+                        null, //wildcard (*)
+                        accountRecord.getRealm(),
+                        null, // wildcard (*)
+                        null // not applicable
+                ));
+            }
         } else {
             // Legacy path: preload all credentials (clone-all) once,
             // then filter the pre-cloned list multiple times.

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -42,6 +42,8 @@ import com.microsoft.identity.common.java.dto.CredentialType;
 import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -657,45 +659,138 @@ public class MsalOAuth2TokenCache
                 account.getAuthorityType()
         );
 
-        // 'Preloading' our credentials to avoid repeated expensive cache hits
-        final List<Credential> allCredentials = mAccountCredentialCache.getCredentials();
-
-        // Load the AccessTokens
         final String kid = authScheme instanceof PopAuthenticationSchemeWithClientKeyInternal ?
                 ((PopAuthenticationSchemeWithClientKeyInternal) authScheme).getKid()
                 : null;
-        final List<Credential> accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                allCredentials,
-                account.getHomeAccountId(),
-                account.getEnvironment(),
-                getAccessTokenCredentialTypeForAuthenticationScheme(authScheme),
-                clientId,
-                applicationIdentifier,
-                mamEnrollmentIdentifier, //Null unless Intune reports one available for this app
-                account.getRealm(),
-                target,
-                authScheme.getName(),
-                null,
-                kid
-                );
 
-        // Load the RefreshTokens
-        List<Credential> refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                account.getHomeAccountId(),
-                account.getEnvironment(),
-                CredentialType.RefreshToken,
-                clientId,
-                null, //wildcard (*)
-                null, //wildcard (*)
-                isMultiResourceCapable
-                        ? null // wildcard (*)
-                        : account.getRealm(),
-                isMultiResourceCapable
-                        ? null // wildcard (*)
-                        : target,
-                null, // not applicable
-                allCredentials
-        );
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        final List<Credential> accessTokens;
+        final List<Credential> idTokens;
+        final List<Credential> v1IdTokens;
+        List<Credential> refreshTokens;
+
+        if (useFilterThenClone) {
+            // When filter-then-clone is enabled, call direct (non-input-list) overloads
+            // so each call filters on uncloned in-memory references, cloning only matches.
+            accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    getAccessTokenCredentialTypeForAuthenticationScheme(authScheme),
+                    clientId,
+                    applicationIdentifier,
+                    mamEnrollmentIdentifier,
+                    account.getRealm(),
+                    target,
+                    authScheme.getName(),
+                    null,
+                    kid
+            );
+
+            refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    CredentialType.RefreshToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    isMultiResourceCapable
+                            ? null // wildcard (*)
+                            : account.getRealm(),
+                    isMultiResourceCapable
+                            ? null // wildcard (*)
+                            : target,
+                    null // not applicable
+            );
+
+            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    IdToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    account.getRealm(),
+                    null, // wildcard (*),
+                    null // not applicable
+            );
+
+            v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    CredentialType.V1IdToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    account.getRealm(),
+                    null, // wildcard (*)
+                    null // not applicable
+            );
+        } else {
+            // Legacy path: preload all credentials (clone-all) once,
+            // then filter the pre-cloned list multiple times.
+            final List<Credential> allCredentials = mAccountCredentialCache.getCredentials();
+
+            accessTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    allCredentials,
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    getAccessTokenCredentialTypeForAuthenticationScheme(authScheme),
+                    clientId,
+                    applicationIdentifier,
+                    mamEnrollmentIdentifier,
+                    account.getRealm(),
+                    target,
+                    authScheme.getName(),
+                    null,
+                    kid
+            );
+
+            refreshTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    CredentialType.RefreshToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    isMultiResourceCapable
+                            ? null // wildcard (*)
+                            : account.getRealm(),
+                    isMultiResourceCapable
+                            ? null // wildcard (*)
+                            : target,
+                    null, // not applicable
+                    allCredentials
+            );
+
+            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    IdToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    account.getRealm(),
+                    null, // wildcard (*),
+                    null, // not applicable
+                    allCredentials
+            );
+
+            v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    account.getHomeAccountId(),
+                    account.getEnvironment(),
+                    CredentialType.V1IdToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    account.getRealm(),
+                    null, // wildcard (*)
+                    null, // not applicable
+                    allCredentials
+            );
+        }
 
         if (refreshTokens.isEmpty()) {
             // If we didn't find an RT in the cache, this could be a "TSL-seed" or "dual-client stack"
@@ -726,34 +821,6 @@ public class MsalOAuth2TokenCache
                 refreshTokens.add(fallbackFrt);
             }
         }
-
-        // Load the IdTokens
-        final List<Credential> idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                account.getHomeAccountId(),
-                account.getEnvironment(),
-                IdToken,
-                clientId,
-                null, //wildcard (*)
-                null, //wildcard (*)
-                account.getRealm(),
-                null, // wildcard (*),
-                null, // not applicable
-                allCredentials
-        );
-
-        // Load the v1 IdTokens
-        final List<Credential> v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                account.getHomeAccountId(),
-                account.getEnvironment(),
-                CredentialType.V1IdToken,
-                clientId,
-                null, //wildcard (*)
-                null, //wildcard (*)
-                account.getRealm(),
-                null, // wildcard (*)
-                null, // not applicable
-                allCredentials
-        );
 
         final CacheRecord.CacheRecordBuilder result = CacheRecord.builder();
         result.account(account);
@@ -880,39 +947,80 @@ public class MsalOAuth2TokenCache
                                                            @NonNull AccountRecord accountRecord) {
         final List<IdTokenRecord> result = new ArrayList<>();
 
-        // Load all the credentials to inspect once, such that we don't need to requery the cache
-        // pass these into the new getCredentialsFilteredBy overload, rather than hit disk again
-        final List<Credential> allCredentials = mAccountCredentialCache.getCredentials();
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
 
-        final List<Credential> idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
-                accountRecord.getHomeAccountId(),
-                accountRecord.getEnvironment(),
-                IdToken,
-                clientId, // If null, behaves as wildcard
-                null,
-                null,
-                accountRecord.getRealm(),
-                null, // wildcard (*),
-                null, // not applicable
-                allCredentials
-        );
+        final List<Credential> idTokens;
+        final List<Credential> v1IdTokens;
 
-        idTokens.addAll(
-                mAccountCredentialCache.getCredentialsFilteredBy(
-                        accountRecord.getHomeAccountId(),
-                        accountRecord.getEnvironment(),
-                        CredentialType.V1IdToken,
-                        clientId,
-                        null, //wildcard (*)
-                        null, //wildcard (*)
-                        accountRecord.getRealm(),
-                        null, // wildcard (*)
-                        null, // not applicable
-                        allCredentials
-                )
-        );
+        if (useFilterThenClone) {
+            // When filter-then-clone is enabled, call direct (non-input-list) overloads
+            // so each call filters on uncloned in-memory references, cloning only matches.
+            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    accountRecord.getHomeAccountId(),
+                    accountRecord.getEnvironment(),
+                    IdToken,
+                    clientId, // If null, behaves as wildcard
+                    null,
+                    null,
+                    accountRecord.getRealm(),
+                    null, // wildcard (*),
+                    null // not applicable
+            );
+
+            v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    accountRecord.getHomeAccountId(),
+                    accountRecord.getEnvironment(),
+                    CredentialType.V1IdToken,
+                    clientId,
+                    null, //wildcard (*)
+                    null, //wildcard (*)
+                    accountRecord.getRealm(),
+                    null, // wildcard (*)
+                    null // not applicable
+            );
+        } else {
+            // Legacy path: preload all credentials (clone-all) once,
+            // then filter the pre-cloned list multiple times.
+            final List<Credential> allCredentials = mAccountCredentialCache.getCredentials();
+
+            idTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+                    accountRecord.getHomeAccountId(),
+                    accountRecord.getEnvironment(),
+                    IdToken,
+                    clientId, // If null, behaves as wildcard
+                    null,
+                    null,
+                    accountRecord.getRealm(),
+                    null, // wildcard (*),
+                    null, // not applicable
+                    allCredentials
+            );
+
+            v1IdTokens = new ArrayList<>(
+                    mAccountCredentialCache.getCredentialsFilteredBy(
+                            accountRecord.getHomeAccountId(),
+                            accountRecord.getEnvironment(),
+                            CredentialType.V1IdToken,
+                            clientId,
+                            null, //wildcard (*)
+                            null, //wildcard (*)
+                            accountRecord.getRealm(),
+                            null, // wildcard (*)
+                            null, // not applicable
+                            allCredentials
+                    )
+            );
+        }
 
         for (final Credential credential : idTokens) {
+            if (credential instanceof IdTokenRecord) {
+                result.add((IdTokenRecord) credential);
+            }
+        }
+
+        for (final Credential credential : v1IdTokens) {
             if (credential instanceof IdTokenRecord) {
                 result.add((IdTokenRecord) credential);
             }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -952,7 +952,6 @@ public class MsalOAuth2TokenCache
                 .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
 
         final List<Credential> idTokens;
-        final List<Credential> v1IdTokens;
 
         if (useFilterThenClone) {
             // When filter-then-clone is enabled, call direct (non-input-list) overloads
@@ -969,7 +968,7 @@ public class MsalOAuth2TokenCache
                     null // not applicable
             );
 
-            v1IdTokens = mAccountCredentialCache.getCredentialsFilteredBy(
+            idTokens.addAll(mAccountCredentialCache.getCredentialsFilteredBy(
                     accountRecord.getHomeAccountId(),
                     accountRecord.getEnvironment(),
                     CredentialType.V1IdToken,
@@ -979,7 +978,7 @@ public class MsalOAuth2TokenCache
                     accountRecord.getRealm(),
                     null, // wildcard (*)
                     null // not applicable
-            );
+            ));
         } else {
             // Legacy path: preload all credentials (clone-all) once,
             // then filter the pre-cloned list multiple times.
@@ -998,7 +997,7 @@ public class MsalOAuth2TokenCache
                     allCredentials
             );
 
-            v1IdTokens = new ArrayList<>(
+            idTokens.addAll(
                     mAccountCredentialCache.getCredentialsFilteredBy(
                             accountRecord.getHomeAccountId(),
                             accountRecord.getEnvironment(),
@@ -1015,12 +1014,6 @@ public class MsalOAuth2TokenCache
         }
 
         for (final Credential credential : idTokens) {
-            if (credential instanceof IdTokenRecord) {
-                result.add((IdTokenRecord) credential);
-            }
-        }
-
-        for (final Credential credential : v1IdTokens) {
             if (credential instanceof IdTokenRecord) {
                 result.add((IdTokenRecord) credential);
             }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -584,8 +584,7 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
             @Nullable final String requestedClaims,
             @Nullable final String kid) {
         final List<Credential> allCredentials = getCredentials();
-        final List<Credential> result = new ArrayList<>();
-        result.addAll(
+        return new ArrayList<>(
                 getCredentialsFilteredByInternal(
                         allCredentials,
                         homeAccountId,
@@ -602,7 +601,6 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
                         false
                 )
         );
-        return result;
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCache.java
@@ -571,6 +571,41 @@ public class SharedPreferencesAccountCredentialCache extends AbstractAccountCred
     }
 
     @Override
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @Nullable final String requestedClaims,
+            @Nullable final String kid) {
+        final List<Credential> allCredentials = getCredentials();
+        final List<Credential> result = new ArrayList<>();
+        result.addAll(
+                getCredentialsFilteredByInternal(
+                        allCredentials,
+                        homeAccountId,
+                        environment,
+                        credentialType,
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        realm,
+                        target,
+                        authScheme,
+                        requestedClaims,
+                        kid,
+                        false
+                )
+        );
+        return result;
+    }
+
+    @Override
     public boolean removeAccount(@NonNull final AccountRecord accountToRemove) {
         final String methodTag = TAG + ":removeAccount";
         Logger.info(methodTag, "Removing Account...");

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -65,6 +65,16 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
     private final ICacheKeyValueDelegate mCacheValueDelegate;
 
     private final Object mCacheLock = new Object();
+
+    /**
+     * Returns the internal cache lock for callers that need to atomically perform
+     * multiple filtered reads under a single lock acquisition (e.g., MsalOAuth2TokenCache.load()).
+     * The lock is reentrant via Java's synchronized semantics.
+     */
+    public Object getCacheLock() {
+        return mCacheLock;
+    }
+
     private boolean mLoaded = false;
     private Map<String, AccountRecord> mCachedAccountRecordsWithKeys = new HashMap<>();
     private Map<String, Credential> mCachedCredentialsWithKeys = new HashMap<>();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -762,6 +762,79 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
     }
 
     @Override
+    @NonNull
+    public List<Credential> getCredentialsFilteredBy(
+            @Nullable final String homeAccountId,
+            @Nullable final String environment,
+            @Nullable final CredentialType credentialType,
+            @Nullable final String clientId,
+            @Nullable final String applicationIdentifier,
+            @Nullable final String mamEnrollmentIdentifier,
+            @Nullable final String realm,
+            @Nullable final String target,
+            @Nullable final String authScheme,
+            @Nullable final String requestedClaims,
+            @Nullable final String kid) {
+        final String methodTag = TAG + ":getCredentialsFilteredBy";
+        Logger.verbose(methodTag, "getCredentialsFilteredBy() -- with kid");
+
+        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
+                .getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
+
+        SpanExtension.current().setAttribute(
+                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
+
+        if (useFilterThenClone) {
+            synchronized (mCacheLock) {
+                waitForInitialLoad();
+                final List<Credential> unclonedCredentials =
+                        new ArrayList<>(mCachedCredentialsWithKeys.values());
+                final List<Credential> matchingUncloned = getCredentialsFilteredByInternal(
+                        unclonedCredentials,
+                        homeAccountId,
+                        environment,
+                        credentialType,
+                        clientId,
+                        applicationIdentifier,
+                        mamEnrollmentIdentifier,
+                        realm,
+                        target,
+                        authScheme,
+                        requestedClaims,
+                        kid,
+                        false
+                );
+                final List<Credential> clonedMatches = cloneItems(matchingUncloned, methodTag);
+                Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Credentials...");
+                return clonedMatches;
+            }
+        }
+
+        final List<Credential> allCredentials = getCredentials();
+
+        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
+                allCredentials,
+                homeAccountId,
+                environment,
+                credentialType,
+                clientId,
+                applicationIdentifier,
+                mamEnrollmentIdentifier,
+                realm,
+                target,
+                authScheme,
+                requestedClaims,
+                kid,
+                false
+        );
+
+        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
+
+        return matchingCredentials;
+    }
+
+    @Override
     public boolean removeAccount(@NonNull final AccountRecord accountToRemove) {
         final String methodTag = TAG + ":removeAccount";
         Logger.info(methodTag, "Removing Account...");

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/SharedPreferencesAccountCredentialCacheWithMemoryCache.java
@@ -778,60 +778,32 @@ public class SharedPreferencesAccountCredentialCacheWithMemoryCache extends Abst
         final String methodTag = TAG + ":getCredentialsFilteredBy";
         Logger.verbose(methodTag, "getCredentialsFilteredBy() -- with kid");
 
-        final boolean useFilterThenClone = CommonFlightsManager.INSTANCE
-                .getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE);
-
-        SpanExtension.current().setAttribute(
-                AttributeName.is_filter_then_clone_enabled.name(), useFilterThenClone);
-
-        if (useFilterThenClone) {
-            synchronized (mCacheLock) {
-                waitForInitialLoad();
-                final List<Credential> unclonedCredentials =
-                        new ArrayList<>(mCachedCredentialsWithKeys.values());
-                final List<Credential> matchingUncloned = getCredentialsFilteredByInternal(
-                        unclonedCredentials,
-                        homeAccountId,
-                        environment,
-                        credentialType,
-                        clientId,
-                        applicationIdentifier,
-                        mamEnrollmentIdentifier,
-                        realm,
-                        target,
-                        authScheme,
-                        requestedClaims,
-                        kid,
-                        false
-                );
-                final List<Credential> clonedMatches = cloneItems(matchingUncloned, methodTag);
-                Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Credentials...");
-                return clonedMatches;
-            }
+        // No flight check here — the caller (MsalOAuth2TokenCache) already gates
+        // entry to this overload via the ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight.
+        // Always use the optimized filter-then-clone path.
+        synchronized (mCacheLock) {
+            waitForInitialLoad();
+            final List<Credential> unclonedCredentials =
+                    new ArrayList<>(mCachedCredentialsWithKeys.values());
+            final List<Credential> matchingUncloned = getCredentialsFilteredByInternal(
+                    unclonedCredentials,
+                    homeAccountId,
+                    environment,
+                    credentialType,
+                    clientId,
+                    applicationIdentifier,
+                    mamEnrollmentIdentifier,
+                    realm,
+                    target,
+                    authScheme,
+                    requestedClaims,
+                    kid,
+                    false
+            );
+            final List<Credential> clonedMatches = cloneItems(matchingUncloned, methodTag);
+            Logger.verbose(methodTag, "Found [" + clonedMatches.size() + "] matching Credentials...");
+            return clonedMatches;
         }
-
-        final List<Credential> allCredentials = getCredentials();
-
-        final List<Credential> matchingCredentials = getCredentialsFilteredByInternal(
-                allCredentials,
-                homeAccountId,
-                environment,
-                credentialType,
-                clientId,
-                applicationIdentifier,
-                mamEnrollmentIdentifier,
-                realm,
-                target,
-                authScheme,
-                requestedClaims,
-                kid,
-                false
-        );
-
-        Logger.verbose(methodTag, "Found [" + matchingCredentials.size() + "] matching Credentials...");
-
-        return matchingCredentials;
     }
 
     @Override


### PR DESCRIPTION
Fixes [AB#3588022](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3588022) Apply filter-then-clone optimization to MsalOAuth2TokenCache.load() and getIdTokensForAccountRecord() methods behind the existing ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight.

When the flight is enabled, these methods now call the direct (non-input-list) getCredentialsFilteredBy overloads which filter on uncloned in-memory references first, then clone only the matching credentials. This avoids cloning all cached credentials on every AcquireTokenSilent cache-hit path.

Changes:
- Add new getCredentialsFilteredBy overload with kid parameter to IAccountCredentialCache, SharedPreferencesAccountCredentialCache, and SharedPreferencesAccountCredentialCacheWithMemoryCache
- Gate load() to skip preload pattern and use direct filtered lookups when flight is enabled
- Gate getIdTokensForAccountRecord() with same optimization pattern
- Add tests for new kid overload (flight enabled/disabled)
- Add MsalOAuth2TokenCache-level tests for flight-gated load() and getIdTokensForAccountRecord() paths