### PR TITLE
Add a separate span for BatteryOptimizationExemption prompt, Fixes AB#3662220

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/SpanName.java
@@ -116,5 +116,10 @@ public enum SpanName {
     /**
      * Span name for switching browser flow operations.
      */
-    SwitchBrowserFlow
+    SwitchBrowserFlow,
+
+    /**
+     * Span name for the battery optimization exemption prompt.
+     */
+    BatteryOptimizationExemption
 }


### PR DESCRIPTION
[AB#3662220](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3662220)

previously, this was meant to be emitted with the parent acquireToken flow.

but there seems to be a bug where anything recorded in the interrupt flow aren't properly emitted.
(already double checked that it's the same span id)

To minimize the change, I decided to create a new span for this.

