### PR TITLE
Bump WrappedSecretKeySerializerVersion flight default to 1, Fixes AB#3684385

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Bump WrappedSecretKeySerializerVersion flight default to 1, switching WrappedSecretKey serialization to the metadata-aware format by default (#3176)
 - [PATCH] Fix KeyStore key generation failures on API <= 30 by adding a conservative RSA/PKCS1/SHA-256 spec (ECS kill-switch flighted) (#3167)
 - [PATCH] Add moshi-adapters dependency to Common module so downstream consumers like OneAuth do not have to add it explicitly (#3168)
 - [PATCH] Harden Authority.isKnownAuthority() to use exact, case-insensitive host matching for developer-configured known authorities (#3165)

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -133,7 +133,7 @@ public enum CommonFlight implements IFlightConfig {
     /**
      * Flight to control the WrappedSecretKey serializer version
      */
-    WRAPPED_SECRET_KEY_SERIALIZER_VERSION("WrappedSecretKeySerializerVersion", 0),
+    WRAPPED_SECRET_KEY_SERIALIZER_VERSION("WrappedSecretKeySerializerVersion", 1),
 
     /**
      * Flight to enable the Web CP in WebView.


### PR DESCRIPTION
Updates the default value of the WRAPPED_SECRET_KEY_SERIALIZER_VERSION flight from 0 to 1 in CommonFlight.java, switching the WrappedSecretKey serializer to version 1 by default.

[AB#3684385](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3684385)