### PR TITLE
Fix WebView stuck on server (5xx) error during login (AB#3408586), Fixes AB#3408586

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Fail the embedded WebView auth flow when the main-frame request returns a server HTTP error (5xx) instead of leaving the user stuck on an infinite loading spinner; gated by FAIL_WEBVIEW_FLOW_ON_SERVER_HTTP_ERROR flight (default on), Fixes AB#3408586
 - [PATCH] Improve switch browser error handling and telemetry: standardize result delivery via setResultAndFinish, add error bundles for all failure paths, fix span/scope lifecycle, and move RESUME_REQUEST to shared SWITCH_BROWSER constants (#3134)
 - [PATCH] Fix incorrect Chrome Dev (com.chrome.dev) signing certificate thumbprint in AppRegistry (#3153)
 - [MINOR] Add IS_SWITCH_BROWSER_FLOW flag to PropertyBag so OneAuth can detect when the switch browser protocol was used during interactive auth (#3145)

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -95,6 +95,7 @@ import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.net.MalformedURLException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -1393,9 +1394,30 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     public void onReceivedHttpError(final WebView view,
                                     final WebResourceRequest request,
                                     final WebResourceResponse errorResponse) {
+        final String methodTag = TAG + ":onReceivedHttpError";
+        if (request == null || !request.isForMainFrame()) {
+            // Sub-resource HTTP errors (scripts, images, iframes) don't necessarily affect the
+            // sign-in experience, so we ignore them to preserve existing behavior.
+            return;
+        }
+
+        final int statusCode = errorResponse != null ? errorResponse.getStatusCode() : 0;
+
         // Track HTTP error for the URL
-        if (mUrlLoadTracker != null && request.isForMainFrame()) {
-            mUrlLoadTracker.updateLatestUrlStatus("HTTP Error Code: " + errorResponse.getStatusCode(), null);
+        if (mUrlLoadTracker != null) {
+            mUrlLoadTracker.updateLatestUrlStatus("HTTP Error Code: " + statusCode, null);
+        }
+
+        // A server-side error (5xx) on the main frame means the page will never finish loading,
+        // so onPageFinished/onPageLoaded is never invoked and the progress spinner would stay up
+        // indefinitely, blocking the UI. Surface the error to the caller so the user is shown an
+        // informative error instead of being stuck on the login screen.
+        if (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
+                && CommonFlightsManager.INSTANCE.getFlightsProvider()
+                        .isFlightEnabled(CommonFlight.FAIL_WEBVIEW_FLOW_ON_SERVER_HTTP_ERROR)) {
+            Logger.warn(methodTag, "Received server HTTP error on main frame. Status code: " + statusCode
+                    + ". Failing the WebView authorization flow.");
+            sendErrorToCallback(view, statusCode, "Received server HTTP error during authorization. Status code: " + statusCode);
         }
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -1408,10 +1408,10 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             mUrlLoadTracker.updateLatestUrlStatus("HTTP Error Code: " + statusCode, null);
         }
 
-        // A server-side error (5xx) on the main frame means the page will never finish loading,
-        // so onPageFinished/onPageLoaded is never invoked and the progress spinner would stay up
-        // indefinitely, blocking the UI. Surface the error to the caller so the user is shown an
-        // informative error instead of being stuck on the login screen.
+        // In the reported main-frame 5xx failure mode, the WebView can get stuck before the normal
+        // page-finished callback unwinds the loading UI. Surface the error to the caller so the
+        // auth flow terminates with a ClientException instead of leaving the user stuck on the
+        // login screen.
         if (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
                 && CommonFlightsManager.INSTANCE.getFlightsProvider()
                         .isFlightEnabled(CommonFlight.FAIL_WEBVIEW_FLOW_ON_SERVER_HTTP_ERROR)) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/OAuth2WebViewClient.java
@@ -171,9 +171,9 @@ public abstract class OAuth2WebViewClient extends WebViewClient {
         }
     }
 
-    private void sendErrorToCallback(@NonNull final WebView view,
-                                     final int errorCode,
-                                     @NonNull final String description) {
+    protected void sendErrorToCallback(@NonNull final WebView view,
+                                       final int errorCode,
+                                       @NonNull final String description) {
         view.stopLoading();
 
         // Send the result back to the calling activity

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -946,6 +946,101 @@ public class AzureActiveDirectoryWebViewClientTest {
         Mockito.verify(mockTracker, never()).updateLatestUrlStatus(any(), any());
     }
 
+    // -----------------------------------------------------------------------
+    // onReceivedHttpError -> fail flow on server (5xx) errors (AB#3408586)
+    // -----------------------------------------------------------------------
+
+    private AzureActiveDirectoryWebViewClient createWebViewClientWithCallback(
+            final IAuthorizationCompletionCallback callback) throws ClientException {
+        return new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                callback,
+                url -> {},
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserRequestHandler.class),
+                "homeTenantId",
+                false);
+    }
+
+    private void initFailWebViewOnServerHttpErrorFlight(final boolean enabled) {
+        final IFlightsManager mockFlightsManager = Mockito.mock(IFlightsManager.class);
+        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
+        when(mockFlightsProvider.isFlightEnabled(eq(CommonFlight.FAIL_WEBVIEW_FLOW_ON_SERVER_HTTP_ERROR)))
+                .thenReturn(enabled);
+        when(mockFlightsManager.getFlightsProvider(anyLong())).thenReturn(mockFlightsProvider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(mockFlightsManager);
+    }
+
+    @Test
+    public void testOnReceivedHttpError_serverError_mainFrame_sendsErrorToCallback() throws ClientException {
+        initFailWebViewOnServerHttpErrorFlight(true);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithCallback(mockCallback);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(true);
+        Mockito.when(mockErrorResponse.getStatusCode()).thenReturn(500);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        final ArgumentCaptor<RawAuthorizationResult> resultCaptor =
+                ArgumentCaptor.forClass(RawAuthorizationResult.class);
+        Mockito.verify(mockCallback, Mockito.times(1)).onChallengeResponseReceived(resultCaptor.capture());
+        assertTrue(resultCaptor.getValue().getException() instanceof ClientException);
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void testOnReceivedHttpError_clientError_mainFrame_doesNotSendErrorToCallback() throws ClientException {
+        initFailWebViewOnServerHttpErrorFlight(true);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithCallback(mockCallback);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(true);
+        Mockito.when(mockErrorResponse.getStatusCode()).thenReturn(403);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        Mockito.verify(mockCallback, never()).onChallengeResponseReceived(any());
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void testOnReceivedHttpError_serverError_subResource_doesNotSendErrorToCallback() throws ClientException {
+        initFailWebViewOnServerHttpErrorFlight(true);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithCallback(mockCallback);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(false);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        Mockito.verify(mockCallback, never()).onChallengeResponseReceived(any());
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    @Test
+    public void testOnReceivedHttpError_serverError_flightDisabled_doesNotSendErrorToCallback() throws ClientException {
+        initFailWebViewOnServerHttpErrorFlight(false);
+        final IAuthorizationCompletionCallback mockCallback = Mockito.mock(IAuthorizationCompletionCallback.class);
+        final AzureActiveDirectoryWebViewClient client = createWebViewClientWithCallback(mockCallback);
+
+        final WebResourceRequest mockRequest = Mockito.mock(WebResourceRequest.class);
+        final WebResourceResponse mockErrorResponse = Mockito.mock(WebResourceResponse.class);
+        Mockito.when(mockRequest.isForMainFrame()).thenReturn(true);
+        Mockito.when(mockErrorResponse.getStatusCode()).thenReturn(503);
+
+        client.onReceivedHttpError(mMockWebView, mockRequest, mockErrorResponse);
+
+        Mockito.verify(mockCallback, never()).onChallengeResponseReceived(any());
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
     // ===== Authenticator activation app link tests =====
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -268,7 +268,15 @@ public enum CommonFlight implements IFlightConfig {
      * references first, then clones only the matching items — avoiding the cost of
      * cloning the entire cache when only a subset is needed.
      */
-    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
+    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false),
+
+    /**
+     * Flight to fail the embedded WebView authorization flow when the main-frame request
+     * returns a server-side HTTP error (status code >= 500). When enabled, the user is shown
+     * an error and returned to the caller instead of being stuck on an indefinite loading
+     * spinner. Enabled by default; can be turned off via ECS if any issues arise in production.
+     */
+    FAIL_WEBVIEW_FLOW_ON_SERVER_HTTP_ERROR("FailWebViewFlowOnServerHttpError", true);
 
     private String key;
     private Object defaultValue;


### PR DESCRIPTION
## Summary
Fixes **[AB#3408586](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3408586)** — *User should not be stuck on the login if server is unavailable.*

When the embedded WebView auth flow receives a server-side HTTP error (5xx) on the **main frame**, `onReceivedHttpError` previously only logged and tracked the error. It never dismissed the loading spinner or invoked an error callback, so `onPageFinished` (which hides the spinner via `onPageLoaded`) was never reached and the user was stuck on the login screen indefinitely.

This is asymmetric with network errors (`onReceivedError`), which already call `sendErrorToCallback`. HTTP 5xx now does the same.

## Root cause
- `WebViewAuthorizationFragment.launchWebView()` shows the progress bar.
- On a 5xx, the page never finishes loading, so `OAuth2WebViewClient.onPageFinished` -> `onPageLoaded()` (hides spinner) is never called.
- Old `onReceivedHttpError` only called `mUrlLoadTracker.updateLatestUrlStatus(...)`, leaving the spinner up forever.

## Fix
- `AzureActiveDirectoryWebViewClient.onReceivedHttpError`: for **main-frame** requests with `statusCode >= 500`, log a warning and call `sendErrorToCallback` (stops loading + sends a `ClientException` through the completion callback).
- Restricted to main-frame 5xx only — 4xx flows (e.g. 401/403 handled via redirects) and sub-resource errors are unaffected.
- `OAuth2WebViewClient.sendErrorToCallback`: changed `private` -> `protected` so the subclass can invoke it.
- Gated behind a new **default-on** flight `FailWebViewFlowOnServerHttpError` (`CommonFlight`) so it can be disabled via ECS if it causes regressions.

## Tests
Added 4 unit tests to `AzureActiveDirectoryWebViewClientTest`:
- main-frame 5xx -> callback invoked with `ClientException`
- main-frame 4xx -> no callback
- sub-resource 5xx -> no callback
- 5xx with flight disabled -> no callback

All tests pass (`:common:testLocalDebugUnitTest`, JDK 17).