### PR TITLE
Fixes AB#3648260 Add PersistToStorageAsync span name

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -70,6 +70,7 @@ public enum SpanName {
     ProvisionResourceAccount,
     ProcessWebsiteRequest,
     GetAllSsoTokens,
+    PersistToStorageAsync,
     ProcessWebCpEnrollmentRedirect,
     ProcessWebCpAuthorizeUrlRedirect,
     ProcessOpenIdVcRequest,


### PR DESCRIPTION
Fixes [AB#3648260](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3648260) Re-add SpanName enum value for async token cache persistence span.

I introduced a flight (persist_to_storage_async) but then reverted it because it was causing a regression in MSAL for the guest account scenarios (due to its need for account aggregation). At that time, we planned to revisit the flight at a later stage.
This flight submits the task of saving tokens to the cache asynchronously
 
Given the fact that 85% of ATS requests in broker come from OneAuth-MSAL and 99.99% of those requests come from force_refresh=true, we can benefit by enabling this flight for OneAuth only (just like we did for skip_account_aggregation flight). This will help bring down the elapsed_time_save_token_result for LTW by 2 seconds in P95. 

LTW
--
Percentile | elapsed_time_save_token_result | elapsed_time_save_token_result
P50 | 267 ms | 283 ms
P75 | 610 ms | 658 ms
P90 | 1357 ms | 1477 ms
P95 | 2208 ms | 2389 ms
P99 | 5342 ms | 5781 ms