### PR TITLE
Add moshi adapter dependency, Fixes AB#3673534

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3673534)
 
 Version 24.4.0
 ----------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3673534)
+- [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
 
 Version 24.4.0
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -233,6 +233,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "com.squareup.moshi:moshi:$rootProject.ext.moshiVersion"
+    implementation "com.squareup.moshi:moshi-adapters:$rootProject.ext.moshiAdaptersVersion"
     implementation "androidx.browser:browser:$rootProject.ext.browserVersion"
     implementation "androidx.core:core:$rootProject.ext.androidxCoreVersion"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"


### PR DESCRIPTION
Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly. 

Moshi is used device registration API IPC serialization. OneAuth is soon going call device registration APIs.

Fixes [AB#3673534](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3673534)