### PR TITLE
Use exact host matching for known-authority validation, Fixes AB#3607019

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 vNext
 ----------
 - [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
+- [PATCH] Harden Authority.isKnownAuthority() to use exact, case-insensitive host matching for developer-configured known authorities; gated behind CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH (default on)
 
 Version 24.4.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 vNext
 ----------
 - [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
-- [PATCH] Harden Authority.isKnownAuthority() to use exact, case-insensitive host matching for developer-configured known authorities; gated behind CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH (default on)
+- [PATCH] Harden Authority.isKnownAuthority() to use exact, case-insensitive host matching for developer-configured known authorities (#3165)
 
 Version 24.4.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -217,14 +217,9 @@ public abstract class Authority {
      * Returns the developer-configured known authority whose parsed host matches (case-insensitively)
      * the host of {@code authorityStr}, or {@code null} if none matches.
      * <p>
-     * Matching is performed by parsed host only; port and path are intentionally ignored. The trust
-     * boundary for a developer-configured known authority is the host (DNS/TLS trust is per-host), so
-     * {@code https://example.com}, {@code https://example.com:443} and {@code https://example.com:8443}
-     * are all treated as the same trusted host. This deliberately mirrors the comparison performed by
-     * the known-authority gate in {@link #isKnownAuthority(Authority)} (both delegate to
-     * {@link #matchesConfiguredHost}) so that the gate and authority resolution
-     * ({@link #getAuthorityFromAuthorityUrl(String, String)}) never disagree about whether a URL is
-     * developer-configured.
+     * Matching is by parsed host only; port and path are ignored (trust is per-host). This uses the
+     * same {@link #matchesConfiguredHost} comparison as the gate in {@link #isKnownAuthority(Authority)},
+     * so resolution and the gate never disagree about whether a URL is developer-configured.
      *
      * @param authorityStr the candidate authority URL.
      * @return the matching configured {@link Authority}, or {@code null} if none matches.
@@ -259,11 +254,9 @@ public abstract class Authority {
     }
 
     /**
-     * Compares a candidate host against a single developer-configured known authority URL by parsed
-     * host, case-insensitively. Port, path and userinfo are ignored (see
-     * {@link #getEquivalentConfiguredAuthority(String)} for the rationale). A malformed or blank
-     * configured URL is treated as a non-match so that one bad entry never aborts the surrounding
-     * scan of the remaining configured authorities.
+     * Compares a candidate host against a single configured known authority URL by parsed host,
+     * case-insensitively (port, path and userinfo ignored). A malformed or blank configured URL is a
+     * non-match, so one bad entry never aborts the scan of the remaining authorities.
      *
      * @param candidateHost               the already-parsed candidate host (non-null, non-empty).
      * @param configuredAuthorityUrlString the configured known authority URL string; may be null/blank.
@@ -410,12 +403,10 @@ public abstract class Authority {
             return true; // onebox authorities are always considered to be known.
         }
 
-        // Developer-configured known authorities are matched by parsed host only (see
-        // matchesConfiguredHost). Host-only comparison (never substring, never the raw authority
-        // component) prevents an untrusted host from passing this gate merely because it is a
-        // substring of a configured URL, and avoids userinfo confusion such as
-        // "https://contoso.b2clogin.com@evil.com". This shares matchesConfiguredHost with
-        // getEquivalentConfiguredAuthority so the gate and authority resolution never disagree.
+        // Match developer-configured authorities by parsed host only, via matchesConfiguredHost
+        // (shared with getEquivalentConfiguredAuthority so the gate and resolution never disagree).
+        // Host-only equality - never substring - stops an untrusted host passing merely by being a
+        // substring of a configured URL (e.g. "login.com" inside "contoso.b2clogin.com").
         final String candidateHost = authorityUrl.getHost();
         if (!StringUtil.isNullOrEmpty(candidateHost)) {
             synchronized (sLock) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -367,7 +367,7 @@ public abstract class Authority {
                 .isFlightEnabled(CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH);
 
         knownToDeveloper = useExactHostMatch
-                ? isKnownToDeveloperByExactHost(authorityUrl, methodTag)
+                ? isKnownToDeveloperByExactHost(authorityUrl)
                 : isKnownToDeveloperByLegacySubstring(authorityUrl);
 
         // Check whether the authority is known to Microsoft or not.  Microsoft can recognize authorities that exist within public clouds.
@@ -393,11 +393,10 @@ public abstract class Authority {
      * {@link #getEquivalentConfiguredAuthority(String)}.
      *
      * @param authorityUrl the candidate authority URL whose host is being validated.
-     * @param methodTag    logging tag of the caller.
      * @return true if the candidate host exactly matches a developer-configured known authority host.
      */
-    private static boolean isKnownToDeveloperByExactHost(@NonNull final URL authorityUrl,
-                                                         @NonNull final String methodTag) {
+    private static boolean isKnownToDeveloperByExactHost(@NonNull final URL authorityUrl) {
+        final String methodTag = TAG + ":isKnownToDeveloperByExactHost";
         final String candidateHost = authorityUrl.getAuthority();
         synchronized (sLock) {
             for (final Authority currentAuthority : knownAuthorities) {
@@ -429,7 +428,7 @@ public abstract class Authority {
      *
      * @param authorityUrl the candidate authority URL whose host is being validated.
      * @return true if the candidate host appears as a substring of any configured known authority URL.
-     * @deprecated superseded by {@link #isKnownToDeveloperByExactHost(URL, String)}.
+     * @deprecated superseded by {@link #isKnownToDeveloperByExactHost(URL)}.
      */
     @Deprecated
     private static boolean isKnownToDeveloperByLegacySubstring(@NonNull final URL authorityUrl) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -221,8 +221,8 @@ public abstract class Authority {
      * boundary for a developer-configured known authority is the host (DNS/TLS trust is per-host), so
      * {@code https://example.com}, {@code https://example.com:443} and {@code https://example.com:8443}
      * are all treated as the same trusted host. This deliberately mirrors the comparison performed by
-     * {@link #isKnownToDeveloperByExactHost(URL)} (both delegate to {@link #matchesConfiguredHost})
-     * so that the known-authority gate ({@link #isKnownAuthority(Authority)}) and authority resolution
+     * the known-authority gate in {@link #isKnownAuthority(Authority)} (both delegate to
+     * {@link #matchesConfiguredHost}) so that the gate and authority resolution
      * ({@link #getAuthorityFromAuthorityUrl(String, String)}) never disagree about whether a URL is
      * developer-configured.
      *
@@ -388,7 +388,7 @@ public abstract class Authority {
      */
     public static boolean isKnownAuthority(Authority authority) {
         final String methodTag = TAG + ":isKnownAuthority";
-        final boolean knownToDeveloper;
+        boolean knownToDeveloper = false;
         final boolean knownToMicrosoft;
 
         if (authority == null) {
@@ -410,7 +410,23 @@ public abstract class Authority {
             return true; // onebox authorities are always considered to be known.
         }
 
-        knownToDeveloper = isKnownToDeveloperByExactHost(authorityUrl);
+        // Developer-configured known authorities are matched by parsed host only (see
+        // matchesConfiguredHost). Host-only comparison (never substring, never the raw authority
+        // component) prevents an untrusted host from passing this gate merely because it is a
+        // substring of a configured URL, and avoids userinfo confusion such as
+        // "https://contoso.b2clogin.com@evil.com". This shares matchesConfiguredHost with
+        // getEquivalentConfiguredAuthority so the gate and authority resolution never disagree.
+        final String candidateHost = authorityUrl.getHost();
+        if (!StringUtil.isNullOrEmpty(candidateHost)) {
+            synchronized (sLock) {
+                for (final Authority currentAuthority : knownAuthorities) {
+                    if (matchesConfiguredHost(candidateHost, currentAuthority.mAuthorityUrlString, methodTag)) {
+                        knownToDeveloper = true;
+                        break;
+                    }
+                }
+            }
+        }
 
         // Check whether the authority is known to Microsoft or not.  Microsoft can recognize authorities that exist within public clouds.
         // Microsoft does not maintain a list of B2C authorities or a list of ADFS or 3rd party authorities (issuers).
@@ -424,41 +440,6 @@ public abstract class Authority {
                 "Authority is known to Microsoft? [" + knownToMicrosoft + "]");
 
         return isKnown;
-    }
-
-    /**
-     * Compares the candidate authority against each developer-configured known authority by parsed
-     * host (case-insensitive) only. Port and path are intentionally ignored: the trust boundary for
-     * this gate is the host (DNS/TLS trust is per-host), so {@code https://example.com},
-     * {@code https://example.com:443} and {@code https://example.com:8443} are all treated as the
-     * same trusted host.
-     * <p>
-     * Substring matching is never used here, since it would allow an untrusted host (e.g.
-     * "login.com") to pass the gate merely because it is a substring of a configured URL (e.g.
-     * "https://contoso.b2clogin.com/..."). Using the parsed host (rather than the raw authority
-     * component) also avoids userinfo confusion such as "https://contoso.b2clogin.com@evil.com".
-     * <p>
-     * This shares its per-authority comparison with {@link #getEquivalentConfiguredAuthority(String)}
-     * via {@link #matchesConfiguredHost}, guaranteeing that the known-authority gate and authority
-     * resolution stay in agreement about which hosts are developer-configured.
-     *
-     * @param authorityUrl the candidate authority URL whose host is being validated.
-     * @return true if the candidate host matches a developer-configured known authority host.
-     */
-    private static boolean isKnownToDeveloperByExactHost(@NonNull final URL authorityUrl) {
-        final String methodTag = TAG + ":isKnownToDeveloperByExactHost";
-        final String candidateHost = authorityUrl.getHost();
-        if (StringUtil.isNullOrEmpty(candidateHost)) {
-            return false;
-        }
-        synchronized (sLock) {
-            for (final Authority currentAuthority : knownAuthorities) {
-                if (matchesConfiguredHost(candidateHost, currentAuthority.mAuthorityUrlString, methodTag)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     public static KnownAuthorityResult getKnownAuthorityResult(Authority authority) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -385,25 +385,34 @@ public abstract class Authority {
     }
 
     /**
-     * Compares the parsed host (and optional port) of the candidate authority against the parsed host
-     * of each developer-configured known authority. An exact, case-insensitive host match is required;
-     * substring matching is never used here, since it would allow an untrusted host (e.g.
+     * Compares the candidate authority against each developer-configured known authority by parsed
+     * host (case-insensitive) only. Port and path are intentionally ignored: the trust boundary for
+     * this gate is the host (DNS/TLS trust is per-host), so {@code https://example.com},
+     * {@code https://example.com:443} and {@code https://example.com:8443} are all treated as the
+     * same trusted host.
+     * <p>
+     * Substring matching is never used here, since it would allow an untrusted host (e.g.
      * "login.com") to pass the gate merely because it is a substring of a configured URL (e.g.
-     * "https://contoso.b2clogin.com/..."). This mirrors the pattern used by
+     * "https://contoso.b2clogin.com/..."). Using the parsed host (rather than the raw authority
+     * component) also avoids userinfo confusion such as "https://contoso.b2clogin.com@evil.com".
+     * This is consistent with the host-equality intent of
      * {@link #getEquivalentConfiguredAuthority(String)}.
      *
      * @param authorityUrl the candidate authority URL whose host is being validated.
-     * @return true if the candidate host exactly matches a developer-configured known authority host.
+     * @return true if the candidate host matches a developer-configured known authority host.
      */
     private static boolean isKnownToDeveloperByExactHost(@NonNull final URL authorityUrl) {
         final String methodTag = TAG + ":isKnownToDeveloperByExactHost";
-        final String candidateHost = authorityUrl.getAuthority();
+        final String candidateHost = authorityUrl.getHost();
+        if (StringUtil.isNullOrEmpty(candidateHost)) {
+            return false;
+        }
         synchronized (sLock) {
             for (final Authority currentAuthority : knownAuthorities) {
-                if (currentAuthority.mAuthorityUrlString != null && candidateHost != null) {
+                if (currentAuthority.mAuthorityUrlString != null) {
                     try {
                         final URL knownAuthorityUrl = new URL(currentAuthority.mAuthorityUrlString);
-                        if (candidateHost.equalsIgnoreCase(knownAuthorityUrl.getAuthority())) {
+                        if (candidateHost.equalsIgnoreCase(knownAuthorityUrl.getHost())) {
                             return true;
                         }
                     } catch (final MalformedURLException e) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -26,8 +26,6 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.BuildConfig;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.nativeauth.authorities.NativeAuthCIAMAuthority;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -360,15 +358,7 @@ public abstract class Authority {
             return true; // onebox authorities are always considered to be known.
         }
 
-        // Determine which known-authority matching strategy to use. The exact-host comparison is the
-        // secure default; the legacy substring comparison is retained only behind a kill-switch flight
-        // so it can be re-enabled via ECS if the stricter matching ever rejects a legitimate authority.
-        final boolean useExactHostMatch = CommonFlightsManager.INSTANCE.getFlightsProvider()
-                .isFlightEnabled(CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH);
-
-        knownToDeveloper = useExactHostMatch
-                ? isKnownToDeveloperByExactHost(authorityUrl)
-                : isKnownToDeveloperByLegacySubstring(authorityUrl);
+        knownToDeveloper = isKnownToDeveloperByExactHost(authorityUrl);
 
         // Check whether the authority is known to Microsoft or not.  Microsoft can recognize authorities that exist within public clouds.
         // Microsoft does not maintain a list of B2C authorities or a list of ADFS or 3rd party authorities (issuers).
@@ -423,31 +413,6 @@ public abstract class Authority {
                             Logger.error(methodTag, "Error parsing configured known authority URL", null);
                         }
                     }
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Legacy substring-based comparison between the candidate authority host and the full configured
-     * known-authority URL strings. This is insecure (a substring host can bypass the gate) and is
-     * retained only behind the {@link CommonFlight#ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH} kill switch
-     * so the previous behavior can be restored via ECS in an emergency. Do not use for new code.
-     *
-     * @param authorityUrl the candidate authority URL whose host is being validated.
-     * @return true if the candidate host appears as a substring of any configured known authority URL.
-     * @deprecated superseded by {@link #isKnownToDeveloperByExactHost(URL)}.
-     */
-    @Deprecated
-    private static boolean isKnownToDeveloperByLegacySubstring(@NonNull final URL authorityUrl) {
-        synchronized (sLock) {
-            for (final Authority currentAuthority : knownAuthorities) {
-                if (currentAuthority.mAuthorityUrlString != null &&
-                        authorityUrl.getAuthority() != null &&
-                        currentAuthority.mAuthorityUrlString.toLowerCase(Locale.ROOT).contains(
-                                authorityUrl.getAuthority().toLowerCase(Locale.ROOT))) {
-                    return true;
                 }
             }
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -213,39 +213,91 @@ public abstract class Authority {
         return authority;
     }
 
+    /**
+     * Returns the developer-configured known authority whose parsed host matches (case-insensitively)
+     * the host of {@code authorityStr}, or {@code null} if none matches.
+     * <p>
+     * Matching is performed by parsed host only; port and path are intentionally ignored. The trust
+     * boundary for a developer-configured known authority is the host (DNS/TLS trust is per-host), so
+     * {@code https://example.com}, {@code https://example.com:443} and {@code https://example.com:8443}
+     * are all treated as the same trusted host. This deliberately mirrors the comparison performed by
+     * {@link #isKnownToDeveloperByExactHost(URL)} (both delegate to {@link #matchesConfiguredHost})
+     * so that the known-authority gate ({@link #isKnownAuthority(Authority)}) and authority resolution
+     * ({@link #getAuthorityFromAuthorityUrl(String, String)}) never disagree about whether a URL is
+     * developer-configured.
+     *
+     * @param authorityStr the candidate authority URL.
+     * @return the matching configured {@link Authority}, or {@code null} if none matches.
+     */
     @Nullable
     private static Authority getEquivalentConfiguredAuthority(@NonNull final String authorityStr) {
-        Authority result = null;
+        final String methodTag = TAG + ":getEquivalentConfiguredAuthority";
 
+        final String candidateHost;
         try {
-            final URL authorityUrl = new URL(authorityStr);
-            final String httpAuthority = authorityUrl.getAuthority();
-
-            // Iterate over all of the developer trusted authorities and check if the authorities
-            // are the same...
-            synchronized (sLock) {
-                for (final Authority currentAuthority : knownAuthorities) {
-                    if (!StringUtil.isNullOrEmpty(currentAuthority.mAuthorityUrlString)) {
-                        final URL currentAuthorityUrl = new URL(currentAuthority.mAuthorityUrlString);
-                        final String currentHttpAuthority = currentAuthorityUrl.getAuthority();
-
-                        if (httpAuthority.equalsIgnoreCase(currentHttpAuthority)) {
-                            result = currentAuthority;
-                            break;
-                        }
-                    }
-                }
-            }
-        } catch (MalformedURLException e) {
-            // Shouldn't happen
-            Logger.errorPII(
-                    TAG,
-                    "Error parsing authority",
-                    e
-            );
+            candidateHost = new URL(authorityStr).getHost();
+        } catch (final MalformedURLException e) {
+            // Shouldn't happen for a caller-supplied authority URL.
+            logConfiguredAuthorityParseError(methodTag, "Error parsing authority", e);
+            return null;
         }
 
-        return result;
+        if (StringUtil.isNullOrEmpty(candidateHost)) {
+            return null;
+        }
+
+        // Iterate over all of the developer trusted authorities and check if the hosts match...
+        synchronized (sLock) {
+            for (final Authority currentAuthority : knownAuthorities) {
+                if (matchesConfiguredHost(candidateHost, currentAuthority.mAuthorityUrlString, methodTag)) {
+                    return currentAuthority;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Compares a candidate host against a single developer-configured known authority URL by parsed
+     * host, case-insensitively. Port, path and userinfo are ignored (see
+     * {@link #getEquivalentConfiguredAuthority(String)} for the rationale). A malformed or blank
+     * configured URL is treated as a non-match so that one bad entry never aborts the surrounding
+     * scan of the remaining configured authorities.
+     *
+     * @param candidateHost               the already-parsed candidate host (non-null, non-empty).
+     * @param configuredAuthorityUrlString the configured known authority URL string; may be null/blank.
+     * @param methodTag                   caller's log tag, used when a configured URL fails to parse.
+     * @return true if the candidate host equals the configured authority's parsed host.
+     */
+    private static boolean matchesConfiguredHost(@NonNull final String candidateHost,
+                                                 @Nullable final String configuredAuthorityUrlString,
+                                                 @NonNull final String methodTag) {
+        if (StringUtil.isNullOrEmpty(configuredAuthorityUrlString)) {
+            return false;
+        }
+        try {
+            final URL configuredAuthorityUrl = new URL(configuredAuthorityUrlString);
+            return candidateHost.equalsIgnoreCase(configuredAuthorityUrl.getHost());
+        } catch (final MalformedURLException e) {
+            // Skip malformed configured authority URLs; keep checking the rest.
+            logConfiguredAuthorityParseError(methodTag, "Error parsing configured known authority URL", e);
+            return false;
+        }
+    }
+
+    /**
+     * Logs a known-authority URL parse failure without leaking PII by default. The exception (which
+     * may embed the offending URL) is only included when PII logging is explicitly enabled.
+     */
+    private static void logConfiguredAuthorityParseError(@NonNull final String methodTag,
+                                                         @NonNull final String message,
+                                                         @NonNull final MalformedURLException e) {
+        if (Logger.isAllowPii()) {
+            Logger.errorPII(methodTag, message, e);
+        } else {
+            Logger.error(methodTag, message, null);
+        }
     }
 
     private static boolean authorityIsKnownFromConfiguration(@NonNull final String authorityStr) {
@@ -385,8 +437,10 @@ public abstract class Authority {
      * "login.com") to pass the gate merely because it is a substring of a configured URL (e.g.
      * "https://contoso.b2clogin.com/..."). Using the parsed host (rather than the raw authority
      * component) also avoids userinfo confusion such as "https://contoso.b2clogin.com@evil.com".
-     * This is consistent with the host-equality intent of
-     * {@link #getEquivalentConfiguredAuthority(String)}.
+     * <p>
+     * This shares its per-authority comparison with {@link #getEquivalentConfiguredAuthority(String)}
+     * via {@link #matchesConfiguredHost}, guaranteeing that the known-authority gate and authority
+     * resolution stay in agreement about which hosts are developer-configured.
      *
      * @param authorityUrl the candidate authority URL whose host is being validated.
      * @return true if the candidate host matches a developer-configured known authority host.
@@ -399,20 +453,8 @@ public abstract class Authority {
         }
         synchronized (sLock) {
             for (final Authority currentAuthority : knownAuthorities) {
-                if (currentAuthority.mAuthorityUrlString != null) {
-                    try {
-                        final URL knownAuthorityUrl = new URL(currentAuthority.mAuthorityUrlString);
-                        if (candidateHost.equalsIgnoreCase(knownAuthorityUrl.getHost())) {
-                            return true;
-                        }
-                    } catch (final MalformedURLException e) {
-                        // Skip malformed configured authority URLs.
-                        if (Logger.isAllowPii()) {
-                            Logger.errorPII(methodTag, "Error parsing configured known authority URL", e);
-                        } else {
-                            Logger.error(methodTag, "Error parsing configured known authority URL", null);
-                        }
-                    }
+                if (matchesConfiguredHost(candidateHost, currentAuthority.mAuthorityUrlString, methodTag)) {
+                    return true;
                 }
             }
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -26,6 +26,8 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.common.java.BuildConfig;
 import com.microsoft.identity.common.java.WarningType;
 import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.logging.Logger;
 import com.microsoft.identity.common.java.nativeauth.authorities.NativeAuthCIAMAuthority;
 import com.microsoft.identity.common.java.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -336,8 +338,8 @@ public abstract class Authority {
      */
     public static boolean isKnownAuthority(Authority authority) {
         final String methodTag = TAG + ":isKnownAuthority";
-        boolean knownToDeveloper = false;
-        boolean knownToMicrosoft;
+        final boolean knownToDeveloper;
+        final boolean knownToMicrosoft;
 
         if (authority == null) {
             Logger.warn(methodTag, "Authority is null");
@@ -358,17 +360,15 @@ public abstract class Authority {
             return true; // onebox authorities are always considered to be known.
         }
 
-        synchronized (sLock) {
-            for (final Authority currentAuthority : knownAuthorities) {
-                if (currentAuthority.mAuthorityUrlString != null &&
-                        authorityUrl.getAuthority() != null &&
-                        currentAuthority.mAuthorityUrlString.toLowerCase(Locale.ROOT).contains(
-                                authorityUrl.getAuthority().toLowerCase(Locale.ROOT))) {
-                    knownToDeveloper = true;
-                    break;
-                }
-            }
-        }
+        // Determine which known-authority matching strategy to use. The exact-host comparison is the
+        // secure default; the legacy substring comparison is retained only behind a kill-switch flight
+        // so it can be re-enabled via ECS if the stricter matching ever rejects a legitimate authority.
+        final boolean useExactHostMatch = CommonFlightsManager.INSTANCE.getFlightsProvider()
+                .isFlightEnabled(CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH);
+
+        knownToDeveloper = useExactHostMatch
+                ? isKnownToDeveloperByExactHost(authorityUrl, methodTag)
+                : isKnownToDeveloperByLegacySubstring(authorityUrl);
 
         // Check whether the authority is known to Microsoft or not.  Microsoft can recognize authorities that exist within public clouds.
         // Microsoft does not maintain a list of B2C authorities or a list of ADFS or 3rd party authorities (issuers).
@@ -382,6 +382,68 @@ public abstract class Authority {
                 "Authority is known to Microsoft? [" + knownToMicrosoft + "]");
 
         return isKnown;
+    }
+
+    /**
+     * Compares the parsed host (and optional port) of the candidate authority against the parsed host
+     * of each developer-configured known authority. An exact, case-insensitive host match is required;
+     * substring matching is never used here, since it would allow an untrusted host (e.g.
+     * "login.com") to pass the gate merely because it is a substring of a configured URL (e.g.
+     * "https://contoso.b2clogin.com/..."). This mirrors the pattern used by
+     * {@link #getEquivalentConfiguredAuthority(String)}.
+     *
+     * @param authorityUrl the candidate authority URL whose host is being validated.
+     * @param methodTag    logging tag of the caller.
+     * @return true if the candidate host exactly matches a developer-configured known authority host.
+     */
+    private static boolean isKnownToDeveloperByExactHost(@NonNull final URL authorityUrl,
+                                                         @NonNull final String methodTag) {
+        final String candidateHost = authorityUrl.getAuthority();
+        synchronized (sLock) {
+            for (final Authority currentAuthority : knownAuthorities) {
+                if (currentAuthority.mAuthorityUrlString != null && candidateHost != null) {
+                    try {
+                        final URL knownAuthorityUrl = new URL(currentAuthority.mAuthorityUrlString);
+                        if (candidateHost.equalsIgnoreCase(knownAuthorityUrl.getAuthority())) {
+                            return true;
+                        }
+                    } catch (final MalformedURLException e) {
+                        // Skip malformed configured authority URLs.
+                        Logger.errorPII(
+                                methodTag,
+                                "Error parsing configured known authority URL",
+                                e
+                        );
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Legacy substring-based comparison between the candidate authority host and the full configured
+     * known-authority URL strings. This is insecure (a substring host can bypass the gate) and is
+     * retained only behind the {@link CommonFlight#ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH} kill switch
+     * so the previous behavior can be restored via ECS in an emergency. Do not use for new code.
+     *
+     * @param authorityUrl the candidate authority URL whose host is being validated.
+     * @return true if the candidate host appears as a substring of any configured known authority URL.
+     * @deprecated superseded by {@link #isKnownToDeveloperByExactHost(URL, String)}.
+     */
+    @Deprecated
+    private static boolean isKnownToDeveloperByLegacySubstring(@NonNull final URL authorityUrl) {
+        synchronized (sLock) {
+            for (final Authority currentAuthority : knownAuthorities) {
+                if (currentAuthority.mAuthorityUrlString != null &&
+                        authorityUrl.getAuthority() != null &&
+                        currentAuthority.mAuthorityUrlString.toLowerCase(Locale.ROOT).contains(
+                                authorityUrl.getAuthority().toLowerCase(Locale.ROOT))) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public static KnownAuthorityResult getKnownAuthorityResult(Authority authority) {

--- a/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/authorities/Authority.java
@@ -417,11 +417,11 @@ public abstract class Authority {
                         }
                     } catch (final MalformedURLException e) {
                         // Skip malformed configured authority URLs.
-                        Logger.errorPII(
-                                methodTag,
-                                "Error parsing configured known authority URL",
-                                e
-                        );
+                        if (Logger.isAllowPii()) {
+                            Logger.errorPII(methodTag, "Error parsing configured known authority URL", e);
+                        } else {
+                            Logger.error(methodTag, "Error parsing configured known authority URL", null);
+                        }
                     }
                 }
             }

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -268,7 +268,18 @@ public enum CommonFlight implements IFlightConfig {
      * references first, then clones only the matching items — avoiding the cost of
      * cloning the entire cache when only a subset is needed.
      */
-    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
+    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false),
+
+    /**
+     * Flight to require an exact, case-insensitive host match between a candidate authority and the
+     * developer-configured known authorities in {@code Authority.isKnownAuthority()}.
+     * <p>
+     * Default-on (secure). When enabled, only an exact parsed-host match passes the known-authority
+     * security gate. Turn off via ECS to fall back to the previous substring-based comparison
+     * (legacy behavior) as a kill switch, should the stricter matching ever reject a legitimate,
+     * developer-configured authority.
+     */
+    ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH("EnableKnownAuthorityHostExactMatch", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -268,18 +268,7 @@ public enum CommonFlight implements IFlightConfig {
      * references first, then clones only the matching items — avoiding the cost of
      * cloning the entire cache when only a subset is needed.
      */
-    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false),
-
-    /**
-     * Flight to require an exact, case-insensitive host match between a candidate authority and the
-     * developer-configured known authorities in {@code Authority.isKnownAuthority()}.
-     * <p>
-     * Default-on (secure). When enabled, only an exact parsed-host match passes the known-authority
-     * security gate. Turn off via ECS to fall back to the previous substring-based comparison
-     * (legacy behavior) as a kill switch, should the stricter matching ever reject a legitimate,
-     * developer-configured authority.
-     */
-    ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH("EnableKnownAuthorityHostExactMatch", true);
+    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -174,25 +174,24 @@ public class AuthorityKnownHostTest {
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Tests 6 & 7 - Flow-level regression guards.
+    // Flow-level regression guard (covers the finding's Test 6 - ROPC and Test 7 - silent).
     //
-    // Both the ROPC flow (BaseController.acquireTokenWithPassword, which calls
-    // Authority.getKnownAuthorityResult(...) and then `if (!authorityResult.getKnown()) throw
-    // authorityResult.getClientException();` BEFORE constructing the OAuth2 strategy or POSTing the
-    // username/password) and the silent flow (BaseController.performSilentTokenRequest, which
-    // performs the identical getKnownAuthorityResult(...) check BEFORE setting the refresh token on
-    // the request and POSTing it) gate all outbound credential submission on
-    // Authority.getKnownAuthorityResult(). These tests drive that shared gate with a substring host
-    // and assert it returns "not known" with an UNKNOWN_AUTHORITY exception - i.e. the exact value
-    // that makes those flows throw and abort before any credential-bearing HTTP POST is dispatched.
+    // The ROPC flow (BaseController.acquireTokenWithPassword) and the silent flow
+    // (BaseController.performSilentTokenRequest) both gate all outbound credential submission on the
+    // same chokepoint: they call Authority.getKnownAuthorityResult(...) and then
+    // `if (!authorityResult.getKnown()) throw authorityResult.getClientException();` BEFORE
+    // constructing the OAuth2 strategy / setting the refresh token and POSTing any credential. Since
+    // both paths reduce to this single gate, one test exercises it for both. We drive the gate with a
+    // substring host and assert it returns "not known" with an UNKNOWN_AUTHORITY exception - the exact
+    // value that makes those flows throw and abort before any credential-bearing HTTP POST.
     //
     // The credential POST is preceded only by a credential-free AAD instance-discovery GET, which we
     // mock here so the gate runs deterministically and offline.
     // ---------------------------------------------------------------------------------------------
 
-    /** Test 6 - ROPC: a substring-host authority is denied by the gate before credentials are sent. */
+    /** A substring-host authority is denied by the shared gate before any credential is sent. */
     @Test
-    public void ropcGateRejectsSubstringHostBeforeCredentialSubmission() throws IOException {
+    public void gateRejectsSubstringHostBeforeCredentialSubmission() throws IOException {
         configureKnownAuthority(CONFIGURED_B2C_URL);
         enqueueInstanceDiscoveryResponse();
 
@@ -208,23 +207,7 @@ public class AuthorityKnownHostTest {
                 result.getClientException().getErrorCode());
     }
 
-    /** Test 7 - Silent: a substring-host authority is denied by the gate before the refresh token is sent. */
-    @Test
-    public void silentGateRejectsSubstringHostBeforeRefreshTokenSubmission() throws IOException {
-        configureKnownAuthority(CONFIGURED_B2C_URL);
-        enqueueInstanceDiscoveryResponse();
-
-        final Authority attackerAuthority = candidate("https://login.com/contoso.onmicrosoft.com");
-        final Authority.KnownAuthorityResult result = Authority.getKnownAuthorityResult(attackerAuthority);
-
-        Assert.assertFalse("Substring host must not be treated as known", result.getKnown());
-        Assert.assertNotNull("A blocking exception must be produced for the controller to throw",
-                result.getClientException());
-        Assert.assertEquals(ClientException.UNKNOWN_AUTHORITY,
-                result.getClientException().getErrorCode());
-    }
-
-    /** The legitimate, exactly-configured host must still pass the gate (non-regression for both flows). */
+    /** The legitimate, exactly-configured host must still pass the shared gate (non-regression). */
     @Test
     public void gateAcceptsExactlyConfiguredHost() throws IOException {
         configureKnownAuthority(CONFIGURED_B2C_URL);
@@ -246,17 +229,10 @@ public class AuthorityKnownHostTest {
     // developer-configured authority. The same CommonFlight is honored by Broker automatically
     // through its ECS flights provider (which forwards any IFlightConfig by key), matching the
     // ENABLE_SOVEREIGN_CLOUD_INSTANCE_DISCOVERY precedent in AzureActiveDirectory.
+    //
+    // Contrast with substringHostIsRejected (flight default-on -> rejected): the same substring host
+    // is accepted here when the flight is OFF, demonstrating the switch actually reverts behavior.
     // ---------------------------------------------------------------------------------------------
-
-    /** Flight ON (explicit): substring host is rejected — same as the secure default. */
-    @Test
-    public void flightOn_substringHostIsRejected() {
-        configureKnownAuthority(CONFIGURED_B2C_URL);
-        setExactHostMatchFlight(true);
-
-        Assert.assertFalse(
-                Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
-    }
 
     /** Flight OFF (kill switch): legacy substring behavior is restored, so the substring host matches. */
     @Test
@@ -268,16 +244,6 @@ public class AuthorityKnownHostTest {
         // comparison this (insecurely) passes — documenting exactly what the kill switch reverts to.
         Assert.assertTrue(
                 Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
-    }
-
-    /** Flight OFF: a legitimate exact host still passes (legacy path is a superset of exact matching). */
-    @Test
-    public void flightOff_exactHostStillAccepted() {
-        configureKnownAuthority(CONFIGURED_B2C_URL);
-        setExactHostMatchFlight(false);
-
-        Assert.assertTrue(
-                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/other")));
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -1,0 +1,270 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.authorities;
+
+import com.microsoft.identity.common.java.exception.ClientException;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
+import com.microsoft.identity.common.java.flighting.MockFlightsManager;
+import com.microsoft.identity.common.java.flighting.MockFlightsProvider;
+import com.microsoft.identity.common.java.net.HttpUrlConnectionFactory;
+import com.microsoft.identity.http.MockConnection;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+/**
+ * Regression tests for the security gate in {@link Authority#isKnownAuthority(Authority)}.
+ *
+ * <p>The gate must only accept a candidate authority whose parsed host exactly (case-insensitively)
+ * matches the parsed host of a developer-configured known authority. A previous implementation used
+ * {@code String.contains()} against the full configured URL string, which allowed an untrusted host
+ * (e.g. {@code login.com}) to pass merely because it was a substring of a configured URL
+ * (e.g. {@code https://contoso.b2clogin.com/...}). These tests guard against that bypass.</p>
+ */
+public class AuthorityKnownHostTest {
+
+    private static final String CONFIGURED_B2C_URL =
+            "https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin";
+
+    private Authority configuredAuthority(final String url) {
+        return new AzureActiveDirectoryB2CAuthority(url);
+    }
+
+    private void configureKnownAuthority(final String url) {
+        Authority.addKnownAuthorities(Collections.singletonList(configuredAuthority(url)));
+    }
+
+    private Authority candidate(final String url) {
+        // Using a concrete Authority whose getAuthorityURL() simply parses the supplied URL string,
+        // so the test exercises only the host comparison performed by isKnownAuthority().
+        return new AzureActiveDirectoryB2CAuthority(url);
+    }
+
+    @Before
+    public void setUp() {
+        Authority.clearKnownAuthorities();
+        HttpUrlConnectionFactory.clearMockedConnectionQueue();
+    }
+
+    @After
+    public void tearDown() {
+        Authority.clearKnownAuthorities();
+        HttpUrlConnectionFactory.clearMockedConnectionQueue();
+        CommonFlightsManager.INSTANCE.resetFlightsManager();
+    }
+
+    /**
+     * Overrides the {@link CommonFlight#ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH} kill-switch flight.
+     * Default (no override) is on/secure; pass {@code false} to fall back to legacy substring matching.
+     */
+    private void setExactHostMatchFlight(final boolean enabled) {
+        final MockFlightsProvider provider = new MockFlightsProvider();
+        provider.addFlight(
+                CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH.getKey(),
+                Boolean.toString(enabled));
+        final MockFlightsManager manager = new MockFlightsManager();
+        manager.setMockBrokerFlightsProvider(provider);
+        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(manager);
+    }
+
+    /** Test 1 - A host that is a substring of a configured host must be rejected. */
+    @Test
+    public void substringHostIsRejected() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+
+        // "login.com" is a substring of "b2clogin.com".
+        Assert.assertFalse(
+                Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
+    }
+
+    /** Test 2 - A short generic substring host must be rejected. */
+    @Test
+    public void shortGenericSubstringHostIsRejected() {
+        configureKnownAuthority("https://login.microsoftonline.com/common");
+
+        // "e.com" is a substring of "microsoftonline.com".
+        Assert.assertFalse(
+                Authority.isKnownAuthority(candidate("https://e.com/common")));
+    }
+
+    /** Test 3 - The exact configured host must be accepted (non-regression). */
+    @Test
+    public void exactConfiguredHostIsAccepted() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/anotherpolicy")));
+    }
+
+    /** Test 4 - Case-insensitive exact host match must be accepted. */
+    @Test
+    public void caseInsensitiveExactHostIsAccepted() {
+        configureKnownAuthority("https://Contoso.B2CLogin.com/contoso.onmicrosoft.com/B2C_1_signin");
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin")));
+    }
+
+    /** Test 5 - A look-alike host that merely contains the configured host as a substring must be rejected. */
+    @Test
+    public void pathExtensionLookAlikeHostIsRejected() {
+        configureKnownAuthority("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin");
+
+        Assert.assertFalse(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com.attacker.example/contoso.onmicrosoft.com/B2C_1_signin")));
+    }
+
+    /** A null candidate authority must be rejected. */
+    @Test
+    public void nullAuthorityIsRejected() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+
+        Assert.assertFalse(Authority.isKnownAuthority(null));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Tests 6 & 7 - Flow-level regression guards.
+    //
+    // Both the ROPC flow (BaseController.acquireTokenWithPassword, which calls
+    // Authority.getKnownAuthorityResult(...) and then `if (!authorityResult.getKnown()) throw
+    // authorityResult.getClientException();` BEFORE constructing the OAuth2 strategy or POSTing the
+    // username/password) and the silent flow (BaseController.performSilentTokenRequest, which
+    // performs the identical getKnownAuthorityResult(...) check BEFORE setting the refresh token on
+    // the request and POSTing it) gate all outbound credential submission on
+    // Authority.getKnownAuthorityResult(). These tests drive that shared gate with a substring host
+    // and assert it returns "not known" with an UNKNOWN_AUTHORITY exception - i.e. the exact value
+    // that makes those flows throw and abort before any credential-bearing HTTP POST is dispatched.
+    //
+    // The credential POST is preceded only by a credential-free AAD instance-discovery GET, which we
+    // mock here so the gate runs deterministically and offline.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Test 6 - ROPC: a substring-host authority is denied by the gate before credentials are sent. */
+    @Test
+    public void ropcGateRejectsSubstringHostBeforeCredentialSubmission() throws IOException {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        enqueueInstanceDiscoveryResponse();
+
+        // "login.com" is a substring of the configured "contoso.b2clogin.com" host.
+        final Authority attackerAuthority = candidate("https://login.com/contoso.onmicrosoft.com");
+        final Authority.KnownAuthorityResult result = Authority.getKnownAuthorityResult(attackerAuthority);
+
+        // Gate denies -> BaseController would throw this exception before any token POST.
+        Assert.assertFalse("Substring host must not be treated as known", result.getKnown());
+        Assert.assertNotNull("A blocking exception must be produced for the controller to throw",
+                result.getClientException());
+        Assert.assertEquals(ClientException.UNKNOWN_AUTHORITY,
+                result.getClientException().getErrorCode());
+    }
+
+    /** Test 7 - Silent: a substring-host authority is denied by the gate before the refresh token is sent. */
+    @Test
+    public void silentGateRejectsSubstringHostBeforeRefreshTokenSubmission() throws IOException {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        enqueueInstanceDiscoveryResponse();
+
+        final Authority attackerAuthority = candidate("https://login.com/contoso.onmicrosoft.com");
+        final Authority.KnownAuthorityResult result = Authority.getKnownAuthorityResult(attackerAuthority);
+
+        Assert.assertFalse("Substring host must not be treated as known", result.getKnown());
+        Assert.assertNotNull("A blocking exception must be produced for the controller to throw",
+                result.getClientException());
+        Assert.assertEquals(ClientException.UNKNOWN_AUTHORITY,
+                result.getClientException().getErrorCode());
+    }
+
+    /** The legitimate, exactly-configured host must still pass the gate (non-regression for both flows). */
+    @Test
+    public void gateAcceptsExactlyConfiguredHost() throws IOException {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        enqueueInstanceDiscoveryResponse();
+
+        final Authority legitimateAuthority =
+                candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin");
+        final Authority.KnownAuthorityResult result = Authority.getKnownAuthorityResult(legitimateAuthority);
+
+        Assert.assertTrue("Exactly-configured host must remain known", result.getKnown());
+        Assert.assertNull(result.getClientException());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Kill-switch flight (CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH).
+    //
+    // The fix is gated behind a default-on flight so the previous (insecure) substring behavior can
+    // be restored via ECS in an emergency, should exact-host matching ever reject a legitimate,
+    // developer-configured authority. The same CommonFlight is honored by Broker automatically
+    // through its ECS flights provider (which forwards any IFlightConfig by key), matching the
+    // ENABLE_SOVEREIGN_CLOUD_INSTANCE_DISCOVERY precedent in AzureActiveDirectory.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Flight ON (explicit): substring host is rejected — same as the secure default. */
+    @Test
+    public void flightOn_substringHostIsRejected() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        setExactHostMatchFlight(true);
+
+        Assert.assertFalse(
+                Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
+    }
+
+    /** Flight OFF (kill switch): legacy substring behavior is restored, so the substring host matches. */
+    @Test
+    public void flightOff_substringHostIsAcceptedByLegacyBehavior() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        setExactHostMatchFlight(false);
+
+        // "login.com" is a substring of the configured "contoso.b2clogin.com" host. Under the legacy
+        // comparison this (insecurely) passes — documenting exactly what the kill switch reverts to.
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
+    }
+
+    /** Flight OFF: a legitimate exact host still passes (legacy path is a superset of exact matching). */
+    @Test
+    public void flightOff_exactHostStillAccepted() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+        setExactHostMatchFlight(false);
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/other")));
+    }
+
+    /**
+     * Enqueues a mocked AAD instance-discovery response so the cloud-discovery step inside
+     * {@link Authority#getKnownAuthorityResult(Authority)} completes offline. A 4xx response makes
+     * discovery return without throwing and without registering any host as a Microsoft cloud, so the
+     * gate's decision is driven solely by the developer-configured known-authority comparison under
+     * test (and the resulting exception for an unknown host is {@code UNKNOWN_AUTHORITY}).
+     */
+    private void enqueueInstanceDiscoveryResponse() throws IOException {
+        HttpUrlConnectionFactory.addMockedConnection(
+                MockConnection.getMockedConnectionWithFailureResponse(HttpURLConnection.HTTP_BAD_REQUEST));
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -141,6 +141,30 @@ public class AuthorityKnownHostTest {
                 Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com.attacker.example/contoso.onmicrosoft.com/B2C_1_signin")));
     }
 
+    /**
+     * Port is ignored: an explicit default port on the candidate must still match a configured
+     * authority that omits the port. The trust boundary is the host, not the port.
+     */
+    @Test
+    public void explicitDefaultPortMatchesImplicitPort() {
+        configureKnownAuthority("https://login.microsoftonline.com/common");
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://login.microsoftonline.com:443/common")));
+    }
+
+    /**
+     * Port is ignored: a different, non-default port on the same configured host is still accepted,
+     * since the gate trusts the host regardless of port.
+     */
+    @Test
+    public void differentPortSameHostIsAccepted() {
+        configureKnownAuthority("https://login.microsoftonline.com/common");
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://login.microsoftonline.com:8443/common")));
+    }
+
     /** A null candidate authority must be rejected. */
     @Test
     public void nullAuthorityIsRejected() {

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -97,16 +97,6 @@ public class AuthorityKnownHostTest {
                 Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
     }
 
-    /** A short generic substring host must be rejected. */
-    @Test
-    public void shortGenericSubstringHostIsRejected() {
-        configureKnownAuthority("https://login.microsoftonline.com/common");
-
-        // "e.com" is a substring of "microsoftonline.com".
-        Assert.assertFalse(
-                Authority.isKnownAuthority(candidate("https://e.com/common")));
-    }
-
     /**
      * Port is ignored: an explicit default port on the candidate must still match a configured
      * authority that omits the port. The trust boundary is the host, not the port. (Legacy
@@ -118,18 +108,6 @@ public class AuthorityKnownHostTest {
 
         Assert.assertTrue(
                 Authority.isKnownAuthority(candidate("https://login.microsoftonline.com:443/common")));
-    }
-
-    /**
-     * Port is ignored: a different, non-default port on the same configured host is still accepted,
-     * since the gate trusts the host regardless of port.
-     */
-    @Test
-    public void differentPortSameHostIsAccepted() {
-        configureKnownAuthority("https://login.microsoftonline.com/common");
-
-        Assert.assertTrue(
-                Authority.isKnownAuthority(candidate("https://login.microsoftonline.com:8443/common")));
     }
 
     // =============================================================================================
@@ -220,10 +198,10 @@ public class AuthorityKnownHostTest {
     }
 
     // =============================================================================================
-    // Group 4 - Path-consistency guards: the known-authority gate (isKnownAuthority ->
-    // isKnownToDeveloperByExactHost) and authority resolution (getAuthorityFromAuthorityUrl ->
-    // getEquivalentConfiguredAuthority) must agree about whether a URL is developer-configured. Both
-    // now compare by parsed host only, so a same-host/different-port candidate is treated as
+    // Group 4 - Path-consistency guards: the known-authority gate (isKnownAuthority) and authority
+    // resolution (getAuthorityFromAuthorityUrl -> getEquivalentConfiguredAuthority) must agree about
+    // whether a URL is developer-configured. Both now compare by parsed host only (via the shared
+    // matchesConfiguredHost helper), so a same-host/different-port candidate is treated as
     // configured by BOTH paths. Before the fix these diverged (gate = host-only, resolution =
     // host:port), so a port-divergent URL was "known" by the gate yet resolved as an unconfigured
     // (fallback AAD) authority. Both tests below only pass WITH the fix: one covers the port-divergence

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -33,16 +33,23 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
- * Regression tests for the security gate in {@link Authority#isKnownAuthority(Authority)}.
+ * Regression tests for the security gate in {@link Authority#isKnownAuthority(Authority)} and for the
+ * agreement between that gate and authority resolution
+ * ({@link Authority#getAuthorityFromAuthorityUrl(String)}).
  *
  * <p>The gate must only accept a candidate authority whose parsed host exactly (case-insensitively)
  * matches the parsed host of a developer-configured known authority. A previous implementation used
  * {@code String.contains()} against the full configured URL string, which allowed an untrusted host
  * (e.g. {@code login.com}) to pass merely because it was a substring of a configured URL
  * (e.g. {@code https://contoso.b2clogin.com/...}). These tests guard against that bypass.</p>
+ *
+ * <p>The gate and authority resolution must also agree about which URLs are developer-configured:
+ * both compare by parsed host only, so a same-host/different-port candidate is treated as configured
+ * by both paths (Group 4).</p>
  */
 public class AuthorityKnownHostTest {
 
@@ -210,6 +217,57 @@ public class AuthorityKnownHostTest {
 
         Assert.assertTrue("Exactly-configured host must remain known", result.getKnown());
         Assert.assertNull(result.getClientException());
+    }
+
+    // =============================================================================================
+    // Group 4 - Path-consistency guards: the known-authority gate (isKnownAuthority ->
+    // isKnownToDeveloperByExactHost) and authority resolution (getAuthorityFromAuthorityUrl ->
+    // getEquivalentConfiguredAuthority) must agree about whether a URL is developer-configured. Both
+    // now compare by parsed host only, so a same-host/different-port candidate is treated as
+    // configured by BOTH paths. Before the fix these diverged (gate = host-only, resolution =
+    // host:port), so a port-divergent URL was "known" by the gate yet resolved as an unconfigured
+    // (fallback AAD) authority. Both tests below only pass WITH the fix: one covers the port-divergence
+    // agreement, the other covers a malformed configured entry being skipped (not aborting) by both paths.
+    // =============================================================================================
+
+    private static final String PORT_DIVERGENT_B2C_URL =
+            "https://contoso.b2clogin.com:8443/contoso.onmicrosoft.com/B2C_1_signin";
+
+    /**
+     * The gate and authority resolution must agree for a same-host/different-port candidate: the gate
+     * reports it as known AND resolution treats it as the configured (B2C) type.
+     */
+    @Test
+    public void gateAndResolutionAgreeForPortDivergentHost() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+
+        Assert.assertTrue("Gate must treat the port-divergent host as known",
+                Authority.isKnownAuthority(candidate(PORT_DIVERGENT_B2C_URL)));
+        Assert.assertTrue("Resolution must treat the port-divergent host as configured (B2C)",
+                Authority.getAuthorityFromAuthorityUrl(PORT_DIVERGENT_B2C_URL)
+                        instanceof AzureActiveDirectoryB2CAuthority);
+    }
+
+    /**
+     * A malformed configured known-authority entry must be skipped by BOTH paths without aborting the
+     * scan, so a valid entry later in the list is still matched. This keeps the gate and resolution in
+     * agreement even when the configured list contains an unparseable URL.
+     */
+    @Test
+    public void malformedConfiguredAuthorityIsSkippedByBothPaths() {
+        // A malformed configured URL (no protocol) precedes a valid configured B2C authority.
+        Authority.addKnownAuthorities(Arrays.asList(
+                configuredAuthority("malformed-configured-url"),
+                configuredAuthority(CONFIGURED_B2C_URL)));
+
+        final String validCandidateUrl =
+                "https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin";
+
+        Assert.assertTrue("Gate must still match the valid entry after skipping the malformed one",
+                Authority.isKnownAuthority(candidate(validCandidateUrl)));
+        Assert.assertTrue("Resolution must still match the valid entry after skipping the malformed one",
+                Authority.getAuthorityFromAuthorityUrl(validCandidateUrl)
+                        instanceof AzureActiveDirectoryB2CAuthority);
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -94,7 +94,12 @@ public class AuthorityKnownHostTest {
         CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(manager);
     }
 
-    /** Test 1 - A host that is a substring of a configured host must be rejected. */
+    // =============================================================================================
+    // Group 1 - Security regression guards: these FAIL on the legacy .contains() logic and pass only
+    // WITH the fix. They are the tests that actually catch the substring-bypass vulnerability.
+    // =============================================================================================
+
+    /** A host that is a substring of a configured host must be rejected. */
     @Test
     public void substringHostIsRejected() {
         configureKnownAuthority(CONFIGURED_B2C_URL);
@@ -104,7 +109,7 @@ public class AuthorityKnownHostTest {
                 Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
     }
 
-    /** Test 2 - A short generic substring host must be rejected. */
+    /** A short generic substring host must be rejected. */
     @Test
     public void shortGenericSubstringHostIsRejected() {
         configureKnownAuthority("https://login.microsoftonline.com/common");
@@ -114,36 +119,10 @@ public class AuthorityKnownHostTest {
                 Authority.isKnownAuthority(candidate("https://e.com/common")));
     }
 
-    /** Test 3 - The exact configured host must be accepted (non-regression). */
-    @Test
-    public void exactConfiguredHostIsAccepted() {
-        configureKnownAuthority(CONFIGURED_B2C_URL);
-
-        Assert.assertTrue(
-                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/anotherpolicy")));
-    }
-
-    /** Test 4 - Case-insensitive exact host match must be accepted. */
-    @Test
-    public void caseInsensitiveExactHostIsAccepted() {
-        configureKnownAuthority("https://Contoso.B2CLogin.com/contoso.onmicrosoft.com/B2C_1_signin");
-
-        Assert.assertTrue(
-                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin")));
-    }
-
-    /** Test 5 - A look-alike host that merely contains the configured host as a substring must be rejected. */
-    @Test
-    public void pathExtensionLookAlikeHostIsRejected() {
-        configureKnownAuthority("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin");
-
-        Assert.assertFalse(
-                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com.attacker.example/contoso.onmicrosoft.com/B2C_1_signin")));
-    }
-
     /**
      * Port is ignored: an explicit default port on the candidate must still match a configured
-     * authority that omits the port. The trust boundary is the host, not the port.
+     * authority that omits the port. The trust boundary is the host, not the port. (Legacy
+     * substring matching would have compared "host:443" and failed, so this only passes with the fix.)
      */
     @Test
     public void explicitDefaultPortMatchesImplicitPort() {
@@ -165,7 +144,43 @@ public class AuthorityKnownHostTest {
                 Authority.isKnownAuthority(candidate("https://login.microsoftonline.com:8443/common")));
     }
 
-    /** A null candidate authority must be rejected. */
+    // =============================================================================================
+    // Group 2 - Non-regression guards: these pass WITH AND WITHOUT the fix. They do not catch the
+    // bug; they ensure the stricter matching does not break legitimate authority validation.
+    // =============================================================================================
+
+    /** The exact configured host must be accepted. */
+    @Test
+    public void exactConfiguredHostIsAccepted() {
+        configureKnownAuthority(CONFIGURED_B2C_URL);
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/anotherpolicy")));
+    }
+
+    /** Case-insensitive exact host match must be accepted. */
+    @Test
+    public void caseInsensitiveExactHostIsAccepted() {
+        configureKnownAuthority("https://Contoso.B2CLogin.com/contoso.onmicrosoft.com/B2C_1_signin");
+
+        Assert.assertTrue(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin")));
+    }
+
+    /**
+     * A look-alike host that merely contains the configured host as a substring must be rejected.
+     * (Legacy already rejects this because the candidate host is longer than the configured host, so
+     * it is a non-regression guard rather than a bug-catcher.)
+     */
+    @Test
+    public void pathExtensionLookAlikeHostIsRejected() {
+        configureKnownAuthority("https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signin");
+
+        Assert.assertFalse(
+                Authority.isKnownAuthority(candidate("https://contoso.b2clogin.com.attacker.example/contoso.onmicrosoft.com/B2C_1_signin")));
+    }
+
+    /** A null candidate authority must be rejected (early return, before any matching). */
     @Test
     public void nullAuthorityIsRejected() {
         configureKnownAuthority(CONFIGURED_B2C_URL);
@@ -173,21 +188,16 @@ public class AuthorityKnownHostTest {
         Assert.assertFalse(Authority.isKnownAuthority(null));
     }
 
-    // ---------------------------------------------------------------------------------------------
-    // Flow-level regression guard (covers the finding's Test 6 - ROPC and Test 7 - silent).
-    //
-    // The ROPC flow (BaseController.acquireTokenWithPassword) and the silent flow
-    // (BaseController.performSilentTokenRequest) both gate all outbound credential submission on the
-    // same chokepoint: they call Authority.getKnownAuthorityResult(...) and then
-    // `if (!authorityResult.getKnown()) throw authorityResult.getClientException();` BEFORE
+    // =============================================================================================
+    // Group 3 - Full-gate guards: exercise the shared Authority.getKnownAuthorityResult() chokepoint
+    // (with AAD instance-discovery mocked offline) that both the ROPC flow
+    // (BaseController.acquireTokenWithPassword) and the silent flow
+    // (BaseController.performSilentTokenRequest) consult - via
+    // `if (!authorityResult.getKnown()) throw authorityResult.getClientException();` - BEFORE
     // constructing the OAuth2 strategy / setting the refresh token and POSTing any credential. Since
-    // both paths reduce to this single gate, one test exercises it for both. We drive the gate with a
-    // substring host and assert it returns "not known" with an UNKNOWN_AUTHORITY exception - the exact
-    // value that makes those flows throw and abort before any credential-bearing HTTP POST.
-    //
-    // The credential POST is preceded only by a credential-free AAD instance-discovery GET, which we
-    // mock here so the gate runs deterministically and offline.
-    // ---------------------------------------------------------------------------------------------
+    // both paths reduce to this single gate, one reject test and one accept test cover both flows.
+    // The reject test only passes WITH the fix; the accept test is a non-regression guard (both).
+    // =============================================================================================
 
     /** A substring-host authority is denied by the shared gate before any credential is sent. */
     @Test
@@ -221,8 +231,8 @@ public class AuthorityKnownHostTest {
         Assert.assertNull(result.getClientException());
     }
 
-    // ---------------------------------------------------------------------------------------------
-    // Kill-switch flight (CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH).
+    // =============================================================================================
+    // Group 4 - Kill-switch flight (CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH).
     //
     // The fix is gated behind a default-on flight so the previous (insecure) substring behavior can
     // be restored via ECS in an emergency, should exact-host matching ever reject a legitimate,
@@ -232,7 +242,7 @@ public class AuthorityKnownHostTest {
     //
     // Contrast with substringHostIsRejected (flight default-on -> rejected): the same substring host
     // is accepted here when the flight is OFF, demonstrating the switch actually reverts behavior.
-    // ---------------------------------------------------------------------------------------------
+    // =============================================================================================
 
     /** Flight OFF (kill switch): legacy substring behavior is restored, so the substring host matches. */
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -23,10 +23,6 @@
 package com.microsoft.identity.common.java.authorities;
 
 import com.microsoft.identity.common.java.exception.ClientException;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
-import com.microsoft.identity.common.java.flighting.MockFlightsManager;
-import com.microsoft.identity.common.java.flighting.MockFlightsProvider;
 import com.microsoft.identity.common.java.net.HttpUrlConnectionFactory;
 import com.microsoft.identity.http.MockConnection;
 
@@ -77,21 +73,6 @@ public class AuthorityKnownHostTest {
     public void tearDown() {
         Authority.clearKnownAuthorities();
         HttpUrlConnectionFactory.clearMockedConnectionQueue();
-        CommonFlightsManager.INSTANCE.resetFlightsManager();
-    }
-
-    /**
-     * Overrides the {@link CommonFlight#ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH} kill-switch flight.
-     * Default (no override) is on/secure; pass {@code false} to fall back to legacy substring matching.
-     */
-    private void setExactHostMatchFlight(final boolean enabled) {
-        final MockFlightsProvider provider = new MockFlightsProvider();
-        provider.addFlight(
-                CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH.getKey(),
-                Boolean.toString(enabled));
-        final MockFlightsManager manager = new MockFlightsManager();
-        manager.setMockBrokerFlightsProvider(provider);
-        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(manager);
     }
 
     // =============================================================================================
@@ -229,31 +210,6 @@ public class AuthorityKnownHostTest {
 
         Assert.assertTrue("Exactly-configured host must remain known", result.getKnown());
         Assert.assertNull(result.getClientException());
-    }
-
-    // =============================================================================================
-    // Group 4 - Kill-switch flight (CommonFlight.ENABLE_KNOWN_AUTHORITY_HOST_EXACT_MATCH).
-    //
-    // The fix is gated behind a default-on flight so the previous (insecure) substring behavior can
-    // be restored via ECS in an emergency, should exact-host matching ever reject a legitimate,
-    // developer-configured authority. The same CommonFlight is honored by Broker automatically
-    // through its ECS flights provider (which forwards any IFlightConfig by key), matching the
-    // ENABLE_SOVEREIGN_CLOUD_INSTANCE_DISCOVERY precedent in AzureActiveDirectory.
-    //
-    // Contrast with substringHostIsRejected (flight default-on -> rejected): the same substring host
-    // is accepted here when the flight is OFF, demonstrating the switch actually reverts behavior.
-    // =============================================================================================
-
-    /** Flight OFF (kill switch): legacy substring behavior is restored, so the substring host matches. */
-    @Test
-    public void flightOff_substringHostIsAcceptedByLegacyBehavior() {
-        configureKnownAuthority(CONFIGURED_B2C_URL);
-        setExactHostMatchFlight(false);
-
-        // "login.com" is a substring of the configured "contoso.b2clogin.com" host. Under the legacy
-        // comparison this (insecurely) passes — documenting exactly what the kill switch reverts to.
-        Assert.assertTrue(
-                Authority.isKnownAuthority(candidate("https://login.com/contoso.onmicrosoft.com")));
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/authorities/AuthorityKnownHostTest.java
@@ -198,14 +198,11 @@ public class AuthorityKnownHostTest {
     }
 
     // =============================================================================================
-    // Group 4 - Path-consistency guards: the known-authority gate (isKnownAuthority) and authority
-    // resolution (getAuthorityFromAuthorityUrl -> getEquivalentConfiguredAuthority) must agree about
-    // whether a URL is developer-configured. Both now compare by parsed host only (via the shared
-    // matchesConfiguredHost helper), so a same-host/different-port candidate is treated as
-    // configured by BOTH paths. Before the fix these diverged (gate = host-only, resolution =
-    // host:port), so a port-divergent URL was "known" by the gate yet resolved as an unconfigured
-    // (fallback AAD) authority. Both tests below only pass WITH the fix: one covers the port-divergence
-    // agreement, the other covers a malformed configured entry being skipped (not aborting) by both paths.
+    // Group 4 - Path-consistency guards: the gate (isKnownAuthority) and authority resolution
+    // (getAuthorityFromAuthorityUrl) must agree about whether a URL is developer-configured, since
+    // both now compare by parsed host only via the shared matchesConfiguredHost helper. Before the
+    // fix they diverged (gate = host-only, resolution = host:port). Both tests pass only WITH the
+    // fix: one covers same-host/different-port agreement, the other a malformed entry being skipped.
     // =============================================================================================
 
     private static final String PORT_DIVERGENT_B2C_URL =


### PR DESCRIPTION
[AB#3607019](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3607019)

Harden `Authority.isKnownAuthority()` to compare developer-configured known authorities by exact, case-insensitive parsed host, consistent with `getEquivalentConfiguredAuthority()`. This replaces the previous substring comparison, which let an untrusted host pass the gate when it was a substring of a configured authority URL.

Adds unit tests in `AuthorityKnownHostTest`.