### PR TITLE
Rapong/handle authenticator fre battery opt page, Fixes AB#3694239

### DIFF
--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/LabConstants.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/LabConstants.java
@@ -41,7 +41,6 @@ public class LabConstants {
         public static final String MDM_CA = "mdm_ca";
         public static final String MAM_CA = "mam_ca";
         public static final String MAM_ON_SPO = "mam_on_spo";
-        public static final String TP_CA = "tpca";
         public static final String TRUE_MAM_CA = "true_mam_ca";
         public static final String WP = "wp";
         public static final String FEDERATED = "federated";
@@ -55,6 +54,7 @@ public class LabConstants {
         public static final String PPE = "ppe";
         public static final String QR_PIN = "qr_pin";
         public static final String TOKEN_BINDING = "token_binding";
+        public static final String MDM_AND_TOKEN_BINDING = "mdm_and_token_binding";
         public static final String CBA = "cba";
         public static final String RESOURCE_ACCOUNT_1 = "resource_account_1";
         public static final String RESOURCE_ACCOUNT_2 = "resource_account_2";

--- a/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/UserType.java
+++ b/LabApiUtilities/src/main/com/microsoft/identity/labapi/utilities/constants/UserType.java
@@ -44,6 +44,7 @@ public enum UserType {
     PPE(LabConstants.UserType.PPE),
     QR_PIN(LabConstants.UserType.QR_PIN),
     TOKEN_BINDING(LabConstants.UserType.TOKEN_BINDING),
+    MDM_AND_TOKEN_BINDING(LabConstants.UserType.MDM_AND_TOKEN_BINDING),
     CBA(LabConstants.UserType.CBA),
     RESOURCE_ACCOUNT_1(LabConstants.UserType.RESOURCE_ACCOUNT_1),
     RESOURCE_ACCOUNT_2(LabConstants.UserType.RESOURCE_ACCOUNT_2),

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -48,6 +48,7 @@ import com.microsoft.identity.client.ui.automation.constants.DeviceAdmin;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.logging.Logger;
 import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
@@ -397,12 +398,50 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
             UiAutomatorUtils.handleButtonClick("com.azure.authenticator:id/privacy_consent_button");
             // Continue button
             UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("Continue");
+            // Non-skippable battery optimization page, between privacy and FRX sign-in
+            handleBatteryOptimizationFrePage();
             // the skip button
             UiAutomatorUtils.handleButtonClick("com.azure.authenticator:id/frx_skip_button");
             // This is required for auth app as it has increased the compile sdk version to 34
             UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("NOT NOW", FIND_UI_ELEMENT_TIMEOUT_SHORT);
             shouldHandleFirstRun = false;
         }
+    }
+
+    /**
+     * Handle Authenticator's non-skippable "Turn off battery optimization" page, which sits
+     * between the privacy screens and the FRX sign-in screen.
+     *
+     * Best-effort: the page only renders when the OS reports Authenticator as subject to battery
+     * optimization, so an already-exempt device, the kill-switch flight being off, or an older
+     * Authenticator build all mean we continue straight to FRX.
+     *
+     * When it does render, tapping the button fires
+     * {@link android.provider.Settings#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS}, so the OS
+     * dialog has to be dismissed as well before the app advances.
+     */
+    private void handleBatteryOptimizationFrePage() {
+        // The page is Compose, so its id is published via testTagsAsResourceId and is the bare
+        // tag rather than the "package:id/name" form the XML FRE screens use.
+        final UiObject turnOffButton = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                "fre_battery_opt_button",
+                CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT
+        );
+
+        if (!turnOffButton.exists()) {
+            Logger.i(TAG, "Battery optimization FRE page not shown; continuing to FRX.");
+            return;
+        }
+
+        Logger.i(TAG, "Battery optimization FRE page shown. Tapping the action button..");
+        try {
+            turnOffButton.click();
+        } catch (final UiObjectNotFoundException e) {
+            throw new AssertionError("Failed to click 'Turn off battery optimization'.", e);
+        }
+
+        // Reuse the existing handler rather than duplicating its dialog-identity checks.
+        new AadLoginComponentHandler().handleBatteryOptimizationIgnoreSystemPrompt();
     }
 
     @Override

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/broker/BrokerMicrosoftAuthenticator.java
@@ -441,7 +441,11 @@ public class BrokerMicrosoftAuthenticator extends AbstractTestBroker implements 
         }
 
         // Reuse the existing handler rather than duplicating its dialog-identity checks.
-        new AadLoginComponentHandler().handleBatteryOptimizationIgnoreSystemPrompt();
+        try {
+            new AadLoginComponentHandler().handleBatteryOptimizationIgnoreSystemPrompt();
+        } catch (final AssertionError e) {
+            Logger.w(TAG, "Battery-optimization system prompt did not appear; continuing to FRX.", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
[AB#3694239](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3694239)

Add a new account type MDM_AND_TOKEN_BINDING, which has the non-Work profile MDM policy and Token protection policy enabled.

Adds a logic to handle Authenticator's Battery Optimization prompt in First run experience.
https://msazure.visualstudio.com/One/_git/AD-MFA-phonefactor-phoneApp-android/pullrequest/16719767