### PR TITLE
Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized a…, Fixes AB#3659701

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, SSO_TOKEN, DEVICE_REGISTRATION)
 - [PATCH] Change SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE flight default to true - overridden by Broker to false (#3144)
 - [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available (#3137)
 - [PATCH] Remove stale code, eliminate flickers due to BrokerAuthorizationActivity (#3139)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, SSO_TOKEN, DEVICE_REGISTRATION)
+- [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, SSO_TOKEN, DEVICE_REGISTRATION) (#3149)
 - [PATCH] Change SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE flight default to true - overridden by Broker to false (#3144)
 - [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available (#3137)
 - [PATCH] Remove stale code, eliminate flickers due to BrokerAuthorizationActivity (#3139)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,7 @@
 vNext
 ----------
-<<<<<<< mchand/add-mde-app-registry
 - [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, DEVICE_REGISTRATION) (#3149)
-=======
-- [MINOR] OnboardingTelemetryRecorder.finalizeBlob() emits the populated blob whenever a valid sessionCorrelationId is present (previously returned empty when blockingErrors was empty)
->>>>>>> dev
+- [MINOR] OnboardingTelemetryRecorder.finalizeBlob() emits the populated blob whenever a valid sessionCorrelationId is present (previously returned empty when blockingErrors was empty) (#3148)
 - [PATCH] Change SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE flight default to true - overridden by Broker to false (#3144)
 - [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available (#3137)
 - [PATCH] Remove stale code, eliminate flickers due to BrokerAuthorizationActivity (#3139)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, SSO_TOKEN, DEVICE_REGISTRATION) (#3149)
+- [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, DEVICE_REGISTRATION) (#3149)
 - [PATCH] Change SWITCH_BROWSER_PROTOCOL_REQUIRES_STATE flight default to true - overridden by Broker to false (#3144)
 - [MINOR] Add enableSwitchBrowser opt-in param to AuthorizationActivityFactory/Parameters so consumers (OneAuth) can signal switch_browser=1 when a compatible browser is available (#3137)
 - [PATCH] Remove stale code, eliminate flickers due to BrokerAuthorizationActivity (#3139)

--- a/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
@@ -153,7 +153,6 @@ object AppRegistry {
         if (BrokerData.getShouldTrustDebugBrokers()) {
             add(BrokerData.debugBrokerHost)
             add(ONE_AUTH_TEST_APP)
-            add(MDE_APP_DEBUG)
         }
     }
 
@@ -165,6 +164,7 @@ object AppRegistry {
             add(INTUNE_AOSP_AGENT_DEBUG)
             add(BrokerData.debugBrokerHost)
             add(BrokerData.debugMicrosoftAuthenticator)
+            add(MDE_APP_DEBUG)
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
@@ -133,6 +133,18 @@ object AppRegistry {
         signingCertificateThumbprint = AuthenticationConstants.Broker.BROKER_HOST_APP_SIGNATURE_SHA512
     )
 
+    val MDE_APP_PROD = App(
+        nickName = "Microsoft Defender for Endpoint",
+        packageName = "com.microsoft.scmx",
+        signingCertificateThumbprint = "iPULpH0pq8ms1Qy7cOzGsVRQN7/zW4IbW+UKcajvtrTrzM5o5VcaghNEA1Ho4Wq7ay0efqqJcalxa8eHxVnHKA=="
+    )
+
+    val MDE_APP_DEBUG = App(
+        nickName = "Microsoft Defender for Endpoint",
+        packageName = "com.microsoft.scmx",
+        signingCertificateThumbprint = "k0ZSm/+bEPZAq6mXujRXqP3B6+Zb2yXCiqwuvtCooLfKS91zvHCf+D9FFUYIkJyIKmn1onyWbwRXHEWfS5SaHQ=="
+    )
+
     @JvmField
     val SSO_TOKEN_AUTHORIZED_APPS = buildSet {
         add(EDGE)
@@ -141,12 +153,14 @@ object AppRegistry {
         if (BrokerData.getShouldTrustDebugBrokers()) {
             add(BrokerData.debugBrokerHost)
             add(ONE_AUTH_TEST_APP)
+            add(MDE_APP_DEBUG)
         }
     }
 
     @JvmField
     val GET_DEVICE_TOKEN_AUTHORIZED_APPS = buildSet {
         add(INTUNE_AOSP_AGENT_PROD)
+        add(MDE_APP_PROD)
         if (BrokerData.getShouldTrustDebugBrokers()) {
             add(INTUNE_AOSP_AGENT_DEBUG)
             add(BrokerData.debugBrokerHost)
@@ -161,6 +175,7 @@ object AppRegistry {
         add(INTUNE_CE_PROD)
         add(INTUNE_AOSP_AGENT_PROD)
         add(TEAMS_IPPHONE_PROD)
+        add(MDE_APP_PROD)
         if (BrokerData.getShouldTrustDebugBrokers()) {
             add(INTUNE_AOSP_AGENT_DEBUG)
             add(BrokerData.debugBrokerHost)
@@ -168,6 +183,7 @@ object AppRegistry {
             add(BrokerData.debugCompanyPortal)
             add(INTUNE_CE_DEBUG)
             add(TEAMS_IPPHONE_DEBUG)
+            add(MDE_APP_DEBUG)
         }
     }
 


### PR DESCRIPTION
…pp lists

- Add MDE_APP_PROD and MDE_APP_DEBUG entries (com.microsoft.scmx)
- Register MDE in GET_DEVICE_TOKEN_AUTHORIZED_APPS
- Register MDE in DEVICE_REGISTRATION_AUTHORIZED_APPS

[AB#3659701](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3659701)