### PR TITLE
Fixes AB#3601828 Fix ClassCastException when cloneThenFilter flight is enabled without in-memory cache instance

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -1642,6 +1642,8 @@ public class MsalOAuth2TokenCacheTest {
         final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
         when(mockFlightsProvider.isFlightEnabled(CommonFlight.ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE))
                 .thenReturn(true);
+        when(mockFlightsProvider.isFlightEnabled(CommonFlight.USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS))
+                .thenReturn(true);
         final MockCommonFlightsManager mockFlightsManager = new MockCommonFlightsManager();
         mockFlightsManager.setMockCommonFlightsProvider(mockFlightsProvider);
         CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);

--- a/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/MsalOAuth2TokenCacheTest.java
@@ -1766,4 +1766,72 @@ public class MsalOAuth2TokenCacheTest {
         assertEquals(1, idTokens.size());
         assertEquals(defaultTestBundleV2.mGeneratedIdToken, idTokens.get(0));
     }
+
+    /**
+     * Regression test for ClassCastException: both flights enabled but the cache was constructed
+     * with a plain {@link SharedPreferencesAccountCredentialCache} (not the memory-cache subclass).
+     * The instanceof guard must cause load() to fall back to the legacy path without throwing.
+     */
+    @Test
+    public void load_flightEnabled_withNonMemoryCache_doesNotThrowAndReturnsCorrectResult()
+            throws ClientException {
+        enableFilterThenCloneFlight();
+        try {
+            // mOauth2TokenCache uses SharedPreferencesAccountCredentialCache (non-memory) from setUp()
+            configureMocksForTestBundle(defaultTestBundleV2);
+            final ICacheRecord saved = mOauth2TokenCache.save(
+                    mockStrategy,
+                    mockRequest,
+                    mockResponse
+            );
+
+            final ICacheRecord loaded = mOauth2TokenCache.load(
+                    CLIENT_ID,
+                    APPLICATION_IDENTIFIER_SHA512,
+                    MAM_ENROLLMENT_IDENTIFIER,
+                    TARGET,
+                    defaultTestBundleV2.mGeneratedAccount,
+                    BEARER_AUTHENTICATION_SCHEME
+            );
+
+            assertNotNull(loaded);
+            assertEquals(saved.getAccount(), loaded.getAccount());
+            assertEquals(saved.getAccessToken(), loaded.getAccessToken());
+            assertEquals(saved.getRefreshToken(), loaded.getRefreshToken());
+            assertEquals(saved.getIdToken(), loaded.getIdToken());
+        } finally {
+            resetFlight();
+        }
+    }
+
+    /**
+     * Regression test for ClassCastException: both flights enabled but the cache was constructed
+     * with a plain {@link SharedPreferencesAccountCredentialCache} (not the memory-cache subclass).
+     * The instanceof guard must cause getIdTokensForAccountRecord() to fall back to the legacy path
+     * without throwing.
+     */
+    @Test
+    public void getIdTokensForAccountRecord_flightEnabled_withNonMemoryCache_doesNotThrowAndReturnsCorrectResult()
+            throws ClientException {
+        enableFilterThenCloneFlight();
+        try {
+            // mOauth2TokenCache uses SharedPreferencesAccountCredentialCache (non-memory) from setUp()
+            configureMocksForTestBundle(defaultTestBundleV2);
+            mOauth2TokenCache.save(
+                    mockStrategy,
+                    mockRequest,
+                    mockResponse
+            );
+
+            final List<IdTokenRecord> idTokens = mOauth2TokenCache.getIdTokensForAccountRecord(
+                    CLIENT_ID,
+                    defaultTestBundleV2.mGeneratedAccount
+            );
+
+            assertEquals(1, idTokens.size());
+            assertEquals(defaultTestBundleV2.mGeneratedIdToken, idTokens.get(0));
+        } finally {
+            resetFlight();
+        }
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -675,11 +675,10 @@ public class MsalOAuth2TokenCache
         final List<Credential> v1IdTokens;
         List<Credential> refreshTokens;
 
-        if (useFilterThenClone) {
+        if (useFilterThenClone
+                && mAccountCredentialCache instanceof SharedPreferencesAccountCredentialCacheWithMemoryCache) {
             // Wrap all reads under one lock to ensure a consistent snapshot and prevent
             // a concurrent removal from causing partial/inconsistent cache records.
-            // Safe to cast — USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS guarantees
-            // mAccountCredentialCache is SharedPreferencesAccountCredentialCacheWithMemoryCache.
             final Object cacheLock = ((SharedPreferencesAccountCredentialCacheWithMemoryCache)
                     mAccountCredentialCache).getCacheLock();
             synchronized (cacheLock) {
@@ -965,7 +964,8 @@ public class MsalOAuth2TokenCache
 
         final List<Credential> idTokens;
 
-        if (useFilterThenClone) {
+        if (useFilterThenClone
+                && mAccountCredentialCache instanceof SharedPreferencesAccountCredentialCacheWithMemoryCache) {
             // Wrap under one lock for snapshot consistency (same rationale as load()).
             final Object cacheLock = ((SharedPreferencesAccountCredentialCacheWithMemoryCache)
                     mAccountCredentialCache).getCacheLock();

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MsalOAuth2TokenCache.java
@@ -675,6 +675,12 @@ public class MsalOAuth2TokenCache
         final List<Credential> v1IdTokens;
         List<Credential> refreshTokens;
 
+        // The instanceof guard is necessary because the cache type is fixed at construction time,
+        // but flights are evaluated at runtime. For example, BrokerClientIdRefreshTokenAccessor
+        // always calls MsalOAuth2TokenCache.create(components) with useInMemoryCache=false,
+        // producing a plain SharedPreferencesAccountCredentialCache regardless of flight state.
+        // If both flights are later enabled at runtime, casting without this guard would throw
+        // a ClassCastException.
         if (useFilterThenClone
                 && mAccountCredentialCache instanceof SharedPreferencesAccountCredentialCacheWithMemoryCache) {
             // Wrap all reads under one lock to ensure a consistent snapshot and prevent
@@ -964,6 +970,8 @@ public class MsalOAuth2TokenCache
 
         final List<Credential> idTokens;
 
+        // See the same instanceof guard in load() for a full explanation of why the cache type
+        // may not match the flight state at runtime.
         if (useFilterThenClone
                 && mAccountCredentialCache instanceof SharedPreferencesAccountCredentialCacheWithMemoryCache) {
             // Wrap under one lock for snapshot consistency (same rationale as load()).


### PR DESCRIPTION
Fixes [AB#3601828](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3601828)

## Problem

PR #3100 introduced casts from `mAccountCredentialCache` to `SharedPreferencesAccountCredentialCacheWithMemoryCache` in `MsalOAuth2TokenCache.load()` and `getIdTokensForAccountRecord()`. The cast assumed that when both `ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE` and `USE_IN_MEMORY_CACHE_FOR_ACCOUNTS_AND_CREDENTIALS` flights are enabled, the cache instance is always the memory-cache subclass.

This assumption is **incorrect** because:
- `mAccountCredentialCache` type is determined **at construction time** (whoever creates the `MsalOAuth2TokenCache` decides the cache type)
- Flight values can **change at runtime** — the flight may have been `false` when the cache was constructed but `true` when `load()` is called later
- This causes: `java.lang.ClassCastException: SharedPreferencesAccountCredentialCache cannot be cast to SharedPreferencesAccountCredentialCacheWithMemoryCache`

## Fix

- Added `instanceof` guard before each cast. If the cache is not the expected subclass, it gracefully falls back to the legacy (clone-all) path
- Fixed `enableFilterThenCloneFlight()` test helper to mock **both** required flights so the optimized path is actually exercised in tests

## Changes
- `MsalOAuth2TokenCache.java`: 2 cast sites guarded with `instanceof`
- `MsalOAuth2TokenCacheTest.java`: Test helper now mocks both flights