### PR TITLE
Retry Outlook account drawer lookup so a transient popup can't fail confirmAccount, Fixes AB#3737877

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Make OutlookApp.confirmAccount resilient to popups that hide the Outlook account drawer from the accessibility tree. Both Outlook's transient teaching callout (e.g. the folder-ordering tip, raised in its own popup window) and its modal alert dialogs (e.g. the Android 13+ "Enable Notifications" opt-in prompt) cause UiAutomator to resolve selectors against the popup rather than the drawer, so the account label lookup failed even though the account was visible on screen. The drawer lookup now dismisses any blocking dialog, re-opens the drawer, and retries up to 3 times, and the assertion message states the actual expectation (AB#3737877) (#3231)
+- [PATCH] Retry the Outlook account drawer lookup in OutlookApp.confirmAccount so a transient popup (teaching callout or modal dialog) can't fail the check (AB#3737877) (#3231)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Make OutlookApp.confirmAccount resilient to Outlook's transient teaching callout (e.g. the folder-ordering tip). The callout is raised in its own popup window, which causes UiAutomator to resolve selectors against the popup rather than the navigation drawer, so the account label lookup failed even though the account was visible on screen. The drawer is now re-opened after dismissing the popup, retrying up to 3 times, and the assertion message states the actual expectation (AB#3737877) (#3231)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Retry the Outlook account drawer lookup in OutlookApp.confirmAccount so a transient popup (teaching callout or modal dialog) can't fail the check (AB#3737877) (#3231)
+- [PATCH] Retry the Outlook account drawer lookup in OutlookApp.confirmAccount so a transient popup (teaching callout or modal dialog) can't fail the check (#3231)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Security: validate a PKeyAuth WebView-redirect SubmitUrl (attacker-controllable) as an HTTPS URL same-origin with the challenging endpoint before the device key signs or the WebView submits; flight-gated and ships in shadow mode (CWE-918 / AB#3706623)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [PATCH] Make OutlookApp.confirmAccount resilient to Outlook's transient teaching callout (e.g. the folder-ordering tip). The callout is raised in its own popup window, which causes UiAutomator to resolve selectors against the popup rather than the navigation drawer, so the account label lookup failed even though the account was visible on screen. The drawer is now re-opened after dismissing the popup, retrying up to 3 times, and the assertion message states the actual expectation (AB#3737877) (#3231)
+- [PATCH] Make OutlookApp.confirmAccount resilient to popups that hide the Outlook account drawer from the accessibility tree. Both Outlook's transient teaching callout (e.g. the folder-ordering tip, raised in its own popup window) and its modal alert dialogs (e.g. the Android 13+ "Enable Notifications" opt-in prompt) cause UiAutomator to resolve selectors against the popup rather than the drawer, so the account label lookup failed even though the account was visible on screen. The drawer lookup now dismisses any blocking dialog, re-opens the drawer, and retries up to 3 times, and the assertion message states the actual expectation (AB#3737877) (#3231)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -63,6 +63,15 @@ public class OutlookApp extends App implements IFirstPartyApp {
     private final static String ANDROID_DIALOG_NEGATIVE_BUTTON_RESOURCE_ID = "android:id/button2";
 
     /**
+     * Timeout for the blocking-dialog presence probe. A dialog that blocks the drawer is already on
+     * screen by the time we look, so this only needs to cover the accessibility tree settling rather
+     * than wait for a dialog to appear. It is kept short deliberately: the probe runs on every
+     * attempt, so a long timeout would be added to the common no-dialog path. A dialog that does
+     * turn up late is still caught by the next attempt.
+     */
+    private final static long BLOCKING_DIALOG_PROBE_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+
+    /**
      * Number of times we open the navigation drawer looking for the signed-in account before giving
      * up. Outlook can raise a transient teaching callout over the drawer which hides the drawer from
      * the accessibility tree; dismissing it and re-opening the drawer clears the condition.
@@ -230,7 +239,7 @@ public class OutlookApp extends App implements IFirstPartyApp {
      */
     private void dismissBlockingDialog() {
         final UiObject negativeButton = UiAutomatorUtils.obtainUiObjectWithResourceId(
-                ANDROID_DIALOG_NEGATIVE_BUTTON_RESOURCE_ID, CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT
+                ANDROID_DIALOG_NEGATIVE_BUTTON_RESOURCE_ID, BLOCKING_DIALOG_PROBE_TIMEOUT
         );
 
         if (!negativeButton.exists()) {

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -182,8 +182,16 @@ public class OutlookApp extends App implements IFirstPartyApp {
         handleIntroDialogueAfterSignIn();
 
         for (int attempt = 1; attempt <= CONFIRM_ACCOUNT_MAX_ATTEMPTS; attempt++) {
-            // Click the account drawer
-            UiAutomatorUtils.handleButtonClick(ACCOUNT_BUTTON_RESOURCE_ID, FIND_UI_ELEMENT_TIMEOUT_LONG);
+            // Click the account drawer. On the first attempt the drawer is closed, so a strict click
+            // surfaces a genuinely missing button. On retries the drawer may still be open: a popup
+            // that is dismissed by an outside tap consumes that tap, leaving the drawer up. In that
+            // case the account button is covered, so click safely and fall through to the lookup,
+            // which is the state we want anyway.
+            if (attempt == 1) {
+                UiAutomatorUtils.handleButtonClick(ACCOUNT_BUTTON_RESOURCE_ID, FIND_UI_ELEMENT_TIMEOUT_LONG);
+            } else {
+                UiAutomatorUtils.handleButtonClickSafely(ACCOUNT_BUTTON_RESOURCE_ID, CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
+            }
 
             // Make sure our account is listed in the account drawer. Give the first attempt the full
             // timeout; retries only need to outlast the drawer animation as the account is either

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -65,11 +65,12 @@ public class OutlookApp extends App implements IFirstPartyApp {
     /**
      * Timeout for the blocking-dialog presence probe. A dialog that blocks the drawer is already on
      * screen by the time we look, so this only needs to cover the accessibility tree settling rather
-     * than wait for a dialog to appear. It is kept short deliberately: the probe runs on every
-     * attempt, so a long timeout would be added to the common no-dialog path. A dialog that does
-     * turn up late is still caught by the next attempt.
+     * than wait for a dialog to appear — measured at well under a second on a physical device. It is
+     * kept short deliberately, since the probe runs on every attempt and its full value is added to
+     * the common no-dialog path, but not so short that a slower emulator would miss a dialog that is
+     * genuinely present. A dialog that does turn up late is still caught by the next attempt.
      */
-    private final static long BLOCKING_DIALOG_PROBE_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+    private final static long BLOCKING_DIALOG_PROBE_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
 
     /**
      * Number of times we open the navigation drawer looking for the signed-in account before giving

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -58,6 +58,11 @@ public class OutlookApp extends App implements IFirstPartyApp {
     private final static String ACCOUNT_BUTTON_RESOURCE_ID = OUTLOOK_PACKAGE_NAME + ":id/account_button";
 
     /**
+     * Negative ("No Thanks" / "Cancel") button of a framework AlertDialog.
+     */
+    private final static String ANDROID_DIALOG_NEGATIVE_BUTTON_RESOURCE_ID = "android:id/button2";
+
+    /**
      * Number of times we open the navigation drawer looking for the signed-in account before giving
      * up. Outlook can raise a transient teaching callout over the drawer which hides the drawer from
      * the accessibility tree; dismissing it and re-opening the drawer clears the condition.
@@ -182,16 +187,15 @@ public class OutlookApp extends App implements IFirstPartyApp {
         handleIntroDialogueAfterSignIn();
 
         for (int attempt = 1; attempt <= CONFIRM_ACCOUNT_MAX_ATTEMPTS; attempt++) {
-            // Click the account drawer. On the first attempt the drawer is closed, so a strict click
-            // surfaces a genuinely missing button. On retries the drawer may still be open: a popup
-            // that is dismissed by an outside tap consumes that tap, leaving the drawer up. In that
-            // case the account button is covered, so click safely and fall through to the lookup,
-            // which is the state we want anyway.
-            if (attempt == 1) {
-                UiAutomatorUtils.handleButtonClick(ACCOUNT_BUTTON_RESOURCE_ID, FIND_UI_ELEMENT_TIMEOUT_LONG);
-            } else {
-                UiAutomatorUtils.handleButtonClickSafely(ACCOUNT_BUTTON_RESOURCE_ID, CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
-            }
+            // Clear anything sitting in front of the inbox before reaching for the drawer. Outlook
+            // raises modal dialogs of its own (for example the notification opt-in prompt), and while
+            // one is up the drawer button is not in the resolved accessibility tree at all.
+            dismissBlockingDialog();
+
+            // Click the account drawer. This is deliberately non-fatal: if a popup is covering the
+            // button we still want to fall through to the lookup and, failing that, to another
+            // attempt, rather than aborting the whole check on the first try.
+            UiAutomatorUtils.handleButtonClickSafely(ACCOUNT_BUTTON_RESOURCE_ID, FIND_UI_ELEMENT_TIMEOUT_LONG);
 
             // Make sure our account is listed in the account drawer. Give the first attempt the full
             // timeout; retries only need to outlast the drawer animation as the account is either
@@ -213,6 +217,36 @@ public class OutlookApp extends App implements IFirstPartyApp {
 
         Assert.fail("Expected account " + username + " to be listed in the Outlook account drawer, "
                 + "but it was not found after " + CONFIRM_ACCOUNT_MAX_ATTEMPTS + " attempts.");
+    }
+
+    /**
+     * Dismisses a modal dialog sitting in front of the current screen, if one is up.
+     * <p>
+     * Outlook raises its own alert dialogs (for example the "Enable Notifications" opt-in prompt on
+     * Android 13+, which fronts the runtime POST_NOTIFICATIONS permission). A modal dialog takes over
+     * the resolved accessibility tree, so elements behind it — including the account drawer button —
+     * cannot be found at all. The negative button is preferred so the test declines rather than
+     * granting anything it did not intend to.
+     */
+    private void dismissBlockingDialog() {
+        final UiObject negativeButton = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                ANDROID_DIALOG_NEGATIVE_BUTTON_RESOURCE_ID, CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT
+        );
+
+        if (!negativeButton.exists()) {
+            return;
+        }
+
+        Logger.i(TAG, "Dismissing a modal dialog that is covering the Outlook UI..");
+        try {
+            negativeButton.click();
+            UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+                    .waitForIdle(CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
+        } catch (final UiObjectNotFoundException e) {
+            // The dialog went away on its own between the check and the click, which is the state we
+            // wanted anyway.
+            Logger.i(TAG, "Modal dialog disappeared before it could be dismissed.");
+        }
     }
 
     /**

--- a/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
+++ b/uiautomationutilities/src/main/java/com/microsoft/identity/client/ui/automation/app/OutlookApp.java
@@ -27,6 +27,8 @@ import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND
 import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
@@ -52,6 +54,15 @@ public class OutlookApp extends App implements IFirstPartyApp {
     public static final String OUTLOOK_PACKAGE_NAME = "com.microsoft.office.outlook";
     public static final String OUTLOOK_APP_NAME = "Microsoft Outlook";
     public static final String OUTLOOK_APK = "Outlook.apk";
+
+    private final static String ACCOUNT_BUTTON_RESOURCE_ID = OUTLOOK_PACKAGE_NAME + ":id/account_button";
+
+    /**
+     * Number of times we open the navigation drawer looking for the signed-in account before giving
+     * up. Outlook can raise a transient teaching callout over the drawer which hides the drawer from
+     * the accessibility tree; dismissing it and re-opening the drawer clears the condition.
+     */
+    private final static int CONFIRM_ACCOUNT_MAX_ATTEMPTS = 3;
     private static final String ADD_ANOTHER_ACCOUNT_TEXT = "Add another account";
     private static final String M365_ACCOUNT_TYPE_RESOURCE_ID_REGEX =
             "com\\.microsoft\\.office\\.outlook:id/btn_add_account_(m365|o365)_rest";
@@ -170,15 +181,54 @@ public class OutlookApp extends App implements IFirstPartyApp {
 
         handleIntroDialogueAfterSignIn();
 
-        // Click the account drawer
-        UiAutomatorUtils.handleButtonClick("com.microsoft.office.outlook:id/account_button", FIND_UI_ELEMENT_TIMEOUT_LONG);
+        for (int attempt = 1; attempt <= CONFIRM_ACCOUNT_MAX_ATTEMPTS; attempt++) {
+            // Click the account drawer
+            UiAutomatorUtils.handleButtonClick(ACCOUNT_BUTTON_RESOURCE_ID, FIND_UI_ELEMENT_TIMEOUT_LONG);
 
-        // Make sure our account is listed in the account drawer
-        final UiObject testAccountLabel = UiAutomatorUtils.obtainUiObjectWithText(username);
-        Assert.assertTrue(
-                "Provided user account exists in Outlook App.",
-                testAccountLabel.waitForExists(CommonUtils.FIND_UI_ELEMENT_TIMEOUT_LONG)
-        );
+            // Make sure our account is listed in the account drawer. Give the first attempt the full
+            // timeout; retries only need to outlast the drawer animation as the account is either
+            // already there or genuinely absent.
+            final long lookupTimeout = (attempt == 1)
+                    ? FIND_UI_ELEMENT_TIMEOUT_LONG
+                    : CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT;
+
+            if (UiAutomatorUtils.obtainUiObjectWithText(username, lookupTimeout).exists()) {
+                Logger.i(TAG, "Account confirmed in the Outlook account drawer on attempt " + attempt + ".");
+                return;
+            }
+
+            Logger.w(TAG, "Account was not listed in the Outlook account drawer on attempt " + attempt
+                    + " of " + CONFIRM_ACCOUNT_MAX_ATTEMPTS + ". Dismissing any transient popup and retrying..");
+
+            dismissDrawerAndTransientPopups();
+        }
+
+        Assert.fail("Expected account " + username + " to be listed in the Outlook account drawer, "
+                + "but it was not found after " + CONFIRM_ACCOUNT_MAX_ATTEMPTS + " attempts.");
+    }
+
+    /**
+     * Taps the scrim to the right of the Outlook navigation drawer to dismiss any transient popup
+     * and close the drawer.
+     * <p>
+     * Outlook intermittently raises a teaching callout (for example the "Now your folders on mobile
+     * match the same order you have in other Outlook apps" tip) in its own popup window shortly
+     * after the drawer opens. While that popup is up, UiAutomator resolves selectors against the
+     * popup's window, so the drawer's account label is unreachable even though it is plainly visible
+     * on screen. Tapping outside dismisses the callout and closes the drawer so the next attempt
+     * starts from a clean state; the callout is only shown once, so it does not reappear.
+     */
+    private void dismissDrawerAndTransientPopups() {
+        final UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+
+        // The drawer and the callout occupy the left portion of the screen, so a tap near the right
+        // edge lands on the scrim rather than on any drawer or callout content.
+        final int x = (int) (device.getDisplayWidth() * 0.95);
+        final int y = device.getDisplayHeight() / 2;
+
+        Logger.i(TAG, "Dismissing the Outlook navigation drawer and any transient popup..");
+        device.click(x, y);
+        device.waitForIdle(CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
     }
 
     private void handleIntroDialogueAfterSignIn() {


### PR DESCRIPTION
Fixes [AB#3737877](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3737877)

## Summary

`OutlookApp.confirmAccount` intermittently failed with `Provided user account exists in Outlook App.` even though the account was plainly visible in Outlook's navigation drawer.

Outlook raises transient UI over the drawer in **its own window** — a teaching callout ("Now your folders on mobile match the same order you have in other Outlook apps"), and on Android 13+ a modal "Enable Notifications" alert. While either is up, UiAutomator resolves selectors against that window, so the drawer's account label is unreachable and the lookup fails.

The drawer lookup now dismisses any blocking dialog, re-opens the drawer, and retries (up to 3 attempts).

## Reporter / Context

Surfaced by `test_2516571_MAM_BrokerRequired` in the weekly UI automation pipeline, failing at `TestCase2516571.kt:129` → `OutlookApp.confirmAccount`.

The failure initially looked flight-related (failed on `[Local Flights Set to False]`, passed on `[Local Flights Set to True]`), but that does not hold:

- **2026-08-09** — both the all-false and all-true runs failed.
- **2026-08-21** — build `1681651_Monthly Release Work Pipeline_main_20260820.1` ran the test three times from a single build: **passed** at 01:44, **failed with this exact assertion** at 02:36, failed at 04:30. Same commit, same flights.

Screen recordings from builds 1683079 (fail) and 1683084 (pass) isolate the cause. Comparing the drawer at the moment of the check:

| Run | Drawer at line 129 | Teaching callout | Outcome |
|---|---|---|---|
| 1683084 (pass), t=218-222s | account visible | no | proceeds to Broker Host at t=226s |
| 1683079 (fail), earlier attempt, t=222s | account visible | no | proceeds to Broker Host at t=230s |
| 1683079 (fail), final attempt, t=389s | account visible | **yes** | assertion fails |

The account label renders identically in all three (`AndroidTRUEMAMCAUser1@id4s…`), so text matching and ellipsis truncation are not involved — UiAutomator reads the `TextView`'s full text regardless of visual truncation. The popup's presence is the only difference.

## Fix

`uiautomationutilities/.../app/OutlookApp.java`:

- `confirmAccount` loops up to `CONFIRM_ACCOUNT_MAX_ATTEMPTS` (3). Each attempt calls `dismissBlockingDialog()`, opens the drawer, and looks for the account; on a miss it calls `dismissDrawerAndTransientPopups()` before retrying.
- `dismissBlockingDialog()` clears a modal `AlertDialog` via `android:id/button2`. The negative button is preferred so the test declines rather than granting anything it did not intend to.
- `dismissDrawerAndTransientPopups()` taps the scrim near the right edge, dismissing the teaching callout and closing the drawer so the next attempt starts clean.
- The drawer click is non-fatal on **all** attempts. Previously the first attempt used a strict click that threw `UiObjectNotFoundException` outright when a popup covered the button, so the retry loop never ran.
- Extracted `ACCOUNT_BUTTON_RESOURCE_ID`; replaced the inverted assertion message (`"Provided user account exists in Outlook App."` read as the expectation, not the failure) with one naming the account and attempt count.

## Verification

Built and run end-to-end on a physical device (Pixel 5, API 34) against the RC first-party APKs from build 1683079 (Outlook 5.2631.0, Authenticator, Company Portal, BrokerHost) and a `TRUE_MAM_CA` lab account.

Two full runs of `test_2516571_MAM_BrokerRequired`; `RetryTestRule` gives 3 attempts each, so 6 executions. **`confirmAccount` succeeded in every one**, and the new retry path did real work:

| Run | confirmAccount calls | Passed on attempt 1 | Recovered via retry | Failed |
|---|---|---|---|---|
| A | 9 | 6 | 2 (on attempt 3) | 1 |
| B | 3 | 1 | 2 (on attempt 3) | 0 |

The bug reproducing and then recovering, from run B's automation log:

```
03:04:21  W/OutlookApp: Account was not listed in the Outlook account drawer on attempt 1 of 3. Dismissing any transient popup and retrying..
03:04:44  W/OutlookApp: Account was not listed in the Outlook account drawer on attempt 2 of 3. Dismissing any transient popup and retrying..
03:04:57  I/OutlookApp: Account confirmed in the Outlook account drawer on attempt 3.
```

On the previous code the first line is where the test died. Both dismissal paths were exercised (`Dismissing a modal dialog...` and `Dismissing the Outlook navigation drawer...`).

### Known remaining failure (not caused by this change)

Both local runs still fail later, at `TestCase2516571.kt:162` — `Assert.assertFalse("SIGN IN Button still present", ...)` — in the re-auth sequence after `wpjLeave` + clock advance. I confirmed the matched node's text is literally `Sign in`, so the assertion is correct: Outlook genuinely still wants re-auth 35s after the Register click.

This is out of scope here:

- It sits **between** the two `confirmAccount` callsites (lines 129 and 163), and line 163 is never reached, so this change cannot affect it.
- The same test code passes line 162 in the pipeline (build 1683084, 2026-08-23), so it is not universally broken.
- It is most likely environment-specific to this API 34 device — the "Enable Notifications" dialog is Android 13+ only and does not occur on the pipeline's API 32/28 devices, which is direct evidence the UI differs. Outlook's MFA layer also logged `Account Registration Failed ... AUTHENTICATOR_APP_INSTALLED` locally.
- The test's own comment already flags this step as unreliable: *"Not totally sure what prompts outlook to take the snackbar away, sometimes it still appears after re-authentication."*

Filing separately. End-to-end green needs a pipeline run on API 32.

## Follow-ups

- Bump the `common` submodule pointer in `msal` (and `broker`, if it consumes this) once this merges, so the weekly UI automation run picks it up.
- Separate work item for the `TestCase2516571.kt:162` snackbar timing issue described above.
- `test_831126_MDM_FirstPartyAppSignIn` fails in the same suite at `OutlookApp.onAccountAdded()` ("Add another account screen doesn't appear in Outlook") in both the pass and fail pipeline runs — likely the same class of blocked-node-query problem and worth the same treatment.
- Consider a shared `dismissTransientPopups()` helper in `UiAutomatorUtils`, since any Outlook-driven test can hit this.

## Acceptance Criteria

- [x] A popup over the Outlook drawer no longer fails `confirmAccount` (verified on device; recovered in 4 of 12 calls).
- [x] On genuine absence of the account, the test still fails, with a message naming the account and attempt count.
- [ ] `test_2516571_MAM_BrokerRequired` passes in the weekly pipeline across consecutive runs (blocked on the separate line-162 issue).
