### PR TITLE
Enable passkey registration feature in CommonFlight, Fixes AB#3121984

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [PATCH] Fix Token Endpoint Server Telemetry Parsing (#3128)
+- [MINOR] Enable passkey registration by default in CommonFlight (ENABLE_PASSKEY_REGISTRATION) (#3132)
 - [PATCH] Emit ipc_strategy telemetry attribute for successful device registration IPC strategy and refactor execute flow to pack protocol request once before strategy retries (#3124)
 - [PATCH] Fix Edge browser selection on devices where Microsoft Edge is the default browser: add the rotated Edge signing certificate hash to the Edge BrowserDescriptor and accept multi-signer browsers when any signature intersects the safelist, instead of requiring strict set-equality (resolves MSAL #2414)
 - [MINOR] Refactor Auth Tab integration to use provider-based strategy selection. Adds AuthTabStrategyProvider and BrowserLaunchStrategy with Custom Tabs fallback. Compatible with androidx.browser:browser:1.7.0.

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -57,7 +57,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to enable passkey registration feature.
      */
-    ENABLE_PASSKEY_REGISTRATION("EnablePasskeyRegistration", false),
+    ENABLE_PASSKEY_REGISTRATION("EnablePasskeyRegistration", true),
 
     /**
      * Flight to control the timeout duration for UrlConnection connect timeout.


### PR DESCRIPTION
This pull request makes a small but important configuration change to the `CommonFlight` enum. The default value for the `ENABLE_PASSKEY_REGISTRATION` flight has been changed from `false` to `true`, enabling the passkey registration feature by default.

* The `ENABLE_PASSKEY_REGISTRATION` feature flag is now enabled by default in `CommonFlight.java`.
[AB#3121984](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3121984)