### PR TITLE
Auto-resolve changelog merges with union driver, Fixes AB#3621652

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+changelog.txt merge=union


### PR DESCRIPTION
## Summary
- Add .gitattributes in common repo
- Configure changelog.txt with merge=union to auto-resolve append-only changelog conflicts

## Validation
- Verified: git check-attr merge -- changelog.txt => union
[AB#3621652](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3621652)