### PR TITLE
Fix dormant KeyStore key-gen regression (explodes on API <= 30 from broker 16.1.0), Fixed AB#3673639

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Fix KeyStore key generation failures on API <= 30 by adding a conservative RSA/PKCS1/SHA-256 spec (ECS kill-switch flighted) (#3167)
 - [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
 
 Version 24.4.0

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -243,9 +243,9 @@ class CryptoParameterSpecFactory(
     /**
      * Original key generation spec selection (fix flight OFF) - unchanged behaviour.
      *
-     * The advanced specs (PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1) are attempted on every API level.
-     * This is what causes pre-Keystore 2.0 (API &lt;= 30) keymasters to reject every spec; see
-     * [getLegacyDeviceSafeKeyGenSpecs] for the fixed path.
+     * The advanced specs (PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1) are attempted only on API levels
+     * that support them (e.g., wrap-key spec on API 28+; non-wrap spec on API 23+) when their
+     * corresponding feature flags are enabled. See [getLegacyDeviceSafeKeyGenSpecs] for the fixed path.
      */
     private fun getDefaultKeyGenSpecs(): List<IKeyGenSpec> {
         val specs = mutableListOf<IKeyGenSpec>()
@@ -292,9 +292,7 @@ class CryptoParameterSpecFactory(
         // Primary viable spec on API 23..30 keymasters; a safe fallback on API 31+.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             specs.add(keyGenParamSpecConservative)
-        }
-
-        // Always include legacy spec as last resort fallback (API < 23).
+        // Always include legacy spec as last resort fallback.
         specs.add(keyGenParamSpecLegacy)
         return specs
     }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -218,71 +218,84 @@ class CryptoParameterSpecFactory(
      */
     fun getPrioritizedKeyGenParameterSpecs(): List<IKeyGenSpec> {
         val methodTag = "$TAG:getPrioritizedKeyGenParameterSpecs"
-        val specs = mutableListOf<IKeyGenSpec>()
         val conservativeFixEnabled = conservativeKeyGenForLegacyDevices
 
-        // The advanced specs below request features (PURPOSE_WRAP_KEY, SHA-512 digests and
-        // OAEP/MGF1 padding) that are only reliably supported by the hardware keymaster starting
-        // with Keystore 2.0 (API 31). On API <= 30 many hardware-backed keymasters - especially on
-        // rugged/enterprise devices - reject these specs, which previously caused every attempt
-        // (including the deprecated legacy KeyPairGeneratorSpec fallback) to fail with
-        // "All key generation attempts failed". When the legacy-device fix flight is enabled the
-        // advanced specs are restricted to API 31+; otherwise the previous behaviour is preserved.
-        val advancedSpecsAllowed =
-            !conservativeFixEnabled || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        // Record whether the fix flight was on for this attempt so we can correlate, post-deploy,
+        // against the existing DeviceInfo_OsVersion and key_pair_gen_description telemetry.
+        SpanExtension.current().setAttribute(
+            AttributeName.key_gen_conservative_spec_flight_enabled.name,
+            conservativeFixEnabled
+        )
 
-        if (advancedSpecsAllowed) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && keySpecWithWrapPurposeKey) {
-                // First priority: API 28+ with PURPOSE_WRAP_KEY if enabled
-                specs.add(keyGenParamSpecWithPurposeWrapKey)
-            }
-
-            if (keySpecWithoutWrapPurposeKey) {
-                // Second priority: API 23+ without PURPOSE_WRAP_KEY
-                specs.add(keyGenParamSpecWithoutPurposeWrapKey)
-            }
+        // The fix is an ECS kill switch. When the flight is OFF we run the exact original spec
+        // selection; when it is ON we run the legacy-device-safe variant. Keeping the two paths
+        // separate makes the change trivial to reason about and to revert via ECS.
+        val specs = if (conservativeFixEnabled) {
+            getLegacyDeviceSafeKeyGenSpecs()
+        } else {
+            getDefaultKeyGenSpecs()
         }
 
-        // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
-        // Only added when the legacy-device fix is enabled; it is the primary viable spec on
-        // API 23..30 keymasters and a safe fallback on API 31+ before the deprecated legacy spec.
-        if (conservativeFixEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            specs.add(keyGenParamSpecConservative)
-        }
-
-        // Always include legacy spec as last resort fallback (API < 23).
-        specs.add(keyGenParamSpecLegacy)
-
-        recordKeyGenSpecSelectionTelemetry(conservativeFixEnabled, specs)
         Logger.info(methodTag, "Key generation specs: ${specs.joinToString { it.description }}")
         return specs
     }
 
     /**
-     * Records telemetry about which key generation specs were elected for this device on the
-     * current span. This lets us validate, post-deploy, that legacy (API &lt;= 30) devices no
-     * longer attempt the advanced specs and instead elect the conservative spec.
+     * Original key generation spec selection (fix flight OFF) - unchanged behaviour.
      *
-     * @param conservativeFixEnabled whether the legacy-device fix flight is enabled
-     * @param specs the prioritized key generation specs elected for this device
+     * The advanced specs (PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1) are attempted on every API level.
+     * This is what causes pre-Keystore 2.0 (API &lt;= 30) keymasters to reject every spec; see
+     * [getLegacyDeviceSafeKeyGenSpecs] for the fixed path.
      */
-    private fun recordKeyGenSpecSelectionTelemetry(
-        conservativeFixEnabled: Boolean,
-        specs: List<IKeyGenSpec>
-    ) {
-        SpanExtension.current().apply {
-            setAttribute(
-                AttributeName.key_gen_conservative_spec_flight_enabled.name,
-                conservativeFixEnabled
-            )
-            setAttribute(
-                AttributeName.key_gen_api_level.name,
-                Build.VERSION.SDK_INT.toLong()
-            )
-            setAttribute(
-                AttributeName.key_gen_prioritized_spec_list.name,
-                specs.joinToString(separator = ",") { it.description }
-            )
+    private fun getDefaultKeyGenSpecs(): List<IKeyGenSpec> {
+        val specs = mutableListOf<IKeyGenSpec>()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && keySpecWithWrapPurposeKey) {
+            // First priority: API 28+ with PURPOSE_WRAP_KEY if enabled
+            specs.add(keyGenParamSpecWithPurposeWrapKey)
         }
+
+        if (keySpecWithoutWrapPurposeKey) {
+            // Second priority: API 23+ without PURPOSE_WRAP_KEY
+            specs.add(keyGenParamSpecWithoutPurposeWrapKey)
+        }
+
+        // Always include legacy spec as last resort fallback (API < 23).
+        specs.add(keyGenParamSpecLegacy)
+        return specs
+    }
+
+    /**
+     * Legacy-device-safe key generation spec selection (fix flight ON).
+     *
+     * On API &lt;= 30 the advanced specs are skipped entirely - pre-Keystore 2.0 keymasters
+     * (especially on rugged/enterprise devices) reject PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1, which
+     * previously made every attempt fail with "All key generation attempts failed". Instead a
+     * conservative RSA/PKCS1/SHA-256 spec - which those keymasters reliably support - is used. On
+     * API 31+ (Keystore 2.0) the advanced specs are still attempted first, with the conservative
+     * spec added as an extra fallback before the deprecated legacy spec.
+     */
+    private fun getLegacyDeviceSafeKeyGenSpecs(): List<IKeyGenSpec> {
+        val specs = mutableListOf<IKeyGenSpec>()
+
+        // Advanced specs are only reliable from Keystore 2.0 (API 31) onward.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (keySpecWithWrapPurposeKey) {
+                specs.add(keyGenParamSpecWithPurposeWrapKey)
+            }
+            if (keySpecWithoutWrapPurposeKey) {
+                specs.add(keyGenParamSpecWithoutPurposeWrapKey)
+            }
+        }
+
+        // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
+        // Primary viable spec on API 23..30 keymasters; a safe fallback on API 31+.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            specs.add(keyGenParamSpecConservative)
+        }
+
+        // Always include legacy spec as last resort fallback (API < 23).
+        specs.add(keyGenParamSpecLegacy)
+        return specs
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -29,6 +29,8 @@ import androidx.annotation.RequiresApi
 import com.microsoft.identity.common.java.flighting.CommonFlight
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager.getFlightsProvider
 import com.microsoft.identity.common.java.flighting.IFlightsProvider
+import com.microsoft.identity.common.java.opentelemetry.AttributeName
+import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -87,6 +89,10 @@ class CryptoParameterSpecFactory(
         flightsProvider.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY)
     private val enableKeyGenEncryptionPaddingRsaOaep get() =
         flightsProvider.isFlightEnabled(CommonFlight.ENABLE_OAEP_WITH_SHA_AND_MGF1_PADDING)
+    // When enabled, advanced key gen specs are skipped on API <= 30 in favour of a conservative
+    // RSA/PKCS1/SHA-256 spec that legacy keymasters reliably support. Killable via ECS.
+    private val conservativeKeyGenForLegacyDevices get() =
+        flightsProvider.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES)
 
     init {
         val methodTag = "$TAG:init"
@@ -96,7 +102,8 @@ class CryptoParameterSpecFactory(
                     "API: ${Build.VERSION.SDK_INT}, " +
                     "flags: [keySpecWithWrapPurposeKey=$keySpecWithWrapPurposeKey, " +
                     "keySpecWithoutWrapPurposeKey=$keySpecWithoutWrapPurposeKey, " +
-                    "oaepSupported=$enableKeyGenEncryptionPaddingRsaOaep]"
+                    "oaepSupported=$enableKeyGenEncryptionPaddingRsaOaep, " +
+                    "conservativeKeyGenForLegacyDevices=$conservativeKeyGenForLegacyDevices]"
         )
     }
 
@@ -201,41 +208,81 @@ class CryptoParameterSpecFactory(
      * Prioritizes modern Android KeyStore features (API 23+) when enabled by feature flags,
      * with legacy fallback always included for maximum compatibility.
      *
+     * When [CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES] is enabled, the
+     * advanced specs (PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1) are skipped on API &lt;= 30 - where
+     * pre-Keystore 2.0 keymasters frequently reject them - in favour of a conservative
+     * RSA/PKCS1/SHA-256 spec. When the flight is disabled the previous behaviour is restored so the
+     * change can be turned off via ECS.
+     *
      * @return List of [IKeyGenSpec] objects ordered by preference (most modern first)
      */
     fun getPrioritizedKeyGenParameterSpecs(): List<IKeyGenSpec> {
         val methodTag = "$TAG:getPrioritizedKeyGenParameterSpecs"
         val specs = mutableListOf<IKeyGenSpec>()
+        val conservativeFixEnabled = conservativeKeyGenForLegacyDevices
 
         // The advanced specs below request features (PURPOSE_WRAP_KEY, SHA-512 digests and
         // OAEP/MGF1 padding) that are only reliably supported by the hardware keymaster starting
         // with Keystore 2.0 (API 31). On API <= 30 many hardware-backed keymasters - especially on
         // rugged/enterprise devices - reject these specs, which previously caused every attempt
         // (including the deprecated legacy KeyPairGeneratorSpec fallback) to fail with
-        // "All key generation attempts failed". Restrict the advanced specs to API 31+.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (keySpecWithWrapPurposeKey) {
-                // First priority: with PURPOSE_WRAP_KEY if enabled
+        // "All key generation attempts failed". When the legacy-device fix flight is enabled the
+        // advanced specs are restricted to API 31+; otherwise the previous behaviour is preserved.
+        val advancedSpecsAllowed =
+            !conservativeFixEnabled || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+        if (advancedSpecsAllowed) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && keySpecWithWrapPurposeKey) {
+                // First priority: API 28+ with PURPOSE_WRAP_KEY if enabled
                 specs.add(keyGenParamSpecWithPurposeWrapKey)
             }
 
             if (keySpecWithoutWrapPurposeKey) {
-                // Second priority: without PURPOSE_WRAP_KEY
+                // Second priority: API 23+ without PURPOSE_WRAP_KEY
                 specs.add(keyGenParamSpecWithoutPurposeWrapKey)
             }
         }
 
         // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
-        // This is the primary viable spec on API 23..30 keymasters and a safe fallback on API 31+
-        // before resorting to the deprecated legacy spec.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        // Only added when the legacy-device fix is enabled; it is the primary viable spec on
+        // API 23..30 keymasters and a safe fallback on API 31+ before the deprecated legacy spec.
+        if (conservativeFixEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             specs.add(keyGenParamSpecConservative)
         }
 
         // Always include legacy spec as last resort fallback (API < 23).
         specs.add(keyGenParamSpecLegacy)
 
+        recordKeyGenSpecSelectionTelemetry(conservativeFixEnabled, specs)
         Logger.info(methodTag, "Key generation specs: ${specs.joinToString { it.description }}")
         return specs
+    }
+
+    /**
+     * Records telemetry about which key generation specs were elected for this device on the
+     * current span. This lets us validate, post-deploy, that legacy (API &lt;= 30) devices no
+     * longer attempt the advanced specs and instead elect the conservative spec.
+     *
+     * @param conservativeFixEnabled whether the legacy-device fix flight is enabled
+     * @param specs the prioritized key generation specs elected for this device
+     */
+    private fun recordKeyGenSpecSelectionTelemetry(
+        conservativeFixEnabled: Boolean,
+        specs: List<IKeyGenSpec>
+    ) {
+        SpanExtension.current().apply {
+            setAttribute(
+                AttributeName.key_gen_conservative_spec_flight_enabled.name,
+                conservativeFixEnabled
+            )
+            setAttribute(
+                AttributeName.key_gen_api_level.name,
+                Build.VERSION.SDK_INT.toLong()
+            )
+            setAttribute(
+                AttributeName.key_gen_prioritized_spec_list.name,
+                specs.joinToString(separator = ",") { it.description }
+            )
+        }
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -76,6 +76,7 @@ class CryptoParameterSpecFactory(
         // Descriptive identifiers for different key generation specifications
         private const val MODERN_SPEC_WITH_PURPOSE_WRAP_KEY = "modern_spec_with_wrap_key"
         private const val MODERN_SPEC_WITHOUT_PURPOSE_WRAP_KEY = "modern_spec_without_wrap_key"
+        private const val CONSERVATIVE_SPEC = "conservative_spec_for_api_30_and_below"
         private const val LEGACY_SPEC = "legacy_key_gen_spec"
     }
 
@@ -134,6 +135,31 @@ class CryptoParameterSpecFactory(
         )
     }
 
+    /**
+     * Conservative, hardware-friendly key generation spec for API 23..30 (pre-Keystore 2.0).
+     *
+     * Requests only RSA with ENCRYPT/DECRYPT purposes, a single SHA-256 digest and PKCS1
+     * padding. It deliberately avoids PURPOSE_WRAP_KEY, SHA-512 and OAEP/MGF1 - features that
+     * many hardware-backed keymasters on API <= 30 (notably rugged/enterprise devices) reject,
+     * causing key generation to fail. A key produced with PKCS1 padding is also reliably
+     * introspectable via [android.security.keystore.KeyInfo], so a compatible cipher spec is
+     * always found when wrapping the secret key.
+     */
+    private val keyGenParamSpecConservative by lazy {
+        KeyGenSpec(
+            keyAlias = keyAlias,
+            purposes = KeyProperties.PURPOSE_ENCRYPT or
+                    KeyProperties.PURPOSE_DECRYPT,
+            keySize = KEY_SIZE,
+            digestAlgorithms = listOf(
+                KeyProperties.DIGEST_SHA256
+            ),
+            description = CONSERVATIVE_SPEC,
+            encryptionPaddings = listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1),
+            algorithm = RSA_ALGORITHM
+        )
+    }
+
     private val keyGenParamSpecLegacy = LegacyKeyGenSpec(
         context = context,
         keyAlias = keyAlias,
@@ -181,18 +207,32 @@ class CryptoParameterSpecFactory(
         val methodTag = "$TAG:getPrioritizedKeyGenParameterSpecs"
         val specs = mutableListOf<IKeyGenSpec>()
 
-        // Add specs in order of preference
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && keySpecWithWrapPurposeKey) {
-            // First priority: API 28+ with PURPOSE_WRAP_KEY if enabled
-            specs.add(keyGenParamSpecWithPurposeWrapKey)
+        // The advanced specs below request features (PURPOSE_WRAP_KEY, SHA-512 digests and
+        // OAEP/MGF1 padding) that are only reliably supported by the hardware keymaster starting
+        // with Keystore 2.0 (API 31). On API <= 30 many hardware-backed keymasters - especially on
+        // rugged/enterprise devices - reject these specs, which previously caused every attempt
+        // (including the deprecated legacy KeyPairGeneratorSpec fallback) to fail with
+        // "All key generation attempts failed". Restrict the advanced specs to API 31+.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (keySpecWithWrapPurposeKey) {
+                // First priority: with PURPOSE_WRAP_KEY if enabled
+                specs.add(keyGenParamSpecWithPurposeWrapKey)
+            }
+
+            if (keySpecWithoutWrapPurposeKey) {
+                // Second priority: without PURPOSE_WRAP_KEY
+                specs.add(keyGenParamSpecWithoutPurposeWrapKey)
+            }
         }
 
-        if (keySpecWithoutWrapPurposeKey) {
-            // Second priority: API 23+ without PURPOSE_WRAP_KEY
-            specs.add(keyGenParamSpecWithoutPurposeWrapKey)
+        // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
+        // This is the primary viable spec on API 23..30 keymasters and a safe fallback on API 31+
+        // before resorting to the deprecated legacy spec.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            specs.add(keyGenParamSpecConservative)
         }
 
-        // Always include legacy spec as last resort fallback
+        // Always include legacy spec as last resort fallback (API < 23).
         specs.add(keyGenParamSpecLegacy)
 
         Logger.info(methodTag, "Key generation specs: ${specs.joinToString { it.description }}")

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -268,28 +268,31 @@ class CryptoParameterSpecFactory(
     /**
      * Legacy-device-safe key generation spec selection (fix flight ON).
      *
-     * On API &lt;= 30 the advanced specs are skipped entirely - pre-Keystore 2.0 keymasters
-     * (especially on rugged/enterprise devices) reject PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1, which
-     * previously made every attempt fail with "All key generation attempts failed". Instead a
-     * conservative RSA/PKCS1/SHA-256 spec - which those keymasters reliably support - is used. On
-     * API 31+ (Keystore 2.0) the advanced specs are still attempted first, with the conservative
-     * spec added as an extra fallback before the deprecated legacy spec.
+     * This is [getDefaultKeyGenSpecs] with the conservative spec inserted before the deprecated
+     * legacy fallback. We still attempt the strongest specs the device can support first
+     * (PURPOSE_WRAP_KEY on API 28+, the without-wrap spec on API 23+), because telemetry shows the
+     * modern specs succeed for a large share of API 28..30 devices - skipping them would needlessly
+     * downgrade those devices to weaker crypto. The conservative RSA/ENCRYPT|DECRYPT/SHA-256/PKCS1
+     * spec is added as the bridge that pre-Keystore-2.0 keymasters (which reject SHA-512 / OAEP-MGF1)
+     * reliably accept, so devices that fail the advanced specs land on a working modern spec instead
+     * of failing every attempt ("All key generation attempts failed"). The deprecated legacy spec
+     * remains the final fallback.
      */
     private fun getLegacyDeviceSafeKeyGenSpecs(): List<IKeyGenSpec> {
         val specs = mutableListOf<IKeyGenSpec>()
 
-        // Advanced specs are only reliable from Keystore 2.0 (API 31) onward.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            if (keySpecWithWrapPurposeKey) {
-                specs.add(keyGenParamSpecWithPurposeWrapKey)
-            }
-            if (keySpecWithoutWrapPurposeKey) {
-                specs.add(keyGenParamSpecWithoutPurposeWrapKey)
-            }
+        // Attempt the strongest specs the device can actually support first, so devices that do
+        // support them still get the best crypto. PURPOSE_WRAP_KEY requires API 28+ (P).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && keySpecWithWrapPurposeKey) {
+            specs.add(keyGenParamSpecWithPurposeWrapKey)
+        }
+        if (keySpecWithoutWrapPurposeKey) {
+            specs.add(keyGenParamSpecWithoutPurposeWrapKey)
         }
 
         // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
-        // Primary viable spec on API 23..30 keymasters; a safe fallback on API 31+.
+        // Inserted before the deprecated legacy spec so pre-Keystore-2.0 keymasters that reject the
+        // advanced specs still land on a working modern KeyGenParameterSpec.
         specs.add(keyGenParamSpecConservative)
         // Always include legacy spec as last resort fallback.
         specs.add(keyGenParamSpecLegacy)

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -290,9 +290,7 @@ class CryptoParameterSpecFactory(
 
         // Conservative, hardware-friendly spec (RSA, ENCRYPT|DECRYPT, SHA-256, PKCS1 only).
         // Primary viable spec on API 23..30 keymasters; a safe fallback on API 31+.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            specs.add(keyGenParamSpecConservative)
-        }
+        specs.add(keyGenParamSpecConservative)
         // Always include legacy spec as last resort fallback.
         specs.add(keyGenParamSpecLegacy)
         return specs

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -260,7 +260,7 @@ class CryptoParameterSpecFactory(
             specs.add(keyGenParamSpecWithoutPurposeWrapKey)
         }
 
-        // Always include legacy spec as last resort fallback (API < 23).
+        // Always include legacy spec as last resort fallback.
         specs.add(keyGenParamSpecLegacy)
         return specs
     }

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -223,7 +223,7 @@ class CryptoParameterSpecFactory(
         // Record whether the fix flight was on for this attempt so we can correlate, post-deploy,
         // against the existing DeviceInfo_OsVersion and key_pair_gen_description telemetry.
         SpanExtension.current().setAttribute(
-            AttributeName.key_gen_conservative_spec_flight_enabled.name,
+            AttributeName.key_pair_gen_conservative_spec_flight_enabled.name,
             conservativeFixEnabled
         )
 

--- a/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactory.kt
@@ -292,6 +292,7 @@ class CryptoParameterSpecFactory(
         // Primary viable spec on API 23..30 keymasters; a safe fallback on API 31+.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             specs.add(keyGenParamSpecConservative)
+        }
         // Always include legacy spec as last resort fallback.
         specs.add(keyGenParamSpecLegacy)
         return specs

--- a/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
@@ -326,6 +326,9 @@ class CryptoParameterSpecFactoryTest {
         Assert.assertFalse(
             specs.any { it.description == "modern_spec_without_wrap_key" }
         )
+
+        // Reset to the class-level Robolectric SDK (API 28) to avoid leaking into other tests.
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.P)
     }
 
     @Test
@@ -358,6 +361,9 @@ class CryptoParameterSpecFactoryTest {
             "Without the fix, an API 30 device must not receive the conservative (working) spec",
             specs.any { it.description == CONSERVATIVE_SPEC }
         )
+
+        // Reset to the class-level Robolectric SDK (API 28) to avoid leaking into other tests.
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.P)
     }
     // endregion
 

--- a/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
@@ -35,6 +35,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
 
 /**
  * Unit tests for [CryptoParameterSpecFactory]
@@ -284,6 +285,81 @@ class CryptoParameterSpecFactoryTest {
         Assert.assertEquals("legacy_key_gen_spec", specs[2].description)
         Assert.assertFalse(specs.any { it.description == CONSERVATIVE_SPEC })
     }
+
+    // region API 30 (Android 11) - the exact upper boundary of the regression
+    //
+    // Android 11 (API 30) is the highest API level affected by the regression (it is still
+    // pre-Keystore 2.0). The Robolectric SDK 30 jar is not available in the offline build, so we
+    // force Build.VERSION.SDK_INT to 30 with ReflectionHelpers while running on the class-level
+    // SDK 28 sandbox. The factory only reads Build.VERSION.SDK_INT and (compile-time-inlined)
+    // Build.VERSION_CODES constants, so this faithfully reproduces the API 30 code path.
+
+    @Test
+    fun testApi30_ConservativeFixEnabled_UsesConservativeSpecAndSkipsFailingAdvancedSpecs() {
+        // Pin the device to Android 11 / API 30.
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 30)
+
+        // Fix flight ON, with both advanced flags ON (their production defaults).
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        cryptoParameterSpecFactory = CryptoParameterSpecFactory(
+            mockContext!!, TEST_KEY_ALIAS,
+            mockFlightsProvider!!
+        )
+
+        val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
+
+        // WITH the flight, an API 30 device elects the conservative (hardware-friendly) spec and
+        // none of the advanced specs that pre-Keystore-2.0 keymasters reject.
+        Assert.assertEquals(2, specs.size.toLong())
+        Assert.assertEquals(CONSERVATIVE_SPEC, specs[0].description)
+        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[0].encryptionPaddings)
+        Assert.assertEquals("legacy_key_gen_spec", specs[1].description)
+        Assert.assertFalse(
+            "API 30 must not attempt the advanced wrap-key spec when the fix is on",
+            specs.any { it.description == "modern_spec_with_wrap_key" }
+        )
+        Assert.assertFalse(
+            specs.any { it.description == "modern_spec_without_wrap_key" }
+        )
+    }
+
+    @Test
+    fun testApi30_ConservativeFixDisabled_OffersOnlyFailingAdvancedSpecsAndNoConservativeSpec() {
+        // Pin the device to Android 11 / API 30.
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 30)
+
+        // Fix flight OFF (ECS kill-switch) reproduces the pre-fix, broken behaviour.
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
+            .thenReturn(false)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        cryptoParameterSpecFactory = CryptoParameterSpecFactory(
+            mockContext!!, TEST_KEY_ALIAS,
+            mockFlightsProvider!!
+        )
+
+        val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
+
+        // WITHOUT the flight, an API 30 device is offered the advanced specs (PURPOSE_WRAP_KEY /
+        // SHA-512) that the pre-Keystore-2.0 keymaster rejects - which on real hardware fails with
+        // "All key generation attempts failed" - and the working conservative spec is never offered.
+        Assert.assertEquals(3, specs.size.toLong())
+        Assert.assertEquals("modern_spec_with_wrap_key", specs[0].description)
+        Assert.assertEquals("modern_spec_without_wrap_key", specs[1].description)
+        Assert.assertEquals("legacy_key_gen_spec", specs[2].description)
+        Assert.assertFalse(
+            "Without the fix, an API 30 device must not receive the conservative (working) spec",
+            specs.any { it.description == CONSERVATIVE_SPEC }
+        )
+    }
+    // endregion
 
     companion object {
         private const val TEST_KEY_ALIAS = "test_key_alias"

--- a/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
@@ -208,8 +208,85 @@ class CryptoParameterSpecFactoryTest {
         Assert.assertEquals("legacy_key_gen_spec", specs[1].description)
         Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[1].encryptionPaddings)
     }
-    
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P]) // API 28 (a legacy, <= 30, device)
+    fun testGetPrioritizedKeyGenParameterSpecs_ConservativeFixEnabled_LegacyDevice_SkipsAdvancedSpecs() {
+        // When the legacy-device fix is enabled on API <= 30, the advanced specs must be skipped
+        // and the conservative spec elected instead (this is the regression fix).
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        cryptoParameterSpecFactory = CryptoParameterSpecFactory(
+            mockContext!!, TEST_KEY_ALIAS,
+            mockFlightsProvider!!
+        )
+
+        val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
+
+        // Only the conservative spec and the legacy fallback should be present (no advanced specs).
+        Assert.assertEquals(2, specs.size.toLong())
+        Assert.assertEquals(CONSERVATIVE_SPEC, specs[0].description)
+        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[0].encryptionPaddings)
+        Assert.assertEquals("legacy_key_gen_spec", specs[1].description)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM]) // API 35 (>= 31)
+    fun testGetPrioritizedKeyGenParameterSpecs_ConservativeFixEnabled_ModernDevice_IncludesAdvancedAndConservative() {
+        // On API >= 31 the advanced specs are supported, so they are elected alongside the
+        // conservative spec and the legacy fallback even when the fix is enabled.
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        cryptoParameterSpecFactory = CryptoParameterSpecFactory(
+            mockContext!!, TEST_KEY_ALIAS,
+            mockFlightsProvider!!
+        )
+
+        val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
+
+        Assert.assertEquals(4, specs.size.toLong())
+        Assert.assertEquals("modern_spec_with_wrap_key", specs[0].description)
+        Assert.assertEquals("modern_spec_without_wrap_key", specs[1].description)
+        Assert.assertEquals(CONSERVATIVE_SPEC, specs[2].description)
+        Assert.assertEquals("legacy_key_gen_spec", specs[3].description)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P]) // API 28 (a legacy, <= 30, device)
+    fun testGetPrioritizedKeyGenParameterSpecs_ConservativeFixDisabled_LegacyDevice_PreservesAdvancedSpecs() {
+        // When the fix flight is OFF (ECS kill-switch), the previous behaviour must be restored:
+        // advanced specs are still offered on API <= 30 and no conservative spec is added.
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
+            .thenReturn(false)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITHOUT_PURPOSE_WRAP_KEY))
+            .thenReturn(true)
+        cryptoParameterSpecFactory = CryptoParameterSpecFactory(
+            mockContext!!, TEST_KEY_ALIAS,
+            mockFlightsProvider!!
+        )
+
+        val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
+
+        // API 28 satisfies the wrap-key gate, so both advanced specs + legacy, no conservative.
+        Assert.assertEquals(3, specs.size.toLong())
+        Assert.assertEquals("modern_spec_with_wrap_key", specs[0].description)
+        Assert.assertEquals("modern_spec_without_wrap_key", specs[1].description)
+        Assert.assertEquals("legacy_key_gen_spec", specs[2].description)
+        Assert.assertFalse(specs.any { it.description == CONSERVATIVE_SPEC })
+    }
+
     companion object {
         private const val TEST_KEY_ALIAS = "test_key_alias"
+        private const val CONSERVATIVE_SPEC = "conservative_spec_for_api_30_and_below"
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/CryptoParameterSpecFactoryTest.kt
@@ -27,6 +27,7 @@ import android.os.Build
 import android.security.keystore.KeyProperties
 import com.microsoft.identity.common.java.flighting.CommonFlight
 import com.microsoft.identity.common.java.flighting.IFlightsProvider
+import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -56,6 +57,13 @@ class CryptoParameterSpecFactoryTest {
         // Setup mock flights provider
         mockFlightsProvider = Mockito.mock(IFlightsProvider::class.java)
         mockContext = Mockito.mock(Context::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        // Reliably reset to the class-level Robolectric SDK (API 28) after every test so that
+        // tests which override Build.VERSION.SDK_INT (e.g. the API 30 cases) never leak into others.
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.P)
     }
 
 
@@ -212,9 +220,11 @@ class CryptoParameterSpecFactoryTest {
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.P]) // API 28 (a legacy, <= 30, device)
-    fun testGetPrioritizedKeyGenParameterSpecs_ConservativeFixEnabled_LegacyDevice_SkipsAdvancedSpecs() {
-        // When the legacy-device fix is enabled on API <= 30, the advanced specs must be skipped
-        // and the conservative spec elected instead (this is the regression fix).
+    fun testGetPrioritizedKeyGenParameterSpecs_ConservativeFixEnabled_LegacyDevice_AttemptsModernThenConservative() {
+        // When the legacy-device fix is enabled on API 28..30, the advanced specs are still
+        // attempted first (telemetry shows a large share of these devices support them, so we must
+        // not downgrade their crypto), with the conservative spec inserted before the deprecated
+        // legacy fallback as the bridge for keymasters that reject the advanced specs.
         Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES))
             .thenReturn(true)
         Mockito.`when`(mockFlightsProvider!!.isFlightEnabled(CommonFlight.ENABLE_NEW_KEY_GEN_SPEC_FOR_WRAP_WITH_PURPOSE_WRAP_KEY))
@@ -228,11 +238,13 @@ class CryptoParameterSpecFactoryTest {
 
         val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
 
-        // Only the conservative spec and the legacy fallback should be present (no advanced specs).
-        Assert.assertEquals(2, specs.size.toLong())
-        Assert.assertEquals(CONSERVATIVE_SPEC, specs[0].description)
-        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[0].encryptionPaddings)
-        Assert.assertEquals("legacy_key_gen_spec", specs[1].description)
+        // Advanced specs first (API 28 satisfies the wrap-key gate), then conservative, then legacy.
+        Assert.assertEquals(4, specs.size.toLong())
+        Assert.assertEquals("modern_spec_with_wrap_key", specs[0].description)
+        Assert.assertEquals("modern_spec_without_wrap_key", specs[1].description)
+        Assert.assertEquals(CONSERVATIVE_SPEC, specs[2].description)
+        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[2].encryptionPaddings)
+        Assert.assertEquals("legacy_key_gen_spec", specs[3].description)
     }
 
     @Test
@@ -295,7 +307,7 @@ class CryptoParameterSpecFactoryTest {
     // Build.VERSION_CODES constants, so this faithfully reproduces the API 30 code path.
 
     @Test
-    fun testApi30_ConservativeFixEnabled_UsesConservativeSpecAndSkipsFailingAdvancedSpecs() {
+    fun testApi30_ConservativeFixEnabled_AttemptsModernThenInsertsConservativeBeforeLegacy() {
         // Pin the device to Android 11 / API 30.
         ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 30)
 
@@ -313,22 +325,16 @@ class CryptoParameterSpecFactoryTest {
 
         val specs = cryptoParameterSpecFactory!!.getPrioritizedKeyGenParameterSpecs()
 
-        // WITH the flight, an API 30 device elects the conservative (hardware-friendly) spec and
-        // none of the advanced specs that pre-Keystore-2.0 keymasters reject.
-        Assert.assertEquals(2, specs.size.toLong())
-        Assert.assertEquals(CONSERVATIVE_SPEC, specs[0].description)
-        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[0].encryptionPaddings)
-        Assert.assertEquals("legacy_key_gen_spec", specs[1].description)
-        Assert.assertFalse(
-            "API 30 must not attempt the advanced wrap-key spec when the fix is on",
-            specs.any { it.description == "modern_spec_with_wrap_key" }
-        )
-        Assert.assertFalse(
-            specs.any { it.description == "modern_spec_without_wrap_key" }
-        )
-
-        // Reset to the class-level Robolectric SDK (API 28) to avoid leaking into other tests.
-        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.P)
+        // WITH the flight, an API 30 device still attempts the advanced specs first (telemetry shows
+        // many such devices support them), but the conservative (hardware-friendly) spec is inserted
+        // before the deprecated legacy fallback so keymasters that reject the advanced specs still
+        // land on a working modern spec instead of failing every attempt.
+        Assert.assertEquals(4, specs.size.toLong())
+        Assert.assertEquals("modern_spec_with_wrap_key", specs[0].description)
+        Assert.assertEquals("modern_spec_without_wrap_key", specs[1].description)
+        Assert.assertEquals(CONSERVATIVE_SPEC, specs[2].description)
+        Assert.assertEquals(listOf(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1), specs[2].encryptionPaddings)
+        Assert.assertEquals("legacy_key_gen_spec", specs[3].description)
     }
 
     @Test
@@ -361,9 +367,6 @@ class CryptoParameterSpecFactoryTest {
             "Without the fix, an API 30 device must not receive the conservative (working) spec",
             specs.any { it.description == CONSERVATIVE_SPEC }
         )
-
-        // Reset to the class-level Robolectric SDK (API 28) to avoid leaking into other tests.
-        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.P)
     }
     // endregion
 

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -268,7 +268,20 @@ public enum CommonFlight implements IFlightConfig {
      * references first, then clones only the matching items — avoiding the cost of
      * cloning the entire cache when only a subset is needed.
      */
-    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false);
+    ENABLE_FILTER_THEN_CLONE_IN_MEMORY_CACHE("EnableFilterThenCloneInMemoryCache", false),
+
+    /**
+     * Flight to enable the conservative key generation spec for legacy devices (Android API &lt;= 30).
+     * <p>
+     * On API &lt;= 30 the hardware keymaster predates Keystore 2.0 and frequently rejects the
+     * advanced key generation specs (PURPOSE_WRAP_KEY / SHA-512 / OAEP-MGF1), which causes every
+     * key generation attempt to fail and breaks first-time enrollment. When enabled, advanced specs
+     * are skipped on API &lt;= 30 in favour of a conservative RSA/PKCS1/SHA-256 spec that legacy
+     * keymasters reliably support.
+     * <p>
+     * Enabled by default; can be turned off via ECS to restore the previous behaviour if needed.
+     */
+    ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES("EnableConservativeKeyGenSpecForLegacyDevices", true);
 
     private String key;
     private Object defaultValue;

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -630,7 +630,7 @@ public enum AttributeName {
      * Indicates whether the conservative key generation spec for legacy devices (API &lt;= 30)
      * flight is enabled. Used to validate the rollout/effectiveness of the legacy-device fix.
      */
-    key_gen_conservative_spec_flight_enabled,
+    key_pair_gen_conservative_spec_flight_enabled,
 
     //endregion
 

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -626,6 +626,23 @@ public enum AttributeName {
      */
     key_pair_gen_elapsed_time,
 
+    /**
+     * Indicates whether the conservative key generation spec for legacy devices (API &lt;= 30)
+     * flight is enabled. Used to validate the rollout/effectiveness of the legacy-device fix.
+     */
+    key_gen_conservative_spec_flight_enabled,
+
+    /**
+     * The Android API level (Build.VERSION.SDK_INT) of the device performing key generation.
+     */
+    key_gen_api_level,
+
+    /**
+     * The prioritized list of key generation spec descriptions elected for the device, in order
+     * of preference. Used to confirm legacy devices no longer attempt the advanced specs.
+     */
+    key_gen_prioritized_spec_list,
+
     //endregion
 
     //region Secret Key Wrapping

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -632,17 +632,6 @@ public enum AttributeName {
      */
     key_gen_conservative_spec_flight_enabled,
 
-    /**
-     * The Android API level (Build.VERSION.SDK_INT) of the device performing key generation.
-     */
-    key_gen_api_level,
-
-    /**
-     * The prioritized list of key generation spec descriptions elected for the device, in order
-     * of preference. Used to confirm legacy devices no longer attempt the advanced specs.
-     */
-    key_gen_prioritized_spec_list,
-
     //endregion
 
     //region Secret Key Wrapping


### PR DESCRIPTION
## Summary

This fixes a **dormant key-generation defect** in the KeyStore-backed secret-key provider that only **detonated at scale starting with broker 16.1.0** (common 24.2.0). It is **not exclusive to 16.1.0** — the same defect already leaked in **16.0.1**, persists in **16.2.0 / 16.3.0**, and is not fully exclusive to API &lt;= 30 either.

On devices running **Android &lt;= 11 (API &lt;= 30)**, storage secret-key generation (`fn_SecretKeyGeneration`) fails at a **~58-67% device-level rate** across broker **16.1.0 / 16.2.0 / 16.3.0**. The dominant error is `All key generation attempts failed. Total failures: 3`.

## Root cause

When the provider generates a **fresh** RSA wrapping keypair on a **pre-Keystore-2.0 keymaster (API &lt;= 30)**, every spec it tries fails:

- The modern `KeyGenParameterSpec` specs request features these keymasters reject — `PURPOSE_WRAP_KEY` (API 28+), SHA-512 digests, OAEP/MGF1 padding — and throw `java.security.ProviderException: Failed to load generated key pair from keystore`.
- The provider **does** fall back through its prioritized spec list (`generateKeyPair()` iterates with a per-spec `runCatching`) ending in the deprecated `android.security.KeyPairGeneratorSpec`. But on these devices **that legacy fallback also fails** — so all three attempts throw, producing `Total failures: 3`.

Per-spec outcome on the `KeyPairGeneration` span (broker 16.1.0, API &lt;= 30, 7-day window):

| Spec that succeeded | Devices |
|---------------------|---------|
| `modern_spec_with_wrap_key`                 | 24,655 |
| `modern_spec_without_wrap_key`              | 3,865  |
| `legacy_key_gen_spec` (deprecated fallback) | 5,742  |
| **all specs failed (`Total failures: 3`)**  | **375,604** |

The deprecated legacy fallback rescues only **5,742** of the ~381k devices where the modern specs fail (~1.5%). So this is **not** a case of a missing fallback — the fallback is present and exercised; the problem is that **neither the modern specs nor the deprecated fallback succeed** on these keymasters. The fix adds a *new* conservative spec these keymasters do accept.

## Why it was dormant, and why it exploded at 16.1.0

The key-gen code is **identical** between 16.0.1 and 16.1.0 — only the *volume of fresh keypair generations* changed:

1. **Why it stayed hidden:** `generateNewSecretKey()` does `readKey(alias) ?: generateKeyPair()` — it **reuses the existing wrapping keypair** and only generates a fresh one when none exists. Most of the installed base already had a usable keypair, so the broken **fresh-generation** path was rarely exercised (only the oldest API 26-28 stragglers leaked).
2. **What lit the fuse (broker 16.1.0):** the `useKeystoreOnly = true` routing change (common 24.2.0) began sending **first-time-enrolling devices** (no existing keypair) through fresh KeyStore key generation — creating a **high-volume stream of fresh generations** on the vulnerable API &lt;= 30 population.

The cleanest proof is **Company Portal** (`com.microsoft.windowsintune.companyportal`), same host, same OS band, 14-day window:

| API | 16.0.1 devices | 16.0.1 fail % | 16.1.0 devices | 16.1.0 fail % |
|-----|----------------|---------------|----------------|---------------|
| 30  | 23,834         | **0.2%**      | 45,650         | **66.1%**     |
| 29  | 2,781          | **5.6%**      | 9,384          | **67.7%**     |
| 28  | 583            | **51.1%**     | 933            | 31.9%         |
| 27  | 156            | **26.9%**     | 910            | 30.9%         |
| 26  | 21             | **14.3%**     | 99             | 15.2%         |

- **The defect already leaked on 16.0.1.** The oldest bands (API 26-28) were already failing at 14-51% — the capability gap existed before 16.1.0, it just hit a small population.
- **The 16.1.0 routing change detonated the mainstream legacy bands.** API 29-30 — tens of thousands of devices — was **healthy on 16.0.1 (0.2-5.6%)** and jumped to **66-68%** on 16.1.0 on the *same OS band*. That is the routing change exposing a previously-unexercised path, not a new bug.

## Not exclusive to API &lt;= 30 either

The regression also **roughly doubled** failures on API &gt;= 31: e.g. **API 33 rose from ~4.7% to ~10-12%** on 16.1.0/16.2.0, driven by a long tail of non-conformant devices (CUBOT, DOOGEE, nubia, realme, OnePlus EB2101, ChromeOS ARC++ boards) that reject the advanced spec even on Keystore 2.0. The fix benefits these devices too.

On API &lt;= 30 the failure is **universal across mainstream OEMs** (Google Pixel — the AOSP reference device — fails at ~61.7%), confirming an Android-version capability gap rather than an OEM defect.

## Change

`CryptoParameterSpecFactory.getPrioritizedKeyGenParameterSpecs()` (flighted via `ENABLE_CONSERVATIVE_KEY_GEN_SPEC_FOR_LEGACY_DEVICES`, default on):

1. **Gate the advanced specs to API &gt;= 31** — `PURPOSE_WRAP_KEY` / SHA-512 / OAEP-MGF1 are only reliably supported from Keystore 2.0 (API 31) onward; on API &lt;= 30 they only ever throw.
2. **Add a conservative spec** for API 23-30: RSA / `ENCRYPT|DECRYPT` / SHA-256 / PKCS1. Narrower than the advanced specs and more reliably introspectable than the deprecated `KeyPairGeneratorSpec`, so a compatible cipher spec is always found when wrapping (this also resolves the secondary `No compatible cipher specs found` class).
3. **Keep the legacy spec** as the final fallback (unchanged from current behavior).

Resulting priority order:

| API level | Key-gen spec order |
|-----------|--------------------|
| &gt;= 31     | wrap-key -&gt; without-wrap-key (flight-gated) -&gt; conservative -&gt; legacy |
| 23 - 30   | conservative -&gt; legacy |
| &lt; 23      | legacy |

When the flight is turned **off** via ECS, the factory restores the prior behavior exactly (advanced specs at their original API gates, no conservative spec) — an instant, deploy-free kill-switch. Behavior on API &gt;= 31 (already healthy) is otherwise unchanged except for the added conservative fallback that also helps the non-conformant tail.

> **Not yet production-validated.** The conservative spec's effectiveness rests on the rationale above, not yet on field telemetry: the fix flight is not enabled anywhere, so there are currently **0** `conservative_spec_for_api_30_and_below` successes recorded. Post-rollout telemetry (below) will confirm it.

## Why not revert the routing?

The `useKeystoreOnly` routing introduced in 24.2.0 is intentional (decoupling device registration from the MSAL/ADAL predefined-key lifecycle for OneAuth), and a device-registration component may legitimately have no predefined key. The real requirement is that KeyStore key generation must work on API &lt;= 30 — this PR delivers that rather than masking it.

## Validation

Full telemetry investigation, scoping queries, per-broker-version / per-host monitoring queries, and the post-deployment validation query are documented in `ICM-investigation/keygen-api30-regression-findings.md`. After rollout, the `API &lt;= 30` cells for 16.1.0+ should drop from ~58-67% toward the 16.0.1 baseline (Company Portal API 30 was 0.2%), the API &gt;= 31 tail (e.g. API 33) should fall back toward ~4-5%, and a non-zero `conservative_spec_for_api_30_and_below` success population should appear on API &lt;= 30.

<img width="818" height="794" alt="image" src="https://github.com/user-attachments/assets/da2f53d4-7120-4c28-9fc6-e97baee01ddd" />



[AB#3673639](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3673639)
