### PR TITLE
Fix broker GHE migration in shared PR-validation label fetch + consumer build, Fixes AB#3699280

### DIFF
--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -31,7 +31,7 @@ resources:
     ref: dev
     endpoint: ANDROID_GITHUB
   - repository: broker
-    type: githubenterprise
+    type: github
     name: security/ad-accounts-for-android
     ref: dev
     endpoint: MSFT_GHE_SECURITY

--- a/azure-pipelines/pull-request-validation/build-consumers.yml
+++ b/azure-pipelines/pull-request-validation/build-consumers.yml
@@ -31,10 +31,10 @@ resources:
     ref: dev
     endpoint: ANDROID_GITHUB
   - repository: broker
-    type: github
-    name: identity-authnz-teams/ad-accounts-for-android
+    type: githubenterprise
+    name: security/ad-accounts-for-android
     ref: dev
-    endpoint: github-inside-microsoft
+    endpoint: MSFT_GHE_SECURITY
 
 stages:
 - stage: getLabel

--- a/azure-pipelines/pull-request-validation/pr-common-instrumented.yml
+++ b/azure-pipelines/pull-request-validation/pr-common-instrumented.yml
@@ -7,9 +7,13 @@
 #              works as a Build Validation branch policy on the common repo.
 name: $(date:yyyyMMdd)$(rev:.r)
 
-# PR validation is driven by a Build Validation branch policy in ADO, not by YAML triggers.
-pr: none
-trigger: none
+trigger: none  # Disable CI trigger if you only want PR-based runs
+pr:
+  branches:
+    include:
+      - dev
+      - release/*
+
 
 resources:
   repositories:

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -2,9 +2,24 @@ jobs:
 - job: getLabelsJob
   displayName: Fetch PR Labels
   steps:
+    # Shallow checkout so the persisted repo credential can authenticate the labels API
+    # call -- required for private / GitHub Enterprise repos (e.g. broker on msft.ghe.com).
+    - checkout: self
+      fetchDepth: 1
+      persistCredentials: true
     - bash: |
-        echo "Fetching labels from https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-        temp=$(curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | jq -jc '.[] | {name}')
+        # Derive the API base from the repo host: github.com -> api.github.com, else GHE /api/v3.
+        host=$(echo "$BUILD_REPOSITORY_URI" | sed -E 's#^[a-zA-Z]+://([^/]+)/.*#\1#')
+        if [ "$host" = "github.com" ]; then
+          apiBase="https://api.github.com"
+        else
+          apiBase="https://$host/api/v3"
+        fi
+        url="$apiBase/repos/$BUILD_REPOSITORY_NAME/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+        echo "Fetching labels from $url"
+        # Reuse the credential the checkout persisted (empty for public repos, which is fine).
+        authHeader=$(git config --get-regexp '^http\..*\.extraheader$' | grep -i 'AUTHORIZATION:' | head -n1 | sed -E 's/^[^ ]+[[:space:]]+[Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//')
+        temp=$(curl -s -H "Accept: application/vnd.github+json" -H "User-Agent: azure-pipelines-fetch-pr-labels" ${authHeader:+-H "Authorization: $authHeader"} "$url" | jq -jc '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/azure-pipelines/templates/steps/fetch-pr-labels.yml
+++ b/azure-pipelines/templates/steps/fetch-pr-labels.yml
@@ -19,7 +19,9 @@ jobs:
         echo "Fetching labels from $url"
         # Reuse the credential the checkout persisted (empty for public repos, which is fine).
         authHeader=$(git config --get-regexp '^http\..*\.extraheader$' | grep -i 'AUTHORIZATION:' | head -n1 | sed -E 's/^[^ ]+[[:space:]]+[Aa][Uu][Tt][Hh][Oo][Rr][Ii][Zz][Aa][Tt][Ii][Oo][Nn]:[[:space:]]*//')
-        temp=$(curl -s -H "Accept: application/vnd.github+json" -H "User-Agent: azure-pipelines-fetch-pr-labels" ${authHeader:+-H "Authorization: $authHeader"} "$url" | jq -jc '.[] | {name}')
+        curlArgs=(-s -H "Accept: application/vnd.github+json" -H "User-Agent: azure-pipelines-fetch-pr-labels")
+        if [ -n "$authHeader" ]; then curlArgs+=(-H "Authorization: $authHeader"); fi
+        temp=$(curl "${curlArgs[@]}" "$url" | jq -jc '.[] | {name}')
         echo -e "##vso[task.setvariable variable=prLabels;isOutput=true]$temp"
         echo "$temp"
       condition: eq(variables['Build.Reason'], 'PullRequest')


### PR DESCRIPTION
## What
Fixes two broker GHE-migration leftovers in the shared PR-validation pipelines so label-based skips and consumer validation work for broker now that it lives on `msft.ghe.com/security/ad-accounts-for-android`.

## Changes
- **`azure-pipelines/templates/steps/fetch-pr-labels.yml`** - the labels API call was hardcoded to `https://api.github.com` and unauthenticated, so for the private GHE broker repo it returned nothing and `prLabels` was always empty. Now it:
  - derives the API base from the repo host (`github.com` -> `api.github.com`, else `{host}/api/v3`),
  - uses `Build.Repository.Name` for the `owner/repo` path,
  - authenticates by reusing the credential persisted by a shallow `checkout: self`.

  This makes `skip-coverage-check`, `skipConsumerValidationLabel`, etc. actually work on broker PRs. It stays fail-safe: on non-PR/errors `prLabels` is empty so gates still run.
- **`azure-pipelines/pull-request-validation/build-consumers.yml`** - broker repo resource updated from `type: github` / `identity-authnz-teams/ad-accounts-for-android` / `github-inside-microsoft` to `type: githubenterprise` / `security/ad-accounts-for-android` / `MSFT_GHE_SECURITY`.

## Impact
Shared across msal/adal/broker consumers. Additive/host-agnostic - github.com consumers keep working (now authenticated, avoiding rate limits). Adds a shallow `checkout: self` to the label stage (previously none).


[AB#3699280](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3699280)
