### PR TITLE
Update OpenTelemetry to 1.62.0, AB#3611236, Fixes AB#3611236

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [MINOR] Refactor Auth Tab integration to use provider-based strategy selection. Adds AuthTabStrategyProvider and BrowserLaunchStrategy with Custom Tabs fallback. Compatible with androidx.browser:browser:1.7.0.
 - [MINOR] Wire onboarding telemetry hooks into AzureActiveDirectoryWebViewClient for page-transition step capture (broker install, MDM enrollment, Company Portal launch, MFA linking) and last-loaded-domain tracking (#3121)
 - [MINOR] Propagate the onboarding telemetry blob through the broker failure path: add BaseException.onboardingBlob and round-trip it through MsalBrokerResultAdapter so callers can emit onboarding telemetry on failure outcomes. Also add an MsalBrokerResultAdapter overload that accepts an onboarding blob on the success path so the broker can attach the finalized blob to the success result bundle (#3123)
+- [PATCH] Update OpenTelemetry to 1.62.0 (#3125)
 - [MINOR] Add provisionResourceAccountCredentials API to DeviceRegistrationClientApplication with V0 protocol params/response and add IPPhone to AppRegistry (#3086)
 - [PATCH] Extend filter-then-clone optimization to deleteAccessTokensWithIntersectingScopes and add telemetry attributes (#3114)
 - [PATCH] Wire ClientDataInfo through AcquireTokenResult, exceptions (#3109)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -283,7 +283,7 @@ dependencies {
     })
 
     implementation "io.opentelemetry:opentelemetry-api:$rootProject.ext.openTelemetryVersion"
-    implementation("io.opentelemetry:opentelemetry-extension-kotlin:$rootProject.ext.openTelemetryVersion")
+    implementation("io.opentelemetry:opentelemetry-extension-kotlin:$rootProject.ext.openTelemetryExtensionKotlinVersion")
     implementation "androidx.fragment:fragment:1.3.2"
 }
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BenchmarkSpan.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/BenchmarkSpan.kt
@@ -127,7 +127,7 @@ class BenchmarkSpan(
 
     override fun <T : Any?> setAttribute(
         key: AttributeKey<T>,
-        value: T
+        value: T?
     ): Span? {
         statuses.add(Pair(key.toString(), System.nanoTime()))
         return originalSpan.setAttribute(key, value)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -73,7 +73,11 @@ ext {
     androidxAnnotationVersion = "1.4.0"
     spotBugsAnnotationVersion = "4.3.0"
     jcipAnnotationVersion = "1.0-1"
-    openTelemetryVersion = "1.18.0"
+    openTelemetryVersion = "1.62.0"
+    // Pinned to 1.18.0 because newer versions add a 'strictly' kotlin-stdlib 2.x
+    // constraint that conflicts with the project's Kotlin 1.8 compiler. Realign
+    // once the project upgrades Kotlin to 2.x.
+    openTelemetryExtensionKotlinVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     blockstoreVersion="16.2.0"
     lifecycleKtxVersion="2.5.1"


### PR DESCRIPTION
[AB#3611236](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3611236)

Updates `opentelemetry-api` (and transitives) from 1.18.0 to 1.62.0.

## Changes
- `gradle/versions.gradle` -- `openTelemetryVersion` 1.18.0 -> 1.62.0
- `BenchmarkSpan.kt` -- `setAttribute(key, value: T)` -> `value: T?` to match the `@Nullable` annotation on `Span.setAttribute(AttributeKey<T>, T)` in newer versions.
- `common/build.gradle` -- pin `opentelemetry-extension-kotlin` to 1.18.0 via a new `openTelemetryExtensionKotlinVersion` variable. Newer `extension-kotlin` releases add a `strictly` `kotlin-stdlib` 2.x constraint that conflicts with the project's Kotlin 1.8 compiler. The pin is binary-compatible with `opentelemetry-api`/`-context` 1.62 -- `extension-kotlin` only calls stable `Context` APIs that are unchanged across 1.18 -> 1.62.