### PR TITLE
Fix MSA login timeout: use configurable timeout for 'Other ways to si…, Fixes AB#3622375

### DIFF
--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/interaction/microsoftsts/AadLoginComponentHandler.java
@@ -86,7 +86,7 @@ public class AadLoginComponentHandler implements IMicrosoftStsLoginComponentHand
         // says "Other ways to sign in"
         // 2. No OTP or MFA, just prompted for password right away.
         if (isMsaAccount) {
-            final UiObject otherWays = UiAutomatorUtils.obtainUiObjectWithExactText("Other ways to sign in", CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
+            final UiObject otherWays = UiAutomatorUtils.obtainUiObjectWithExactText("Other ways to sign in", mFindLoginUiElementTimeout);
             if (otherWays.exists()) {
                 try {
                     otherWays.click();


### PR DESCRIPTION
The 'Other ways to sign in' UI element check in handlePasswordField() was hardcoded to FIND_UI_ELEMENT_TIMEOUT_SHORT (10s), which was insufficient for the WebView to load login.live.com through the IPC + network chain. This caused intermittent TimeoutExceptions in MSA broker tests.

Changed to use mFindLoginUiElementTimeout (25s default, 30s for NAA tests) which is consistent with other UI element checks in the same handler.

Fixes: TestCase2688459 (NAA ATS), TestCase2637829 (MSA Prompt.Login)

Fixes [AB#3622375](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3622375)