### PR TITLE
Remove condition for fetching PR labels

### DIFF
--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -7,5 +7,4 @@ jobs:
         temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -jc '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
-      condition: eq(variables['Build.Reason'], 'PullRequest')
       name: fetchPrCILabel


### PR DESCRIPTION
Removed condition for fetching PR labels based on build reason.