### PR TITLE
Record root-cause telemetry on KeyStore secret-key wipes to diagnose cache-wipe data loss, Fixes AB#3679391

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Fix KeyStore key generation failures on API <= 30 by adding a conservative RSA/PKCS1/SHA-256 spec (ECS kill-switch flighted) (#3167)
 - [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
 - [PATCH] Harden Authority.isKnownAuthority() to use exact, case-insensitive host matching for developer-configured known authorities (#3165)
+- [PATCH] Record root-cause telemetry (secret_key_wipe_reason, secret_key_read_root_cause, keystore_numeric_error_code, keystore_error_transience) on KeyStore secret-key wipes/re-keys to diagnose cache-wipe data loss, without changing wipe behavior (#3174)
 
 Version 24.4.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/crypto/KeyStoreBackedSecretKeyProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/crypto/KeyStoreBackedSecretKeyProvider.kt
@@ -36,9 +36,12 @@ import com.microsoft.identity.common.java.opentelemetry.SpanExtension
 import com.microsoft.identity.common.java.opentelemetry.SpanName
 import com.microsoft.identity.common.java.util.FileUtil
 import com.microsoft.identity.common.logging.Logger
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode
 import java.io.File
 import java.security.KeyPair
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 import javax.crypto.SecretKey
@@ -74,10 +77,38 @@ class KeyStoreBackedSecretKeyProvider(
         @VisibleForTesting
         const val KEY_FILE_SIZE: Int = 1024
 
+        /** [AttributeName.secret_key_wipe_reason]: wrapped-key file present but its keystore key is gone. */
+        private const val WIPE_REASON_KEYSTORE_KEY_ABSENT_ORPHANED_FILE: String =
+            "keystore_key_absent_orphaned_file"
+
+        /** [AttributeName.secret_key_wipe_reason]: unrecoverable error while reading existing key material. */
+        private const val WIPE_REASON_LOAD_ERROR: String = "load_error"
+
+        /** [AttributeName.secret_key_wipe_reason]: wrapped-key file exists but is empty (silent re-key). */
+        private const val WIPE_REASON_EMPTY_KEY_FILE_REKEY: String = "empty_key_file_rekey"
+
         /**
          * SecretKey cache. Maps wrapped secret key file path to the SecretKey.
          */
         private val sKeyCacheMap: ConcurrentMap<String, SecretKey> = ConcurrentHashMap()
+
+        /**
+         * Walks [throwable]'s cause chain down to its root cause and returns it. Identity tracking
+         * guarantees termination even for self-referential or multi-node cause cycles, so no depth
+         * cap is needed.
+         */
+        @VisibleForTesting
+        fun findRootCause(throwable: Throwable): Throwable {
+            val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+            var current = throwable
+            seen.add(current)
+            var next = current.cause
+            while (next != null && seen.add(next)) {
+                current = next
+                next = current.cause
+            }
+            return current
+        }
     }
 
     override val keyTypeIdentifier = KEY_TYPE_IDENTIFIER
@@ -230,38 +261,107 @@ class KeyStoreBackedSecretKeyProvider(
     @Throws(ClientException::class)
     fun readSecretKeyFromStorage(): SecretKey? {
         val methodTag = "$TAG:readSecretKeyFromStorage"
-        try {
-            // Load KeyPair from Android KeyStore
-            val keyPair = AndroidKeyStoreUtil.readKey(alias) ?: run {
-                Logger.info(methodTag, "key does not exist in keystore")
+        val span = OTelUtility.createSpanFromParent(
+            SpanName.SecretKeyRetrieval.name,
+            SpanExtension.current().spanContext
+        )
+        SpanExtension.makeCurrentSpan(span).use { _ ->
+            try {
+                // Load KeyPair from Android KeyStore
+                val keyPair = AndroidKeyStoreUtil.readKey(alias) ?: run {
+                    Logger.info(methodTag, "key does not exist in keystore")
+                    // Orphaned wrapped-key file with no keystore key = discarding undecryptable data,
+                    // so record it. No file = legitimate first-time read, not recorded.
+                    if (keyFile.exists()) {
+                        recordWipe(span, WIPE_REASON_KEYSTORE_KEY_ABSENT_ORPHANED_FILE)
+                    }
+                    deleteSecretKeyFromStorage()
+                    span.setStatus(StatusCode.OK)
+                    return null
+                }
+                // Load wrapped secret key from file
+                val rawWrappedSecretKey = readRawWrappedSecretKeyFromFile() ?: run {
+                    Logger.warn(methodTag, "Key file is empty")
+                    // Do not delete the KeyStoreKeyPair even if the key file is empty. This caused credential cache
+                    // to be deleted in Office because of sharedUserId allowing keystore to be shared amongst apps.
+                    // An existing-but-empty file is a silent re-key of undecryptable data, so record it; an absent
+                    // file is the legitimate first-time / sharedUserId read and is not recorded.
+                    if (keyFile.exists()) {
+                        recordWipe(span, WIPE_REASON_EMPTY_KEY_FILE_REKEY)
+                    }
+                    FileUtil.deleteFile(keyFile)
+                    clearKeyFromCache()
+                    span.setStatus(StatusCode.OK)
+                    return null
+                }
+                // Deserialize and unwrap the secret key
+                val secretKey = deserializeAndUnwrapSecretKey(rawWrappedSecretKey, keyPair)
+                span.setStatus(StatusCode.OK)
+                return secretKey
+            } catch (e: ClientException) {
+                // Reset KeyPair info so that new request will generate correct KeyPairs.
+                // All tokens with previous SecretKey are not possible to decrypt.
+                Logger.warn(
+                    methodTag, "Error when loading key from Storage, " +
+                            "wipe all existing key data "
+                )
+                recordWipe(span, WIPE_REASON_LOAD_ERROR, e)
+                span.setStatus(StatusCode.ERROR)
+                span.recordException(e)
                 deleteSecretKeyFromStorage()
-                return null
+                throw e
+            } catch (e: Exception) {
+                // Non-ClientException failures are recorded but not wiped (only ClientException wipes).
+                span.setStatus(StatusCode.ERROR)
+                span.recordException(e)
+                throw e
+            } finally {
+                span.end()
             }
-            // Load wrapped secret key from file
-            val rawWrappedSecretKey = readRawWrappedSecretKeyFromFile() ?: run {
-                Logger.warn(methodTag, "Key file is empty")
-                // Do not delete the KeyStoreKeyPair even if the key file is empty. This caused credential cache
-                // to be deleted in Office because of sharedUserId allowing keystore to be shared amongst apps.
-                FileUtil.deleteFile(keyFile)
-                clearKeyFromCache()
-                return null
+        }
+    }
+
+    /**
+     * Records telemetry for a genuine wipe / silent re-key of EXISTING secret-key material onto the
+     * current [SpanName.SecretKeyRetrieval] span. Never called for legitimate first-time reads. Any
+     * failure here is swallowed so telemetry can never break the read/wipe path.
+     *
+     * @param span the active SecretKeyRetrieval span.
+     * @param reason a stable identifier for which check triggered the wipe.
+     * @param exception the failure that triggered the wipe, when caused by an exception.
+     */
+    private fun recordWipe(span: Span, reason: String, exception: ClientException? = null) {
+        try {
+            span.setAttribute(AttributeName.secret_key_wipe_reason.name, reason)
+            if (exception != null) {
+                // Record the true root cause, not the generic ClientException wrapper.
+                val rootCause = findRootCause(exception)
+                span.setAttribute(
+                    AttributeName.secret_key_read_root_cause.name,
+                    "${rootCause.javaClass.simpleName}: ${rootCause.message ?: "null"}"
+                )
+                // Exact platform error code, when a KeyStoreException is present (API 33+).
+                AndroidKeyStoreUtil.getKeyStoreExceptionNumericErrorCode(exception)?.let { numericCode ->
+                    span.setAttribute(AttributeName.keystore_numeric_error_code.name, numericCode)
+                }
+                // Whether the failure is transient/permanent (API 33+) so a retryable error is
+                // distinguishable from genuine data loss.
+                span.setAttribute(
+                    AttributeName.keystore_error_transience.name,
+                    AndroidKeyStoreUtil.getKeyStoreErrorTransience(exception).name
+                )
             }
-            // Deserialize and unwrap the secret key
-            return deserializeAndUnwrapSecretKey(rawWrappedSecretKey, keyPair)
-        } catch (e: ClientException) {
-            // Reset KeyPair info so that new request will generate correct KeyPairs.
-            // All tokens with previous SecretKey are not possible to decrypt.
-            Logger.warn(
-                methodTag, "Error when loading key from Storage, " +
-                        "wipe all existing key data "
-            )
-            deleteSecretKeyFromStorage()
-            throw e
+        } catch (e: Exception) {
+            Logger.warn("$TAG:recordWipe", "Failed to record wipe telemetry: ${e.message}")
         }
     }
 
     /**
      * Deserializes the raw wrapped secret key data and unwraps it using the provided KeyPair.
+     *
+     * Runs under the [SpanName.SecretKeyRetrieval] span created by [readSecretKeyFromStorage]. Telemetry
+     * recorded here (and inside [WrappedSecretKey]) via [SpanExtension.current] therefore lands on that
+     * span, and any failure propagates to [readSecretKeyFromStorage] where the wipe is recorded.
      *
      * @param rawWrappedSecretKey The raw byte array of the wrapped secret key.
      * @param keyPair The KeyPair used to unwrap the secret key.
@@ -272,31 +372,9 @@ class KeyStoreBackedSecretKeyProvider(
         rawWrappedSecretKey: ByteArray,
         keyPair: KeyPair
     ): SecretKey {
-        val methodTag = "$TAG:deserializeAndUnwrapSecretKey"
-        val span = OTelUtility.createSpanFromParent(
-            SpanName.SecretKeyRetrieval.name,
-            SpanExtension.current().spanContext
-        )
-        SpanExtension.makeCurrentSpan(span).use { _ ->
-            try {
-                val wrappedSecretKey = WrappedSecretKey.deserialize(rawWrappedSecretKey)
-                recordSecretKey(wrappedSecretKey)
-                val secretKey = unwrapSecretKey(wrappedSecretKey, keyPair)
-                span.setStatus(StatusCode.OK)
-                return secretKey
-            } catch (exception: Exception) {
-                Logger.error(
-                    methodTag,
-                    "Failed to deserialize and unwrap secret key",
-                    exception
-                )
-                span.setStatus(StatusCode.ERROR)
-                span.recordException(exception)
-                throw exception
-            } finally {
-                span.end()
-            }
-        }
+        val wrappedSecretKey = WrappedSecretKey.deserialize(rawWrappedSecretKey)
+        recordSecretKey(wrappedSecretKey)
+        return unwrapSecretKey(wrappedSecretKey, keyPair)
     }
 
     /**

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -49,7 +49,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -615,7 +614,8 @@ public class AndroidKeyStoreUtil {
      * @return List of supported padding names (e.g., "PKCS1", "OAEP"),
      *         or empty list on API < 23 or if retrieval fails
      */
-    public static synchronized List<String> getKeyPairEncryptionPaddings(@NonNull final KeyPair keyPair) {
+    public static synchronized List<String> getKeyPairEncryptionPaddings(@NonNull final KeyPair keyPair)
+        throws ClientException {
         final String methodTag = TAG + ":getKeyPairEncryptionPaddings";
         try {
             final PrivateKey privateKey = keyPair.getPrivate();
@@ -630,8 +630,14 @@ public class AndroidKeyStoreUtil {
             Logger.info(methodTag, "Supported encryption paddings: " + encryptionPaddings);
             return encryptionPaddings;
         } catch (final Exception e) {
+            // Do NOT swallow the failure. Propagate with the cause preserved so callers (and the wipe
+            // telemetry they feed) can see the real KeyStoreException in the cause chain.
             Logger.warn(methodTag, "Failed to retrieve key padding information" + ": " + e.getMessage());
+            throw new ClientException(
+                    UNKNOWN_CRYPTO_ERROR,
+                    "Failed to retrieve key pair encryption paddings: " + e.getMessage(),
+                    e
+            );
         }
-        return Collections.emptyList();
     }
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtil.java
@@ -546,6 +546,66 @@ public class AndroidKeyStoreUtil {
     }
 
     /**
+     * Extracts the exact numeric error code from an {@link android.security.KeyStoreException} found in
+     * the causal chain of the given throwable, if present. This is the most precise error identifier
+     * available for KeyStore failures, distinguishing transient from permanent causes where the
+     * higher-level {@link ClientException} error code cannot.
+     *
+     * @param throwable the throwable to inspect.
+     * @return the numeric error code as a String, or {@code null} when no KeyStoreException is found or
+     *         the API level is below 33 (where the numeric code is unavailable).
+     */
+    public static @Nullable String getKeyStoreExceptionNumericErrorCode(@NonNull final Throwable throwable) {
+        // getNumericErrorCode() is only available on API 33+. Keep the SDK_INT check inline (rather than
+        // relying on findKeyStoreException's internal guard) so lint's NewApi flow analysis is satisfied.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            final android.security.KeyStoreException keyStoreException = findKeyStoreException(throwable);
+            if (keyStoreException != null) {
+                return String.valueOf(keyStoreException.getNumericErrorCode());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a KeyStore failure is transient (worth retrying) or permanent. Lets callers distinguish
+     * recoverable failures from genuine data loss when a secret-key wipe is triggered.
+     */
+    public enum KeyStoreErrorTransience {
+        /** API 33+: KeyStoreException reported the failure as transient (a retry may succeed). */
+        TRANSIENT,
+        /** API 33+: KeyStoreException reported the failure as permanent (a retry will not help). */
+        NOT_TRANSIENT,
+        /** API < 33: transience cannot be determined (KeyStoreException.isTransientFailure() unavailable). */
+        API_TOO_OLD,
+        /** API 33+: no KeyStoreException in the cause chain, so the failure is not a KeyStore error. */
+        NOT_KEYSTORE_ERROR
+    }
+
+    /**
+     * Classifies whether the KeyStore failure in the given throwable's cause chain is transient or
+     * permanent, using {@link android.security.KeyStoreException#isTransientFailure()} (API 33+).
+     * This is more precise than the higher-level {@link ClientException} error code, which cannot
+     * distinguish a retryable failure from one that warrants discarding key material.
+     *
+     * @param throwable the throwable to inspect.
+     * @return one of {@link KeyStoreErrorTransience}; never {@code null}.
+     */
+    public static @NonNull KeyStoreErrorTransience getKeyStoreErrorTransience(@NonNull final Throwable throwable) {
+        // isTransientFailure()/KeyStoreException are only available on API 33+.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return KeyStoreErrorTransience.API_TOO_OLD;
+        }
+        final android.security.KeyStoreException keyStoreException = findKeyStoreException(throwable);
+        if (keyStoreException == null) {
+            return KeyStoreErrorTransience.NOT_KEYSTORE_ERROR;
+        }
+        return keyStoreException.isTransientFailure()
+                ? KeyStoreErrorTransience.TRANSIENT
+                : KeyStoreErrorTransience.NOT_TRANSIENT;
+    }
+
+    /**
      * Returns encryption paddings supported by a KeyStore key pair.
      * <p>
      * Extracts supported padding schemes from the key's metadata on API 23+.

--- a/common/src/test/java/com/microsoft/identity/common/crypto/KeyStoreBackedSecretKeyProviderTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/crypto/KeyStoreBackedSecretKeyProviderTest.kt
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.crypto
+
+import com.microsoft.identity.common.java.exception.ClientException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Tests for the wipe-telemetry root-cause resolution used by
+ * [KeyStoreBackedSecretKeyProvider.readSecretKeyFromStorage]. These verify that the real underlying
+ * failure (not the generic [ClientException] wrapper) is recovered, that the full cause message is
+ * preserved, and that pathological cause chains cannot crash or hang the read/wipe path.
+ */
+class KeyStoreBackedSecretKeyProviderTest {
+
+    /**
+     * A [Throwable] whose cause can be redirected to any node (including itself), used to build
+     * self-referential and multi-node cause cycles that a normal [Throwable.initCause] forbids.
+     */
+    private class LoopingThrowable(message: String) : Throwable(message) {
+        var link: Throwable? = null
+        override val cause: Throwable? get() = link
+    }
+
+    @Test
+    fun findRootCause_returnsThrowableItself_whenNoCause() {
+        val solo = ClientException("io_error", "no wrapped cause")
+
+        assertSame(solo, KeyStoreBackedSecretKeyProvider.findRootCause(solo))
+    }
+
+    @Test
+    fun findRootCause_returnsDeepestCause_forNestedChain() {
+        val root = IllegalStateException("keystore hardware unavailable")
+        val middle = RuntimeException("unwrap failed", root)
+        val wrapper = ClientException("failed_to_load_key", "generic wrapper message", middle)
+
+        assertSame(root, KeyStoreBackedSecretKeyProvider.findRootCause(wrapper))
+    }
+
+    @Test
+    fun findRootCause_preservesFullRootCauseMessage() {
+        // Longer than the previously-hardcoded 256-char cap to prove the message is no longer truncated.
+        val longMessage = "x".repeat(1024)
+        val root = IllegalStateException(longMessage)
+        val wrapper = ClientException("failed_to_load_key", "wrapper", root)
+
+        val rootCause = KeyStoreBackedSecretKeyProvider.findRootCause(wrapper)
+
+        assertEquals(longMessage, rootCause.message)
+    }
+
+    @Test(timeout = 5_000)
+    fun findRootCause_terminates_onSelfReferentialCause() {
+        val self = LoopingThrowable("self-caused")
+        self.link = self
+
+        assertSame(self, KeyStoreBackedSecretKeyProvider.findRootCause(self))
+    }
+
+    @Test(timeout = 5_000)
+    fun findRootCause_terminates_onMultiNodeCycle() {
+        val a = LoopingThrowable("A")
+        val b = LoopingThrowable("B")
+        a.link = b
+        b.link = a
+
+        // Must terminate (guarded by timeout) and return the last unvisited node before the cycle closes.
+        assertSame(b, KeyStoreBackedSecretKeyProvider.findRootCause(a))
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
@@ -44,6 +44,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -416,85 +417,122 @@ public class AndroidKeyStoreUtilTest {
 
     @Test
     @Config(sdk = Build.VERSION_CODES.M) // API 23
-    public void testGetKeyPairEncryptionPaddings_ModernAPI_KeyFactoryException_ReturnsEmptyList() {
+    public void testGetKeyPairEncryptionPaddings_ModernAPI_KeyFactoryException_ThrowsClientExceptionPreservingCause() {
         // Arrange
+        final NoSuchAlgorithmException cause = new NoSuchAlgorithmException("Algorithm not found");
         try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
             keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
-                    .thenThrow(new NoSuchAlgorithmException("Algorithm not found"));
+                    .thenThrow(cause);
 
             // Act
-            List<String> result = AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
-
-            // Assert
-            assertNotNull(result);
-            assertTrue(result.isEmpty());
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
+            // Assert - the failure is surfaced (not swallowed) with the original cause preserved so
+            // downstream wipe telemetry can resolve the real root cause.
+            assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
+            assertSame(cause, e.getCause());
         }
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.M) // API 23
-    public void testGetKeyPairEncryptionPaddings_ModernAPI_KeySpecException_ReturnsEmptyList() throws Exception {
+    public void testGetKeyPairEncryptionPaddings_ModernAPI_KeySpecException_ThrowsClientExceptionPreservingCause() throws Exception {
         // Arrange
+        final InvalidKeySpecException cause = new InvalidKeySpecException("Invalid key spec");
         try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
             keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
                     .thenReturn(mockKeyFactory);
             when(mockKeyFactory.getKeySpec(mockPrivateKey, KeyInfo.class))
-                    .thenThrow(new InvalidKeySpecException("Invalid key spec"));
+                    .thenThrow(cause);
 
             // Act
-            List<String> result = AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
-
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
             // Assert
-            assertNotNull(result);
-            assertTrue(result.isEmpty());
+            assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
+            assertSame(cause, e.getCause());
         }
     }
 
     @Test
     @Config(sdk = Build.VERSION_CODES.M) // API 23
-    public void testGetKeyPairEncryptionPaddings_ModernAPI_NoSuchProviderException_ReturnsEmptyList() {
-        // Arrange
-        try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
-            keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
-                    .thenThrow(new NoSuchProviderException("Provider not found"));
-
-            // Act
-            List<String> result = AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
-
-            // Assert
-            assertNotNull(result);
-            assertTrue(result.isEmpty());
-        }
-    }
-
-    @Test
-    @Config(sdk = Build.VERSION_CODES.M) // API 23
-    public void testGetKeyPairEncryptionPaddings_ModernAPI_RuntimeException_ReturnsEmptyList() throws Exception {
-        // Arrange
+    public void testGetKeyPairEncryptionPaddings_ModernAPI_NestedCause_IsPreservedThroughChain() throws Exception {
+        // Arrange - mirrors the real failure: getKeySpec throws an InvalidKeyException whose cause is a
+        // lower-level keystore fault. The whole chain must survive so findRootCause / findKeyStoreException
+        // can classify transience instead of seeing a causeless "no compatible cipher specs" error.
+        final Exception rootCause = new IllegalStateException("simulated KeyStoreException");
+        final InvalidKeyException cause = new InvalidKeyException("key went bad", rootCause);
         try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
             keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
                     .thenReturn(mockKeyFactory);
             when(mockKeyFactory.getKeySpec(mockPrivateKey, KeyInfo.class))
-                    .thenThrow(new RuntimeException("Unexpected runtime error"));
+                    .thenThrow(cause);
 
             // Act
-            List<String> result = AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
-
-            // Assert
-            assertNotNull(result);
-            assertTrue(result.isEmpty());
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
+            // Assert - both the direct cause and the deepest root cause are reachable from the throw.
+            assertSame(cause, e.getCause());
+            assertSame(rootCause, e.getCause().getCause());
         }
     }
 
     @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP) // API 21, before M
-    public void testGetKeyPairEncryptionPaddings_LegacyAPI_ReturnsEmptyList() {
-        // Act - Call the REAL method on legacy API
-        List<String> result = AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+    @Config(sdk = Build.VERSION_CODES.M) // API 23
+    public void testGetKeyPairEncryptionPaddings_ModernAPI_NoSuchProviderException_ThrowsClientExceptionPreservingCause() {
+        // Arrange
+        final NoSuchProviderException cause = new NoSuchProviderException("Provider not found");
+        try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
+            keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
+                    .thenThrow(cause);
 
-        // Assert - Should return empty list because API < 23
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+            // Act
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
+            // Assert
+            assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
+            assertSame(cause, e.getCause());
+        }
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.M) // API 23
+    public void testGetKeyPairEncryptionPaddings_ModernAPI_RuntimeException_ThrowsClientExceptionPreservingCause() throws Exception {
+        // Arrange
+        final RuntimeException cause = new RuntimeException("Unexpected runtime error");
+        try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
+            keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
+                    .thenReturn(mockKeyFactory);
+            when(mockKeyFactory.getKeySpec(mockPrivateKey, KeyInfo.class))
+                    .thenThrow(cause);
+
+            // Act
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
+            // Assert
+            assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
+            assertSame(cause, e.getCause());
+        }
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.LOLLIPOP) // API 21, below the library min SDK (24)
+    public void testGetKeyPairEncryptionPaddings_LegacyAPI_ThrowsClientException() {
+        // Act - Call the REAL method on legacy API. Padding retrieval fails (no AndroidKeyStore
+        // KeyFactory), and the failure is now surfaced rather than swallowed.
+        try {
+            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
+            fail("Expected ClientException to be thrown");
+        } catch (final ClientException e) {
+            // Assert - failure is propagated with the triggering exception preserved as the cause.
+            assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
+            assertNotNull(e.getCause());
+        }
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
@@ -614,6 +614,52 @@ public class AndroidKeyStoreUtilTest {
         }
     }
 
+    @Test
+    @Config(sdk = Build.VERSION_CODES.P) // API 28, below TIRAMISU
+    public void testGetKeyStoreErrorTransience_ApiBelow33_ReturnsApiTooOld() {
+        final ClientException exception = new ClientException("failed_to_load_key", "wrapper",
+                new java.io.IOException("disk error"));
+
+        assertEquals(AndroidKeyStoreUtil.KeyStoreErrorTransience.API_TOO_OLD,
+                AndroidKeyStoreUtil.getKeyStoreErrorTransience(exception));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.TIRAMISU) // API 33
+    public void testGetKeyStoreErrorTransience_NoKeyStoreException_ReturnsNotKeystoreError() {
+        final ClientException exception = new ClientException("failed_to_load_key", "wrapper",
+                new java.io.IOException("disk error"));
+
+        assertEquals(AndroidKeyStoreUtil.KeyStoreErrorTransience.NOT_KEYSTORE_ERROR,
+                AndroidKeyStoreUtil.getKeyStoreErrorTransience(exception));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.TIRAMISU) // API 33
+    public void testGetKeyStoreErrorTransience_TransientKeyStoreException_ReturnsTransient() {
+        final android.security.KeyStoreException keyStoreException =
+                mock(android.security.KeyStoreException.class);
+        when(keyStoreException.isTransientFailure()).thenReturn(true);
+        final ClientException exception =
+                new ClientException("failed_to_load_key", "wrapper", keyStoreException);
+
+        assertEquals(AndroidKeyStoreUtil.KeyStoreErrorTransience.TRANSIENT,
+                AndroidKeyStoreUtil.getKeyStoreErrorTransience(exception));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.TIRAMISU) // API 33
+    public void testGetKeyStoreErrorTransience_PermanentKeyStoreException_ReturnsNotTransient() {
+        final android.security.KeyStoreException keyStoreException =
+                mock(android.security.KeyStoreException.class);
+        when(keyStoreException.isTransientFailure()).thenReturn(false);
+        final ClientException exception =
+                new ClientException("failed_to_load_key", "wrapper", keyStoreException);
+
+        assertEquals(AndroidKeyStoreUtil.KeyStoreErrorTransience.NOT_TRANSIENT,
+                AndroidKeyStoreUtil.getKeyStoreErrorTransience(exception));
+    }
+
     /**
      * Helper method to create a legacy KeyPairGeneratorSpec for testing
      */

--- a/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/util/AndroidKeyStoreUtilTest.java
@@ -44,7 +44,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.math.BigInteger;
-import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -428,8 +427,7 @@ public class AndroidKeyStoreUtilTest {
             AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
             fail("Expected ClientException to be thrown");
         } catch (final ClientException e) {
-            // Assert - the failure is surfaced (not swallowed) with the original cause preserved so
-            // downstream wipe telemetry can resolve the real root cause.
+            // Assert - failure is surfaced with the original cause preserved.
             assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
             assertSame(cause, e.getCause());
         }
@@ -453,30 +451,6 @@ public class AndroidKeyStoreUtilTest {
             // Assert
             assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
             assertSame(cause, e.getCause());
-        }
-    }
-
-    @Test
-    @Config(sdk = Build.VERSION_CODES.M) // API 23
-    public void testGetKeyPairEncryptionPaddings_ModernAPI_NestedCause_IsPreservedThroughChain() throws Exception {
-        // Arrange - mirrors the real failure: getKeySpec throws an InvalidKeyException whose cause is a
-        // lower-level keystore fault. The whole chain must survive so findRootCause / findKeyStoreException
-        // can classify transience instead of seeing a causeless "no compatible cipher specs" error.
-        final Exception rootCause = new IllegalStateException("simulated KeyStoreException");
-        final InvalidKeyException cause = new InvalidKeyException("key went bad", rootCause);
-        try (MockedStatic<KeyFactory> keyFactoryMock = mockStatic(KeyFactory.class)) {
-            keyFactoryMock.when(() -> KeyFactory.getInstance(RSA_ALGORITHM, ANDROID_KEYSTORE_PROVIDER))
-                    .thenReturn(mockKeyFactory);
-            when(mockKeyFactory.getKeySpec(mockPrivateKey, KeyInfo.class))
-                    .thenThrow(cause);
-
-            // Act
-            AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
-            fail("Expected ClientException to be thrown");
-        } catch (final ClientException e) {
-            // Assert - both the direct cause and the deepest root cause are reachable from the throw.
-            assertSame(cause, e.getCause());
-            assertSame(rootCause, e.getCause().getCause());
         }
     }
 
@@ -521,15 +495,14 @@ public class AndroidKeyStoreUtilTest {
     }
 
     @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP) // API 21, below the library min SDK (24)
+    @Config(sdk = Build.VERSION_CODES.LOLLIPOP) // API 21
     public void testGetKeyPairEncryptionPaddings_LegacyAPI_ThrowsClientException() {
-        // Act - Call the REAL method on legacy API. Padding retrieval fails (no AndroidKeyStore
-        // KeyFactory), and the failure is now surfaced rather than swallowed.
+        // Act
         try {
             AndroidKeyStoreUtil.getKeyPairEncryptionPaddings(mockKeyPair);
             fail("Expected ClientException to be thrown");
         } catch (final ClientException e) {
-            // Assert - failure is propagated with the triggering exception preserved as the cause.
+            // Assert
             assertEquals(ClientException.UNKNOWN_CRYPTO_ERROR, e.getErrorCode());
             assertNotNull(e.getCause());
         }

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -677,6 +677,29 @@ public enum AttributeName {
     secret_key_serialization_duration,
 
     /**
+     * Indicates which check in the secret-key read path triggered a wipe of existing key material
+     * (e.g. an unrecoverable load error, or an orphaned wrapped-key file whose keystore key is gone).
+     * Legitimate first-time reads (no keystore key and no wrapped-key file) are intentionally not recorded.
+     */
+    secret_key_wipe_reason,
+
+    /**
+     * The actual root cause (simple class name + message) of the exception that caused a secret-key
+     * read failure (e.g. "IOException: /data/.../key (No space left on device)"). This is the
+     * underlying failure the ClientException wraps, captured unconditionally so the real reason is
+     * never lost behind the generic wrapper message, even for deeply nested cause chains.
+     */
+    secret_key_read_root_cause,
+
+    /**
+     * Whether the KeyStore failure that triggered a secret-key wipe is transient (retry may succeed)
+     * or permanent. One of TRANSIENT, NOT_TRANSIENT (API 33+, derived from
+     * KeyStoreException.isTransientFailure()), API_TOO_OLD (API < 33, cannot be determined), or
+     * NOT_KEYSTORE_ERROR (no KeyStoreException in the cause chain).
+     */
+    keystore_error_transience,
+
+    /**
      * Indicates if an external handler was found to handle the openid-vc:// URI.
      */
     is_openid_vc_handler_found,


### PR DESCRIPTION
[AB#3679391](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3679391)

## Summary

`KeyStoreBackedSecretKeyProvider.readSecretKeyFromStorage()` wipes the KeyStore keypair **and** the wrapped-key file on **any** `ClientException` (and on orphaned/empty key-file paths). Because the encrypted material becomes undecryptable once the keypair is gone, this can silently discard recoverable data and force mass re-auth. The `ClientException` error code conflates transient and permanent causes, so today we can't tell **why** a wipe actually happened.

This PR adds **telemetry-only** diagnostics (**no behavior change**) so we can classify these wipes before designing the real fix (retry/caps/classifier).

## What's recorded

On genuine wipes / silent re-keys of **existing** material, on the `SecretKeyRetrieval` span:

| Attribute | Meaning |
|-----------|---------|
| `secret_key_wipe_reason` | which check triggered the wipe (`load_error`, `keystore_key_absent_orphaned_file`, `empty_key_file_rekey`) |
| `secret_key_read_root_cause` | the **true root cause** (type + trimmed message), walked down the cause chain — not the generic `ClientException` wrapper |
| `keystore_numeric_error_code` | exact `android.security.KeyStoreException` numeric code (API 33+) |

## Why root cause (not the wrapper, not a stack trace)

- The `ClientException` wrapper's message is often generic (`"Error while reading..."`); the real reason (e.g. `No space left on device`, a specific `KeyStoreException`) lives further down the chain.
- A full stack trace was considered and rejected: the Aria/1DS span exporter emits span **attributes** but drops the `recordException` stacktrace event, and stack traces print the root cause **last**, so any backend field-size truncation would drop exactly the part we need. The explicit root-cause attribute is captured up-front and is groupable/queryable.

## Safety

- Legitimate **first-time** reads (no keystore key **and** no file, or a simply-absent file — e.g. Office `sharedUserId`) are intentionally **not** recorded.
- `recordWipe` swallows any failure (logs a warning), so telemetry can **never** break the read/wipe path.
- Wipe/delete behavior is unchanged; only `ClientException` triggers a wipe, exactly as before.

## Testing

- `:common:compileLocalDebugJavaWithJavac` — BUILD SUCCESSFUL
- `:common:testLocalDebugUnitTest` (`*WrappedSecretKey*`, `*AndroidKeyStoreUtil*`) — passing

> Note: the companion `AriaSpanDataAdapter` fix (so the exporter records the cause's message, not its class name) is a separate PR in the broker repo.