### PR TITLE
[Hotfix 24.2.1] Wire ClientDataInfo through AcquireTokenResult (#3109), Fixes AB#3604499

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Wire ClientDataInfo through AcquireTokenResult, exceptions (#3109)
 
 Version 24.2.1-RC1
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,9 @@
 vNext
 ----------
-- [PATCH] Wire ClientDataInfo through AcquireTokenResult, exceptions (#3109)
 
 Version 24.2.1-RC1
 ----------
+- [PATCH] Wire ClientDataInfo through AcquireTokenResult, exceptions (#3109)
 - [MINOR] Add additional step ID and blocking error constants for full onboarding telemetry coverage (#3117)
 - [MINOR] Add onboarding telemetry blob fields to BrokerRequest/BrokerResult and command parameters for client↔broker IPC transport (#3111)
 - [MINOR] Add onboarding telemetry recorder, field keys, and session persistence for mobile onboarding flow (#3088)

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Version 24.2.1-RC1
 - [MINOR] Add additional step ID and blocking error constants for full onboarding telemetry coverage (#3117)
 - [MINOR] Add onboarding telemetry blob fields to BrokerRequest/BrokerResult and command parameters for client↔broker IPC transport (#3111)
 - [MINOR] Add onboarding telemetry recorder, field keys, and session persistence for mobile onboarding flow (#3088)
+
 Version 24.2.0
 ----------
 - [PATCH] Add support for Authenticator app activation links in WebView, enabling account pairing/MFA flows to launch Microsoft Authenticator directly instead of redirecting to the Play Store (#3090)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -97,6 +97,7 @@ public class BrokerResult {
         static final String SPE_RING = "spe_ring";
         static final String CLI_TELEM_ERRORCODE = "cli_telem_error_code";
         static final String CLI_TELEM_SUB_ERROR_CODE = "cli_telem_suberror_code";
+        static final String CLIENT_DATA_INFO = "client_data_info";
     }
 
     private static final long serialVersionUID = 8606631820514878489L;
@@ -237,6 +238,13 @@ public class BrokerResult {
     private String mRefreshTokenAge;
 
     /**
+     * Server client data info from x-ms-clientdata response header (pipe-delimited format).
+     */
+    @Nullable
+    @SerializedName(SerializedNames.CLIENT_DATA_INFO)
+    private String mClientDataInfoRaw;
+
+    /**
      * Boolean to indicate if the request succeeded without exceptions.
      */
     @NonNull
@@ -347,6 +355,7 @@ public class BrokerResult {
         mCachedAt = builder.mCachedAt;
         mSpeRing = builder.mSpeRing;
         mRefreshTokenAge = builder.mRefreshTokenAge;
+        mClientDataInfoRaw = builder.mClientDataInfoRaw;
         mSuccess = builder.mSuccess;
         mTenantProfileData = builder.mTenantProfileData;
         mServicedFromCache = builder.mServicedFromCache;
@@ -424,6 +433,11 @@ public class BrokerResult {
 
     public String getSpeRing() {
         return mSpeRing;
+    }
+
+    @Nullable
+    public String getClientDataInfoRaw() {
+        return mClientDataInfoRaw;
     }
 
     public long getCachedAt() {
@@ -518,6 +532,7 @@ public class BrokerResult {
         private long mCachedAt;
         private String mSpeRing;
         private String mRefreshTokenAge;
+        private String mClientDataInfoRaw;
         private boolean mSuccess;
         private String mNegotiatedBrokerProtocolVersion;
         private List<ICacheRecord> mTenantProfileData;
@@ -628,6 +643,11 @@ public class BrokerResult {
 
         public Builder refreshTokenAge(final String refreshTokenAge) {
             this.mRefreshTokenAge = refreshTokenAge;
+            return this;
+        }
+
+        public Builder clientDataInfoRaw(@Nullable final String clientDataInfoRaw) {
+            this.mClientDataInfoRaw = clientDataInfoRaw;
             return this;
         }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/controllers/LocalMSALController.java
@@ -57,11 +57,15 @@ import com.microsoft.identity.common.java.platform.DevicePoPUtils;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.GenerateShrResult;
 import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod;
 import com.microsoft.identity.common.java.util.ThreadUtils;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.providers.RawAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResponse;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
 import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsTokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
@@ -205,6 +209,23 @@ public class LocalMSALController extends BaseController {
                                 false
                         )
                 );
+
+                // Set ClientDataInfo on the LocalAuthenticationResult for IPC propagation.
+                // Prefer the token-endpoint value (later, more authoritative); fall back to the
+                // authorize-endpoint value.
+                final LocalAuthenticationResult localResult =
+                        (LocalAuthenticationResult) acquireTokenResult.getLocalAuthenticationResult();
+                if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                    if (tokenResult != null && tokenResult.getClientDataInfo() != null) {
+                        localResult.setClientDataInfo(tokenResult.getClientDataInfo());
+                    } else if (result instanceof MicrosoftStsAuthorizationResult) {
+                        final ClientDataInfo authClientData =
+                                ((MicrosoftStsAuthorizationResult) result).getClientDataInfo();
+                        if (authClientData != null) {
+                            localResult.setClientDataInfo(authClientData);
+                        }
+                    }
+                }
             }
         }
 
@@ -764,6 +785,13 @@ public class LocalMSALController extends BaseController {
                             false
                     )
             );
+
+            // Set ClientDataInfo on the LocalAuthenticationResult for IPC propagation
+            if (tokenResult != null && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                final LocalAuthenticationResult localResult =
+                        (LocalAuthenticationResult) acquireTokenResult.getLocalAuthenticationResult();
+                localResult.setClientDataInfo(tokenResult.getClientDataInfo());
+            }
         } catch (Exception error) {
             Telemetry.emit(
                     new ApiEndEvent()

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -98,6 +98,7 @@ import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.GenerateShrResult;
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult;
 import com.microsoft.identity.common.java.result.LocalAuthenticationResult;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod;
 import com.microsoft.identity.common.java.util.BrokerProtocolVersionUtil;
 import com.microsoft.identity.common.java.util.HeaderSerializationUtil;
@@ -284,6 +285,18 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 .success(true)
                 .servicedFromCache(authenticationResult.isServicedFromCache());
 
+        // Serialize ClientDataInfo as raw pipe-delimited string for IPC transfer.
+        // The raw field is populated by ClientDataInfo.fromPipeDelimited(), the only
+        // path that populates the parsed fields, so it is safe to ship as-is.
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)
+                && authenticationResult instanceof LocalAuthenticationResult) {
+            final ClientDataInfo clientDataInfo =
+                    ((LocalAuthenticationResult) authenticationResult).getClientDataInfo();
+            if (clientDataInfo != null) {
+                brokerResultBuilder.clientDataInfoRaw(clientDataInfo.getRaw());
+            }
+        }
+
         if (shouldRemoveRefreshTokenFromResult(authenticationResult, negotiatedBrokerProtocolVersion)){
             brokerResultBuilder.tenantProfileRecords(
                     removeRefreshTokenFromCacheRecords(
@@ -411,6 +424,13 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 .speRing(exception.getSpeRing())
                 .refreshTokenAge(exception.getRefreshTokenAge());
 
+        // Serialize ClientDataInfo (server telemetry from x-ms-clientdata) so it
+        // survives the broker IPC boundary on error paths.
+        if (exception.getClientDataInfo() != null
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+            builder.clientDataInfoRaw(exception.getClientDataInfo().getRaw());
+        }
+
         if (exception instanceof ServiceException) {
             final ServiceException serviceException = (ServiceException) exception;
             builder.subErrorCode(serviceException.getSubErrorCode())
@@ -476,12 +496,23 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             throw new ClientException(INVALID_BROKER_BUNDLE, "getTenantProfileData is null.");
         }
 
-        return new LocalAuthenticationResult(
+        final LocalAuthenticationResult localAuthResult = new LocalAuthenticationResult(
                 tenantProfileCacheRecords.get(0),
                 tenantProfileCacheRecords,
                 SdkType.MSAL,
                 brokerResult.isServicedFromCache()
         );
+
+        // Deserialize ClientDataInfo from the broker result if available
+        if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+            final ClientDataInfo clientDataInfo =
+                    ClientDataInfo.fromPipeDelimited(brokerResult.getClientDataInfoRaw());
+            if (clientDataInfo != null) {
+                localAuthResult.setClientDataInfo(clientDataInfo);
+            }
+        }
+
+        return localAuthResult;
     }
 
     @NonNull
@@ -514,6 +545,15 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         // Attach broker performance metrics if available
         if (metrics != null) {
             baseException.setBrokerPerformanceMetrics(metrics);
+        }
+
+        // Restore ClientDataInfo (server telemetry) from the broker result so callers
+        // catching the exception can inspect server-side error context.
+        if (!StringUtil.isNullOrEmpty(brokerResult.getClientDataInfoRaw())
+                && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+            baseException.setClientDataInfo(
+                    ClientDataInfo.fromPipeDelimited(brokerResult.getClientDataInfoRaw())
+            );
         }
 
         // Set broker app info if available
@@ -994,7 +1034,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
 
             if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
                 final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
-                acquireTokenResult.setLocalAuthenticationResult(authenticationResultFromBundle(resultBundle));
+                final ILocalAuthenticationResult authResult = authenticationResultFromBundle(resultBundle);
+                acquireTokenResult.setLocalAuthenticationResult(authResult);
+
                 span.setStatus(StatusCode.OK);
                 return acquireTokenResult;
             } else if (brokerResult.getErrorCode().equals(ErrorStrings.DEVICE_CODE_FLOW_AUTHORIZATION_PENDING_ERROR_CODE)) {

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.exception.UiRequiredException
 import com.microsoft.identity.common.java.request.SdkType
 import com.microsoft.identity.common.java.result.LocalAuthenticationResult
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo
 import com.microsoft.identity.common.java.util.SchemaUtil
 import com.microsoft.identity.internal.testutils.MockRecords
 import lombok.SneakyThrows
@@ -658,4 +659,82 @@ class MsalBrokerResultAdapterTests {
             resultString.contains(SchemaUtil.MISSING_FROM_THE_TOKEN_RESPONSE)
         )
     }
+
+    // ==================== ClientDataInfo IPC round-trip tests (PR #3109) ====================
+
+    private val clientDataRaw = "m|AADSTS50058|login_required|us|public"
+
+    private fun newCacheRecord() = CacheRecord.builder()
+        .account(MockRecords.getMockAccountRecord_AAD())
+        .idToken(MockRecords.getMockIdTokenRecord_AAD())
+        .accessToken(MockRecords.getMockAccessTokenRecord_AAD())
+        .refreshToken(MockRecords.getMockRefreshTokenRecord_AAD())
+        .build()
+
+    @Test
+    fun testClientDataInfo_RoundTripsThroughBrokerResult_OnSuccess() {
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(cacheRecord, cacheRecords, SdkType.MSAL, false)
+        authResult.clientDataInfo = ClientDataInfo.fromPipeDelimited(clientDataRaw)
+
+        val brokerResult = getInstance().buildBrokerResultFromAuthenticationResult(authResult, "16.0")
+        assertEquals("Raw payload should be serialized into BrokerResult", clientDataRaw, brokerResult.clientDataInfoRaw)
+    }
+
+    @Test
+    fun testClientDataInfo_NullOnLocalAuthResult_ResultsInNullOnBrokerResult() {
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(cacheRecord, cacheRecords, SdkType.MSAL, false)
+        // No ClientDataInfo set
+
+        val brokerResult = getInstance().buildBrokerResultFromAuthenticationResult(authResult, "16.0")
+        assertNull(brokerResult.clientDataInfoRaw)
+    }
+
+    @Test
+    fun testClientDataInfo_RoundTripsThroughBaseExceptionBundle() {
+        val exception = ClientException("invalid_grant", "token failure")
+        exception.clientDataInfo = ClientDataInfo.fromPipeDelimited(clientDataRaw)
+
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromBaseException(exception, null)
+        val brokerResult = resultAdapter.brokerResultFromBundle(resultBundle)
+        assertEquals(clientDataRaw, brokerResult.clientDataInfoRaw)
+
+        val received = resultAdapter.getBaseExceptionFromBundle(resultBundle)
+        assertNotNull("ClientDataInfo should be reconstructed on the exception", received.clientDataInfo)
+        assertEquals("AADSTS50058", received.clientDataInfo!!.error)
+        assertEquals("login_required", received.clientDataInfo!!.subError)
+        assertEquals(clientDataRaw, received.clientDataInfo!!.raw)
+    }
+
+    @Test
+    fun testClientDataInfo_NullOnException_NotInBundle() {
+        val exception = ClientException("invalid_grant", "token failure")
+        // No ClientDataInfo set
+
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromBaseException(exception, null)
+        val received = resultAdapter.getBaseExceptionFromBundle(resultBundle)
+        assertNull(received.clientDataInfo)
+    }
+
+    @Test
+    fun testClientDataInfo_RoundTripsThroughGetAcquireTokenResultFromResultBundle() {
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(cacheRecord, cacheRecords, SdkType.MSAL, false)
+        authResult.clientDataInfo = ClientDataInfo.fromPipeDelimited(clientDataRaw)
+
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromAuthenticationResult(authResult, "16.0")
+
+        val acquireTokenResult = resultAdapter.getAcquireTokenResultFromResultBundle(resultBundle)
+        assertNotNull("ClientDataInfo should be present on AcquireTokenResult", acquireTokenResult.clientDataInfo)
+        assertEquals("AADSTS50058", acquireTokenResult.clientDataInfo!!.error)
+        assertEquals(clientDataRaw, acquireTokenResult.clientDataInfo!!.raw)
+    }
+
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/BaseController.java
@@ -58,6 +58,8 @@ import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
 import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.foci.FociQueryUtilities;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -249,6 +251,11 @@ public abstract class BaseController {
             } else {
                 // we can't put SpeInfo as the CliTelemInfo is null
                 Telemetry.emit(new CacheEndEvent());
+            }
+
+            // Set server client data info on the authentication result for IPC propagation
+            if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                authenticationResult.setClientDataInfo(tokenResult.getClientDataInfo());
             }
 
             // Set the AuthenticationResult on the final result object
@@ -526,6 +533,11 @@ public abstract class BaseController {
             } else {
                 // we can't put SpeInfo as the CliTelemInfo is null
                 Telemetry.emit(new CacheEndEvent());
+            }
+
+            // Set server client data info on the authentication result for IPC propagation
+            if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                authenticationResult.setClientDataInfo(tokenResult.getClientDataInfo());
             }
 
             // Set the AuthenticationResult on the final result object

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -39,11 +39,14 @@ import com.microsoft.identity.common.java.exception.StrongDeviceRegistrationRequ
 import com.microsoft.identity.common.java.exception.TerminalException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.exception.UserCancelException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthorizationErrorResponse;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
@@ -84,7 +87,16 @@ public class ExceptionAdapter {
 
         if (null != authorizationResult) {
             if (!authorizationResult.getSuccess()) {
-                return exceptionFromAuthorizationResult(authorizationResult, commandParameters);
+                final BaseException authException = exceptionFromAuthorizationResult(authorizationResult, commandParameters);
+                // Attach ClientDataInfo from the authorize redirect (clientdata query param)
+                // so callers can inspect server-side error context on auth failures.
+                if (authorizationResult instanceof MicrosoftStsAuthorizationResult
+                        && CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                    authException.setClientDataInfo(
+                            ((MicrosoftStsAuthorizationResult) authorizationResult).getClientDataInfo()
+                    );
+                }
+                return authException;
             }
         } else {
             Logger.warn(
@@ -183,6 +195,9 @@ public class ExceptionAdapter {
 
             outErr = getExceptionFromTokenErrorResponse(commandParameters, tokenResult.getErrorResponse());
             applyCliTelemInfo(tokenResult.getCliTelemInfo(), outErr);
+            if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
+                outErr.setClientDataInfo(tokenResult.getClientDataInfo());
+            }
         } else {
             Logger.warn(
                     TAG + methodName,

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.java.exception;
 
 import com.microsoft.identity.common.java.broker.IBrokerInfoProvider;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 import com.microsoft.identity.common.java.telemetry.ITelemetryAccessor;
 import com.microsoft.identity.common.java.telemetry.Telemetry;
 import com.microsoft.identity.common.java.telemetry.events.ErrorEvent;
@@ -69,6 +70,14 @@ public class BaseException extends Exception implements IErrorInformation, ITele
 
     @Nullable
     private String mCliTelemSubErrorCode;
+
+    /**
+     * Server-side telemetry from the x-ms-clientdata response header (/token error responses)
+     * or the clientdata query parameter (/authorize error redirects). Useful for diagnosing
+     * server-driven failures (account_type, error, sub_error, caller_data_boundary, cloud_instance).
+     */
+    @Nullable
+    private ClientDataInfo mClientDataInfo;
 
     private String mErrorCode;
 
@@ -211,6 +220,15 @@ public class BaseException extends Exception implements IErrorInformation, ITele
 
     public void setCliTelemSubErrorCode(@Nullable final String cliTelemSubErrorCode) {
         this.mCliTelemSubErrorCode = cliTelemSubErrorCode;
+    }
+
+    @Nullable
+    public ClientDataInfo getClientDataInfo() {
+        return mClientDataInfo;
+    }
+
+    public void setClientDataInfo(@Nullable final ClientDataInfo clientDataInfo) {
+        this.mClientDataInfo = clientDataInfo;
     }
 
     @Nullable

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/AbstractMicrosoftStsTokenResponseHandler.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/AbstractMicrosoftStsTokenResponseHandler.java
@@ -113,6 +113,7 @@ public abstract class AbstractMicrosoftStsTokenResponseHandler implements IToken
                 final ClientDataInfo clientDataInfo = ClientDataInfo.fromPipeDelimited(clientDataHeader);
                 if (null != clientDataInfo) {
                     clientDataInfo.emitToSpan();
+                    result.setClientDataInfo(clientDataInfo);
                 }
             }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResult.java
@@ -26,6 +26,9 @@ import com.microsoft.identity.common.java.providers.microsoft.MicrosoftAuthoriza
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationErrorResponse;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResponse;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationStatus;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
+
+import javax.annotation.Nullable;
 
 /**
  * Sub class of {@link MicrosoftAuthorizationResult}.
@@ -33,6 +36,9 @@ import com.microsoft.identity.common.java.providers.oauth2.AuthorizationStatus;
  */
 public class MicrosoftStsAuthorizationResult
         extends MicrosoftAuthorizationResult<MicrosoftStsAuthorizationResponse, MicrosoftStsAuthorizationErrorResponse> {
+
+    @Nullable
+    private ClientDataInfo mClientDataInfo;
 
     /**
      * Constructor of {@link MicrosoftStsAuthorizationResult}.
@@ -54,4 +60,22 @@ public class MicrosoftStsAuthorizationResult
         super(authStatus, errorResponse);
     }
 
+    /**
+     * Gets the {@link ClientDataInfo} parsed from the clientdata redirect query parameter.
+     *
+     * @return The ClientDataInfo, or null if the parameter was absent or unparseable.
+     */
+    @Nullable
+    public ClientDataInfo getClientDataInfo() {
+        return mClientDataInfo;
+    }
+
+    /**
+     * Sets the {@link ClientDataInfo} parsed from the clientdata redirect query parameter.
+     *
+     * @param clientDataInfo The ClientDataInfo to set.
+     */
+    public void setClientDataInfo(@Nullable final ClientDataInfo clientDataInfo) {
+        mClientDataInfo = clientDataInfo;
+    }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactory.java
@@ -75,8 +75,9 @@ public class MicrosoftStsAuthorizationResultFactory
 
         final Map<String, String> urlParameters = UrlUtil.getParameters(redirectUri);
 
+        ClientDataInfo clientDataInfo = null;
         if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY)) {
-            final ClientDataInfo clientDataInfo = ClientDataInfo.fromPipeDelimited(urlParameters.get(ClientDataInfo.CLIENTDATA_QUERY_PARAMETER));
+            clientDataInfo = ClientDataInfo.fromPipeDelimited(urlParameters.get(ClientDataInfo.CLIENTDATA_QUERY_PARAMETER));
             if (null != clientDataInfo) {
                 clientDataInfo.emitToSpan();
             }
@@ -105,6 +106,17 @@ public class MicrosoftStsAuthorizationResultFactory
                     MicrosoftAuthorizationErrorResponse.AUTHORIZATION_FAILED,
                     MicrosoftAuthorizationErrorResponse.AUTHORIZATION_SERVER_INVALID_RESPONSE
             );
+        }
+
+        // Attach ClientDataInfo for both success and trusted server errors.
+        // Exclude state-mismatch (CSRF) redirects only, as they may originate from untrusted sources.
+        if (null != clientDataInfo) {
+            final MicrosoftStsAuthorizationErrorResponse errorResponse = result.getAuthorizationErrorResponse();
+            final boolean isStateMismatch = errorResponse != null
+                    && ErrorStrings.STATE_MISMATCH.equals(errorResponse.getError());
+            if (!isStateMismatch) {
+                result.setClientDataInfo(clientDataInfo);
+            }
         }
 
         return result;

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/TokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/oauth2/TokenResult.java
@@ -23,6 +23,9 @@
 package com.microsoft.identity.common.java.providers.oauth2;
 
 import com.microsoft.identity.common.java.telemetry.CliTelemInfo;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
+
+import javax.annotation.Nullable;
 
 /**
  * Holds the request of a token request.  The request will either contain the success result or the error result.
@@ -32,6 +35,8 @@ public class TokenResult implements IResult {
     private TokenResponse mTokenResponse;
     private TokenErrorResponse mTokenErrorResponse;
     private CliTelemInfo mCliTelemInfo;
+    @Nullable
+    private ClientDataInfo mClientDataInfo;
     private boolean mSuccess = false;
 
     public TokenResult() {
@@ -108,6 +113,25 @@ public class TokenResult implements IResult {
      */
     public void setCliTelemInfo(final CliTelemInfo cliTelemInfo) {
         mCliTelemInfo = cliTelemInfo;
+    }
+
+    /**
+     * Gets the {@link ClientDataInfo} parsed from the x-ms-clientdata response header.
+     *
+     * @return The ClientDataInfo, or null if the header was absent or unparseable.
+     */
+    @Nullable
+    public ClientDataInfo getClientDataInfo() {
+        return mClientDataInfo;
+    }
+
+    /**
+     * Sets the {@link ClientDataInfo} parsed from the x-ms-clientdata response header.
+     *
+     * @param clientDataInfo The ClientDataInfo to set.
+     */
+    public void setClientDataInfo(@Nullable final ClientDataInfo clientDataInfo) {
+        mClientDataInfo = clientDataInfo;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -28,6 +28,8 @@ import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationResult;
 import com.microsoft.identity.common.java.broker.BrokerPerformanceMetrics;
 import com.microsoft.identity.common.java.broker.IBrokerPerformanceMetricsProvider;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 
 import javax.annotation.Nullable;
 
@@ -105,5 +107,39 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
     @Override
     public String getBrokerAppPackageName() {
         return mBrokerAppPackageName;
+    }
+
+    /**
+     * Gets the {@link ClientDataInfo} containing server-side telemetry data from the
+     * x-ms-clientdata response header (/token) or clientdata redirect query parameter (/authorize).
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>{@link LocalAuthenticationResult} — authoritative on success paths; the only carrier
+     *       that survives the broker IPC boundary.</li>
+     *   <li>{@link TokenResult} — fallback for paths where token call succeeded but no
+     *       {@code LocalAuthenticationResult} was constructed (e.g., error responses).</li>
+     *   <li>{@link MicrosoftStsAuthorizationResult} — fallback for failures before the
+     *       /token call (e.g., authorize-step errors).</li>
+     * </ol>
+     *
+     * @return The ClientDataInfo, or null if not available from any source.
+     */
+    @Nullable
+    public ClientDataInfo getClientDataInfo() {
+        if (mLocalAuthenticationResult instanceof LocalAuthenticationResult) {
+            final ClientDataInfo fromLocalAuth =
+                    ((LocalAuthenticationResult) mLocalAuthenticationResult).getClientDataInfo();
+            if (fromLocalAuth != null) {
+                return fromLocalAuth;
+            }
+        }
+        if (mTokenResult != null && mTokenResult.getClientDataInfo() != null) {
+            return mTokenResult.getClientDataInfo();
+        }
+        if (mAuthorizationResult instanceof MicrosoftStsAuthorizationResult) {
+            return ((MicrosoftStsAuthorizationResult) mAuthorizationResult).getClientDataInfo();
+        }
+        return null;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/LocalAuthenticationResult.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.dto.IdTokenRecord;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.request.ILocalAuthenticationCallback;
 import com.microsoft.identity.common.java.request.SdkType;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 import com.microsoft.identity.common.java.telemetry.ITelemetryAccessor;
 import com.microsoft.identity.common.java.util.StringUtil;
 
@@ -54,6 +55,8 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
     private String mFamilyId;
     private String mSpeRing;
     private String mRefreshTokenAge;
+    @Nullable
+    private ClientDataInfo mClientDataInfo;
     private List<ICacheRecord> mCompleteResultFromCache;
     private boolean mServicedFromCache;
     private String mCorrelationId;
@@ -201,6 +204,26 @@ public class LocalAuthenticationResult implements ILocalAuthenticationResult, IT
      */
     public void setRefreshTokenAge(final String refreshTokenAge) {
         mRefreshTokenAge = refreshTokenAge;
+    }
+
+    /**
+     * Gets the server client data info parsed from the {@code x-ms-clientdata} header, which can
+     * be returned by either the {@code /authorize} or {@code /token} endpoint.
+     *
+     * @return The ClientDataInfo, or null if not available.
+     */
+    @Nullable
+    public ClientDataInfo getClientDataInfo() {
+        return mClientDataInfo;
+    }
+
+    /**
+     * Sets the server client data info.
+     *
+     * @param clientDataInfo The ClientDataInfo to set.
+     */
+    public void setClientDataInfo(@Nullable final ClientDataInfo clientDataInfo) {
+        mClientDataInfo = clientDataInfo;
     }
 
     @Override

--- a/common4j/src/main/com/microsoft/identity/common/java/telemetry/ClientDataInfo.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/telemetry/ClientDataInfo.java
@@ -29,8 +29,9 @@ import com.microsoft.identity.common.java.util.StringUtil;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.trace.Span;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 /**
@@ -40,7 +41,7 @@ import lombok.experimental.Accessors;
  * Contains server-side error codes, account type, cloud instance, and data boundary info.
  */
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Accessors(prefix = "m")
 public class ClientDataInfo {
 
@@ -86,6 +87,14 @@ public class ClientDataInfo {
     private String mCallerDataBoundary;
 
     /**
+     * The original raw pipe-delimited string this instance was parsed from.
+     * Always set when the instance was constructed via {@link #fromPipeDelimited(String)},
+     * which is the only public entry point. Exposed for partner teams that want to
+     * inspect or forward the unparsed payload.
+     */
+    private String mRaw;
+
+    /**
      * Parses an already-decoded pipe-delimited clientdata query parameter value.
      * The caller is responsible for URL-decoding before passing (e.g. values from
      * {@link com.microsoft.identity.common.java.util.UrlUtil#getParameters} are
@@ -110,6 +119,7 @@ public class ClientDataInfo {
             }
 
             final ClientDataInfo info = new ClientDataInfo();
+            info.mRaw = decodedValue;
             info.mAccountType = emptyToNull(segments[PIPE_INDEX_ACCOUNT_TYPE]);
             info.mError = emptyToNull(segments[PIPE_INDEX_ERROR]);
             info.mSubError = emptyToNull(segments[PIPE_INDEX_SUB_ERROR]);

--- a/common4j/src/test/com/microsoft/identity/common/java/controllers/ExceptionAdapterTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/controllers/ExceptionAdapterTests.java
@@ -43,6 +43,8 @@ import com.microsoft.identity.common.java.exception.TerminalException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErrorResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
+import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -211,5 +213,42 @@ public class ExceptionAdapterTests {
         assertTrue(exception instanceof UiRequiredException);
         assertEquals(OAuth2ErrorCode.INVALID_GRANT, exception.getErrorCode());
         assertEquals("UI required.", exception.getMessage());
+    }
+
+    // -----------------------------------------------------------------------
+    // ClientDataInfo wiring tests (PR #3109)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testExceptionFromTokenResult_attachesClientDataInfo() {
+        final TokenErrorResponse errorResponse = new TokenErrorResponse();
+        errorResponse.setError(OAuth2ErrorCode.INVALID_GRANT);
+        errorResponse.setErrorDescription("token failure");
+
+        final ClientDataInfo clientDataInfo = ClientDataInfo.fromPipeDelimited("m|AADSTS50058|login_required|us|public");
+        Assert.assertNotNull(clientDataInfo);
+
+        final TokenResult tokenResult = new TokenResult(null, errorResponse);
+        tokenResult.setClientDataInfo(clientDataInfo);
+
+        final ServiceException exception = ExceptionAdapter.exceptionFromTokenResult(tokenResult, null);
+
+        Assert.assertNotNull("ClientDataInfo should be attached to the exception", exception.getClientDataInfo());
+        assertEquals("AADSTS50058", exception.getClientDataInfo().getError());
+        assertEquals("login_required", exception.getClientDataInfo().getSubError());
+        assertEquals("m|AADSTS50058|login_required|us|public", exception.getClientDataInfo().getRaw());
+    }
+
+    @Test
+    public void testExceptionFromTokenResult_nullClientDataInfo_doesNotThrow() {
+        final TokenErrorResponse errorResponse = new TokenErrorResponse();
+        errorResponse.setError(OAuth2ErrorCode.INVALID_GRANT);
+        errorResponse.setErrorDescription("token failure");
+
+        final TokenResult tokenResult = new TokenResult(null, errorResponse);
+        // No ClientDataInfo set
+
+        final ServiceException exception = ExceptionAdapter.exceptionFromTokenResult(tokenResult, null);
+        Assert.assertNull(exception.getClientDataInfo());
     }
 }

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactoryTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/microsoftsts/MicrosoftStsAuthorizationResultFactoryTest.java
@@ -338,6 +338,78 @@ public class MicrosoftStsAuthorizationResultFactoryTest {
     }
 
     @Test
+    public void testClientDataParam_serverError_clientDataInfoAttached() {
+        // When the server returns an error in the redirect (e.g., access_denied), clientDataInfo
+        // must still be attached — this is a trusted failure we especially want telemetry for.
+        // Pipe-delimited format: account_type|error|sub_error|caller_data_boundary|cloud_instance
+        final String redirectUrl = MOCK_REDIRECT_URI
+                + "?error=access_denied"
+                + "&error_description=user+denied+consent"
+                + "&" + ClientDataInfo.CLIENTDATA_QUERY_PARAMETER + "=m%7CAADSTS65004%7Cconsent_required%7Cus%7Cpublic";
+
+        final Span mockSpan = mock(Span.class);
+        when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
+
+        try (MockedStatic<SpanExtension> mockedExtension = Mockito.mockStatic(SpanExtension.class)) {
+            mockedExtension.when(SpanExtension::current).thenReturn(mockSpan);
+
+            final MicrosoftStsAuthorizationResult result = (MicrosoftStsAuthorizationResult)
+                    mAuthorizationResultFactory.createAuthorizationResult(
+                            RawAuthorizationResult.fromRedirectUri(redirectUrl), getMstsAuthorizationRequest());
+
+            assertNotNull(result);
+            assertEquals(AuthorizationStatus.FAIL, result.getAuthorizationStatus());
+            // ClientDataInfo must be attached even for server-error redirects (not state-mismatch)
+            assertNotNull(result.getClientDataInfo());
+            assertEquals("AADSTS65004", result.getClientDataInfo().getError());
+        }
+    }
+
+    @Test
+    public void testClientDataParam_stateMismatch_clientDataInfoNotAttached() {
+        // Pipe-delimited format: account_type|error|sub_error|caller_data_boundary|cloud_instance
+        final String redirectUrl = MOCK_REDIRECT_URI
+                + "?" + MOCK_AUTH_CODE_AND_STATE
+                + "&" + ClientDataInfo.CLIENTDATA_QUERY_PARAMETER + "=m%7CAADSTS50058%7Clogin_required%7Cus%7Cpublic";
+
+        // Pass a mismatched state to trigger state validation failure (potential CSRF redirect)
+        final MicrosoftStsAuthorizationResult result = (MicrosoftStsAuthorizationResult)
+                mAuthorizationResultFactory.createAuthorizationResult(
+                        RawAuthorizationResult.fromRedirectUri(redirectUrl),
+                        getMstsAuthorizationRequestWithState("incorrect_state"));
+
+        assertNotNull(result);
+        assertEquals(AuthorizationStatus.FAIL, result.getAuthorizationStatus());
+        // ClientDataInfo must NOT be attached for untrusted/state-mismatch redirects
+        assertNull(result.getClientDataInfo());
+    }
+
+    @Test
+    public void testClientDataParam_validState_clientDataInfoAttached() {
+        // Pipe-delimited format: account_type|error|sub_error|caller_data_boundary|cloud_instance
+        final String redirectUrl = MOCK_REDIRECT_URI
+                + "?code=auth_code&state=" + MOCK_STATE_ENCODED
+                + "&" + ClientDataInfo.CLIENTDATA_QUERY_PARAMETER + "=m%7CAADSTS50058%7Clogin_required%7Cus%7Cpublic";
+
+        final Span mockSpan = mock(Span.class);
+        when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
+
+        try (MockedStatic<SpanExtension> mockedExtension = Mockito.mockStatic(SpanExtension.class)) {
+            mockedExtension.when(SpanExtension::current).thenReturn(mockSpan);
+
+            final MicrosoftStsAuthorizationResult result = (MicrosoftStsAuthorizationResult)
+                    mAuthorizationResultFactory.createAuthorizationResult(
+                            RawAuthorizationResult.fromRedirectUri(redirectUrl), getMstsAuthorizationRequest());
+
+            assertNotNull(result);
+            assertEquals(AuthorizationStatus.SUCCESS, result.getAuthorizationStatus());
+            // ClientDataInfo must be attached when state validation passes
+            assertNotNull(result.getClientDataInfo());
+        }
+    }
+
+
+    @Test
     public void testClientDataParam_flightDisabled_attributesNotEmitted() {
         final MockFlightsProvider provider = new MockFlightsProvider();
         provider.addFlight(CommonFlight.ENABLE_SERVER_CLIENT_DATA_TELEMETRY.getKey(), "false");

--- a/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.result;
+
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResponse;
+import com.microsoft.identity.common.java.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationResult;
+import com.microsoft.identity.common.java.providers.oauth2.AuthorizationStatus;
+import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class AcquireTokenResultTest {
+
+    private static final String PIPE_DELIMITED_A = "m|AADSTS50058|login_required|us|public";
+    private static final String PIPE_DELIMITED_B = "e|AADSTS70011|invalid_scope|eu|sovereign";
+    private static final String PIPE_DELIMITED_C = "m|AADSTS50076|mfa_required|us|public";
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private ClientDataInfo makeClientDataInfo(final String raw) {
+        return ClientDataInfo.fromPipeDelimited(raw);
+    }
+
+    private LocalAuthenticationResult makeLocalAuthResult(final ClientDataInfo clientDataInfo) {
+        final LocalAuthenticationResult localAuthResult = mock(LocalAuthenticationResult.class);
+        when(localAuthResult.getClientDataInfo()).thenReturn(clientDataInfo);
+        return localAuthResult;
+    }
+
+    private MicrosoftStsAuthorizationResult makeAuthResult(final ClientDataInfo clientDataInfo) {
+        final MicrosoftStsAuthorizationResult authResult = new MicrosoftStsAuthorizationResult(
+                AuthorizationStatus.SUCCESS, (MicrosoftStsAuthorizationResponse) null);
+        authResult.setClientDataInfo(clientDataInfo);
+        return authResult;
+    }
+
+    // ---------------------------------------------------------------------------
+    // No sources populated
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void getClientDataInfo_noSources_returnsNull() {
+        final AcquireTokenResult result = new AcquireTokenResult();
+        assertNull(result.getClientDataInfo());
+    }
+
+    // ---------------------------------------------------------------------------
+    // LocalAuthenticationResult source
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void getClientDataInfo_localAuthResultHasData_returnsIt() {
+        final ClientDataInfo expected = makeClientDataInfo(PIPE_DELIMITED_A);
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setLocalAuthenticationResult(makeLocalAuthResult(expected));
+
+        assertSame(expected, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_localAuthResultHasNull_fallsBackToTokenResult() {
+        final ClientDataInfo tokenData = makeClientDataInfo(PIPE_DELIMITED_A);
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(tokenData);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setLocalAuthenticationResult(makeLocalAuthResult(null));
+        result.setTokenResult(tokenResult);
+
+        assertSame(tokenData, result.getClientDataInfo());
+    }
+
+    // ---------------------------------------------------------------------------
+    // TokenResult fallback
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void getClientDataInfo_tokenResultHasData_returnsIt() {
+        final ClientDataInfo expected = makeClientDataInfo(PIPE_DELIMITED_A);
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(expected);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setTokenResult(tokenResult);
+
+        assertSame(expected, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_tokenResultHasNull_fallsBackToAuthResult() {
+        final ClientDataInfo authData = makeClientDataInfo(PIPE_DELIMITED_A);
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(null);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setTokenResult(tokenResult);
+        result.setAuthorizationResult(makeAuthResult(authData));
+
+        assertSame(authData, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_noTokenResult_fallsBackToAuthResult() {
+        final ClientDataInfo authData = makeClientDataInfo(PIPE_DELIMITED_A);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setAuthorizationResult(makeAuthResult(authData));
+
+        assertSame(authData, result.getClientDataInfo());
+    }
+
+    // ---------------------------------------------------------------------------
+    // MicrosoftStsAuthorizationResult fallback
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void getClientDataInfo_authResultHasData_returnsIt() {
+        final ClientDataInfo expected = makeClientDataInfo(PIPE_DELIMITED_A);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setAuthorizationResult(makeAuthResult(expected));
+
+        assertSame(expected, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_authResultHasNull_returnsNull() {
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setAuthorizationResult(makeAuthResult(null));
+
+        assertNull(result.getClientDataInfo());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Precedence: LocalAuthResult > TokenResult > AuthResult
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void getClientDataInfo_allSourcesPopulated_prefersLocalAuthResult() {
+        final ClientDataInfo localData = makeClientDataInfo(PIPE_DELIMITED_A);
+        final ClientDataInfo tokenData = makeClientDataInfo(PIPE_DELIMITED_B);
+        final ClientDataInfo authData = makeClientDataInfo(PIPE_DELIMITED_C);
+
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(tokenData);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setLocalAuthenticationResult(makeLocalAuthResult(localData));
+        result.setTokenResult(tokenResult);
+        result.setAuthorizationResult(makeAuthResult(authData));
+
+        assertSame(localData, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_localAuthNullTokenPopulated_prefersTokenResult() {
+        final ClientDataInfo tokenData = makeClientDataInfo(PIPE_DELIMITED_A);
+        final ClientDataInfo authData = makeClientDataInfo(PIPE_DELIMITED_B);
+
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(tokenData);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setLocalAuthenticationResult(makeLocalAuthResult(null));
+        result.setTokenResult(tokenResult);
+        result.setAuthorizationResult(makeAuthResult(authData));
+
+        assertSame(tokenData, result.getClientDataInfo());
+    }
+
+    @Test
+    public void getClientDataInfo_localAuthNullTokenNull_returnsAuthResult() {
+        final ClientDataInfo authData = makeClientDataInfo(PIPE_DELIMITED_A);
+
+        final TokenResult tokenResult = new TokenResult();
+        tokenResult.setClientDataInfo(null);
+
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setLocalAuthenticationResult(makeLocalAuthResult(null));
+        result.setTokenResult(tokenResult);
+        result.setAuthorizationResult(makeAuthResult(authData));
+
+        assertSame(authData, result.getClientDataInfo());
+    }
+
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/telemetry/ClientDataInfoTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/telemetry/ClientDataInfoTest.java
@@ -54,7 +54,8 @@ public class ClientDataInfoTest {
     @Test
     public void fromPipeDelimited_validFiveSegments_allFieldsParsed() {
         // format: account_type|error|sub_error|caller_data_boundary|cloud_instance
-        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("m|AADSTS50058|login_required|us|public");
+        final String raw = "m|AADSTS50058|login_required|us|public";
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited(raw);
 
         assertNotNull(info);
         assertEquals("m", info.getAccountType());
@@ -62,6 +63,7 @@ public class ClientDataInfoTest {
         assertEquals("login_required", info.getSubError());
         assertEquals("us", info.getCallerDataBoundary());
         assertEquals("public", info.getCloudInstance());
+        assertEquals(raw, info.getRaw());
     }
 
     @Test
@@ -108,12 +110,9 @@ public class ClientDataInfoTest {
 
     @Test
     public void emitToSpan_allFieldsSet_allAttributesEmitted() {
-        final ClientDataInfo info = new ClientDataInfo();
-        info.setError("AADSTS50058");
-        info.setSubError("login_required");
-        info.setAccountType("m");
-        info.setCloudInstance("public");
-        info.setCallerDataBoundary("us");
+        // format: account_type|error|sub_error|caller_data_boundary|cloud_instance
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("m|AADSTS50058|login_required|us|public");
+        assertNotNull(info);
 
         final Span mockSpan = mock(Span.class);
         when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
@@ -133,9 +132,9 @@ public class ClientDataInfoTest {
 
     @Test
     public void emitToSpan_someFieldsNull_nullFieldsNotEmitted() {
-        final ClientDataInfo info = new ClientDataInfo();
-        info.setError("AADSTS50058");
-        // subError, accountType, cloudInstance, callerDataBoundary all null
+        // Only error populated; account_type and sub_error empty
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("|AADSTS50058|");
+        assertNotNull(info);
 
         final Span mockSpan = mock(Span.class);
         when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
@@ -159,8 +158,9 @@ public class ClientDataInfoTest {
 
     @Test
     public void emitToSpan_accountTypeMsa_mappedToMSA() {
-        final ClientDataInfo info = new ClientDataInfo();
-        info.setAccountType("m");
+        // Only account_type populated (m for MSA)
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("m||");
+        assertNotNull(info);
 
         final Span mockSpan = mock(Span.class);
         when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
@@ -176,8 +176,9 @@ public class ClientDataInfoTest {
 
     @Test
     public void emitToSpan_accountTypeAad_mappedToAAD() {
-        final ClientDataInfo info = new ClientDataInfo();
-        info.setAccountType("e");
+        // Only account_type populated (e for AAD)
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("e||");
+        assertNotNull(info);
 
         final Span mockSpan = mock(Span.class);
         when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);
@@ -207,8 +208,9 @@ public class ClientDataInfoTest {
             expected256.append('A');
         }
 
-        final ClientDataInfo info = new ClientDataInfo();
-        info.setError(longValue);
+        // Construct via the only public entry point; long value goes in the error field
+        final ClientDataInfo info = ClientDataInfo.fromPipeDelimited("|" + longValue + "|");
+        assertNotNull(info);
 
         final Span mockSpan = mock(Span.class);
         when(mockSpan.setAttribute(Mockito.anyString(), Mockito.anyString())).thenReturn(mockSpan);


### PR DESCRIPTION
Cherry-picks #3109 (squash commit `26de108`) onto `working/release/24.2.1` for the 24.2.1 hotfix.

Propagates the parsed `x-ms-clientdata` (token endpoint) and `clientdata` query parameter (authorize endpoint) data from the response handlers through `TokenResult`, `MicrosoftStsAuthorizationResult`, and ultimately onto `AcquireTokenResult` so callers can access server-side telemetry (error, sub-error, account type, cloud instance, data boundary). All propagation is gated behind the `ENABLE_SERVER_CLIENT_DATA_TELEMETRY` flight.

### Conflict resolution notes
The hotfix branch does not contain the onboarding-blob feature (PR #3088 / #3111) that landed on `dev` alongside #3109. To keep this hotfix scoped to ClientDataInfo only, the following PR-side additions were dropped during cherry-pick:
- `BrokerResult.ONBOARDING_BLOB` constant (kept only `CLIENT_DATA_INFO`)
- `MsalBrokerResultAdapterTests.testOnboardingBlob_*` tests
- `AcquireTokenResultTest.onboardingBlob_*` tests
- Other `vNext` changelog entries unrelated to #3109

All `ClientDataInfo` plumbing from #3109 is preserved unchanged.

[AB#3604499](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3604499)