### PR TITLE
Rename WebAppError 'error' field to 'code' in WebApps API error response, Fixes AB#3692269

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Rename WebAppError 'error' field to 'code' in WebApps API error response (#3192)
 
 Version 24.5.0
 ----------

--- a/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppError.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/webapps/WebAppError.kt
@@ -28,7 +28,7 @@ import com.google.gson.annotations.SerializedName
  * This class represents an error that occurs during WebApps operations.
  */
 data class WebAppError(
-    @SerializedName(FIELD_ERROR)
+    @SerializedName(FIELD_CODE)
     val errorCode: String? = BROKER_ERROR_CODE,
 
     @SerializedName(FIELD_DESCRIPTION)
@@ -38,7 +38,7 @@ data class WebAppError(
     val extra: WebAppErrorDetails
 ) {
     companion object {
-        const val FIELD_ERROR = "error"
+        const val FIELD_CODE = "code"
         const val FIELD_DESCRIPTION = "description"
         const val FIELD_EXTRA = "ext"
         const val BROKER_ERROR_CODE = "OSError" // Per the protocol, this is the dedicated error code for broker-related errors.

--- a/common4j/src/test/com/microsoft/identity/common/java/commands/webapps/WebAppErrorTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/commands/webapps/WebAppErrorTest.kt
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.commands.webapps
+
+import com.google.gson.JsonParser
+import com.microsoft.identity.common.java.util.ObjectMapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Verifies the serialized JSON schema (field names and nesting) of the WebApps API
+ * error response produced by [WebAppError]'s throwable-based constructors, including
+ * its nested [WebAppErrorDetails] and [MatsProperties].
+ */
+class WebAppErrorTest {
+
+    @Test
+    fun serialize_throwableConstructor_producesExpectedSchema() {
+        // An IOException maps to the NO_NETWORK broker error status.
+        val webAppError = WebAppError(
+            IOException("network down"),
+            "Something went wrong"
+        )
+
+        val json = JsonParser.parseString(
+            ObjectMapper.serializeObjectToJsonString(webAppError)
+        ).asJsonObject
+
+        // Top-level WebAppError schema: the error code is serialized under "code", not "error".
+        assertEquals(setOf("code", "description", "ext"), json.keySet())
+        assertFalse("'error' should no longer be a top-level field", json.has("error"))
+        assertEquals(WebAppError.BROKER_ERROR_CODE, json.get("code").asString)
+        assertEquals("Something went wrong", json.get("description").asString)
+
+        // Nested WebAppErrorDetails schema. protocol_error and properties are null, so
+        // GSON omits them, leaving only "error" and "status".
+        val ext = json.getAsJsonObject("ext")
+        assertEquals(setOf("error", "status"), ext.keySet())
+        assertEquals(0, ext.get("error").asInt)
+        assertEquals(WebAppBrokerErrorCode.NO_NETWORK.name, ext.get("status").asString)
+    }
+
+    @Test
+    fun serialize_throwableAndMatsConstructor_producesExpectedSchema() {
+        val webAppError = WebAppError(
+            RuntimeException("boom"),
+            "Unexpected failure",
+            MatsProperties(matsData = "mats-blob")
+        )
+
+        val json = JsonParser.parseString(
+            ObjectMapper.serializeObjectToJsonString(webAppError)
+        ).asJsonObject
+
+        // Top-level WebAppError schema.
+        assertEquals(setOf("code", "description", "ext"), json.keySet())
+        assertFalse("'error' should no longer be a top-level field", json.has("error"))
+        assertEquals(WebAppError.BROKER_ERROR_CODE, json.get("code").asString)
+        assertEquals("Unexpected failure", json.get("description").asString)
+
+        // Nested WebAppErrorDetails schema now includes "properties"; protocol_error is
+        // still null and therefore omitted. A RuntimeException maps to UNEXPECTED.
+        val ext = json.getAsJsonObject("ext")
+        assertEquals(setOf("error", "status", "properties"), ext.keySet())
+        assertEquals(0, ext.get("error").asInt)
+        assertEquals(WebAppBrokerErrorCode.UNEXPECTED.name, ext.get("status").asString)
+
+        // Nested MatsProperties schema (under "properties").
+        val properties = ext.getAsJsonObject("properties")
+        assertEquals(setOf("MATS"), properties.keySet())
+        assertEquals("mats-blob", properties.get("MATS").asString)
+    }
+}


### PR DESCRIPTION
### Summary
Renames the top-level `error` field to `code` in the WebApps API error response produced by `WebAppError` (`FIELD_ERROR` -> `FIELD_CODE`). This field naming was not correct from the beginning, so we don't need to worry about any downstream regressions.

The serialized error response now looks like:
```json
{ "code": "OSError", "description": "...", "ext": { ... } }
```

### Changes
- `common4j/.../commands/webapps/WebAppError.kt`: `@SerializedName("error")` -> `@SerializedName("code")`.
- `common4j/.../commands/webapps/WebAppErrorTest.kt`: new test validating the full serialized JSON schema (top-level `code`/`description`/`ext`, nested `error`/`status`/`properties`, and `MATS`).

Note: the nested `ext.error` integer field in `WebAppErrorDetails` is intentionally unchanged.

### Testing
- `:common4j:test --tests WebAppErrorTest` -> passing.

[AB#3692269](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3692269/)