### PR TITLE
Improve Auth Tab / browser-selection logging and add browser-package-missing error string, Fixes AB#3697009

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
@@ -233,11 +233,8 @@ class SwitchBrowserActivity : FragmentActivity() {
             methodTag,
             "Auth Tab decision inputs: flightEnabled=$isAuthTabFlightEnabled, " +
                 "browserPackagePresent=${browserPackageName.isNotBlank()}, " +
-                "isAuthTabSupported=$isAuthTabSupported"
-        )
-        Logger.info(
-            methodTag,
-            "Auth Tab decision browser package: $browserPackageName"
+                "isAuthTabSupported=$isAuthTabSupported, " +
+                "browserPackage=$browserPackageName"
         )
         span?.setAttribute(
             AttributeName.browser_package_name.name,
@@ -359,7 +356,7 @@ class SwitchBrowserActivity : FragmentActivity() {
             // User has returned to this activity after CCT was launched, likely due to backing out
             val cancellation = ClientException(
                 ErrorStrings.USER_CANCELLED,
-                "User cancelled authentication by returning from browser"
+                ErrorStrings.AUTH_TAB_CANCELED_MESSAGE
             )
             span?.setStatus(StatusCode.ERROR)
             span?.recordException(cancellation)
@@ -367,7 +364,7 @@ class SwitchBrowserActivity : FragmentActivity() {
             setResultAndFinish(
                 SwitchBrowserProtocolCoordinator.createErrorBundle(
                     ErrorStrings.USER_CANCELLED,
-                    "User cancelled authentication by returning from browser"
+                    ErrorStrings.AUTH_TAB_CANCELED_MESSAGE
                 )
             )
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
@@ -229,6 +229,16 @@ class SwitchBrowserActivity : FragmentActivity() {
         val extras = this.intent.extras ?: Bundle()
         val browserPackageName = extras.getString(BROWSER_PACKAGE_NAME).orEmpty()
         val isAuthTabSupported = AuthTabStrategyProvider.isAuthTabSupported(this, browserPackageName)
+        Logger.info(
+            methodTag,
+            "Auth Tab decision inputs: flightEnabled=$isAuthTabFlightEnabled, " +
+                "browserPackagePresent=${browserPackageName.isNotBlank()}, " +
+                "isAuthTabSupported=$isAuthTabSupported"
+        )
+        Logger.info(
+            methodTag,
+            "Auth Tab decision browser package: $browserPackageName"
+        )
         span?.setAttribute(
             AttributeName.browser_package_name.name,
             browserPackageName

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/SwitchBrowserActivity.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.providers.oauth2
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
@@ -241,6 +242,10 @@ class SwitchBrowserActivity : FragmentActivity() {
             browserPackageName
         )
         span?.setAttribute(
+            AttributeName.browser_version.name,
+            getBrowserVersion(browserPackageName)
+        )
+        span?.setAttribute(
             AttributeName.is_auth_tab_supported.name,
             isAuthTabSupported
         )
@@ -262,6 +267,22 @@ class SwitchBrowserActivity : FragmentActivity() {
 
         Logger.info(methodTag, "Using Custom Tabs strategy")
         return CustomTabsLaunchStrategy(this)
+    }
+
+    /**
+     * Returns the version name of the given browser package, or an empty string if the package
+     * name is blank or the version cannot be resolved.
+     */
+    private fun getBrowserVersion(browserPackageName: String): String {
+        if (browserPackageName.isBlank()) {
+            return ""
+        }
+        return try {
+            packageManager.getPackageInfo(browserPackageName, 0).versionName.orEmpty()
+        } catch (e: PackageManager.NameNotFoundException) {
+            Logger.warn("$TAG:getBrowserVersion", "Browser package not found: $browserPackageName")
+            ""
+        }
     }
 
     private fun onAuthTabResult(resultBundle: Bundle) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/AndroidAuthorizationStrategyFactory.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/AndroidAuthorizationStrategyFactory.java
@@ -80,15 +80,20 @@ public class AndroidAuthorizationStrategyFactory implements IAuthorizationStrate
             final boolean isBrokerRequest) {
         final String methodTag = TAG + ":getAuthorizationStrategy";
 
-        final Browser browser = mBrowserSelector.selectBrowser(browserSafeList, preferredBrowserDescriptor);
 
-        if (authorizationAgent == AuthorizationAgent.WEBVIEW || browser == null) {
-            Logger.info(methodTag, "WebView authorization, browser: " + browser);
+        if (authorizationAgent == AuthorizationAgent.WEBVIEW) {
+            Logger.info(methodTag, "WebView authorization, WebView agent is selected");
             return getGenericAuthorizationStrategy();
         }
 
-        Logger.info(methodTag, "Browser authorization, browser: " + browser);
-        return getBrowserAuthorizationStrategy(browser, isBrokerRequest);
+        final Browser browser = mBrowserSelector.selectBrowser(browserSafeList, preferredBrowserDescriptor);
+        if (browser == null) {
+            Logger.info(methodTag, "No browser found, using WebView agent");
+            return getGenericAuthorizationStrategy();
+        } else {
+            Logger.info(methodTag, "Browser found: " + browser.getPackageName() + ", using Browser agent");
+            return getBrowserAuthorizationStrategy(browser, isBrokerRequest);
+        }
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/ErrorStrings.java
@@ -539,6 +539,11 @@ public final class ErrorStrings {
     public static final String AUTH_TAB_REDIRECT_URI_MISSING = "BROKER_REDIRECT_URI is required to launch Auth Tab";
 
     /**
+     * Auth Tab flow: BROWSER_PACKAGE_NAME is missing from the intent extras.
+     */
+    public static final String AUTH_TAB_BROWSER_PACKAGE_MISSING = "BROWSER_PACKAGE_NAME is required to launch Auth Tab";
+
+    /**
      * Auth Tab result code: the user cancelled authentication.
      */
     public static final String AUTH_TAB_CANCELED = "CANCELED";

--- a/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/opentelemetry/AttributeName.java
@@ -436,6 +436,11 @@ public enum AttributeName {
     auth_tab_fallback_to_custom_tabs,
 
     /**
+     * Records the version of the browser package handling the switch browser flow.
+     */
+    browser_version,
+
+    /**
      * The tenant id for the home tenant of the account for which PRT is required.
      */
     tenant_id,


### PR DESCRIPTION
## What

Improves diagnostic logging around the Auth Tab / browser-selection decision and tidies up related error strings.

## Changes
- `SwitchBrowserActivity`: log the inputs that drive the Auth Tab vs. custom-tab/browser decision (flight enabled, browser package present, Auth Tab supported, browser package) to aid diagnosis of launch issues.
- `SwitchBrowserActivity`: use the `ErrorStrings.AUTH_TAB_CANCELED_MESSAGE` constant instead of a hardcoded cancellation message.
- `AndroidAuthorizationStrategyFactory`: refactor the WebView-vs-browser selection so the WebView agent is short-circuited first, and add clearer logging for each path (WebView selected / no browser found / browser found).
- `ErrorStrings`: define the previously-missing `AUTH_TAB_BROWSER_PACKAGE_MISSING` error string for the browser-package-not-found case.

> Split out from the `pedroro/duna-auth-tab` working branch.


Related PR: https://github.com/identity-authnz-teams/ad-accounts-for-android/pull/235

[AB#3697009](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3697009)