### PR TITLE
Require HTTPS for WebApps sender validation, Fixes AB#3715681

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [PATCH] Require HTTPS for WebApps sender authority validation (AB#3715681)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 vNext
 ----------
-- [PATCH] Require HTTPS for WebApps sender authority validation (AB#3715681)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -503,7 +503,7 @@ public class AzureActiveDirectory
                 throw new ClientException(ClientException.MALFORMED_URL, "Missing host in sender url");
             }
 
-            final URI normalized = new URI(scheme + "://" + host + "/common");
+            final URI normalized = new URI("https://" + host + "/common");
             final URL authorityUrl = normalized.toURL();
 
             ensureCloudDiscoveryForAuthority(authorityUrl);

--- a/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectory.java
@@ -495,6 +495,9 @@ public class AzureActiveDirectory
             if (scheme == null) {
                 throw new ClientException(ClientException.MALFORMED_URL, "Missing scheme in sender url");
             }
+            if (!"https".equalsIgnoreCase(scheme)) {
+                throw new ClientException(ClientException.MALFORMED_URL, "Sender url must use HTTPS");
+            }
             final String host = uri.getHost();
             if (host == null) {
                 throw new ClientException(ClientException.MALFORMED_URL, "Missing host in sender url");

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.java.providers.microsoft.azureactivedirect
 import com.microsoft.identity.common.java.authorities.Authority
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority
 import com.microsoft.identity.common.java.authorities.Environment
+import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.flighting.CommonFlight
 import com.microsoft.identity.common.java.flighting.CommonFlightsManager
 import com.microsoft.identity.common.java.flighting.MockFlightsManager
@@ -34,6 +35,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -166,6 +168,29 @@ class AzureActiveDirectoryTest {
 
         assertTrue(AzureActiveDirectory.hasCloudHost(URL("https://$host/common")))
         assertFalse(AzureActiveDirectory.isValidCloudHost(URL("https://$host/common")))
+    }
+
+    @Test
+    fun testBuildAndValidateAuthorityFromWebAppSender_httpsKnownHost_returnsAuthority() {
+        val host = "login.testcloud.com"
+        AzureActiveDirectory.putCloud(host, AzureActiveDirectoryCloud(host, host))
+
+        assertEquals(
+            "https://$host/common",
+            AzureActiveDirectory.buildAndValidateAuthorityFromWebAppSender("https://$host/path")
+        )
+    }
+
+    @Test
+    fun testBuildAndValidateAuthorityFromWebAppSender_httpKnownHost_throwsMalformedUrl() {
+        val host = "login.testcloud.com"
+        AzureActiveDirectory.putCloud(host, AzureActiveDirectoryCloud(host, host))
+
+        val exception = assertThrows(ClientException::class.java) {
+            AzureActiveDirectory.buildAndValidateAuthorityFromWebAppSender("http://$host/path")
+        }
+
+        assertEquals(ClientException.MALFORMED_URL, exception.errorCode)
     }
 
     // --- ensureCloudDiscoveryForAuthority caching behavior ---

--- a/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/providers/microsoft/azureactivedirectory/AzureActiveDirectoryTest.kt
@@ -182,6 +182,17 @@ class AzureActiveDirectoryTest {
     }
 
     @Test
+    fun testBuildAndValidateAuthorityFromWebAppSender_uppercaseHttps_returnsNormalizedAuthority() {
+        val host = "login.testcloud.com"
+        AzureActiveDirectory.putCloud(host, AzureActiveDirectoryCloud(host, host))
+
+        assertEquals(
+            "https://$host/common",
+            AzureActiveDirectory.buildAndValidateAuthorityFromWebAppSender("HTTPS://$host/path")
+        )
+    }
+
+    @Test
     fun testBuildAndValidateAuthorityFromWebAppSender_httpKnownHost_throwsMalformedUrl() {
         val host = "login.testcloud.com"
         AzureActiveDirectory.putCloud(host, AzureActiveDirectoryCloud(host, host))


### PR DESCRIPTION
## Summary
- Require WebApps sender URLs to use HTTPS before deriving an AAD authority.
- Preserve existing known-cloud host validation.
- Add regression coverage for accepted HTTPS and rejected HTTP senders.

## Related PR
- Broker GetCookies reenablement: https://msft.ghe.com/security/ad-accounts-for-android/pull/278

## Testing
- `AzureActiveDirectoryTest`

## Tracking
- [AB#3715681](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3715681)