### PR TITLE
Broker IPC plumbing for onboarding telemetry blob, Fixes AB#3568357

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [PATCH] Handle app_link Intent redirection by validating broker install links and rejecting unsupported redirect URIs with appropriate error responses (#3102)
+- [MINOR] Add onboarding telemetry blob fields to BrokerRequest/BrokerResult and command parameters for client↔broker IPC transport (#3111)
 - [PATCH] Extend filter-then-clone optimization to load() and getIdTokensForAccountRecord() in MsalOAuth2TokenCache: when ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight is enabled, skip clone-all preload and call direct flight-gated overloads that clone only matching credentials; add new getCredentialsFilteredBy overload with kid support (#3100)
 - [MINOR] Add onboarding telemetry recorder, field keys, and session persistence for mobile onboarding flow (#3088)
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -299,8 +299,12 @@ public class BrokerRequest implements Serializable {
 
     /**
      * Onboarding telemetry seed JSON blob.
-     * Contains sessionCorrelationId, onboarding_mode, schema_version.
-     * Broker populates this with blocking errors and returns in the result.
+     * Direction: client → broker (input only). Contains sessionCorrelationId,
+     * onboarding_mode, and schema_version, supplied by the client (OneAuth/MSAL)
+     * so the broker can construct an OnboardingTelemetryRecorder using the same
+     * correlation id. The broker returns the populated blob (with steps and
+     * blocking errors) via {@link BrokerResult#getOnboardingBlob()}, not via
+     * this field.
      */
     @Nullable
     @SerializedName(SerializedNames.ONBOARDING_SEED_JSON)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerRequest.java
@@ -87,6 +87,7 @@ public class BrokerRequest implements Serializable {
         final static String TENANT_ID = "tenant_id";
         final static String REQUEST_TYPE = "request_type";
         final static String WEB_APPS_STATE = "web_apps_state";
+        final static String ONBOARDING_SEED_JSON = "onboarding_seed_json";
     }
 
     /**
@@ -295,4 +296,13 @@ public class BrokerRequest implements Serializable {
     @Nullable
     @SerializedName(SerializedNames.REQUEST_TYPE)
     private String mRequestType;
+
+    /**
+     * Onboarding telemetry seed JSON blob.
+     * Contains sessionCorrelationId, onboarding_mode, schema_version.
+     * Broker populates this with blocking errors and returns in the result.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.ONBOARDING_SEED_JSON)
+    private String mOnboardingSeedJson;
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -97,6 +97,7 @@ public class BrokerResult {
         static final String SPE_RING = "spe_ring";
         static final String CLI_TELEM_ERRORCODE = "cli_telem_error_code";
         static final String CLI_TELEM_SUB_ERROR_CODE = "cli_telem_suberror_code";
+        static final String ONBOARDING_BLOB = "onboarding_blob";
     }
 
     private static final long serialVersionUID = 8606631820514878489L;
@@ -327,6 +328,13 @@ public class BrokerResult {
     @SerializedName(SerializedNames.BROKER_AAD_DEVICE_ID_RECORD)
     private final AadDeviceIdRecord mAadDeviceIdRecord;
 
+    /**
+     * Populated onboarding telemetry blob JSON returned by the broker.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.ONBOARDING_BLOB)
+    private final String mOnboardingBlob;
+
     private BrokerResult(@NonNull final Builder builder) {
         mAccessToken = builder.mAccessToken;
         mIdToken = builder.mIdToken;
@@ -362,6 +370,7 @@ public class BrokerResult {
         mCliTelemSubErrorCode = builder.mCliTelemSubErrorCode;
         mExceptionType = builder.mExceptionType;
         mAadDeviceIdRecord = builder.mAadDeviceIdRecord;
+        mOnboardingBlob = builder.mOnboardingBlob;
     }
 
     public String getExceptionType() {
@@ -498,6 +507,11 @@ public class BrokerResult {
         return mAadDeviceIdRecord;
     }
 
+    @Nullable
+    public String getOnboardingBlob() {
+        return mOnboardingBlob;
+    }
+
     public static class Builder {
         private String mAccessToken;
         private String mIdToken;
@@ -523,6 +537,7 @@ public class BrokerResult {
         private List<ICacheRecord> mTenantProfileData;
         private boolean mServicedFromCache;
         private AadDeviceIdRecord mAadDeviceIdRecord;
+        private String mOnboardingBlob;
 
         // Exception parameters
         private String mErrorCode;
@@ -535,7 +550,6 @@ public class BrokerResult {
         private String mCliTelemErrorCode;
         private String mCliTelemSubErrorCode;
         private String mExceptionType;
-
         public Builder accessToken(@Nullable final String accessToken) {
             this.mAccessToken = accessToken;
             return this;
@@ -710,6 +724,11 @@ public class BrokerResult {
 
         public Builder exceptionType(String exceptionType) {
             this.mExceptionType = exceptionType;
+            return this;
+        }
+
+        public Builder onboardingBlob(String onboardingBlob) {
+            this.mOnboardingBlob = onboardingBlob;
             return this;
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -727,7 +727,7 @@ public class BrokerResult {
             return this;
         }
 
-        public Builder onboardingBlob(String onboardingBlob) {
+        public Builder onboardingBlob(@Nullable final String onboardingBlob) {
             this.mOnboardingBlob = onboardingBlob;
             return this;
         }

--- a/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapter.java
@@ -139,7 +139,8 @@ public class MsalBrokerRequestAdapter implements IBrokerRequestAdapter {
                 .preferredBrowser(parameters.getPreferredBrowser())
                 .preferredAuthMethod(parameters.getPreferredAuthMethod())
                 .accountTransferToken(parameters.getAccountTransferToken())
-                .suppressAccountPicker(parameters.isSuppressBrokerAccountPicker());
+                .suppressAccountPicker(parameters.isSuppressBrokerAccountPicker())
+                .onboardingSeedJson(parameters.getOnboardingSeedJson());
 
         if (parameters instanceof AndroidInteractiveTokenCommandParameters) {
             final AndroidInteractiveTokenCommandParameters androidInteractiveTokenCommandParameters = (AndroidInteractiveTokenCommandParameters) parameters;

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -1015,6 +1015,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
     public @NonNull
     AcquireTokenResult getAcquireTokenResultFromResultBundle(@NonNull final Bundle resultBundle) throws BaseException {
+        final String methodTag = TAG + ":getAcquireTokenResultFromResultBundle";
         final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
         if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
             final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
@@ -1039,14 +1040,17 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 );
             }
 
-            // Extract onboarding blob from BrokerResult if present
+            // Extract onboarding blob from BrokerResult if present. Best-effort — telemetry
+            // failures must never fail an otherwise-successful auth result. Logged at warn so
+            // diagnosing IPC/regression issues remains possible. Blob contents are not logged
+            // (may contain sessionCorrelationId).
             try {
                 final BrokerResult brokerResult = resultAdapter.brokerResultFromBundle(resultBundle);
-                if (brokerResult != null && brokerResult.getOnboardingBlob() != null) {
+                if (brokerResult.getOnboardingBlob() != null) {
                     acquireTokenResult.setOnboardingBlob(brokerResult.getOnboardingBlob());
                 }
-            } catch (final Exception e) {
-                // Best-effort — don't fail the result for telemetry
+            } catch (final ClientException e) {
+                Logger.warn(methodTag, "Failed to extract onboarding blob from broker result: " + e.getErrorCode());
             }
 
             return acquireTokenResult;

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -1038,6 +1038,17 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                         resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)
                 );
             }
+
+            // Extract onboarding blob from BrokerResult if present
+            try {
+                final BrokerResult brokerResult = resultAdapter.brokerResultFromBundle(resultBundle);
+                if (brokerResult != null && brokerResult.getOnboardingBlob() != null) {
+                    acquireTokenResult.setOnboardingBlob(brokerResult.getOnboardingBlob());
+                }
+            } catch (final Exception e) {
+                // Best-effort — don't fail the result for telemetry
+            }
+
             return acquireTokenResult;
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -465,9 +465,16 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     @NonNull
     @Override
     public ILocalAuthenticationResult authenticationResultFromBundle(@NonNull final Bundle resultBundle) throws ClientException {
-        final String methodTag = TAG + ":authenticationResultFromBundle";
-        final BrokerResult brokerResult = brokerResultFromBundle(resultBundle);
+        return authenticationResultFromBrokerResult(brokerResultFromBundle(resultBundle));
+    }
 
+    /**
+     * Overload that builds the authentication result from an already-deserialized
+     * {@link BrokerResult}. Use this when the caller has the [BrokerResult] in hand
+     * to avoid a redundant deserialization of the result bundle.
+     */
+    public ILocalAuthenticationResult authenticationResultFromBrokerResult(@NonNull final BrokerResult brokerResult) throws ClientException {
+        final String methodTag = TAG + ":authenticationResultFromBrokerResult";
         Logger.info(methodTag, "Broker Result returned from Bundle, constructing authentication result");
 
         final List<ICacheRecord> tenantProfileCacheRecords = brokerResult.getTenantProfileData();
@@ -570,6 +577,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
      * Best-effort: returns null if the bundle cannot be deserialized into a BrokerResult
      * or if no blob is present. Telemetry failures must never fail an otherwise-successful
      * auth result. Blob contents are not logged (may carry sessionCorrelationId).
+     *
+     * If the caller has already deserialized the [BrokerResult], prefer the overload
+     * [getOnboardingBlobFromBundle(BrokerResult)] to avoid a second deserialization.
      */
     @Nullable
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -582,6 +592,17 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             Logger.warn(methodTag, "Failed to extract onboarding blob from broker result: " + e.getErrorCode());
             return null;
         }
+    }
+
+    /**
+     * Overload that reads the onboarding telemetry blob from a {@link BrokerResult}
+     * that has already been deserialized by the caller. Use this when you already
+     * have a [BrokerResult] in hand to avoid a second deserialization of the bundle.
+     */
+    @Nullable
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public String getOnboardingBlobFromBundle(@NonNull final BrokerResult brokerResult) {
+        return brokerResult.getOnboardingBlob();
     }
 
     @NonNull
@@ -1036,9 +1057,14 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     AcquireTokenResult getAcquireTokenResultFromResultBundle(@NonNull final Bundle resultBundle) throws BaseException {
         final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
         if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
+            // Deserialize BrokerResult once and reuse for both the local authentication result
+            // and the onboarding telemetry blob, instead of letting authenticationResultFromBundle
+            // and getOnboardingBlobFromBundle each pay the deserialization cost.
+            final BrokerResult brokerResult = resultAdapter.brokerResultFromBundle(resultBundle);
+
             final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
             acquireTokenResult.setLocalAuthenticationResult(
-                    resultAdapter.authenticationResultFromBundle(resultBundle)
+                    resultAdapter.authenticationResultFromBrokerResult(brokerResult)
             );
             // Set broker performance metrics if available
             final BrokerPerformanceMetrics metrics = resultAdapter.getBrokerPerformanceMetricsFromBundle(resultBundle);
@@ -1059,7 +1085,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             }
 
             // Set onboarding telemetry blob if present (best-effort; never fails the result).
-            final String onboardingBlob = resultAdapter.getOnboardingBlobFromBundle(resultBundle);
+            final String onboardingBlob = resultAdapter.getOnboardingBlobFromBundle(brokerResult);
             if (onboardingBlob != null) {
                 acquireTokenResult.setOnboardingBlob(onboardingBlob);
             }

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -565,6 +565,25 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
     }
 
+    /**
+     * Extracts the onboarding telemetry blob (JSON string) from the result bundle.
+     * Best-effort: returns null if the bundle cannot be deserialized into a BrokerResult
+     * or if no blob is present. Telemetry failures must never fail an otherwise-successful
+     * auth result. Blob contents are not logged (may carry sessionCorrelationId).
+     */
+    @Nullable
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    public String getOnboardingBlobFromBundle(@NonNull final Bundle resultBundle) {
+        final String methodTag = TAG + ":getOnboardingBlobFromBundle";
+        try {
+            final BrokerResult brokerResult = brokerResultFromBundle(resultBundle);
+            return brokerResult.getOnboardingBlob();
+        } catch (final ClientException e) {
+            Logger.warn(methodTag, "Failed to extract onboarding blob from broker result: " + e.getErrorCode());
+            return null;
+        }
+    }
+
     @NonNull
     @Override
     public AcquirePrtSsoTokenResult getAcquirePrtSsoTokenResultFromBundle(Bundle resultBundle) {
@@ -1015,7 +1034,6 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
     public @NonNull
     AcquireTokenResult getAcquireTokenResultFromResultBundle(@NonNull final Bundle resultBundle) throws BaseException {
-        final String methodTag = TAG + ":getAcquireTokenResultFromResultBundle";
         final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
         if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
             final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
@@ -1040,17 +1058,10 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 );
             }
 
-            // Extract onboarding blob from BrokerResult if present. Best-effort — telemetry
-            // failures must never fail an otherwise-successful auth result. Logged at warn so
-            // diagnosing IPC/regression issues remains possible. Blob contents are not logged
-            // (may contain sessionCorrelationId).
-            try {
-                final BrokerResult brokerResult = resultAdapter.brokerResultFromBundle(resultBundle);
-                if (brokerResult.getOnboardingBlob() != null) {
-                    acquireTokenResult.setOnboardingBlob(brokerResult.getOnboardingBlob());
-                }
-            } catch (final ClientException e) {
-                Logger.warn(methodTag, "Failed to extract onboarding blob from broker result: " + e.getErrorCode());
+            // Set onboarding telemetry blob if present (best-effort; never fails the result).
+            final String onboardingBlob = resultAdapter.getOnboardingBlobFromBundle(resultBundle);
+            if (onboardingBlob != null) {
+                acquireTokenResult.setOnboardingBlob(onboardingBlob);
             }
 
             return acquireTokenResult;

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapterTests.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerRequestAdapterTests.java
@@ -386,4 +386,73 @@ public class MsalBrokerRequestAdapterTests {
         assertEquals(mockRedirectUri, brokerRequest.getRedirect());
         assertEquals(mockTenantId, brokerRequest.getTenantId());
     }
+
+    /**
+     * Verify that {@code onboardingSeedJson} from {@link InteractiveTokenCommandParameters}
+     * is propagated into {@link BrokerRequest} by
+     * {@link MsalBrokerRequestAdapter#brokerRequestFromAcquireTokenParameters(InteractiveTokenCommandParameters)}.
+     */
+    @Test
+    public void test_brokerRequestFromAcquireTokenParameters_PropagatesOnboardingSeedJson() {
+        final String seedJson = "{\"schema_version\":\"1.0.0\","
+                + "\"session_correlation_id\":\"abc-123\","
+                + "\"onboarding_mode\":\"brokered\"}";
+        final Set<String> scopes = new HashSet<>();
+        scopes.add("user.read");
+
+        final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
+        final AndroidInteractiveTokenCommandParameters params = AndroidInteractiveTokenCommandParameters.builder()
+                .platformComponents(components)
+                .correlationId("987d8962-3f4d-4054-a852-ac0c4b6a602e")
+                .clientId("aClientId")
+                .redirectUri("msauth://com.example/foo")
+                .applicationName("com.example")
+                .applicationVersion("1.0.0")
+                .sdkType(SdkType.MSAL)
+                .sdkVersion("5.4.0")
+                .authority(new AzureActiveDirectoryAuthority())
+                .scopes(scopes)
+                .authenticationScheme(new BearerAuthenticationSchemeInternal())
+                .prompt(OpenIdConnectPromptParameter.LOGIN)
+                .requiredBrokerProtocolVersion("10.0")
+                .onboardingSeedJson(seedJson)
+                .build();
+
+        final BrokerRequest brokerRequest =
+                new MsalBrokerRequestAdapter().brokerRequestFromAcquireTokenParameters(params);
+
+        assertEquals(seedJson, brokerRequest.getOnboardingSeedJson());
+    }
+
+    /**
+     * Verify that when {@code onboardingSeedJson} is not set on the parameters,
+     * the resulting {@link BrokerRequest} carries a null seed (i.e. no accidental default value).
+     */
+    @Test
+    public void test_brokerRequestFromAcquireTokenParameters_NoSeedJson_IsNull() {
+        final Set<String> scopes = new HashSet<>();
+        scopes.add("user.read");
+
+        final IPlatformComponents components = MockPlatformComponentsFactory.getNonFunctionalBuilder().build();
+        final AndroidInteractiveTokenCommandParameters params = AndroidInteractiveTokenCommandParameters.builder()
+                .platformComponents(components)
+                .correlationId("987d8962-3f4d-4054-a852-ac0c4b6a602e")
+                .clientId("aClientId")
+                .redirectUri("msauth://com.example/foo")
+                .applicationName("com.example")
+                .applicationVersion("1.0.0")
+                .sdkType(SdkType.MSAL)
+                .sdkVersion("5.4.0")
+                .authority(new AzureActiveDirectoryAuthority())
+                .scopes(scopes)
+                .authenticationScheme(new BearerAuthenticationSchemeInternal())
+                .prompt(OpenIdConnectPromptParameter.LOGIN)
+                .requiredBrokerProtocolVersion("10.0")
+                .build();
+
+        final BrokerRequest brokerRequest =
+                new MsalBrokerRequestAdapter().brokerRequestFromAcquireTokenParameters(params);
+
+        assertNull(brokerRequest.getOnboardingSeedJson());
+    }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
@@ -658,4 +658,34 @@ class MsalBrokerResultAdapterTests {
             resultString.contains(SchemaUtil.MISSING_FROM_THE_TOKEN_RESPONSE)
         )
     }
+
+    @Test
+    fun testOnboardingBlob_RoundTripsThroughBundle() {
+        val blobJson = """{"schema_version":"1.0.0","session_correlation_id":"abc-123","onboarding_mode":"brokered","blocking_errors":["BROKER_INSTALLATION_TRIGGERED"]}"""
+        val brokerResult = BrokerResult.Builder()
+            .clientId("aClientId")
+            .correlationId("987d8962-3f4d-4054-a852-ac0c4b6a602e")
+            .onboardingBlob(blobJson)
+            .build()
+
+        val adapter = getInstance()
+        val resultBundle = adapter.bundleFromBrokerResult(brokerResult, "10.0")
+        val deserialized = adapter.brokerResultFromBundle(resultBundle)
+
+        assertEquals(blobJson, deserialized.onboardingBlob)
+    }
+
+    @Test
+    fun testOnboardingBlob_NotSet_DeserializesAsNull() {
+        val brokerResult = BrokerResult.Builder()
+            .clientId("aClientId")
+            .correlationId("987d8962-3f4d-4054-a852-ac0c4b6a602e")
+            .build()
+
+        val adapter = getInstance()
+        val resultBundle = adapter.bundleFromBrokerResult(brokerResult, "10.0")
+        val deserialized = adapter.brokerResultFromBundle(resultBundle)
+
+        assertNull(deserialized.onboardingBlob)
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParameters.java
@@ -38,6 +38,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(toBuilder = true)
@@ -84,6 +86,13 @@ public class InteractiveTokenCommandParameters extends TokenCommandParameters {
      * Should suppress broker native account picker UX.
      */
     private final boolean suppressBrokerAccountPicker;
+
+    /**
+     * Onboarding telemetry seed JSON blob.
+     * Passed through IPC to the broker for step recording and blocking error tracking.
+     */
+    @Nullable
+    private final String onboardingSeedJson;
 
     public boolean getHandleNullTaskAffinity(){
         return handleNullTaskAffinity;

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -49,6 +49,21 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
 
     private BrokerPerformanceMetrics mBrokerPerformanceMetrics;
 
+    /**
+     * Populated onboarding telemetry blob JSON returned by the broker.
+     */
+    @Nullable
+    private String mOnboardingBlob;
+
+    public void setOnboardingBlob(@Nullable final String onboardingBlob) {
+        this.mOnboardingBlob = onboardingBlob;
+    }
+
+    @Nullable
+    public String getOnboardingBlob() {
+        return this.mOnboardingBlob;
+    }
+
     public void setLocalAuthenticationResult(ILocalAuthenticationResult result) {
         this.mLocalAuthenticationResult = result;
         this.mSucceeded = true;

--- a/common4j/src/test/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParametersTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/commands/parameters/InteractiveTokenCommandParametersTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.commands.parameters;
+
+import static org.mockito.Mockito.mock;
+
+import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InteractiveTokenCommandParameters} accessors, including the onboarding
+ * telemetry seed JSON field carried into the broker IPC request bundle.
+ */
+public class InteractiveTokenCommandParametersTest {
+
+    @Test
+    public void onboardingSeedJson_DefaultsToNull() {
+        final InteractiveTokenCommandParameters params = InteractiveTokenCommandParameters.builder()
+                .platformComponents(mock(IPlatformComponents.class))
+                .build();
+        Assert.assertNull(params.getOnboardingSeedJson());
+    }
+
+    @Test
+    public void onboardingSeedJson_RoundTripsThroughBuilder() {
+        final String seedJson = "{\"schema_version\":\"1.0.0\","
+                + "\"session_correlation_id\":\"abc-123\","
+                + "\"onboarding_mode\":\"brokered\"}";
+        final InteractiveTokenCommandParameters params = InteractiveTokenCommandParameters.builder()
+                .platformComponents(mock(IPlatformComponents.class))
+                .onboardingSeedJson(seedJson)
+                .build();
+        Assert.assertEquals(seedJson, params.getOnboardingSeedJson());
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.result;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AcquireTokenResult} accessors, including the onboarding telemetry blob
+ * field used to convey broker-side onboarding telemetry back to the client.
+ */
+public class AcquireTokenResultTest {
+
+    @Test
+    public void onboardingBlob_DefaultsToNull() {
+        final AcquireTokenResult result = new AcquireTokenResult();
+        Assert.assertNull(result.getOnboardingBlob());
+    }
+
+    @Test
+    public void onboardingBlob_RoundTripsThroughSetter() {
+        final String blobJson = "{\"schema_version\":\"1.0.0\","
+                + "\"session_correlation_id\":\"abc-123\","
+                + "\"onboarding_mode\":\"brokered\"}";
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setOnboardingBlob(blobJson);
+        Assert.assertEquals(blobJson, result.getOnboardingBlob());
+    }
+
+    @Test
+    public void onboardingBlob_NullSetterClearsValue() {
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setOnboardingBlob("non-null");
+        result.setOnboardingBlob(null);
+        Assert.assertNull(result.getOnboardingBlob());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the IPC plumbing for the onboarding telemetry blob to flow client↔broker. Independent of PR #3088 (which adds the recorder/store/constants); both are needed together for end-to-end brokered onboarding telemetry.

Linked Feature: [AB#3462876](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3462876)
Linked PBI: [AB#3568357](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3568357)

## Changes

| File | Change |
|---|---|
| `BrokerRequest.java` | Add `onboarding_seed_json` field (client → broker) |
| `BrokerResult.java` | Add `onboarding_blob` field + builder + getter (broker → client) |
| `InteractiveTokenCommandParameters.java` | Add `onboardingSeedJson` field on the params builder |
| `AcquireTokenResult.java` | Add `onboardingBlob` field for carrying the populated blob through the result chain |
| `MsalBrokerRequestAdapter.java` | Serialize `onboardingSeedJson` from command parameters into `BrokerRequest` |
| `MsalBrokerResultAdapter.java` | Extract `onboardingBlob` from `BrokerResult` into `AcquireTokenResult` |

All additions are pure data fields + adapter wiring. No behavior change for existing callers (fields default to empty/null when not set).

## Design

- **Direction `client → broker`**: OneAuth/MSAL builds the seed JSON (containing `sessionCorrelationId`, `onboardingMode`, `schema_version`) and attaches it to the interactive request. The broker reads it via the new field on `BrokerInteractiveTokenCommandParameters`, constructs its own `OnboardingTelemetryRecorder` from the seed, and uses the same correlation ID for its onboarding telemetry events.
- **Direction `broker → client`**: When the broker emits the populated onboarding blob (after `finalizeBlob()`), it places it into `BrokerResult.onboarding_blob`. The client extracts it into `AcquireTokenResult.onboardingBlob`, where downstream OneAuth code reads it and emits the blob through MATS.

See full design: [Mobile Onboarding Telemetry Design](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3462876) §6.6 (persistence and propagation) and §11.2 (broker → OneAuth blob delivery).

## Dependencies

- **Pairs with**: PR #3088 (`OnboardingTelemetryRecorder` + `OnboardingTelemetryConstants` + `OnboardingSessionCorrelationStore`). The recorder consumes the seed JSON read out of these IPC fields.
- **Consumers**:
  - OneAuth: [`shared/mobile-onboarding-android-fixes`](https://office.visualstudio.com/OneAuth/_git/OneAuth) updates `BrokerRequestConverter` / `BrokerResultConverter` to read/write these fields.
  - Broker (`ad-accounts-for-android`): `MsalAndroidBrokerCommandParameterAdapter` reads `onboardingSeedJson`; broker error handler / SSO controller will write `onboarding_blob` once the recorder lifecycle is wired (separate PBI, [AB#3568359](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3568359)).
- **No breaking changes**: all new optional fields, no modifications to existing serialization order or field semantics.

## Testing

- Round-trip serialization is exercised by existing `BrokerRequest` / `BrokerResult` tests (Gson + Bundle); new fields default to empty/null when not set, so no existing test should regress.
- E2E validated locally via OneAuth `local-only-onboarding-telemetry` branch + a combined Common build (`mavenLocal` `0.0.0-zhipan-mot-7`): seed JSON flows OneAuth → BrokerRequest → broker → BrokerResult → OneAuth.
