### PR TITLE
Fix changelog: move dev-sync entries from Version 24.3.0 to vNext, Fixes AB#3618269

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,18 +1,20 @@
 vNext
 ----------
 - [PATCH] Remove stale code, eliminate flickers due to BrokerAuthorizationActivity (#3139)
+- [MINOR] Add SwitchBrowserRedirectActivity for non-broker Switch Browser protocol flows. BrokerBrowserRedirectActivity now extends this shared base class (#3133)
+- [PATCH] Update OpenTelemetry to 1.62.0 (#3125)
+- [MINOR] Disabling GetCookies API from webapps APIs (#3135)
+- [MINOR] Enable passkey registration by default in CommonFlight (ENABLE_PASSKEY_REGISTRATION) (#3132)
+- [MINOR] Add NativeAuthRequestInterceptor for custom per-request headers in native auth flows (#3112)
 
 Version 24.3.0
 ----------
-- [MINOR] Add SwitchBrowserRedirectActivity for non-broker Switch Browser protocol flows. BrokerBrowserRedirectActivity now extends this shared base class (#3133)
 - [PATCH] Fix Token Endpoint Server Telemetry Parsing (#3128)
-- [MINOR] Enable passkey registration by default in CommonFlight (ENABLE_PASSKEY_REGISTRATION) (#3132)
 - [PATCH] Emit ipc_strategy telemetry attribute for successful device registration IPC strategy and refactor execute flow to pack protocol request once before strategy retries (#3124)
 - [PATCH] Fix Edge browser selection on devices where Microsoft Edge is the default browser: add the rotated Edge signing certificate hash to the Edge BrowserDescriptor and accept multi-signer browsers when any signature intersects the safelist, instead of requiring strict set-equality (resolves MSAL #2414)
 - [MINOR] Refactor Auth Tab integration to use provider-based strategy selection. Adds AuthTabStrategyProvider and BrowserLaunchStrategy with Custom Tabs fallback. Compatible with androidx.browser:browser:1.7.0.
 - [MINOR] Wire onboarding telemetry hooks into AzureActiveDirectoryWebViewClient for page-transition step capture (broker install, MDM enrollment, Company Portal launch, MFA linking) and last-loaded-domain tracking (#3121)
 - [MINOR] Propagate the onboarding telemetry blob through the broker failure path: add BaseException.onboardingBlob and round-trip it through MsalBrokerResultAdapter so callers can emit onboarding telemetry on failure outcomes. Also add an MsalBrokerResultAdapter overload that accepts an onboarding blob on the success path so the broker can attach the finalized blob to the success result bundle (#3123)
-- [PATCH] Update OpenTelemetry to 1.62.0 (#3125)
 - [MINOR] Add provisionResourceAccountCredentials API to DeviceRegistrationClientApplication with V0 protocol params/response and add IPPhone to AppRegistry (#3086)
 - [PATCH] Extend filter-then-clone optimization to deleteAccessTokensWithIntersectingScopes and add telemetry attributes (#3114)
 - [PATCH] Wire ClientDataInfo through AcquireTokenResult, exceptions (#3109)
@@ -22,9 +24,7 @@ Version 24.3.0
 - [PATCH] Extend filter-then-clone optimization to load() and getIdTokensForAccountRecord() in MsalOAuth2TokenCache: when ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE flight is enabled, skip clone-all preload and call direct flight-gated overloads that clone only matching credentials; add new getCredentialsFilteredBy overload with kid support (#3100)
 - [MINOR] Add onboarding telemetry recorder, field keys, and session persistence for mobile onboarding flow (#3088)
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#3070)
-- [MINOR] Add NativeAuthRequestInterceptor for custom per-request headers in native auth flows (#3112)
 - [PATCH] Edge TB: Fix lookup mode (#3108)
-- [MINOR] Disabling GetCookies API from webapps APIs (#3135)
 
 Version 24.2.0
 ----------


### PR DESCRIPTION
[AB#3618269](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3618269)

When release-integration/24.3.0 was back-merged into dev (#3131), some entries that were merged to dev *after* the 24.3.0 RC cut got listed under `Version 24.3.0`. They actually shipped in dev *after* 24.3.0 was finalized, so they belong under `vNext` for the next release.

This PR moves 5 entries from `Version 24.3.0` to `vNext`:

- #3133 SwitchBrowserRedirectActivity for non-broker Switch Browser flows
- #3125 Update OpenTelemetry to 1.62.0
- #3135 Disabling GetCookies API from webapps APIs
- #3132 Enable passkey registration by default in CommonFlight
- #3112 Add NativeAuthRequestInterceptor for native auth flows

Note: #3128 (Fix Token Endpoint Server Telemetry Parsing) correctly stays under Version 24.3.0 because it was cherry-picked into the release branch before the RC cut.

### Verification
Identified by diffing the current dev `changelog.txt` against the file at commit `e80117451` (final 24.3.0 "remove RC" cut). Any entry currently listed under Version 24.3.0 that wasn't present at the RC cut must have arrived via the back-merge.