### PR TITLE
Fix incorrect Chrome Dev signing certificate thumbprint in AppRegistry (release/24.4.0), Fixes AB#3662317

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Fix incorrect Chrome Dev (com.chrome.dev) signing certificate thumbprint in AppRegistry — Browser SSO previously rejected Chrome Dev with "Caller is not an authorized browser application"
 - [MINOR] Add IS_SWITCH_BROWSER_FLOW flag to PropertyBag so OneAuth can detect when the switch browser protocol was used during interactive auth (#3145)
 - [MINOR] Add Microsoft Defender for Endpoint (MDE) to AppRegistry authorized app lists (GET_DEVICE_TOKEN, DEVICE_REGISTRATION) (#3149)
 - [MINOR] OnboardingTelemetryRecorder.finalizeBlob() emits the populated blob whenever a valid sessionCorrelationId is present (previously returned empty when blockingErrors was empty) (#3148)

--- a/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/apps/AppRegistry.kt
@@ -94,7 +94,7 @@ object AppRegistry {
     val CHROME_DEV = App(
         nickName = "Google Chrome Dev",
         packageName = "com.chrome.dev",
-        signingCertificateThumbprint = "JlOLOTFn6OFBFWuWQJYJ8h/aozEN7/zLFTfioXiXTrU6Yaft4cdEbdpkoJIvmB7GvHpHu6QOz+XIaXybtzL7A=="
+        signingCertificateThumbprint = "JlOLOTFn6OFBFWuWQJYJ8h/aozEN7/zLFTfioXiXTrU6Yaft4cdEbdpkoJIvmB7Gv2HpHu6QOz+XIaXybtzL7A=="
     )
 
     val CHROME_CANARY = App(


### PR DESCRIPTION
Fixes [AB#3662317](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3662317)

Cherry-picks the Chrome Dev signature fix from #3153 onto `release/24.4.0` (consumed by broker `release/16.3.0`).

The `CHROME_DEV.signingCertificateThumbprint` in `AppRegistry` was missing the `2H` characters in the middle of the base64 string, so Browser SSO requests from Chrome Dev were being rejected with:

```
android.accounts.AuthenticatorException: Caller is not an authorized browser application
```

Reported by the Chrome team during Browser SSO testing — they recomputed the signature against an installed Chrome Dev build and got the corrected value. Chrome Beta, Canary, and production signatures already match and are unchanged.

**Diff**
```diff
- signingCertificateThumbprint = "JlOLOTFn6OFBFWuWQJYJ8h/aozEN7/zLFTfioXiXTrU6Yaft4cdEbdpkoJIvmB7GvHpHu6QOz+XIaXybtzL7A=="
+ signingCertificateThumbprint = "JlOLOTFn6OFBFWuWQJYJ8h/aozEN7/zLFTfioXiXTrU6Yaft4cdEbdpkoJIvmB7Gv2HpHu6QOz+XIaXybtzL7A=="
```

Cherry-pick was clean (release/24.4.0 was at the same commit as dev at the time of branching).