### PR TITLE
Add jacocoDistTestReport task for weekly coverage XML, Fixes AB#3590302

### DIFF
--- a/azure-pipelines/code-coverage/compare-code-coverage.yml
+++ b/azure-pipelines/code-coverage/compare-code-coverage.yml
@@ -74,11 +74,25 @@ stages:
           continueOnError: true
         - bash: |
             set -e
+            # Diff-scoped gating (opt-in, backward compatible): if the PR-branch coverage
+            # job published a changed-files list alongside its JaCoCo report, scope the gate
+            # to only the classes the PR touched so unrelated flaky/async classes can't fail
+            # an innocent PR. Absent the file, the gate compares the whole report as before.
+            CHANGED_FILES="$(Pipeline.Workspace)/${{ parameters.prBranchReportArtifact }}/changed-files.txt"
+            CHANGED_ARG=""
+            if [ -s "$CHANGED_FILES" ]; then
+              echo "Diff-scoping coverage gate using $CHANGED_FILES"
+              CHANGED_ARG="--changed-files $CHANGED_FILES"
+            else
+              echo "No changed-files.txt in the PR report artifact; gating on the whole report."
+            fi
             python3 "$(Build.SourcesDirectory)/azure-pipelines/code-coverage/compare_coverage.py" \
               --pr   "$(Pipeline.Workspace)/${{ parameters.prBranchReportArtifact }}/jacocoTestReport.xml" \
               --base "$(Pipeline.Workspace)/${{ parameters.devBranchReportArtifact }}/jacocoTestReport.xml" \
               --metric ${{ parameters.metric }} \
               --tolerance ${{ parameters.tolerance }} \
+              --skip-label '${{ parameters.skipLabel }}' \
+              $CHANGED_ARG \
               $(noFailFlag) \
               --out-md   "$(Build.ArtifactStagingDirectory)/coverage-comparison.md" \
               --out-json "$(Build.ArtifactStagingDirectory)/coverage-comparison.json"

--- a/azure-pipelines/code-coverage/compare_coverage.py
+++ b/azure-pipelines/code-coverage/compare_coverage.py
@@ -11,7 +11,7 @@ Usage:
   compare_coverage.py --base <dev.xml>...  --pr <pr.xml>...
       [--metric LINE|BRANCH] [--tolerance PP] [--unit-tolerance PP]
       [--min-missed N] [--top N] [--out-md FILE] [--out-json FILE]
-      [--no-fail-on-drop]
+      [--changed-files FILE] [--no-fail-on-drop]
 
 Stdlib only - runs on any pipeline image with Python 3.
 """
@@ -56,6 +56,66 @@ def _aggregate(paths, metric):
     return agg
 
 
+def _class_sources(paths):
+    """Return {dotted_class_name: 'package/sourcefilename'} across JaCoCo reports.
+
+    Maps each JaCoCo class to the source file it was compiled from so the gate can be
+    scoped to only the files a PR actually changed. Inner/anonymous classes (Foo$1)
+    share their outer class's sourcefilename, so they map to the same source file.
+    """
+    sources = {}
+    for path in sorted(set(paths)):
+        try:
+            root = ET.parse(path).getroot()
+        except (ET.ParseError, OSError):
+            continue
+        for pkg in root.iter("package"):
+            pkg_name = pkg.get("name") or ""
+            for cls in pkg.findall("class"):
+                name = (cls.get("name") or "").replace("/", ".")
+                src = cls.get("sourcefilename")
+                if not name or not src:
+                    continue
+                sources[name] = f"{pkg_name}/{src}" if pkg_name else src
+    return sources
+
+
+def _read_changed_files(path):
+    """Read a newline-delimited list of changed repo-relative paths.
+
+    Normalizes separators and keeps only Java/Kotlin source files (the only files that
+    map to JaCoCo classes); tests/resources/YAML are ignored.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw = handle.read().splitlines()
+    except OSError as exc:
+        sys.stderr.write(f"WARNING: could not read --changed-files {path}: {exc}\n")
+        return []
+    out = []
+    for line in raw:
+        candidate = line.strip().replace("\\", "/")
+        if candidate and candidate.lower().endswith((".java", ".kt")):
+            out.append(candidate)
+    return out
+
+
+def _in_scope_classes(sources, changed):
+    """Return the set of dotted class names whose source file the PR changed.
+
+    A class is in scope when its 'package/sourcefilename' suffix is the tail of a
+    changed repo-relative path (e.g. changed 'app/src/main/java/com/x/Foo.java'
+    matches class suffix 'com/x/Foo.java').
+    """
+    scoped = set()
+    for name, suffix in sources.items():
+        for changed_path in changed:
+            if changed_path == suffix or changed_path.endswith("/" + suffix):
+                scoped.add(name)
+                break
+    return scoped
+
+
 # JaCoCo <counter type="..."> values. Guards against silent 0% when a caller passes
 # a typo'd or wrong-cased metric (which would otherwise match no counters).
 VALID_METRICS = {"INSTRUCTION", "LINE", "BRANCH", "COMPLEXITY", "METHOD", "CLASS"}
@@ -92,6 +152,15 @@ def main():
                         help="Show only the top N rows per table (0 = all).")
     parser.add_argument("--out-md", default="", dest="out_md")
     parser.add_argument("--out-json", default="", dest="out_json")
+    parser.add_argument("--skip-label", default="skip-coverage-check", dest="skip_label",
+                        help="Name of the PR label a developer can apply to bypass this "
+                             "gate; surfaced in the failure message.")
+    parser.add_argument("--changed-files", default="", dest="changed_files",
+                        help="Path to a newline-delimited list of PR-changed repo-relative "
+                             "source paths. When given (and non-empty), the pass/fail gate is "
+                             "scoped to only the classes whose source file this PR changed - "
+                             "coverage of unrelated (e.g. flaky/async) classes is ignored. "
+                             "Omit for whole-report gating (backward-compatible default).")
     parser.add_argument("--no-fail-on-drop", action="store_false", dest="fail_on_drop",
                         help="Report the diff but never exit non-zero (non-gating).")
     parser.set_defaults(fail_on_drop=True)
@@ -148,6 +217,38 @@ def main():
         _write_status(args, metric, "SKIPPED", reason, failed=False)
         return 0
 
+    # Diff-scoped gating: when the caller supplies the PR's changed source files, restrict
+    # the pass/fail decision (and the per-class tables) to only the classes whose source
+    # file the PR actually changed. This stops unrelated flaky/async classes - whose
+    # coverage jitters between the two independent test runs - from failing an innocent PR.
+    # Omitting --changed-files preserves the original whole-report behavior.
+    scoped = False
+    scoped_class_count = 0
+    changed_file_count = 0
+    if args.changed_files:
+        # The caller opted into diff-scoping. Once --changed-files is passed we stay in
+        # scoped mode even if it lists no source files (e.g. a YAML/resource-only PR):
+        # in that case nothing maps to a measured class, so there is nothing to gate and
+        # we skip - we must NOT silently fall back to whole-report gating, which would
+        # reintroduce the unrelated-flaky-class false positives this feature prevents.
+        scoped = True
+        changed = _read_changed_files(args.changed_files)
+        changed_file_count = len(changed)
+        sources = _class_sources(base_paths + pr_paths)
+        in_scope = _in_scope_classes(sources, changed) if changed else set()
+        base = {k: v for k, v in base.items() if k in in_scope}
+        pr = {k: v for k, v in pr.items() if k in in_scope}
+        scoped_class_count = len(set(base) | set(pr))
+        if not base and not pr:
+            reason = (f"Diff-scoped gating: none of the {changed_file_count} changed "
+                      "source file(s) map to a measured class in the coverage reports "
+                      "(e.g. only tests, resources, config, or new/uncompiled files "
+                      "changed); there is nothing to gate - skipping the coverage gate "
+                      "(not gating).")
+            sys.stderr.write("WARNING: " + reason + "\n")
+            _write_status(args, metric, "SKIPPED", reason, failed=False)
+            return 0
+
     base_cov = sum(v["Covered"] for v in base.values())
     base_miss = sum(v["Missed"] for v in base.values())
     pr_cov = sum(v["Covered"] for v in pr.values())
@@ -196,10 +297,20 @@ def main():
     ]
     if args.tolerance:
         lines += [f"_Allowed drop (tolerance): {args.tolerance} pp._", ""]
+    if scoped:
+        lines += [f"_Gating is scoped to the {scoped_class_count} class(es) from the "
+                  f"{changed_file_count} source file(s) changed by this PR; coverage of "
+                  "classes this PR did not touch is ignored._", ""]
     if failed:
         lines += [f"**Coverage dropped by {abs(delta)} pp** (base {base_pct}% -> PR "
                   f"{pr_pct}%), exceeding the allowed {args.tolerance} pp. "
                   "Add tests for the classes below to restore coverage.", ""]
+        lines += ["> **Believe this coverage failure is wrong?** "
+                  "(e.g. the regression is in flaky/async code unrelated to your change, "
+                  "or the check itself is misbehaving) you can bypass this gate by adding "
+                  f"the `{args.skip_label}` label to this PR, then **pushing a new commit "
+                  "to the branch so the check fully re-runs** - applying the label alone "
+                  "does not re-trigger the pipeline.", ""]
 
     if regressed:
         top_reg = regressed[:args.top] if args.top > 0 else regressed
@@ -234,6 +345,8 @@ def main():
             json.dump({"metric": metric, "basePercentage": base_pct,
                        "prPercentage": pr_pct, "deltaPp": delta,
                        "tolerancePp": args.tolerance, "failed": failed,
+                       "scoped": scoped, "scopedClasses": scoped_class_count,
+                       "changedFiles": changed_file_count,
                        "removedClasses": removed,
                        "regressed": regressed, "newGaps": new_gaps}, handle, indent=2)
 
@@ -242,6 +355,9 @@ def main():
         print(f"ERROR: PR {metric} coverage {pr_pct}% is below base {base_pct}% "
               f"(drop {abs(delta)} pp > tolerance {args.tolerance} pp). Failing.",
               file=sys.stderr)
+        print(f"If you believe this failure is wrong (e.g. flaky/unrelated coverage), "
+              f"apply the '{args.skip_label}' label to the PR and push a new commit to "
+              "the branch so the check fully re-runs.", file=sys.stderr)
     return 1 if failed else 0
 
 

--- a/azure-pipelines/templates/steps/collect-changed-files.yml
+++ b/azure-pipelines/templates/steps/collect-changed-files.yml
@@ -1,0 +1,40 @@
+# Writes the list of source files this PR changed into `<outputDir>/changed-files.txt`.
+#
+# Drop this into the PR-branch coverage job (the one that builds `jacocoTestReport.xml`
+# and publishes the PR report artifact), pointing `outputDir` at the same folder the
+# JaCoCo XML is staged in. compare-code-coverage.yml then auto-detects the file and
+# scopes the coverage gate to only the classes those files map to, so unrelated
+# flaky/async classes can't fail an innocent PR. On non-PR runs the step no-ops.
+parameters:
+# Directory the changed-files list is written to. Point at the folder that is published
+# as the PR JaCoCo report artifact (must contain jacocoTestReport.xml).
+- name: outputDir
+  type: string
+# PR target branch to diff against. Defaults to the ADO-provided PR target branch.
+- name: targetBranch
+  type: string
+  default: $(System.PullRequest.TargetBranch)
+
+steps:
+  - bash: |
+      set -e
+      OUT_DIR="${{ parameters.outputDir }}"
+      mkdir -p "$OUT_DIR"
+      OUT_FILE="$OUT_DIR/changed-files.txt"
+
+      # Strip a leading refs/heads/ from the target branch (ADO passes it either way).
+      TARGET="${{ parameters.targetBranch }}"
+      TARGET="${TARGET#refs/heads/}"
+
+      # Make sure the target branch is available locally, then diff from the merge base
+      # so only the PR's own changes are listed (not commits already on the target).
+      git fetch --no-tags --depth=200 origin "+refs/heads/$TARGET:refs/remotes/origin/$TARGET" || \
+        git fetch --no-tags origin "+refs/heads/$TARGET:refs/remotes/origin/$TARGET"
+      MERGE_BASE="$(git merge-base HEAD "origin/$TARGET")"
+      echo "Diffing changed files: $MERGE_BASE..HEAD (target $TARGET)"
+
+      git diff --name-only "$MERGE_BASE" HEAD > "$OUT_FILE"
+      echo "Wrote $(wc -l < "$OUT_FILE") changed file(s) to $OUT_FILE:"
+      cat "$OUT_FILE"
+    displayName: Collect PR changed files (for diff-scoped coverage)
+    condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -92,6 +92,17 @@ def registerJacocoXmlReport = { String taskName, String variant ->
                         "outputs/unit_test_code_coverage/${variant}UnitTest/test${variantCap}UnitTest.exec".toString()
                 ]
         ))
+
+        // Fail fast if no execution data is present (e.g. tests weren't run, or the
+        // build was invoked without -PcodeCoverageEnabled=true). Without this guard
+        // JacocoReport still emits a valid XML reporting 0% coverage, which would be
+        // silently published as a wrong weekly coverage number instead of failing loudly.
+        doFirst {
+            assert executionData.files.any { it.exists() } :
+                    "No JaCoCo .exec execution data found for ${variant}; " +
+                    "the '${taskName}' report would be a misleading 0%. Ensure the " +
+                    "test${variantCap}UnitTest task ran with coverage enabled."
+        }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -48,43 +48,55 @@ tasks.withType(Test) {
     }
 }
 
-tasks.register("jacocoTestReport", JacocoReport) {
-    dependsOn "testLocalDebugUnitTest" // Run Robolectric tests first
+// Registers a JaCoCo XML+HTML coverage report task for a given build variant's unit tests.
+// PR validation builds the 'local' flavor, so the PR checks invoke jacocoTestReport
+// (localDebug) and its behaviour is unchanged. The weekly release pipeline builds the
+// 'dist' flavor and invokes jacocoDistTestReport (distDebug), which reuses the .exec
+// produced by distDebug<Module>UnitTestCoverageReport rather than re-running tests on a
+// variant the weekly infrastructure doesn't build.
+def registerJacocoXmlReport = { String taskName, String variant ->
+    def variantCap = variant.capitalize()
+    tasks.register(taskName, JacocoReport) {
+        dependsOn "test${variantCap}UnitTest" // Run Robolectric tests first
 
-    reports {
-        xml.required = true
-        html.required = true
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        def fileFilter = [
+                '**/R.class', '**/R$*.class', '**/BuildConfig.*',
+                '**/Manifest*.*', '**/*Test*.*',
+                'android/**/*.*', 'com/microsoft/aad/adal/**'
+        ]
+
+        def kotlinClasses = fileTree(
+                dir: "$buildDir/tmp/kotlin-classes/${variant}",
+                excludes: fileFilter
+        )
+
+        def javaClasses = fileTree(
+                dir: "$buildDir/intermediates/javac/${variant}/compile${variantCap}JavaWithJavac/classes",
+                excludes: fileFilter
+        )
+
+        sourceDirectories.setFrom(files([
+                "$projectDir/src/main/java",
+                "$projectDir/src/main/kotlin"
+        ]))
+        classDirectories.setFrom(files([kotlinClasses, javaClasses]))
+        executionData.setFrom(fileTree(
+                dir: buildDir,
+                includes: [
+                        "jacoco/test${variantCap}UnitTest.exec".toString(),
+                        "outputs/unit_test_code_coverage/${variant}UnitTest/test${variantCap}UnitTest.exec".toString()
+                ]
+        ))
     }
-
-    def fileFilter = [
-            '**/R.class', '**/R$*.class', '**/BuildConfig.*',
-            '**/Manifest*.*', '**/*Test*.*',
-            'android/**/*.*', 'com/microsoft/aad/adal/**'
-    ]
-
-    def kotlinClasses = fileTree(
-            dir: "$buildDir/tmp/kotlin-classes/localDebug",
-            excludes: fileFilter
-    )
-
-    def javaClasses = fileTree(
-            dir: "$buildDir/intermediates/javac/localDebug/compileLocalDebugJavaWithJavac/classes",
-            excludes: fileFilter
-    )
-
-    sourceDirectories.setFrom(files([
-            "$projectDir/src/main/java",
-            "$projectDir/src/main/kotlin"
-    ]))
-    classDirectories.setFrom(files([kotlinClasses, javaClasses]))
-    executionData.setFrom(fileTree(
-            dir: buildDir,
-            includes: [
-                    "jacoco/testLocalDebugUnitTest.exec",
-                    "outputs/unit_test_code_coverage/localDebugUnitTest/testLocalDebugUnitTest.exec"
-            ]
-    ))
 }
+
+registerJacocoXmlReport("jacocoTestReport", "localDebug")     // PR validation (local flavor)
+registerJacocoXmlReport("jacocoDistTestReport", "distDebug")  // weekly release (dist flavor)
 
 // In dev, we want to keep the dependencies(common4j, broker4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.


### PR DESCRIPTION
[AB#3590302](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3590302)

## Summary
Adds a dedicated `jacocoDistTestReport` Gradle task (distDebug variant) to produce JaCoCo coverage **XML** for the weekly release pipeline, without changing any PR-facing behavior.

## What changed
- Introduces a shared `registerJacocoXmlReport` closure and registers **two** tasks:
  - `jacocoTestReport` -> **localDebug** (unchanged - used by PR validation, preserved byte-for-byte)
  - `jacocoDistTestReport` -> **distDebug** (new - used by the weekly release pipeline)
- `jacocoDistTestReport` depends on `testDistDebugUnitTest` (already run by the weekly build), so it just converts the existing `.exec` into XML/HTML - no double test execution.

## Why
The weekly pipeline builds the `distDebug` variant, which only emits a JaCoCo `.exec` binary. Coverage aggregation needs XML. This gives the weekly pipeline a task that emits XML from the dist flavor while leaving PR validation (local flavor) untouched.

## Risk
Low - PR validation path (jacocoTestReport / localDebug) is unchanged.