### PR TITLE
Add enableSwitchBrowser opt-in to AuthorizationActivityFactory, Fixes AB#3627515

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available
 - [PATCH] Fix Token Endpoint Server Telemetry Parsing (#3128)
 - [MINOR] Enable passkey registration by default in CommonFlight (ENABLE_PASSKEY_REGISTRATION) (#3132)
 - [PATCH] Emit ipc_strategy telemetry attribute for successful device registration IPC strategy and refactor execute flow to pack protocol request once before strategy retries (#3124)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available
+- [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available (#3137)
 - [PATCH] Fix Token Endpoint Server Telemetry Parsing (#3128)
 - [MINOR] Enable passkey registration by default in CommonFlight (ENABLE_PASSKEY_REGISTRATION) (#3132)
 - [PATCH] Emit ipc_strategy telemetry attribute for successful device registration IPC strategy and refactor execute flow to pack protocol request once before strategy retries (#3124)

--- a/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
+++ b/common/src/main/java/com/microsoft/identity/common/adal/internal/AuthenticationConstants.java
@@ -548,7 +548,7 @@ public final class AuthenticationConstants {
         /**
          * String Query parameter key to indicate support for SWITCH_BROWSER protocol.
          */
-        public static final String CLIENT_SUPPORTS_FLOW = "switch_browser";
+        public static final String SWITCH_BROWSER_EXTRA_QUERY_PARAM = "switch_browser";
 
         /**
          * String Query parameter key for the purpose token.

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -27,11 +27,13 @@ import android.os.Bundle
 import androidx.fragment.app.Fragment
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.OTEL_CONTEXT_CARRIER
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
 import com.microsoft.identity.common.internal.msafederation.getIdProviderExtraQueryParamForAuthorization
 import com.microsoft.identity.common.internal.msafederation.getIdProviderHeadersForAuthorization
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleApi.Companion.getInstance
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleCredential
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters
+import com.microsoft.identity.common.internal.ui.browser.AndroidBrowserSelector
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.internal.util.ProcessUtil
 import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID
@@ -45,7 +47,9 @@ import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.TextMapPropagatorExtension
 import com.microsoft.identity.common.java.ui.AuthorizationAgent
+import com.microsoft.identity.common.java.ui.BrowserDescriptor
 import com.microsoft.identity.common.java.util.CommonURIBuilder
+import com.microsoft.identity.common.logging.Logger
 import java.net.URISyntaxException
 
 
@@ -53,6 +57,8 @@ import java.net.URISyntaxException
  * Constructs intents and/or fragments for interactive requests based on library configuration and current request.
  */
 object AuthorizationActivityFactory {
+
+    private val TAG: String = AuthorizationActivityFactory::class.java.simpleName
 
     /**
      * Return the correct authorization activity based on library configuration.
@@ -82,6 +88,13 @@ object AuthorizationActivityFactory {
             intent = Intent(parameters.context, AuthorizationActivity::class.java)
         }
 
+        // If switch browser is enabled, check browser availability and append switch_browser=1
+        val effectiveRequestUrl = if (parameters.enableSwitchBrowser) {
+            appendSwitchBrowserParam(parameters.context, parameters.requestUrl)
+        } else {
+            parameters.requestUrl
+        }
+
         intent.apply {
             putExtra(
                 AuthenticationConstants.AuthorizationIntentKey.AUTH_INTENT,
@@ -89,7 +102,7 @@ object AuthorizationActivityFactory {
             )
             putExtra(
                 AuthenticationConstants.AuthorizationIntentKey.REQUEST_URL,
-                parameters.requestUrl
+                effectiveRequestUrl
             )
             putExtra(
                 AuthenticationConstants.AuthorizationIntentKey.REDIRECT_URI,
@@ -275,5 +288,37 @@ object AuthorizationActivityFactory {
             fragment.setInstanceState(bundle)
         }
         return fragment
+    }
+
+    /**
+     * Checks if a browser compatible with the Switch Browser protocol is available on the device.
+     * If so, appends `switch_browser=1` to the request URL to signal the server that the client
+     * supports the Switch Browser protocol.
+     *
+     * @param context Android context for browser resolution.
+     * @param requestUrl The original authorization request URL.
+     * @return The request URL with `switch_browser=1` appended if a compatible browser is available,
+     *         or the original URL if no compatible browser is found.
+     */
+    private fun appendSwitchBrowserParam(context: android.content.Context, requestUrl: String): String {
+        val methodTag = "$TAG:appendSwitchBrowserParam"
+        try {
+            val browserSelector = AndroidBrowserSelector(context)
+            val browser = browserSelector.selectBrowser(
+                BrowserDescriptor.getBrowserSafeListForSwitchBrowser(),
+                null
+            )
+            if (browser != null) {
+                Logger.info(methodTag, "Compatible browser found for Switch Browser: ${browser.packageName}")
+                val uriBuilder = CommonURIBuilder(requestUrl)
+                uriBuilder.addParameterIfAbsent(SWITCH_BROWSER.SWITCH_BROWSER_EXTRA_QUERY_PARAM, "1")
+                return uriBuilder.build().toString()
+            } else {
+                Logger.info(methodTag, "No compatible browser found for Switch Browser protocol.")
+            }
+        } catch (e: Exception) {
+            Logger.warn(methodTag, "Failed to check browser availability for Switch Browser: ${e.message}")
+        }
+        return requestUrl
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -33,7 +33,7 @@ import com.microsoft.identity.common.internal.msafederation.getIdProviderHeaders
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleApi.Companion.getInstance
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleCredential
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters
-import com.microsoft.identity.common.internal.ui.browser.AndroidBrowserSelector
+import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUtils
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.internal.util.ProcessUtil
 import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID
@@ -47,7 +47,6 @@ import com.microsoft.identity.common.java.opentelemetry.SerializableSpanContext
 import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.TextMapPropagatorExtension
 import com.microsoft.identity.common.java.ui.AuthorizationAgent
-import com.microsoft.identity.common.java.ui.BrowserDescriptor
 import com.microsoft.identity.common.java.util.CommonURIBuilder
 import com.microsoft.identity.common.logging.Logger
 import java.net.URISyntaxException
@@ -90,7 +89,7 @@ object AuthorizationActivityFactory {
 
         // If switch browser is enabled, check browser availability and append switch_browser=1
         val effectiveRequestUrl = if (parameters.enableSwitchBrowser) {
-            appendSwitchBrowserParam(parameters.context, parameters.requestUrl)
+            appendSwitchBrowserParam(parameters.context, parameters.requestUrl, parameters.redirectUri)
         } else {
             parameters.requestUrl
         }
@@ -291,34 +290,30 @@ object AuthorizationActivityFactory {
     }
 
     /**
-     * Checks if a browser compatible with the Switch Browser protocol is available on the device.
-     * If so, appends `switch_browser=1` to the request URL to signal the server that the client
-     * supports the Switch Browser protocol.
+     * If Switch Browser is supported (compatible browser + manifest entry), appends
+     * `switch_browser=1` to the request URL. Otherwise returns the URL unchanged.
      *
-     * @param context Android context for browser resolution.
+     * @param context Android context.
      * @param requestUrl The original authorization request URL.
-     * @return The request URL with `switch_browser=1` appended if a compatible browser is available,
-     *         or the original URL if no compatible browser is found.
+     * @param redirectUri The app's redirect URI.
+     * @return The (possibly modified) request URL.
      */
-    private fun appendSwitchBrowserParam(context: android.content.Context, requestUrl: String): String {
+    private fun appendSwitchBrowserParam(
+        context: android.content.Context,
+        requestUrl: String,
+        redirectUri: String
+    ): String {
         val methodTag = "$TAG:appendSwitchBrowserParam"
-        try {
-            val browserSelector = AndroidBrowserSelector(context)
-            val browser = browserSelector.selectBrowser(
-                BrowserDescriptor.getBrowserSafeListForSwitchBrowser(),
-                null
-            )
-            if (browser != null) {
-                Logger.info(methodTag, "Compatible browser found for Switch Browser: ${browser.packageName}")
-                val uriBuilder = CommonURIBuilder(requestUrl)
-                uriBuilder.addParameterIfAbsent(SWITCH_BROWSER.SWITCH_BROWSER_EXTRA_QUERY_PARAM, "1")
-                return uriBuilder.build().toString()
-            } else {
-                Logger.info(methodTag, "No compatible browser found for Switch Browser protocol.")
-            }
-        } catch (e: Exception) {
-            Logger.warn(methodTag, "Failed to check browser availability for Switch Browser: ${e.message}")
+        if (!SwitchBrowserUtils.isSwitchBrowserSupported(context, redirectUri)) {
+            return requestUrl
         }
-        return requestUrl
+        return try {
+            val uriBuilder = CommonURIBuilder(requestUrl)
+            uriBuilder.addParameterIfAbsent(SWITCH_BROWSER.SWITCH_BROWSER_EXTRA_QUERY_PARAM, "1")
+            uriBuilder.build().toString()
+        } catch (e: Exception) {
+            Logger.warn(methodTag, "Failed to append switch_browser param: ${e.message}")
+            requestUrl
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactory.kt
@@ -33,7 +33,7 @@ import com.microsoft.identity.common.internal.msafederation.getIdProviderHeaders
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleApi.Companion.getInstance
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleCredential
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters
-import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUtils
+import com.microsoft.identity.common.internal.ui.webview.switchbrowser.SwitchBrowserUtil
 import com.microsoft.identity.common.internal.util.CommonMoshiJsonAdapter
 import com.microsoft.identity.common.internal.util.ProcessUtil
 import com.microsoft.identity.common.java.AuthenticationConstants.OAuth2.UTID
@@ -304,7 +304,7 @@ object AuthorizationActivityFactory {
         redirectUri: String
     ): String {
         val methodTag = "$TAG:appendSwitchBrowserParam"
-        if (!SwitchBrowserUtils.isSwitchBrowserSupported(context, redirectUri)) {
+        if (!SwitchBrowserUtil.isSwitchBrowserSupported(context, redirectUri)) {
             return requestUrl
         }
         return try {

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityParameters.kt
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent
  * @param utid                       The tenant unique id, if applicable
  * @param webViewEnableSilentAuthorizationFlowTimeOutMs                 If set to a non-null value, this indicates that the flow is silent and specifies the timeout for the silent authorization flow in milliseconds.
  * @param isWebViewWebCpEnabled        This parameter controls whether webcp URLs should be handled within the WebView or redirected to external browser
+ * @param enableSwitchBrowser       When true, the factory will check for browser availability and append switch_browser=1 to the request URL to opt-in to the Switch Browser protocol
  */
 data class AuthorizationActivityParameters @JvmOverloads constructor(
     val context: Context,
@@ -60,4 +61,5 @@ data class AuthorizationActivityParameters @JvmOverloads constructor(
     val utid: String? = null,
     val webViewEnableSilentAuthorizationFlowTimeOutMs: Long? = null,
     val isWebViewWebCpEnabled: Boolean = false,
+    val enableSwitchBrowser: Boolean = false,
 )

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtil.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtil.kt
@@ -34,7 +34,7 @@ import androidx.core.net.toUri
 /**
  * Utility class for Switch Browser protocol
  */
-object SwitchBrowserUtils {
+object SwitchBrowserUtil {
 
     private const val TAG = "SwitchBrowserUtils"
 
@@ -99,7 +99,8 @@ object SwitchBrowserUtils {
      * @param redirectUri The app's redirect URI.
      * @return true if a valid handler is registered, false otherwise.
      */
-    private fun isSwitchBrowserResumeHandlerRegistered(
+    @JvmStatic
+    fun isSwitchBrowserResumeHandlerRegistered(
         context: Context,
         redirectUri: String
     ): Boolean {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtils.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtils.kt
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.ui.webview.switchbrowser
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants.SWITCH_BROWSER
+import com.microsoft.identity.common.internal.ui.browser.AndroidBrowserSelector
+import com.microsoft.identity.common.java.ui.BrowserDescriptor
+import com.microsoft.identity.common.logging.Logger
+import androidx.core.net.toUri
+
+/**
+ * Utility class for Switch Browser protocol
+ */
+object SwitchBrowserUtils {
+
+    private const val TAG = "SwitchBrowserUtils"
+
+    /**
+     * Determines whether the Switch Browser protocol can be used for the current request.
+     * Both conditions must be met:
+     * 1. A compatible browser is installed on the device.
+     * 2. The app manifest declares a handler for the switch_browser_resume redirect.
+     *
+     * @param context Android context for browser and manifest resolution.
+     * @param redirectUri The app's redirect URI.
+     * @return true if switch browser is supported, false otherwise.
+     */
+    @JvmStatic
+    fun isSwitchBrowserSupported(context: Context, redirectUri: String): Boolean {
+        val methodTag = "$TAG:isSwitchBrowserSupported"
+        try {
+            // Check 1: Compatible browser available
+            val browserSelector = AndroidBrowserSelector(context)
+            val browser = browserSelector.selectBrowser(
+                BrowserDescriptor.getBrowserSafeListForSwitchBrowser(),
+                null
+            )
+            if (browser == null) {
+                Logger.info(methodTag, "No compatible browser found for Switch Browser protocol.")
+                return false
+            }
+            Logger.info(methodTag, "Compatible browser found for Switch Browser: ${browser.packageName}")
+
+            // Check 2: Manifest declares handler for switch_browser_resume redirect
+            if (!isSwitchBrowserResumeHandlerRegistered(context, redirectUri)) {
+                Logger.warn(
+                    methodTag,
+                    "SwitchBrowserRedirectActivity not registered in manifest for redirect URI. " +
+                        "Switch Browser will not be enabled."
+                )
+                return false
+            }
+            return true
+        } catch (e: Exception) {
+            Logger.warn(methodTag, "Failed to check Switch Browser prerequisites: ${e.message}")
+        }
+        return false
+    }
+
+    /**
+     * Checks whether the app's manifest declares an Activity that can handle the
+     * switch_browser_resume redirect URI. To be used by non-broker flows to check
+     * if the consuming app has properly configured the manifest to handle the Switch
+     * Browser redirect from browser.
+     *
+     * @param context Android context for PackageManager access.
+     * @param redirectUri The app's redirect URI.
+     * @return true if a handler is registered, false otherwise.
+     */
+    private fun isSwitchBrowserResumeHandlerRegistered(
+        context: Context,
+        redirectUri: String
+    ): Boolean {
+        val resumeUri = (redirectUri.trimEnd('/') + "/" + SWITCH_BROWSER.RESUME_PATH).toUri()
+        val intent = Intent(Intent.ACTION_VIEW, resumeUri).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
+            addCategory(Intent.CATEGORY_BROWSABLE)
+            setPackage(context.packageName)
+        }
+        val resolvedActivities = context.packageManager.queryIntentActivities(
+            intent, PackageManager.MATCH_DEFAULT_ONLY
+        )
+        return resolvedActivities.isNotEmpty()
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtils.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/switchbrowser/SwitchBrowserUtils.kt
@@ -52,19 +52,11 @@ object SwitchBrowserUtils {
     fun isSwitchBrowserSupported(context: Context, redirectUri: String): Boolean {
         val methodTag = "$TAG:isSwitchBrowserSupported"
         try {
-            // Check 1: Compatible browser available
-            val browserSelector = AndroidBrowserSelector(context)
-            val browser = browserSelector.selectBrowser(
-                BrowserDescriptor.getBrowserSafeListForSwitchBrowser(),
-                null
-            )
-            if (browser == null) {
+            if (!isCompatibleBrowserInstalled(context)) {
                 Logger.info(methodTag, "No compatible browser found for Switch Browser protocol.")
                 return false
             }
-            Logger.info(methodTag, "Compatible browser found for Switch Browser: ${browser.packageName}")
 
-            // Check 2: Manifest declares handler for switch_browser_resume redirect
             if (!isSwitchBrowserResumeHandlerRegistered(context, redirectUri)) {
                 Logger.warn(
                     methodTag,
@@ -81,14 +73,31 @@ object SwitchBrowserUtils {
     }
 
     /**
-     * Checks whether the app's manifest declares an Activity that can handle the
-     * switch_browser_resume redirect URI. To be used by non-broker flows to check
-     * if the consuming app has properly configured the manifest to handle the Switch
-     * Browser redirect from browser.
+     * Checks whether a compatible browser (Chrome, Edge, or AEA) is installed on the device.
+     *
+     * @param context Android context for browser resolution.
+     * @return true if a compatible browser is installed, false otherwise.
+     */
+    @JvmStatic
+    fun isCompatibleBrowserInstalled(context: Context): Boolean {
+        val browserSelector = AndroidBrowserSelector(context)
+        val browser = browserSelector.selectBrowser(
+            BrowserDescriptor.getBrowserSafeListForSwitchBrowser(),
+            null
+        )
+        return browser != null
+    }
+
+    /**
+     * Checks whether the app's manifest declares [SwitchBrowserRedirectActivity] with an
+     * intent-filter that can handle the switch_browser_resume redirect URI. This
+     * validates both that the activity is declared and that it can handle the resume URI.
+     * Note: This check is for non-broker flows only. Broker uses its own subclass via a
+     * different code path.
      *
      * @param context Android context for PackageManager access.
      * @param redirectUri The app's redirect URI.
-     * @return true if a handler is registered, false otherwise.
+     * @return true if a valid handler is registered, false otherwise.
      */
     private fun isSwitchBrowserResumeHandlerRegistered(
         context: Context,

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactoryTest.java
@@ -35,8 +35,10 @@ import static com.microsoft.identity.common.java.AuthenticationConstants.SdkPlat
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -48,14 +50,18 @@ import androidx.fragment.app.Fragment;
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleApi;
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleCredential;
 import com.microsoft.identity.common.internal.msafederation.google.SignInWithGoogleParameters;
+import com.microsoft.identity.common.internal.ui.browser.AndroidBrowserSelector;
+import com.microsoft.identity.common.java.browser.Browser;
 import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 import lombok.SneakyThrows;
@@ -255,5 +261,37 @@ public class AuthorizationActivityFactoryTest {
 
         // Verify it creates BrowserAuthorizationFragment even with silent flow when not WebView
         assertEquals(BrowserAuthorizationFragment.class, fragment.getClass());
+    }
+
+    @Test
+    public void testSwitchBrowserEnabled_noBrowser_urlUnchanged() {
+        // No browsers installed in Robolectric → selectBrowser returns null → URL unchanged
+        final AuthorizationActivityParameters params = new AuthorizationActivityParameters(
+                context, authIntent, requestUrl, redirectUri, requestHeaders,
+                authorizationAgent, webViewZoomEnabled, webViewZoomControlsEnabled,
+                sourceLibraryName, sourceLibraryVersion, null, null, false, true
+        );
+
+        final Intent resultIntent = AuthorizationActivityFactory.getAuthorizationActivityIntent(params);
+        assertEquals(requestUrl, resultIntent.getStringExtra(REQUEST_URL));
+        assertFalse(resultIntent.getStringExtra(REQUEST_URL).contains("switch_browser"));
+    }
+
+    @Test
+    public void testSwitchBrowserEnabled_browserAvailable_appendsParam() {
+        final Browser mockBrowser = new Browser("com.android.chrome", Collections.singleton("hash"), "100", true);
+        try (MockedConstruction<AndroidBrowserSelector> ignored = mockConstruction(
+                AndroidBrowserSelector.class,
+                (mock, ctx) -> when(mock.selectBrowser(any(), any())).thenReturn(mockBrowser)
+        )) {
+            final AuthorizationActivityParameters params = new AuthorizationActivityParameters(
+                    context, authIntent, requestUrl, redirectUri, requestHeaders,
+                    authorizationAgent, webViewZoomEnabled, webViewZoomControlsEnabled,
+                    sourceLibraryName, sourceLibraryVersion, null, null, false, true
+            );
+
+            final Intent resultIntent = AuthorizationActivityFactory.getAuthorizationActivityIntent(params);
+            assertTrue(resultIntent.getStringExtra(REQUEST_URL).contains("switch_browser=1"));
+        }
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactoryTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationActivityFactoryTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ResolveInfo;
 
 import androidx.fragment.app.Fragment;
 
@@ -60,6 +62,8 @@ import org.mockito.MockedConstruction;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowPackageManager;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -279,6 +283,19 @@ public class AuthorizationActivityFactoryTest {
 
     @Test
     public void testSwitchBrowserEnabled_browserAvailable_appendsParam() {
+        // Register a handler for the switch_browser_resume redirect in the shadow PackageManager
+        final ShadowPackageManager shadowPm = Shadows.shadowOf(context.getPackageManager());
+        final Intent resumeIntent = new Intent(Intent.ACTION_VIEW,
+                android.net.Uri.parse("msauth://example.com/redirect/switch_browser_resume"));
+        resumeIntent.addCategory(Intent.CATEGORY_DEFAULT);
+        resumeIntent.addCategory(Intent.CATEGORY_BROWSABLE);
+        resumeIntent.setPackage(context.getPackageName());
+        final ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.activityInfo = new ActivityInfo();
+        resolveInfo.activityInfo.packageName = context.getPackageName();
+        resolveInfo.activityInfo.name = "com.microsoft.identity.common.internal.providers.oauth2.SwitchBrowserRedirectActivity";
+        shadowPm.addResolveInfoForIntent(resumeIntent, resolveInfo);
+
         final Browser mockBrowser = new Browser("com.android.chrome", Collections.singleton("hash"), "100", true);
         try (MockedConstruction<AndroidBrowserSelector> ignored = mockConstruction(
                 AndroidBrowserSelector.class,
@@ -292,6 +309,25 @@ public class AuthorizationActivityFactoryTest {
 
             final Intent resultIntent = AuthorizationActivityFactory.getAuthorizationActivityIntent(params);
             assertTrue(resultIntent.getStringExtra(REQUEST_URL).contains("switch_browser=1"));
+        }
+    }
+
+    @Test
+    public void testSwitchBrowserEnabled_browserAvailable_noManifestEntry_urlUnchanged() {
+        // Browser available but NO manifest handler registered → URL unchanged
+        final Browser mockBrowser = new Browser("com.android.chrome", Collections.singleton("hash"), "100", true);
+        try (MockedConstruction<AndroidBrowserSelector> ignored = mockConstruction(
+                AndroidBrowserSelector.class,
+                (mock, ctx) -> when(mock.selectBrowser(any(), any())).thenReturn(mockBrowser)
+        )) {
+            final AuthorizationActivityParameters params = new AuthorizationActivityParameters(
+                    context, authIntent, requestUrl, redirectUri, requestHeaders,
+                    authorizationAgent, webViewZoomEnabled, webViewZoomControlsEnabled,
+                    sourceLibraryName, sourceLibraryVersion, null, null, false, true
+            );
+
+            final Intent resultIntent = AuthorizationActivityFactory.getAuthorizationActivityIntent(params);
+            assertFalse(resultIntent.getStringExtra(REQUEST_URL).contains("switch_browser"));
         }
     }
 }


### PR DESCRIPTION
## Summary
Add enableSwitchBrowser param to AuthorizationActivityParameters and AuthorizationActivityFactory so consumers (OneAuth) can opt-in to the Switch Browser protocol. When enabled, the factory checks browser availability (Chrome/Edge/AEA), if app has correctly configured SwitchBrowserActivity its manifest and appends switch_browser=1 to the authorization request URL.

## Changes
- AuthorizationActivityParameters.kt: Added enableSwitchBrowser: Boolean = false
- AuthorizationActivityFactory.kt: Added static TAG, appendSwitchBrowserParam() method
- AuthorizationActivityFactoryTest.java: Added 2 unit tests
- changelog.txt: Added entry
- SwitchBrowserUtils which contains methods to check for browser and manifest check

## Fixes [AB#3627515](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3627515)