### PR TITLE
Edge TB: Fix lookup mode: parse real ID token when response is not 'none', Fixes AB#3595497

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)
+- [PATCH] Edge TB: Fix lookup mode (#3108)
 
 Version 24.2.0
 ----------

--- a/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.Micro
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenResponse;
 import com.microsoft.identity.common.java.request.SdkType;
+import com.microsoft.identity.common.java.util.SchemaUtil;
 import com.microsoft.identity.common.java.util.StringUtil;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -287,5 +288,35 @@ public class MicrosoftStsAccountCredentialAdapterTest {
     static String createRawClientInfo(final String uid, final String utid) {
         final String claims = "{\"uid\":\"" + uid + "\",\"utid\":\"" + utid + "\"}";
         return Base64Util.encodeToString(StringUtil.toByteArray(claims), Base64Flags.URL_SAFE);
+    }
+
+    @Test
+    public void testCreateAccountRecord_LookupModeWithRealIdToken_ParsesUsername() throws ServiceException {
+        // In lookup mode, if the ID token is a real JWT (not "none"), username should still be parsed.
+        // This covers the interactive fallback scenario where lookup mode params are preserved
+        // but eSTS returns a real ID token.
+        when(mockParameters.isLookupMode()).thenReturn(true);
+        when(mockResponse.getIdToken()).thenReturn(MOCK_ID_TOKEN_WITH_CLAIMS);
+
+        final AccountRecord account = mAccountCredentialAdapter.createAccountRecord(
+                mockParameters, SdkType.MSAL, mockResponse);
+
+        assertNotNull(account);
+        assertEquals("Username should be parsed from real ID token even in lookup mode",
+                MOCK_PREFERRED_USERNAME, account.getUsername());
+    }
+
+    @Test
+    public void testCreateAccountRecord_LookupModeWithNoneIdToken_UsernameIsMissing() throws ServiceException {
+        // In lookup mode with id_token="none", username cannot be derived from the token.
+        when(mockParameters.isLookupMode()).thenReturn(true);
+        when(mockResponse.getIdToken()).thenReturn("none");
+
+        final AccountRecord account = mAccountCredentialAdapter.createAccountRecord(
+                mockParameters, SdkType.MSAL, mockResponse);
+
+        assertNotNull(account);
+        assertEquals("Username should be MISSING_FROM_THE_TOKEN_RESPONSE when id_token is 'none'",
+                SchemaUtil.MISSING_FROM_THE_TOKEN_RESPONSE, account.getUsername());
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MicrosoftStsAccountCredentialAdapterTest.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common;
 
+import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.base64.Base64Flags;
 import com.microsoft.identity.common.java.base64.Base64Util;
@@ -310,7 +311,7 @@ public class MicrosoftStsAccountCredentialAdapterTest {
     public void testCreateAccountRecord_LookupModeWithNoneIdToken_UsernameIsMissing() throws ServiceException {
         // In lookup mode with id_token="none", username cannot be derived from the token.
         when(mockParameters.isLookupMode()).thenReturn(true);
-        when(mockResponse.getIdToken()).thenReturn("none");
+        when(mockResponse.getIdToken()).thenReturn(AuthenticationConstants.Broker.LOOKUP_MODE_ID_TOKEN_VALUE);
 
         final AccountRecord account = mAccountCredentialAdapter.createAccountRecord(
                 mockParameters, SdkType.MSAL, mockResponse);

--- a/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/AuthenticationConstants.java
@@ -624,6 +624,11 @@ public class AuthenticationConstants {
          * Value for nativebroker mode sent in the extra query param by ESTS when the request is from lookup.
          */
         public static final String LOOKUP_MODE_VALUE = "Lookup";
+
+        /**
+         * When a Lookup mode request is forwarded to ESTS, the ID token in the response will have the value "none".
+         */
+        public static final String LOOKUP_MODE_ID_TOKEN_VALUE = "none";
     }
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -306,7 +306,7 @@ public class MicrosoftStsAccountCredentialAdapter
         } else {
             final String idTokenValue = microsoftStsTokenResponse.getIdToken();
             final MicrosoftStsAccount microsoftStsAccount = new MicrosoftStsAccount(
-                    parameters.isLookupMode() && "none".equals(idTokenValue) ?
+                    parameters.isLookupMode() && IDToken.LOOKUP_MODE_VALUE.equals(idTokenValue) ?
                             IDToken.createForLookup(idTokenValue) : new IDToken(idTokenValue),
                     clientInfo
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -26,6 +26,7 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.DEFAULT
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.authscheme.AbstractAuthenticationScheme;
 import com.microsoft.identity.common.java.authscheme.PopAuthenticationSchemeInternal;
@@ -306,7 +307,7 @@ public class MicrosoftStsAccountCredentialAdapter
         } else {
             final String idTokenValue = microsoftStsTokenResponse.getIdToken();
             final MicrosoftStsAccount microsoftStsAccount = new MicrosoftStsAccount(
-                    parameters.isLookupMode() && IDToken.LOOKUP_MODE_VALUE.equals(idTokenValue) ?
+                    parameters.isLookupMode() && AuthenticationConstants.Broker.LOOKUP_MODE_ID_TOKEN_VALUE.equals(idTokenValue) ?
                             IDToken.createForLookup(idTokenValue) : new IDToken(idTokenValue),
                     clientInfo
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -306,7 +306,7 @@ public class MicrosoftStsAccountCredentialAdapter
         } else {
             final String idTokenValue = microsoftStsTokenResponse.getIdToken();
             final MicrosoftStsAccount microsoftStsAccount = new MicrosoftStsAccount(
-                    parameters.isLookupMode() ?
+                    parameters.isLookupMode() && "none".equals(idTokenValue) ?
                             IDToken.createForLookup(idTokenValue) : new IDToken(idTokenValue),
                     clientInfo
             );

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
@@ -190,11 +190,6 @@ public class IDToken {
      */
     public static final String UPDATED_AT = "updated_at";
 
-    /**
-     * When a Lookup mode request is forwarded to ESTS, the ID token in the response will have the value "none".
-     */
-    public static final String LOOKUP_MODE_VALUE = "none";
-
     private final Map<String, ?> mTokenClaims;
     private final String mRawIdToken;
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/IDToken.java
@@ -190,6 +190,11 @@ public class IDToken {
      */
     public static final String UPDATED_AT = "updated_at";
 
+    /**
+     * When a Lookup mode request is forwarded to ESTS, the ID token in the response will have the value "none".
+     */
+    public static final String LOOKUP_MODE_VALUE = "none";
+
     private final Map<String, ?> mTokenClaims;
     private final String mRawIdToken;
 


### PR DESCRIPTION
In lookup mode, the ID token was always replaced with an empty-claims placeholder regardless of the actual eSTS response. This caused the username to be lost in the interactive fallback path where eSTS returns a real ID token.

Fix: Only use the lookup placeholder when the ID token value is literally 'none' (the eSTS lookup-mode sentinel). Use null-safe comparison to avoid NPE when idTokenValue is null.

Add unit tests covering:
- Lookup mode with real ID token preserves username
- Lookup mode with 'none' ID token returns sentinel username

[AB#3595497](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3595497)