### PR TITLE
Fixes AB#3733031 Remove name value storage lock flight

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Remove the USE_LOCKS_IN_NAME_VALUE_STORAGE flight and always use per-storage read/write locks in NameValueStorageFileManagerSimpleCacheImpl
 - [PATCH] Security (CWE-918): stop the sso_nonce WebView redirect handler (NonceRedirectHandler) from forwarding the PRT credential header (x-ms-RefreshTokenCredential) to untrusted or cleartext redirect targets; only forward to validated HTTPS AAD cloud hosts and otherwise load the page without the credential, gated by ENABLE_NONCE_REDIRECT_CREDENTIAL_HEADER_VALIDATION CommonFlight (default on) (#3199)
 - [MINOR] Add GET_DEVICE_TOKEN_V1 protocol with required clientId and redirectUri, exposed as DeviceRegistrationClientApplication.getDeviceTokenResult returning the full token response (access token, device info, token type, resource, expiry fields). Deprecate getDeviceToken in favour of it (#3147)
 - [PATCH] Remove the abandoned CALL_REFACTORED_SAVE_AND_LOAD_AGGREGATED_ACCOUNT_METHOD flight and its unused optimized cache save-and-load implementation (#3218)

--- a/common4j/src/main/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImpl.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImpl.java
@@ -25,8 +25,6 @@ package com.microsoft.identity.common.java.cache;
 import lombok.NonNull;
 
 import com.google.gson.Gson;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.logging.Logger;
@@ -68,8 +66,6 @@ public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements I
     private static final Map<String, ReentrantReadWriteLock> STORAGE_LOCKS = new ConcurrentHashMap<>();
     private final ReentrantReadWriteLock metadataCacheLock;
 
-    private final boolean useLocks;
-
     /**
      * Constructs a new NameValueStorageFileManagerSimpleCacheImpl. Convenience class for persisting
      * lists of arbitrarily-typed data. Duplicate reinsertion is disabled (backcompat) by default.
@@ -106,7 +102,6 @@ public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements I
         mForceReinsertionOfDuplicates = forceReinsertionOfDuplicates;
         // Get or create a lock for this specific storage file
         metadataCacheLock = STORAGE_LOCKS.computeIfAbsent(name, k -> new ReentrantReadWriteLock());
-        useLocks = CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.USE_LOCKS_IN_NAME_VALUE_STORAGE);
     }
 
     private interface NamedRunnable<V> extends Callable<V> {
@@ -135,36 +130,6 @@ public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements I
 
     @Override
     public boolean insert(final T t) {
-        if (useLocks) {
-            return insertWithLocks(t);
-        }
-        return execWithTiming(new NamedRunnable<Boolean>() {
-            @Override
-            public String getName() {
-                return "insert";
-            }
-
-            @Override
-            public Boolean call() {
-                final Set<T> allMetadata = new HashSet<>(getAllInternal());
-
-                if (mForceReinsertionOfDuplicates) {
-                    // This is a bit of workaround for Set's default behavior
-                    // where items already within the Set are not replaced if they are
-                    // inserted but already exist.
-                    // This makes it behave more like a Map.
-                    allMetadata.remove(t);
-                }
-
-                allMetadata.add(t);
-                final String json = mGson.toJson(allMetadata);
-                mStorage.put(mKeySingleEntry, json);
-                return true;
-            }
-        });
-    }
-
-    private boolean insertWithLocks(final T t) {
         metadataCacheLock.writeLock().lock();
         try {
             return execWithTiming(new NamedRunnable<Boolean>() {
@@ -231,15 +196,6 @@ public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements I
         }
     }
 
-    private List<T> getAllWithLocks() {
-        metadataCacheLock.readLock().lock();
-        try {
-            return getAllInternal();
-        } finally {
-            metadataCacheLock.readLock().unlock();
-        }
-    }
-
     /**
      * Internal helper method to retrieve all items from storage without acquiring a lock.
      * This method should only be called when a lock (read or write) is already held by the caller.
@@ -271,24 +227,6 @@ public abstract class NameValueStorageFileManagerSimpleCacheImpl<T> implements I
 
     @Override
     public boolean clear() {
-        if (useLocks) {
-            return clearWithLocks();
-        }
-        return execWithTiming(new NamedRunnable<Boolean>() {
-            @Override
-            public String getName() {
-                return "clear";
-            }
-
-            @Override
-            public Boolean call() {
-                mStorage.clear();
-                return true;
-            }
-        });
-    }
-
-    private boolean clearWithLocks() {
         metadataCacheLock.writeLock().lock();
         try {
             return execWithTiming(new NamedRunnable<Boolean>() {

--- a/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/flighting/CommonFlight.java
@@ -215,10 +215,6 @@ public enum CommonFlight implements IFlightConfig {
     RE_ENABLE_VALIDATE_SIGNING_CERT_CHAIN_BROKER_APPS("ReEnableValidateSigningCertChainBrokerApps", false),
 
     /**
-     * Flight to enable the use of locks in name value storage to prevent concurrent access issues.
-     */
-    USE_LOCKS_IN_NAME_VALUE_STORAGE("UseLocksInNameValueStorage", false),
-    /**
      * Flight to enable increased thread pool size for silent requests.
      * When true, uses 12 threads. When false, uses legacy 5 threads.
      */

--- a/common4j/src/test/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImplConcurrencyTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/cache/NameValueStorageFileManagerSimpleCacheImplConcurrencyTest.java
@@ -23,23 +23,16 @@
 package com.microsoft.identity.common.java.cache;
 
 import com.google.gson.reflect.TypeToken;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightsManager;
-import com.microsoft.identity.common.java.flighting.IFlightConfig;
-import com.microsoft.identity.common.java.flighting.IFlightsManager;
-import com.microsoft.identity.common.java.flighting.IFlightsProvider;
 import com.microsoft.identity.common.java.interfaces.INameValueStorage;
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents;
 import com.microsoft.identity.common.java.interfaces.IStorageSupplier;
 import com.microsoft.identity.common.java.util.IPlatformUtil;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.Type;
@@ -61,8 +54,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-
-import lombok.NonNull;
 
 /**
  * Concurrency tests for NameValueStorageFileManagerSimpleCacheImpl to verify that the
@@ -191,7 +182,6 @@ public class NameValueStorageFileManagerSimpleCacheImplConcurrencyTest {
         when(mockPlatformUtil.getNanosecondTime()).thenReturn(System.nanoTime());
         when(mockComponents.getStorageSupplier()).thenReturn(mockStorageSupplier);
         when(mockStorageSupplier.<String>getUnencryptedNameValueStore(anyString(), any())).thenReturn(storage);
-        updateFlightForTest(CommonFlight.USE_LOCKS_IN_NAME_VALUE_STORAGE, true);
 
         cache = new TestSimpleCache(mockComponents, TEST_CACHE_NAME, TEST_KEY);
     }
@@ -201,9 +191,6 @@ public class NameValueStorageFileManagerSimpleCacheImplConcurrencyTest {
         if (mocks != null) {
             mocks.close();
         }
-        updateFlightForTest(CommonFlight.USE_LOCKS_IN_NAME_VALUE_STORAGE, false);
-
-        CommonFlightsManager.INSTANCE.resetFlightsManager();
     }
 
     /**
@@ -211,8 +198,6 @@ public class NameValueStorageFileManagerSimpleCacheImplConcurrencyTest {
      */
     @Test
     public void testConcurrentInserts() throws InterruptedException {
-        updateFlightForTest(CommonFlight.USE_LOCKS_IN_NAME_VALUE_STORAGE, true);
-
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch completionLatch = new CountDownLatch(THREAD_COUNT);
         final Set<TestData> expectedData = Collections.synchronizedSet(new HashSet<>());
@@ -262,8 +247,6 @@ public class NameValueStorageFileManagerSimpleCacheImplConcurrencyTest {
      */
     @Test
     public void testConcurrentReadsAndWrites() throws InterruptedException {
-        updateFlightForTest(CommonFlight.USE_LOCKS_IN_NAME_VALUE_STORAGE, true);
-
         final CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT);
         final CountDownLatch completionLatch = new CountDownLatch(THREAD_COUNT);
         final AtomicInteger readCount = new AtomicInteger(0);
@@ -530,33 +513,4 @@ public class NameValueStorageFileManagerSimpleCacheImplConcurrencyTest {
         Assert.assertTrue("Test timed out", completed);
     }
 
-    private void updateFlightForTest(IFlightConfig flightName, boolean enabled) {
-        final IFlightsProvider mockFlightsProvider = Mockito.mock(IFlightsProvider.class);
-        Mockito.when(mockFlightsProvider.isFlightEnabled(flightName))
-                .thenReturn(enabled);
-
-        // Create anonymous IFlightsManager
-        IFlightsManager anonymousFlightsManager = new IFlightsManager() {
-            @Override
-            public @NotNull IFlightsProvider getFlightsProvider(long waitForConfigsWithTimeoutInMs) {
-                return mockFlightsProvider;
-            }
-            @Override
-            public @NotNull IFlightsProvider getFlightsProviderForTenant(@NotNull String tenantId, long waitForConfigsWithTimeoutInMs) {
-                return mockFlightsProvider;
-            }
-            @Override
-            public @NotNull IFlightsProvider getFlightsProviderForTenant(@NotNull String tenantId) {
-                return mockFlightsProvider;
-            }
-            @NonNull
-            @Override
-            public IFlightsProvider getFlightsProvider() {
-                return mockFlightsProvider;
-            }
-        };
-
-        // Initialize CommonFlightsManager with the anonymous implementation
-        CommonFlightsManager.INSTANCE.initializeCommonFlightsManager(anonymousFlightsManager);
-    }
 }


### PR DESCRIPTION
Fixes [AB#3733031](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3733031)

Now since the perf work is done, cleaning up the flight that is no longer needed.

## Summary
- remove the USE_LOCKS_IN_NAME_VALUE_STORAGE Common flight
- always use per-storage read/write locks for insert, remove, read, and clear operations
- remove obsolete flight test scaffolding and update the changelog

## Testing
- targeted concurrency tests could not run locally because the internal NewAndroid Maven feed returned HTTP 401 during Gradle dependency resolution