### PR TITLE
Broker IPC plumbing: add onboarding blob to BrokerRequest, BrokerResu…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add onboarding telemetry recorder, field keys, and session persistence for mobile onboarding flow (#3088)
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)
 - [PATCH] Add support for Authenticator app activation links in WebView, enabling account pairing/MFA flows to launch Microsoft Authenticator directly instead of redirecting to the Play Store (#3090)
 - [PATCH] Fix: WPJ's BrokerDiscovery cache crash due to shared predefined encryption key with MSAL (#3081)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -87,6 +87,7 @@ public class BrokerRequest implements Serializable {
         final static String TENANT_ID = "tenant_id";
         final static String REQUEST_TYPE = "request_type";
         final static String WEB_APPS_STATE = "web_apps_state";
+        final static String ONBOARDING_SEED_JSON = "onboarding_seed_json";
     }
 
     /**
@@ -295,4 +296,13 @@ public class BrokerRequest implements Serializable {
     @Nullable
     @SerializedName(SerializedNames.REQUEST_TYPE)
     private String mRequestType;
+
+    /**
+     * Onboarding telemetry seed JSON blob.
+     * Contains sessionCorrelationId, onboarding_mode, schema_version.
+     * Broker populates this with blocking errors and returns in the result.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.ONBOARDING_SEED_JSON)
+    private String mOnboardingSeedJson;
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -97,6 +97,7 @@ public class BrokerResult {
         static final String SPE_RING = "spe_ring";
         static final String CLI_TELEM_ERRORCODE = "cli_telem_error_code";
         static final String CLI_TELEM_SUB_ERROR_CODE = "cli_telem_suberror_code";
+        static final String ONBOARDING_BLOB = "onboarding_blob";
     }
 
     private static final long serialVersionUID = 8606631820514878489L;
@@ -327,6 +328,13 @@ public class BrokerResult {
     @SerializedName(SerializedNames.BROKER_AAD_DEVICE_ID_RECORD)
     private final AadDeviceIdRecord mAadDeviceIdRecord;
 
+    /**
+     * Populated onboarding telemetry blob JSON returned by the broker.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.ONBOARDING_BLOB)
+    private final String mOnboardingBlob;
+
     private BrokerResult(@NonNull final Builder builder) {
         mAccessToken = builder.mAccessToken;
         mIdToken = builder.mIdToken;
@@ -362,6 +370,7 @@ public class BrokerResult {
         mCliTelemSubErrorCode = builder.mCliTelemSubErrorCode;
         mExceptionType = builder.mExceptionType;
         mAadDeviceIdRecord = builder.mAadDeviceIdRecord;
+        mOnboardingBlob = builder.mOnboardingBlob;
     }
 
     public String getExceptionType() {
@@ -498,6 +507,11 @@ public class BrokerResult {
         return mAadDeviceIdRecord;
     }
 
+    @Nullable
+    public String getOnboardingBlob() {
+        return mOnboardingBlob;
+    }
+
     public static class Builder {
         private String mAccessToken;
         private String mIdToken;
@@ -523,6 +537,7 @@ public class BrokerResult {
         private List<ICacheRecord> mTenantProfileData;
         private boolean mServicedFromCache;
         private AadDeviceIdRecord mAadDeviceIdRecord;
+        private String mOnboardingBlob;
 
         // Exception parameters
         private String mErrorCode;
@@ -535,7 +550,6 @@ public class BrokerResult {
         private String mCliTelemErrorCode;
         private String mCliTelemSubErrorCode;
         private String mExceptionType;
-
         public Builder accessToken(@Nullable final String accessToken) {
             this.mAccessToken = accessToken;
             return this;
@@ -710,6 +724,11 @@ public class BrokerResult {
 
         public Builder exceptionType(String exceptionType) {
             this.mExceptionType = exceptionType;
+            return this;
+        }
+
+        public Builder onboardingBlob(String onboardingBlob) {
+            this.mOnboardingBlob = onboardingBlob;
             return this;
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -139,7 +139,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .preferredBrowser(parameters.getPreferredBrowser())
                 .preferredAuthMethod(parameters.getPreferredAuthMethod())
                 .accountTransferToken(parameters.getAccountTransferToken())
-                .suppressAccountPicker(parameters.isSuppressBrokerAccountPicker());
+                .suppressAccountPicker(parameters.isSuppressBrokerAccountPicker())
+                .onboardingSeedJson(parameters.getOnboardingSeedJson());
 
         if (parameters instanceof AndroidInteractiveTokenCommandParameters) {
             final AndroidInteractiveTokenCommandParameters androidInteractiveTokenCommandParameters = (AndroidInteractiveTokenCommandParameters) parameters;

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -1038,6 +1038,17 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                         resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)
                 );
             }
+
+            // Extract onboarding blob from BrokerResult if present
+            try {
+                final BrokerResult brokerResult = resultAdapter.brokerResultFromBundle(resultBundle);
+                if (brokerResult != null && brokerResult.getOnboardingBlob() != null) {
+                    acquireTokenResult.setOnboardingBlob(brokerResult.getOnboardingBlob());
+                }
+            } catch (final Exception e) {
+                // Best-effort — don't fail the result for telemetry
+            }
+
             return acquireTokenResult;
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/OnboardingSessionCachePersistence.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/OnboardingSessionCachePersistence.java
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.identity.common.internal.telemetry;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+/**
+ * SharedPreferences-backed persistence for session correlation IDs.
+ * Used by both OneAuth (via JNI/Djinni) and the broker app directly.
+ * The same SharedPreferences file is written to by OnboardingTelemetryRecorder
+ * on block detection for app-kill resilience.
+ */
+public class OnboardingSessionCachePersistence {
+
+    private static final String PREFS_FILE = "com.microsoft.oneauth.session_correlation_cache";
+
+    private final Context mContext;
+
+    public OnboardingSessionCachePersistence(@NonNull Context context) {
+        mContext = context.getApplicationContext();
+    }
+
+    /**
+     * Load the persisted session correlation cache JSON string.
+     * @return JSON string, or empty string if nothing is persisted
+     */
+    @NonNull
+    public String load() {
+        SharedPreferences prefs = mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+        String value = prefs.getString(PREFS_FILE, "");
+        return value != null ? value : "";
+    }
+
+    /**
+     * Save the session correlation cache JSON string to SharedPreferences.
+     * @param json The JSON string to persist
+     */
+    public void save(@NonNull String json) {
+        SharedPreferences prefs = mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+        prefs.edit().putString(PREFS_FILE, json).apply();
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/telemetry/OnboardingTelemetryRecorder.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/telemetry/OnboardingTelemetryRecorder.java
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.identity.common.internal.telemetry;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.java.telemetry.OnboardingBlobFieldKeys;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Records onboarding telemetry events during interactive auth flows.
+ * Called by WebView navigation fragments to track steps, blocking errors,
+ * and domain navigation. Operates on an in-memory Java model, converts
+ * to JSON at flow end. On block detection, persists sessionCorrelationId
+ * to SharedPreferences for app-kill resilience (best-effort, async).
+ *
+ * Lives in Android common core so both OneAuth (non-brokered) and broker apps
+ * (brokered) use the same class.
+ */
+public class OnboardingTelemetryRecorder {
+
+    private static final String PREFS_FILE = "com.microsoft.oneauth.session_correlation_cache";
+
+    // Seed field key constants — must match OnboardingBlobConstants (Djinni-generated).
+    // Duplicated here to avoid a dependency on the Djinni-generated Java class in Common.
+    private static final String FIELD_SCHEMA_VERSION = "schema_version";
+    private static final String FIELD_SESSION_CORRELATION_ID = "session_correlation_id";
+    private static final String FIELD_ONBOARDING_MODE = "onboarding_mode";
+    private static final String FIELD_STEPS_LIST = "steps_list";
+    private static final String FIELD_STEP_ID = "step_id";
+    private static final String FIELD_TS = "ts";
+
+    // Seed fields (from C++ common core)
+    private final String mSchemaVersion;
+    private final String mSessionCorrelationId;
+    private final String mOnboardingMode;
+
+    // Recorder identity for persistence
+    private final String mClientId;
+    private final String mTarget;
+    private final Context mContext;
+
+    // Populated fields
+    private final List<StepEntry> mStepsList = new ArrayList<>();
+    private final List<String> mBlockingErrors = new ArrayList<>();
+    private String mLastLoadedDomain;
+    private String mProfile;
+    private final List<String> mUxFlowUsed = new ArrayList<>();
+
+    private static class StepEntry {
+        final String stepId;
+        final String timestamp; // ISO 8601
+
+        StepEntry(String stepId, String timestamp) {
+            this.stepId = stepId;
+            this.timestamp = timestamp;
+        }
+    }
+
+    /**
+     * Construct a recorder from the seed JSON provided by C++ InteractiveRequest.
+     *
+     * @param seedJson  The seed blob JSON string from authParameters
+     * @param clientId  Client ID for cache persistence key
+     * @param target    Target (scopes) for cache persistence key
+     * @param context   Android context for SharedPreferences access
+     */
+    public OnboardingTelemetryRecorder(
+            @NonNull String seedJson,
+            @NonNull String clientId,
+            @NonNull String target,
+            @NonNull Context context) {
+        mClientId = clientId;
+        mTarget = target;
+        mContext = context.getApplicationContext();
+
+        // Deserialize seed JSON
+        String schemaVersion = "";
+        String sessionCorrelationId = "";
+        String onboardingMode = "";
+        try {
+            JSONObject seed = new JSONObject(seedJson);
+            schemaVersion = seed.optString(FIELD_SCHEMA_VERSION, "");
+            sessionCorrelationId = seed.optString(FIELD_SESSION_CORRELATION_ID, "");
+            onboardingMode = seed.optString(FIELD_ONBOARDING_MODE, "");
+        } catch (JSONException e) {
+            // Corrupted seed — use empty values
+        }
+        mSchemaVersion = schemaVersion;
+        mSessionCorrelationId = sessionCorrelationId;
+        mOnboardingMode = onboardingMode;
+    }
+
+    /**
+     * Record a step in the onboarding flow.
+     *
+     * @param stepId    Step ID constant (from OnboardingBlobFieldKeys)
+     * @param isoTimestamp The time when the step occurred, as ISO 8601 string
+     */
+    public void addStep(@NonNull String stepId, @NonNull String isoTimestamp) {
+        mStepsList.add(new StepEntry(stepId, isoTimestamp));
+    }
+
+    /**
+     * Record a blocking error detected during the flow.
+     * Also persists the session correlation entry to SharedPreferences
+     * (best-effort, async) for app-kill resilience.
+     *
+     * @param errorCode The onboarding blocking-error identifier to record
+     *                  (e.g., {@link OnboardingBlobFieldKeys#BLOCKING_ERROR_BROKER_INSTALL}
+     *                  or {@link OnboardingBlobFieldKeys#BLOCKING_ERROR_MDM_FLOW}),
+     *                  not a numeric service auth error code.
+     */
+    public void addBlockingError(@NonNull String errorCode) {
+        mBlockingErrors.add(errorCode);
+
+        // Persist session correlation to SharedPreferences immediately on block
+        persistSessionCorrelation();
+    }
+
+    /**
+     * Set the last loaded domain during WebView navigation.
+     *
+     * @param domain The domain URL (e.g., "login.microsoftonline.com")
+     */
+    public void setLastLoadedDomain(@NonNull String domain) {
+        mLastLoadedDomain = domain;
+    }
+
+    /**
+     * Set the Android profile context.
+     *
+     * @param profile One of OnboardingBlobFieldKeys.PROFILE_USER or PROFILE_WORK
+     */
+    public void setProfile(@NonNull String profile) {
+        mProfile = profile;
+    }
+
+    /**
+     * Add a UX flow variant tag.
+     *
+     * @param flowTag Flow variant (e.g., "MobileOnboardingPhase1")
+     */
+    public void addUxFlowUsed(@NonNull String flowTag) {
+        mUxFlowUsed.add(flowTag);
+    }
+
+    /**
+     * Finalize the blob and return the JSON string.
+     * If no blocking errors were recorded, returns empty string (clears seed blob).
+     * Otherwise serializes the populated blob to JSON.
+     *
+     * @return Populated blob JSON string, or empty string if no blocking errors
+     */
+    @NonNull
+    public String finalizeBlob() {
+        if (mBlockingErrors.isEmpty()) {
+            return "";
+        }
+
+        try {
+            JSONObject blob = new JSONObject();
+
+            // Seed fields
+            blob.put(FIELD_SCHEMA_VERSION, mSchemaVersion);
+            blob.put(FIELD_SESSION_CORRELATION_ID, mSessionCorrelationId);
+            blob.put(FIELD_ONBOARDING_MODE, mOnboardingMode);
+
+            // StepsList
+            JSONArray steps = new JSONArray();
+            for (StepEntry entry : mStepsList) {
+                JSONObject step = new JSONObject();
+                step.put(FIELD_STEP_ID, entry.stepId);
+                step.put(FIELD_TS, entry.timestamp);
+                steps.put(step);
+            }
+            blob.put(FIELD_STEPS_LIST, steps);
+
+            // Platform builder fields
+            JSONArray errorsArray = new JSONArray();
+            for (String error : mBlockingErrors) {
+                errorsArray.put(error);
+            }
+            blob.put(OnboardingBlobFieldKeys.BLOCKING_ERRORS, errorsArray);
+            blob.put(OnboardingBlobFieldKeys.LAST_BLOCKING_ERROR,
+                    mBlockingErrors.get(mBlockingErrors.size() - 1));
+
+            if (mLastLoadedDomain != null) {
+                blob.put(OnboardingBlobFieldKeys.LAST_LOADED_DOMAIN, mLastLoadedDomain);
+            }
+
+            if (!mStepsList.isEmpty()) {
+                blob.put(OnboardingBlobFieldKeys.LAST_COMPLETED_STEP,
+                        mStepsList.get(mStepsList.size() - 1).stepId);
+            }
+
+            if (mProfile != null) {
+                blob.put(OnboardingBlobFieldKeys.PROFILE, mProfile);
+            }
+
+            if (!mUxFlowUsed.isEmpty()) {
+                JSONArray flows = new JSONArray();
+                for (String flow : mUxFlowUsed) {
+                    flows.put(flow);
+                }
+                blob.put(OnboardingBlobFieldKeys.UX_FLOW_USED, flows);
+            }
+
+            return blob.toString();
+        } catch (JSONException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Returns the session correlation ID from the seed blob.
+     */
+    @NonNull
+    public String getSessionCorrelationId() {
+        return mSessionCorrelationId;
+    }
+
+    /**
+     * Persist session correlation entry to SharedPreferences.
+     * Best-effort async write — may be lost if process is killed before disk flush.
+     * Called on block detection for app-kill resilience.
+     */
+    private void persistSessionCorrelation() {
+        if (mSessionCorrelationId.isEmpty()) {
+            return;
+        }
+
+        try {
+            SharedPreferences prefs = mContext.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE);
+            String existing = prefs.getString(PREFS_FILE, "");
+            JSONObject cache;
+            if (existing != null && !existing.isEmpty()) {
+                cache = new JSONObject(existing);
+            } else {
+                cache = new JSONObject();
+            }
+
+            String key = mClientId + "|" + mTarget;
+            JSONObject entry = new JSONObject();
+            entry.put("id", mSessionCorrelationId);
+            entry.put(FIELD_TS, System.currentTimeMillis());
+            cache.put(key, entry);
+
+            prefs.edit().putString(PREFS_FILE, cache.toString()).apply();
+        } catch (JSONException e) {
+            // Best-effort persistence — don't crash
+        }
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/telemetry/OnboardingSessionCachePersistenceTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/telemetry/OnboardingSessionCachePersistenceTest.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.identity.common.internal.telemetry;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class OnboardingSessionCachePersistenceTest {
+
+    private OnboardingSessionCachePersistence mPersistence;
+
+    @Before
+    public void setup() {
+        mPersistence = new OnboardingSessionCachePersistence(
+                ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    public void testLoad_Empty_ReturnsEmptyString() {
+        Assert.assertEquals("", mPersistence.load());
+    }
+
+    @Test
+    public void testSaveAndLoad() {
+        final String json = "{\"key|scope\":{\"id\":\"uuid\",\"ts\":1234567890}}";
+        mPersistence.save(json);
+        Assert.assertEquals(json, mPersistence.load());
+    }
+
+    @Test
+    public void testSave_OverwritesPrevious() {
+        mPersistence.save("first");
+        mPersistence.save("second");
+        Assert.assertEquals("second", mPersistence.load());
+    }
+
+    @Test
+    public void testSave_EmptyString() {
+        mPersistence.save("some data");
+        mPersistence.save("");
+        Assert.assertEquals("", mPersistence.load());
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/telemetry/OnboardingTelemetryRecorderTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/telemetry/OnboardingTelemetryRecorderTest.java
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.identity.common.internal.telemetry;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.common.java.telemetry.OnboardingBlobFieldKeys;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class OnboardingTelemetryRecorderTest {
+
+    private static final String SEED_JSON = "{\"schema_version\":\"1.0.0\","
+            + "\"session_correlation_id\":\"test-uuid-123\","
+            + "\"onboarding_mode\":\"non-brokered\"}";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String TARGET = "scope1 scope2";
+
+    private OnboardingTelemetryRecorder mRecorder;
+
+    @Before
+    public void setup() {
+        mRecorder = new OnboardingTelemetryRecorder(
+                SEED_JSON, CLIENT_ID, TARGET,
+                ApplicationProvider.getApplicationContext());
+    }
+
+    // --- Constructor / seed parsing ---
+
+    @Test
+    public void testGetSessionCorrelationId() {
+        Assert.assertEquals("test-uuid-123", mRecorder.getSessionCorrelationId());
+    }
+
+    @Test
+    public void testConstructorWithCorruptedSeedJson() {
+        final OnboardingTelemetryRecorder recorder = new OnboardingTelemetryRecorder(
+                "not valid json", CLIENT_ID, TARGET,
+                ApplicationProvider.getApplicationContext());
+        Assert.assertEquals("", recorder.getSessionCorrelationId());
+    }
+
+    @Test
+    public void testConstructorWithEmptySeedJson() {
+        final OnboardingTelemetryRecorder recorder = new OnboardingTelemetryRecorder(
+                "{}", CLIENT_ID, TARGET,
+                ApplicationProvider.getApplicationContext());
+        Assert.assertEquals("", recorder.getSessionCorrelationId());
+    }
+
+    // --- finalizeBlob ---
+
+    @Test
+    public void testFinalizeBlob_NoBlockingErrors_ReturnsEmpty() {
+        final String result = mRecorder.finalizeBlob();
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void testFinalizeBlob_WithBlockingError_ReturnsPopulatedJson() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+
+        final String result = mRecorder.finalizeBlob();
+        Assert.assertFalse(result.isEmpty());
+
+        final JSONObject blob = new JSONObject(result);
+        Assert.assertEquals("1.0.0", blob.getString("schema_version"));
+        Assert.assertEquals("test-uuid-123", blob.getString("session_correlation_id"));
+        Assert.assertEquals("non-brokered", blob.getString("onboarding_mode"));
+
+        final JSONArray errors = blob.getJSONArray("blocking_errors");
+        Assert.assertEquals(1, errors.length());
+        Assert.assertEquals("BROKER_INSTALLATION_TRIGGERED", errors.getString(0));
+        Assert.assertEquals("BROKER_INSTALLATION_TRIGGERED", blob.getString("last_blocking_error"));
+    }
+
+    @Test
+    public void testFinalizeBlob_MultipleBlockingErrors() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.addBlockingError("MDM_FLOW");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        final JSONArray errors = blob.getJSONArray("blocking_errors");
+        Assert.assertEquals(2, errors.length());
+        Assert.assertEquals("MDM_FLOW", blob.getString("last_blocking_error"));
+    }
+
+    @Test
+    public void testFinalizeBlob_ContainsSeedFields() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        Assert.assertEquals("1.0.0", blob.getString("schema_version"));
+        Assert.assertEquals("test-uuid-123", blob.getString("session_correlation_id"));
+        Assert.assertEquals("non-brokered", blob.getString("onboarding_mode"));
+    }
+
+    // --- addStep ---
+
+    @Test
+    public void testAddStep_AppearsInFinalizedBlob() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.addStep(OnboardingBlobFieldKeys.STEP_AUTHENTICATION_STARTED, "2025-10-29T15:00:00Z");
+        mRecorder.addStep(OnboardingBlobFieldKeys.STEP_BROKER_INSTALL_PROMPTED, "2025-10-29T15:00:05Z");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        final JSONArray steps = blob.getJSONArray("steps_list");
+        Assert.assertEquals(2, steps.length());
+        Assert.assertEquals("AuthenticationStarted", steps.getJSONObject(0).getString("step_id"));
+        Assert.assertEquals("BrokerInstallPrompted", steps.getJSONObject(1).getString("step_id"));
+    }
+
+    @Test
+    public void testLastCompletedStep_SetAutomatically() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.addStep(OnboardingBlobFieldKeys.STEP_AUTHENTICATION_STARTED, "2025-10-29T15:00:00Z");
+        mRecorder.addStep(OnboardingBlobFieldKeys.STEP_BROKER_INSTALL_PROMPTED, "2025-10-29T15:00:01Z");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        Assert.assertEquals("BrokerInstallPrompted", blob.getString("last_completed_step"));
+    }
+
+    // --- setLastLoadedDomain ---
+
+    @Test
+    public void testSetLastLoadedDomain() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.setLastLoadedDomain("login.microsoftonline.com");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        Assert.assertEquals("login.microsoftonline.com", blob.getString("last_loaded_domain"));
+    }
+
+    @Test
+    public void testLastLoadedDomain_NotSetByDefault() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        Assert.assertFalse(blob.has("last_loaded_domain"));
+    }
+
+    // --- setProfile ---
+
+    @Test
+    public void testSetProfile() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.setProfile(OnboardingBlobFieldKeys.PROFILE_WORK);
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        Assert.assertEquals("workProfile", blob.getString("profile"));
+    }
+
+    // --- addUxFlowUsed ---
+
+    @Test
+    public void testAddUxFlowUsed() throws Exception {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+        mRecorder.addUxFlowUsed("MobileOnboardingPhase1");
+
+        final JSONObject blob = new JSONObject(mRecorder.finalizeBlob());
+        final JSONArray flows = blob.getJSONArray("ux_flow_used");
+        Assert.assertEquals(1, flows.length());
+        Assert.assertEquals("MobileOnboardingPhase1", flows.getString(0));
+    }
+
+    // --- SharedPreferences persistence ---
+
+    @Test
+    public void testAddBlockingError_PersistsToSharedPreferences() {
+        mRecorder.addBlockingError("BROKER_INSTALLATION_TRIGGERED");
+
+        // Verify SharedPreferences was written
+        final android.content.SharedPreferences prefs =
+                ApplicationProvider.getApplicationContext().getSharedPreferences(
+                        "com.microsoft.oneauth.session_correlation_cache",
+                        android.content.Context.MODE_PRIVATE);
+        final String cached = prefs.getString("com.microsoft.oneauth.session_correlation_cache", "");
+        Assert.assertFalse("SharedPreferences should contain cached session data", cached.isEmpty());
+        Assert.assertTrue("Cached data should contain the session correlation ID",
+                cached.contains("test-uuid-123"));
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
@@ -38,6 +38,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
@@ -84,6 +86,13 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
      * Should suppress broker native account picker UX.
      */
     private final boolean suppressBrokerAccountPicker;
+
+    /**
+     * Onboarding telemetry seed JSON blob.
+     * Passed through IPC to the broker for step recording and blocking error tracking.
+     */
+    @Nullable
+    private final String onboardingSeedJson;
 
     public boolean getHandleNullTaskAffinity(){
         return handleNullTaskAffinity;

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -49,6 +49,21 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
 
     private BrokerPerformanceMetrics mBrokerPerformanceMetrics;
 
+    /**
+     * Populated onboarding telemetry blob JSON returned by the broker.
+     */
+    @Nullable
+    private String mOnboardingBlob;
+
+    public void setOnboardingBlob(@Nullable final String onboardingBlob) {
+        this.mOnboardingBlob = onboardingBlob;
+    }
+
+    @Nullable
+    public String getOnboardingBlob() {
+        return this.mOnboardingBlob;
+    }
+
     public void setLocalAuthenticationResult(ILocalAuthenticationResult result) {
         this.mLocalAuthenticationResult = result;
         this.mSucceeded = true;

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/OnboardingBlobFieldKeys.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/OnboardingBlobFieldKeys.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.identity.common.java.telemetry;
+
+/**
+ * JSON field keys for the onboarding telemetry blob.
+ * All keys use snake_case to match MATS convention — EntityStore prepends "mo_"
+ * to produce the final MATS column name (e.g., "blocking_errors" → "mo_blocking_errors").
+ * Seed creation + aggregation keys come from OnboardingBlobConstants (Djinni-generated).
+ */
+public final class OnboardingBlobFieldKeys {
+    // Field keys for populated blob (written by OnboardingTelemetryRecorder, read by EntityStore with mo_ prefix)
+    public static final String BLOCKING_ERRORS = "blocking_errors";
+    public static final String LAST_BLOCKING_ERROR = "last_blocking_error";
+    public static final String LAST_LOADED_DOMAIN = "last_loaded_domain";
+    public static final String LAST_COMPLETED_STEP = "last_completed_step";
+    public static final String PROFILE = "profile";
+    public static final String UX_FLOW_USED = "ux_flow_used";
+
+    // Step ID values not used in C++ aggregation (no derived duration metric computed from these)
+    public static final String STEP_AUTHENTICATION_STARTED = "AuthenticationStarted";
+    public static final String STEP_CREDENTIAL_ENTRY_COMPLETED = "CredentialEntryCompleted";
+    public static final String STEP_BROKER_INSTALL_PROMPTED = "BrokerInstallPrompted";
+    public static final String STEP_BROKER_INSTALL_PROMPTED_FOR_MDM = "BrokerInstallPromptedForMDM";
+    public static final String STEP_DEVICE_REGISTRATION_STARTED = "DeviceRegistrationStarted";
+    public static final String STEP_DEVICE_REGISTRATION_COMPLETED = "DeviceRegistrationCompleted";
+    public static final String STEP_FLOW_COMPLETED = "FlowCompleted";
+
+    // Blocking error values — must match C++ hardcoded strings in InteractiveRequest.cpp
+    public static final String BLOCKING_ERROR_BROKER_INSTALL = "BROKER_INSTALLATION_TRIGGERED";
+    public static final String BLOCKING_ERROR_MDM_FLOW = "MDM_FLOW";
+
+    // Platform-specific values
+    public static final String PROFILE_USER = "userProfile";
+    public static final String PROFILE_WORK = "workProfile";
+
+    private OnboardingBlobFieldKeys() {} // non-instantiable
+}


### PR DESCRIPTION
…lt, and command parameters

- BrokerRequest: add onboarding_seed_json field (client → broker)
- BrokerResult: add onboarding_blob field + builder + getter (broker → client)
- InteractiveTokenCommandParameters: add onboardingSeedJson field
- AcquireTokenResult: add onboardingBlob field for carrying blob through result chain
- MsalBrokerRequestAdapter: serialize onboardingSeedJson from command parameters
- MsalBrokerResultAdapter: extract onboardingBlob from BrokerResult into AcquireTokenResult