### PR TITLE
Gate PR checks on code-coverage drop with per-class breakdown, Fixes AB#3590302

### DIFF
--- a/azure-pipelines/code-coverage/compare-code-coverage.yml
+++ b/azure-pipelines/code-coverage/compare-code-coverage.yml
@@ -25,15 +25,35 @@ parameters:
 - name: dependsOn
   type: object
   default: []
+# PR label that, when applied, SKIPS the coverage gate (the compare job does not run).
+# Escape hatch for emergencies or when the coverage check itself is broken; remove the
+# label to re-enable the gate. Matched case-insensitively as a substring of the PR's
+# GitHub labels, mirroring the skipConsumerValidationLabel pattern in build-consumers.yml.
+- name: skipLabel
+  type: string
+  default: skip-coverage-check
 
 stages:
+# Fetch the PR's GitHub labels first so the compare job can opt out when skipLabel is set.
+# On non-PR runs fetch-pr-labels.yml leaves prLabels empty, so the gate still runs.
+- stage: coverage_get_label
+  displayName: Check for PR Label (coverage)
+  dependsOn: []
+  jobs:
+    - template: ../templates/steps/fetch-pr-labels.yml
 - stage: compare_coverage
   displayName: Compare Code Coverage
-  dependsOn: ${{ parameters.dependsOn }}
+  dependsOn:
+  - coverage_get_label
+  - ${{ each stage in parameters.dependsOn }}:
+    - ${{ stage }}
   jobs:
     - job: compare
       displayName: PR VS. Dev
+      # Skip the whole comparison when the PR carries the skip label.
+      condition: and( succeeded(), not( contains( variables['prLabels'], '${{ parameters.skipLabel }}' ) ) )
       variables:
+        prLabels: $[ stageDependencies.coverage_get_label.getLabelsJob.outputs['fetchPrCILabel.prLabels'] ]
         # Report-only mode passes --no-fail-on-drop so the diff is surfaced without gating.
         ${{ if parameters.failOnDrop }}:
           noFailFlag: ''

--- a/azure-pipelines/code-coverage/compare-code-coverage.yml
+++ b/azure-pipelines/code-coverage/compare-code-coverage.yml
@@ -1,4 +1,7 @@
-# Description: Template to build & publish any auth client android sdk library to internal maven feed
+# Description: Compare code coverage between a PR branch and the base (dev) branch and
+# FAIL the PR check when coverage drops. Also surfaces a per-class breakdown of where
+# coverage regressed (published as an artifact and shown in the build summary) so the
+# PR author knows exactly which classes need tests.
 
 parameters:
 - name: prBranchReportArtifact
@@ -6,6 +9,18 @@ parameters:
 - name: devBranchReportArtifact
   default: jacocoReportDev
 - name: commonRepoAlias
+# LINE (default) or BRANCH.
+- name: metric
+  type: string
+  default: LINE
+# Allowed overall drop in percentage points before the check fails. 0 = any drop fails.
+- name: tolerance
+  type: number
+  default: 0
+# When false, the comparison is reported but never fails the build (report-only mode).
+- name: failOnDrop
+  type: boolean
+  default: true
 # List of stages this templates depends on to start.
 - name: dependsOn
   type: object
@@ -18,7 +33,12 @@ stages:
   jobs:
     - job: compare
       displayName: PR VS. Dev
-      continueOnError: true
+      variables:
+        # Report-only mode passes --no-fail-on-drop so the diff is surfaced without gating.
+        ${{ if parameters.failOnDrop }}:
+          noFailFlag: ''
+        ${{ else }}:
+          noFailFlag: '--no-fail-on-drop'
       steps:
         - checkout: ${{ parameters.commonRepoAlias }}
           clean: true
@@ -28,6 +48,30 @@ stages:
           artifact: ${{ parameters.prBranchReportArtifact }} # Adjust artifact name as needed
         - download: current
           artifact: ${{ parameters.devBranchReportArtifact }} # Adjust artifact name as needed
-        - script: |
-            python $(Build.SourcesDirectory)/azure-pipelines/code-coverage/compare_coverage.py $(Pipeline.Workspace)/${{ parameters.prBranchReportArtifact }}/jacocoTestReport.xml $(Pipeline.Workspace)/${{ parameters.devBranchReportArtifact }}/jacocoTestReport.xml
+          # The base (dev) coverage job is best-effort (continueOnError). If it didn't
+          # publish a report, don't hard-fail here: compare_coverage.py treats a missing
+          # baseline as "nothing to compare" and skips gating instead of blocking the PR.
+          continueOnError: true
+        - bash: |
+            set -e
+            python "$(Build.SourcesDirectory)/azure-pipelines/code-coverage/compare_coverage.py" \
+              --pr   "$(Pipeline.Workspace)/${{ parameters.prBranchReportArtifact }}/jacocoTestReport.xml" \
+              --base "$(Pipeline.Workspace)/${{ parameters.devBranchReportArtifact }}/jacocoTestReport.xml" \
+              --metric ${{ parameters.metric }} \
+              --tolerance ${{ parameters.tolerance }} \
+              $(noFailFlag) \
+              --out-md   "$(Build.ArtifactStagingDirectory)/coverage-comparison.md" \
+              --out-json "$(Build.ArtifactStagingDirectory)/coverage-comparison.json"
           displayName: Compare Jacoco Coverage
+        - bash: |
+            # Surface the per-class breakdown in the build's Extensions/Summary tab even
+            # when the comparison step failed the build on a coverage drop.
+            echo "##vso[task.uploadsummary]$(Build.ArtifactStagingDirectory)/coverage-comparison.md"
+          displayName: Publish comparison to build summary
+          condition: succeededOrFailed()
+        - task: PublishPipelineArtifact@1
+          displayName: Publish coverage comparison
+          condition: succeededOrFailed()
+          inputs:
+            targetPath: '$(Build.ArtifactStagingDirectory)/coverage-comparison.md'
+            artifactName: coverage-comparison

--- a/azure-pipelines/code-coverage/compare-code-coverage.yml
+++ b/azure-pipelines/code-coverage/compare-code-coverage.yml
@@ -54,7 +54,7 @@ stages:
           continueOnError: true
         - bash: |
             set -e
-            python "$(Build.SourcesDirectory)/azure-pipelines/code-coverage/compare_coverage.py" \
+            python3 "$(Build.SourcesDirectory)/azure-pipelines/code-coverage/compare_coverage.py" \
               --pr   "$(Pipeline.Workspace)/${{ parameters.prBranchReportArtifact }}/jacocoTestReport.xml" \
               --base "$(Pipeline.Workspace)/${{ parameters.devBranchReportArtifact }}/jacocoTestReport.xml" \
               --metric ${{ parameters.metric }} \

--- a/azure-pipelines/code-coverage/compare-code-coverage.yml
+++ b/azure-pipelines/code-coverage/compare-code-coverage.yml
@@ -65,13 +65,22 @@ stages:
           displayName: Compare Jacoco Coverage
         - bash: |
             # Surface the per-class breakdown in the build's Extensions/Summary tab even
-            # when the comparison step failed the build on a coverage drop.
-            echo "##vso[task.uploadsummary]$(Build.ArtifactStagingDirectory)/coverage-comparison.md"
+            # when the comparison step failed the build on a coverage drop. Guard on the
+            # file existing so this step can't fail/obscure the real error if the compare
+            # script exited before writing it.
+            summary="$(Build.ArtifactStagingDirectory)/coverage-comparison.md"
+            if [ -f "$summary" ]; then
+              echo "##vso[task.uploadsummary]$summary"
+            else
+              echo "No coverage-comparison.md was produced; nothing to upload to summary."
+            fi
           displayName: Publish comparison to build summary
           condition: succeededOrFailed()
         - task: PublishPipelineArtifact@1
           displayName: Publish coverage comparison
           condition: succeededOrFailed()
           inputs:
-            targetPath: '$(Build.ArtifactStagingDirectory)/coverage-comparison.md'
+            # Publish the staging directory (not the single .md) so publishing still
+            # succeeds when only the JSON exists (or the comparison was skipped).
+            targetPath: '$(Build.ArtifactStagingDirectory)'
             artifactName: coverage-comparison

--- a/azure-pipelines/code-coverage/compare_coverage.py
+++ b/azure-pipelines/code-coverage/compare_coverage.py
@@ -56,6 +56,23 @@ def _aggregate(paths, metric):
     return agg
 
 
+# JaCoCo <counter type="..."> values. Guards against silent 0% when a caller passes
+# a typo'd or wrong-cased metric (which would otherwise match no counters).
+VALID_METRICS = {"INSTRUCTION", "LINE", "BRANCH", "COMPLEXITY", "METHOD", "CLASS"}
+
+
+def _write_skip(args, metric, reason):
+    """Write a 'skipped/not gating' Markdown + JSON so downstream publish steps that
+    always run (succeededOrFailed) still find the expected output files."""
+    if args.out_md:
+        with open(args.out_md, "w", encoding="utf-8") as handle:
+            handle.write(f"# Code Coverage Comparison ({metric}) - SKIPPED\n\n{reason}\n")
+    if args.out_json:
+        with open(args.out_json, "w", encoding="utf-8") as handle:
+            json.dump({"metric": metric, "skipped": True, "reason": reason,
+                       "failed": False}, handle, indent=2)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -80,6 +97,14 @@ def main():
     args = parser.parse_args()
 
     metric = args.metric.upper()
+    if metric not in VALID_METRICS:
+        sys.stderr.write(f"ERROR: --metric must be one of {sorted(VALID_METRICS)}; "
+                         f"got {args.metric!r}\n")
+        return 2
+    if args.tolerance < 0 or args.unit_tolerance < 0:
+        sys.stderr.write("ERROR: --tolerance and --unit-tolerance must be "
+                         "non-negative percentage points.\n")
+        return 2
     base_paths, pr_paths = [], []
     for pattern in args.base:
         base_paths.extend(glob.glob(pattern, recursive=True))
@@ -88,11 +113,16 @@ def main():
 
     if not pr_paths:
         sys.stderr.write(f"ERROR: no PR coverage files matched: {', '.join(args.pr)}\n")
+        _write_skip(args, metric, "No PR coverage report was found, so no comparison "
+                    "could be made (not gating).")
         return 2
     if not base_paths:
         # No baseline (e.g. new module / first run): don't block the PR.
+        reason = ("No base (dev) coverage report was found, so there is nothing to "
+                  "compare against; skipping the coverage gate (not gating).")
         sys.stderr.write("WARNING: no base coverage files matched: "
                          f"{', '.join(args.base)}; skipping comparison (not gating).\n")
+        _write_skip(args, metric, reason)
         return 0
 
     base = _aggregate(base_paths, metric)
@@ -106,18 +136,24 @@ def main():
     pr_pct = _pct(pr_cov, pr_miss)
     delta = round(pr_pct - base_pct, 2)
 
-    regressed, new_gaps = [], []
+    regressed, new_gaps, removed = [], [], 0
     for unit in sorted(set(base) | set(pr)):
         b = base.get(unit)
-        p = pr.get(unit, {"Covered": 0, "Missed": 0})
-        p_pct = _pct(p["Covered"], p["Missed"])
+        p = pr.get(unit)
         if b is None:
+            # New class in the PR: report it as a gap if it lacks coverage.
+            p_pct = _pct(p["Covered"], p["Missed"])
             if p["Missed"] >= args.min_missed:
                 new_gaps.append({"Unit": unit, "Percentage": p_pct,
                                  "Missed": p["Missed"],
                                  "Total": p["Covered"] + p["Missed"]})
             continue
+        if p is None:
+            # Class removed in the PR: not a coverage regression, so don't list it.
+            removed += 1
+            continue
         b_pct = _pct(b["Covered"], b["Missed"])
+        p_pct = _pct(p["Covered"], p["Missed"])
         d = round(p_pct - b_pct, 2)
         if d < -args.unit_tolerance:
             regressed.append({"Unit": unit, "BasePct": b_pct, "PrPct": p_pct,
@@ -178,6 +214,7 @@ def main():
             json.dump({"metric": metric, "basePercentage": base_pct,
                        "prPercentage": pr_pct, "deltaPp": delta,
                        "tolerancePp": args.tolerance, "failed": failed,
+                       "removedClasses": removed,
                        "regressed": regressed, "newGaps": new_gaps}, handle, indent=2)
 
     print(markdown)

--- a/azure-pipelines/code-coverage/compare_coverage.py
+++ b/azure-pipelines/code-coverage/compare_coverage.py
@@ -1,28 +1,192 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Compare JaCoCo coverage between a base (target/dev) report and a PR report.
+
+Used as a blocking PR check: it fails (exit 1) when overall coverage drops by more
+than the allowed tolerance, and prints a per-class breakdown of WHERE coverage
+regressed so the PR author knows exactly which classes need tests.
+
+Usage:
+  compare_coverage.py --base <dev.xml>...  --pr <pr.xml>...
+      [--metric LINE|BRANCH] [--tolerance PP] [--unit-tolerance PP]
+      [--min-missed N] [--top N] [--out-md FILE] [--out-json FILE]
+      [--no-fail-on-drop]
+
+Stdlib only - runs on any pipeline image with Python 3.
+"""
+
+import argparse
+import glob
+import json
 import sys
 import xml.etree.ElementTree as ET
 
-def get_coverage(xml_path):
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-    # Get the overall counter (direct child of report element, not nested in packages/classes)
-    # Use LINE coverage to match Azure DevOps reporting
-    counter = root.find("./counter[@type='LINE']")
-    covered = int(counter.attrib['covered'])
-    missed = int(counter.attrib['missed'])
-    return covered / (covered + missed)
+
+def _pct(covered, missed):
+    total = covered + missed
+    return round(100.0 * covered / total, 2) if total else 0.0
+
+
+def _class_units(xml_path, metric):
+    """Return {class_name: {'Covered': c, 'Missed': m}} for a JaCoCo report."""
+    root = ET.parse(xml_path).getroot()
+    units = {}
+    for cls in root.iter("class"):
+        name = (cls.get("name") or "").replace("/", ".")
+        for counter in cls.findall("counter"):
+            if counter.get("type", "").upper() == metric:
+                entry = units.setdefault(name, {"Covered": 0, "Missed": 0})
+                entry["Covered"] += int(counter.get("covered", 0))
+                entry["Missed"] += int(counter.get("missed", 0))
+                break
+    return units
+
+
+def _aggregate(paths, metric):
+    agg = {}
+    for path in sorted(set(paths)):
+        try:
+            for name, cm in _class_units(path, metric).items():
+                entry = agg.setdefault(name, {"Covered": 0, "Missed": 0})
+                entry["Covered"] += cm["Covered"]
+                entry["Missed"] += cm["Missed"]
+        except (ET.ParseError, OSError) as exc:
+            sys.stderr.write(f"WARNING: skipping {path}: {exc}\n")
+    return agg
+
 
 def main():
-    pr_cov = get_coverage(sys.argv[1])
-    dev_cov = get_coverage(sys.argv[2])
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", nargs="+", required=True,
+                        help="Baseline (target/dev) JaCoCo XML file(s) or glob(s).")
+    parser.add_argument("--pr", nargs="+", required=True,
+                        help="PR branch JaCoCo XML file(s) or glob(s).")
+    parser.add_argument("--metric", default="LINE", help="LINE (default) or BRANCH.")
+    parser.add_argument("--tolerance", type=float, default=0.0,
+                        help="Allowed overall drop (percentage points) before failing.")
+    parser.add_argument("--unit-tolerance", type=float, default=0.0, dest="unit_tolerance",
+                        help="Per-class drop (pp) below which a class is listed as regressed.")
+    parser.add_argument("--min-missed", type=int, default=1, dest="min_missed",
+                        help="Ignore new classes with fewer missed units than this.")
+    parser.add_argument("--top", type=int, default=25,
+                        help="Show only the top N rows per table (0 = all).")
+    parser.add_argument("--out-md", default="", dest="out_md")
+    parser.add_argument("--out-json", default="", dest="out_json")
+    parser.add_argument("--no-fail-on-drop", action="store_false", dest="fail_on_drop",
+                        help="Report the diff but never exit non-zero (non-gating).")
+    parser.set_defaults(fail_on_drop=True)
+    args = parser.parse_args()
 
-    print(f"PR branch coverage: {pr_cov:.2%}")
-    print(f"Dev branch coverage: {dev_cov:.2%}")
+    metric = args.metric.upper()
+    base_paths, pr_paths = [], []
+    for pattern in args.base:
+        base_paths.extend(glob.glob(pattern, recursive=True))
+    for pattern in args.pr:
+        pr_paths.extend(glob.glob(pattern, recursive=True))
 
-    if pr_cov < dev_cov:
-        print("ERROR: PR branch coverage is lower than dev branch. Failing...")
-        sys.exit(1)
-    else:
-        print("SUCCESS: PR branch coverage is not lower than dev branch, this is acceptable!")
-        sys.exit(0)
+    if not pr_paths:
+        sys.stderr.write(f"ERROR: no PR coverage files matched: {', '.join(args.pr)}\n")
+        return 2
+    if not base_paths:
+        # No baseline (e.g. new module / first run): don't block the PR.
+        sys.stderr.write("WARNING: no base coverage files matched: "
+                         f"{', '.join(args.base)}; skipping comparison (not gating).\n")
+        return 0
 
-main()
+    base = _aggregate(base_paths, metric)
+    pr = _aggregate(pr_paths, metric)
+
+    base_cov = sum(v["Covered"] for v in base.values())
+    base_miss = sum(v["Missed"] for v in base.values())
+    pr_cov = sum(v["Covered"] for v in pr.values())
+    pr_miss = sum(v["Missed"] for v in pr.values())
+    base_pct = _pct(base_cov, base_miss)
+    pr_pct = _pct(pr_cov, pr_miss)
+    delta = round(pr_pct - base_pct, 2)
+
+    regressed, new_gaps = [], []
+    for unit in sorted(set(base) | set(pr)):
+        b = base.get(unit)
+        p = pr.get(unit, {"Covered": 0, "Missed": 0})
+        p_pct = _pct(p["Covered"], p["Missed"])
+        if b is None:
+            if p["Missed"] >= args.min_missed:
+                new_gaps.append({"Unit": unit, "Percentage": p_pct,
+                                 "Missed": p["Missed"],
+                                 "Total": p["Covered"] + p["Missed"]})
+            continue
+        b_pct = _pct(b["Covered"], b["Missed"])
+        d = round(p_pct - b_pct, 2)
+        if d < -args.unit_tolerance:
+            regressed.append({"Unit": unit, "BasePct": b_pct, "PrPct": p_pct,
+                              "Delta": d, "Missed": p["Missed"]})
+
+    regressed.sort(key=lambda r: (r["Delta"], -r["Missed"]))
+    new_gaps.sort(key=lambda r: (-r["Missed"], r["Percentage"]))
+
+    failed = args.fail_on_drop and (pr_pct < base_pct - args.tolerance - 1e-9)
+    verdict = "FAIL" if failed else "PASS"
+    sign = "+" if delta >= 0 else ""
+
+    lines = [
+        f"# Code Coverage Comparison ({metric}) - {verdict}",
+        "",
+        "| | Base | PR | Delta |",
+        "| --- | --- | --- | --- |",
+        f"| **{metric} coverage** | {base_pct}% | {pr_pct}% | {sign}{delta} pp |",
+        "",
+    ]
+    if args.tolerance:
+        lines += [f"_Allowed drop (tolerance): {args.tolerance} pp._", ""]
+    if failed:
+        lines += [f"**Coverage dropped by {abs(delta)} pp** (base {base_pct}% -> PR "
+                  f"{pr_pct}%), exceeding the allowed {args.tolerance} pp. "
+                  "Add tests for the classes below to restore coverage.", ""]
+
+    if regressed:
+        top_reg = regressed[:args.top] if args.top > 0 else regressed
+        lines += [f"## Classes with reduced coverage ({len(regressed)})", "",
+                  "| Class | Base | PR | Delta | Missed (PR) |",
+                  "| --- | --- | --- | --- | --- |"]
+        for r in top_reg:
+            lines.append(f"| {r['Unit']} | {r['BasePct']}% | {r['PrPct']}% | "
+                         f"{r['Delta']} pp | {r['Missed']} |")
+        lines.append("")
+
+    if new_gaps:
+        top_new = new_gaps[:args.top] if args.top > 0 else new_gaps
+        lines += [f"## New/changed classes lacking coverage ({len(new_gaps)})", "",
+                  "| Class | Coverage | Missed | Covered/Total |",
+                  "| --- | --- | --- | --- |"]
+        for r in top_new:
+            covered = r["Total"] - r["Missed"]
+            lines.append(f"| {r['Unit']} | {r['Percentage']}% | {r['Missed']} | "
+                         f"{covered}/{r['Total']} |")
+        lines.append("")
+
+    if not regressed and not new_gaps:
+        lines += ["_No per-class coverage regressions detected._", ""]
+
+    markdown = "\n".join(lines) + "\n"
+    if args.out_md:
+        with open(args.out_md, "w", encoding="utf-8") as handle:
+            handle.write(markdown)
+    if args.out_json:
+        with open(args.out_json, "w", encoding="utf-8") as handle:
+            json.dump({"metric": metric, "basePercentage": base_pct,
+                       "prPercentage": pr_pct, "deltaPp": delta,
+                       "tolerancePp": args.tolerance, "failed": failed,
+                       "regressed": regressed, "newGaps": new_gaps}, handle, indent=2)
+
+    print(markdown)
+    if failed:
+        print(f"ERROR: PR {metric} coverage {pr_pct}% is below base {base_pct}% "
+              f"(drop {abs(delta)} pp > tolerance {args.tolerance} pp). Failing.",
+              file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/azure-pipelines/code-coverage/compare_coverage.py
+++ b/azure-pipelines/code-coverage/compare_coverage.py
@@ -61,16 +61,17 @@ def _aggregate(paths, metric):
 VALID_METRICS = {"INSTRUCTION", "LINE", "BRANCH", "COMPLEXITY", "METHOD", "CLASS"}
 
 
-def _write_skip(args, metric, reason):
-    """Write a 'skipped/not gating' Markdown + JSON so downstream publish steps that
-    always run (succeededOrFailed) still find the expected output files."""
+def _write_status(args, metric, status, reason, failed):
+    """Write a status-only ('SKIPPED' or 'ERROR') Markdown + JSON so downstream publish
+    steps that always run (succeededOrFailed) still find the expected output files, and
+    so the published report matches the job outcome (skipped vs failed)."""
     if args.out_md:
         with open(args.out_md, "w", encoding="utf-8") as handle:
-            handle.write(f"# Code Coverage Comparison ({metric}) - SKIPPED\n\n{reason}\n")
+            handle.write(f"# Code Coverage Comparison ({metric}) - {status}\n\n{reason}\n")
     if args.out_json:
         with open(args.out_json, "w", encoding="utf-8") as handle:
-            json.dump({"metric": metric, "skipped": True, "reason": reason,
-                       "failed": False}, handle, indent=2)
+            json.dump({"metric": metric, "status": status.lower(), "reason": reason,
+                       "failed": failed}, handle, indent=2)
 
 
 def main():
@@ -112,9 +113,11 @@ def main():
         pr_paths.extend(glob.glob(pattern, recursive=True))
 
     if not pr_paths:
+        # PR coverage is required; a missing PR report is an error, not a skip.
+        reason = ("No PR coverage report was found, so no comparison could be made. "
+                  "PR coverage is required - failing.")
         sys.stderr.write(f"ERROR: no PR coverage files matched: {', '.join(args.pr)}\n")
-        _write_skip(args, metric, "No PR coverage report was found, so no comparison "
-                    "could be made (not gating).")
+        _write_status(args, metric, "ERROR", reason, failed=True)
         return 2
     if not base_paths:
         # No baseline (e.g. new module / first run): don't block the PR.
@@ -122,11 +125,28 @@ def main():
                   "compare against; skipping the coverage gate (not gating).")
         sys.stderr.write("WARNING: no base coverage files matched: "
                          f"{', '.join(args.base)}; skipping comparison (not gating).\n")
-        _write_skip(args, metric, reason)
+        _write_status(args, metric, "SKIPPED", reason, failed=False)
         return 0
 
     base = _aggregate(base_paths, metric)
     pr = _aggregate(pr_paths, metric)
+
+    # _aggregate() only warns on unreadable/invalid XML. If every report failed to
+    # parse the aggregate is empty, which would otherwise score 0% and produce a
+    # misleading PASS/FAIL - so treat an empty aggregate explicitly.
+    if not pr:
+        reason = ("PR coverage report(s) matched but none could be parsed (empty/invalid "
+                  f"JaCoCo XML or no '{metric}' counters). Failing.")
+        sys.stderr.write("ERROR: " + reason + "\n")
+        _write_status(args, metric, "ERROR", reason, failed=True)
+        return 2
+    if not base:
+        reason = ("Base (dev) coverage report(s) matched but none could be parsed "
+                  f"(empty/invalid JaCoCo XML or no '{metric}' counters); skipping the "
+                  "coverage gate (not gating).")
+        sys.stderr.write("WARNING: " + reason + "\n")
+        _write_status(args, metric, "SKIPPED", reason, failed=False)
+        return 0
 
     base_cov = sum(v["Covered"] for v in base.values())
     base_miss = sum(v["Missed"] for v in base.values())

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/PackageHelperTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/PackageHelperTest.java
@@ -38,14 +38,10 @@ import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-// TEMP: disabled to intentionally drop PackageHelper coverage and validate the
-// PR code-coverage gate end-to-end. REVERT before merge.
-@Ignore("Temporary: validating the code-coverage gate; revert before merge.")
 @RunWith(RobolectricTestRunner.class)
 public class PackageHelperTest {
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/broker/PackageHelperTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/broker/PackageHelperTest.java
@@ -38,10 +38,14 @@ import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+// TEMP: disabled to intentionally drop PackageHelper coverage and validate the
+// PR code-coverage gate end-to-end. REVERT before merge.
+@Ignore("Temporary: validating the code-coverage gate; revert before merge.")
 @RunWith(RobolectricTestRunner.class)
 public class PackageHelperTest {
 


### PR DESCRIPTION
## What
Make the PR-vs-dev JaCoCo coverage comparison a real **gate** and show **where** coverage regressed.

- Rewrote `azure-pipelines/code-coverage/compare_coverage.py` to diff base(dev) vs PR **per class**: reports overall LINE/BRANCH delta, lists classes whose coverage **regressed**, and lists new/changed classes lacking coverage. Exits non-zero when overall coverage drops beyond `--tolerance`.
- Updated `compare-code-coverage.yml` to pass `metric`/`tolerance`/`failOnDrop`, upload the per-class Markdown breakdown to the build **Summary**, publish it as an artifact, and **remove `continueOnError`** on the compare job so a drop actually fails the check. Base-report download is tolerant so a flaky/missing baseline skips gating instead of blocking PRs.

## Why
Previously the compare job had `continueOnError: true` (never failed) and only compared the overall %. Now a coverage drop blocks the PR and the author sees exactly which classes to add tests for.

Consumed by the broker PR pipeline via `compare-code-coverage.yml@common` once merged to dev.

## Skipping the gate (escape hatch)
A dev can bypass the coverage gate on their PR in an emergency, or if the check itself breaks, by applying the **`skip-coverage-check`** label to the PR. When present, the compare job is skipped entirely; remove the label to re-enable the gate.

- Implemented by fetching the PR's GitHub labels via the existing `fetch-pr-labels.yml` template (a new `coverage_get_label` stage that runs in parallel with the build, so no extra wall-clock cost), then gating the compare job on `not(contains(prLabels, skipLabel))` — the same pattern `build-consumers.yml` uses for `skipConsumerValidationLabel`.
- The label name is a template parameter (`skipLabel`, default `skip-coverage-check`), so no pipeline UI variable is required. On non-PR runs no labels are read, so the gate still runs.


[AB#3590302](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3590302)
