### PR TITLE
Enable toBuilder on AcquirePrtSsoTokenResult, Fixes AB#3702570

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/commands/AcquirePrtSsoTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/commands/AcquirePrtSsoTokenResult.java
@@ -35,7 +35,7 @@ import lombok.experimental.Accessors;
 /**
  * A DTO for the results from an AcquirePrtSsoToken request.
  */
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @Accessors(prefix = "m")
 public class AcquirePrtSsoTokenResult {


### PR DESCRIPTION
Enables `toBuilder` on `AcquirePrtSsoTokenResult` so callers can copy an immutable result with a single field changed.

### Change
- `@Builder` -> `@Builder(toBuilder = true)` on `AcquirePrtSsoTokenResult` (purely additive; Lombok generates an extra `toBuilder()` method, no existing callers affected).

### Why
Unblocks the broker unique-PRT-header-names fix, which needs to copy a per-PRT result with only `cookieName` changed. Without `toBuilder` the broker must manually re-copy all 9 fields; with it the broker collapses that to `result.toBuilder().cookieName(...).build()`.

Related work item: [AB#3702570](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3702570)