### PR TITLE
Fadi/ci nonblocking ignore china, Fixes AB#3686928

### DIFF
--- a/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
+++ b/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.labapi.utilities.rules.RetryTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -120,6 +121,7 @@ public class LabClientTest {
     }
 
     @Test
+    @Ignore
     public void canFetchChinaAccount() {
         try {
             final ILabAccount labAccount = mLabClient.getAccountFromLabJsonStringInMobileBuildVault(UserType.CHINA);

--- a/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
+++ b/LabApiUtilities/src/test/com/microsoft/identity/labapi/utilities/client/LabClientTest.java
@@ -121,6 +121,7 @@ public class LabClientTest {
     }
 
     @Test
+    // Ignored because the China tenant is being decommissioned.
     @Ignore
     public void canFetchChinaAccount() {
         try {

--- a/azure-pipelines/pull-request-validation/common.yml
+++ b/azure-pipelines/pull-request-validation/common.yml
@@ -78,6 +78,7 @@ stages:
     - job: build_test_dev
       displayName: Dev Branch Testing
       cancelTimeoutInMinutes: 1
+      continueOnError: true
       variables:
         Codeql.Enabled: true
       steps:

--- a/azure-pipelines/pull-request-validation/common4j.yml
+++ b/azure-pipelines/pull-request-validation/common4j.yml
@@ -71,6 +71,7 @@ stages:
 
     - job: build_test_dev
       displayName: Dev Branch Testing
+      continueOnError: true
       steps:
         - checkout: common-dev
           clean: true


### PR DESCRIPTION
Extracted from #3177 to keep that PR focused solely on the Intune browser-validation change.

This PR contains only the CI / test-infrastructure changes that were previously bundled in #3177:

- **common.yml / common4j.yml**: add `continueOnError: true` to the build_test_dev (Dev Branch Testing) job so it no longer blocks PR validation.
- **LabClientTest.java**: `@Ignore` on canFetchChinaAccount because the China cloud test is currently failing.

No product code changes.

[AB#3686928](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3686928)