### PR TITLE
Fixes AB#3732728 : Classify the outcome of an eSTS FoCI membership query

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Add FociQueryOutcome and FociQueryUtilities.queryFociMembership, a classified result for the FoCI membership query, so callers can tell a definitive non-membership response apart from a transient or refresh-token-specific failure. The existing tryFociTokenWithGivenClientId overloads are unchanged in behaviour and now delegate to it (#TBD)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Add FociQueryOutcome and FociQueryUtilities.queryFociMembership, a classified result for the FoCI membership query, so callers can tell a definitive non-membership response apart from a transient or refresh-token-specific failure. The existing tryFociTokenWithGivenClientId overloads are unchanged in behaviour and now delegate to it (#TBD)
+- [MINOR] Add FociQueryOutcome and FociQueryUtilities.queryFociMembership, a classified result for the FoCI membership query, so callers can tell a definitive non-membership response apart from a transient or refresh-token-specific failure. The existing tryFociTokenWithGivenClientId overloads are unchanged in behaviour and now delegate to it (#3234)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryOutcome.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryOutcome.java
@@ -42,6 +42,10 @@ import lombok.NonNull;
  * Both arrive as HTTP 400 {@code invalid_grant} and are distinguishable only by the suberror, so
  * callers that need to tell them apart require this classification rather than a boolean.
  *
+ * <p>{@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED} is the one modelled suberror that
+ * arrives on {@code unauthorized_client} rather than {@code invalid_grant}, matching the pairing
+ * {@code ExceptionAdapter.isIntunePolicyRequiredError} recognises, so it is classified separately.
+ *
  * <p>The value set is deliberately closed. The suberror is a service-controlled string, so it is
  * mapped onto a bounded set rather than surfaced verbatim, keeping it safe to use as a telemetry
  * dimension.
@@ -73,8 +77,9 @@ public enum FociQueryOutcome {
     TOKEN_EXPIRED,
 
     /**
-     * {@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED} — a policy blocked the exchange. Says
-     * nothing about the client id's membership.
+     * {@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED} — an Intune app protection policy
+     * blocked the exchange. Says nothing about the client id's membership. Unlike the other
+     * modelled suberrors this one accompanies an HTTP 400 {@code unauthorized_client}.
      */
     PROTECTION_POLICY_REQUIRED,
 
@@ -90,8 +95,9 @@ public enum FociQueryOutcome {
     OTHER_INVALID_GRANT,
 
     /**
-     * An error response that was not an HTTP 400 {@code invalid_grant} — for example a throttling
-     * or service-side failure.
+     * An error response that was neither an HTTP 400 {@code invalid_grant} nor the HTTP 400
+     * {@code unauthorized_client} carrying {@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED} —
+     * for example a throttling or service-side failure.
      */
     OTHER_ERROR,
 
@@ -103,9 +109,11 @@ public enum FociQueryOutcome {
     /**
      * Classifies a token result produced by a FoCI membership query.
      *
-     * <p>Only an HTTP 400 {@code invalid_grant} is examined for a suberror. A suberror arriving on
-     * any other status or error code is not treated as a membership answer, so such responses
-     * classify as {@link #OTHER_ERROR}.
+     * <p>Only an HTTP 400 {@code invalid_grant} is examined for a membership suberror. A membership
+     * suberror arriving on any other status or error code is not treated as a membership answer, so
+     * such responses classify as {@link #OTHER_ERROR}. The sole exception is
+     * {@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED}, which the service returns on an HTTP
+     * 400 {@code unauthorized_client}; it is matched before the {@code invalid_grant} gate.
      *
      * @param tokenResult the result of the membership query.
      * @return the classified outcome; {@link #GRANTED} if and only if
@@ -122,14 +130,24 @@ public enum FociQueryOutcome {
             return NO_ERROR_RESPONSE;
         }
 
-        final boolean isInvalidGrant =
-                HttpURLConnection.HTTP_BAD_REQUEST == errorResponse.getStatusCode()
-                        && OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(errorResponse.getError());
+        final boolean isBadRequest =
+                HttpURLConnection.HTTP_BAD_REQUEST == errorResponse.getStatusCode();
+        final String subError = errorResponse.getSubError();
+
+        // protection_policy_required accompanies unauthorized_client rather than invalid_grant, so
+        // it has to be matched ahead of the invalid_grant gate or it would never be reached.
+        if (isBadRequest
+                && OAuth2ErrorCode.UNAUTHORIZED_CLIENT.equalsIgnoreCase(errorResponse.getError())
+                && OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED.equalsIgnoreCase(subError)) {
+            return PROTECTION_POLICY_REQUIRED;
+        }
+
+        final boolean isInvalidGrant = isBadRequest
+                && OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(errorResponse.getError());
         if (!isInvalidGrant) {
             return OTHER_ERROR;
         }
 
-        final String subError = errorResponse.getSubError();
         if (OAuth2SubErrorCode.CLIENT_MISMATCH.equalsIgnoreCase(subError)) {
             return CLIENT_MISMATCH;
         }
@@ -138,9 +156,6 @@ public enum FociQueryOutcome {
         }
         if (OAuth2SubErrorCode.TOKEN_EXPIRED.equalsIgnoreCase(subError)) {
             return TOKEN_EXPIRED;
-        }
-        if (OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED.equalsIgnoreCase(subError)) {
-            return PROTECTION_POLICY_REQUIRED;
         }
         if (OAuth2SubErrorCode.CONSENT_REQUIRED.equalsIgnoreCase(subError)) {
             return CONSENT_REQUIRED;

--- a/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryOutcome.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryOutcome.java
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.foci;
+
+import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
+import com.microsoft.identity.common.java.constants.OAuth2SubErrorCode;
+import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
+import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+
+import java.net.HttpURLConnection;
+
+import lombok.NonNull;
+
+/**
+ * Classified result of a family-of-client-ids (FoCI) membership query, as performed by
+ * {@code FociQueryUtilities.queryFociMembership}.
+ *
+ * <p>The query asks the service whether a given client id may redeem a family refresh token. A
+ * boolean answer conflates two very different situations: the service stating that the client id is
+ * <em>not</em> a family member, and the query failing for a reason that says nothing about
+ * membership — for example the refresh token it was attempted with having been revoked or expired.
+ * Both arrive as HTTP 400 {@code invalid_grant} and are distinguishable only by the suberror, so
+ * callers that need to tell them apart require this classification rather than a boolean.
+ *
+ * <p>The value set is deliberately closed. The suberror is a service-controlled string, so it is
+ * mapped onto a bounded set rather than surfaced verbatim, keeping it safe to use as a telemetry
+ * dimension.
+ */
+public enum FociQueryOutcome {
+
+    /**
+     * The service issued a token: the client id is a member of the family.
+     */
+    GRANTED,
+
+    /**
+     * {@link OAuth2SubErrorCode#CLIENT_MISMATCH} — the service states the client id is not a member
+     * of the family the refresh token belongs to. The only value that is a definitive statement
+     * about membership.
+     */
+    CLIENT_MISMATCH,
+
+    /**
+     * {@link OAuth2SubErrorCode#BAD_TOKEN} — the refresh token the query was attempted with was
+     * rejected. Says nothing about the client id's membership.
+     */
+    BAD_TOKEN,
+
+    /**
+     * {@link OAuth2SubErrorCode#TOKEN_EXPIRED} — the refresh token the query was attempted with had
+     * expired. Says nothing about the client id's membership.
+     */
+    TOKEN_EXPIRED,
+
+    /**
+     * {@link OAuth2SubErrorCode#PROTECTION_POLICY_REQUIRED} — a policy blocked the exchange. Says
+     * nothing about the client id's membership.
+     */
+    PROTECTION_POLICY_REQUIRED,
+
+    /**
+     * {@link OAuth2SubErrorCode#CONSENT_REQUIRED} — consent is needed before the exchange can
+     * complete. Says nothing about the client id's membership.
+     */
+    CONSENT_REQUIRED,
+
+    /**
+     * An {@code invalid_grant} carrying a suberror this enum does not model, or no suberror at all.
+     */
+    OTHER_INVALID_GRANT,
+
+    /**
+     * An error response that was not an HTTP 400 {@code invalid_grant} — for example a throttling
+     * or service-side failure.
+     */
+    OTHER_ERROR,
+
+    /**
+     * The result was unsuccessful but carried no error response to classify.
+     */
+    NO_ERROR_RESPONSE;
+
+    /**
+     * Classifies a token result produced by a FoCI membership query.
+     *
+     * <p>Only an HTTP 400 {@code invalid_grant} is examined for a suberror. A suberror arriving on
+     * any other status or error code is not treated as a membership answer, so such responses
+     * classify as {@link #OTHER_ERROR}.
+     *
+     * @param tokenResult the result of the membership query.
+     * @return the classified outcome; {@link #GRANTED} if and only if
+     * {@link TokenResult#getSuccess()} is {@code true}.
+     */
+    @NonNull
+    public static FociQueryOutcome fromTokenResult(@NonNull final TokenResult tokenResult) {
+        if (tokenResult.getSuccess()) {
+            return GRANTED;
+        }
+
+        final TokenErrorResponse errorResponse = tokenResult.getErrorResponse();
+        if (errorResponse == null) {
+            return NO_ERROR_RESPONSE;
+        }
+
+        final boolean isInvalidGrant =
+                HttpURLConnection.HTTP_BAD_REQUEST == errorResponse.getStatusCode()
+                        && OAuth2ErrorCode.INVALID_GRANT.equalsIgnoreCase(errorResponse.getError());
+        if (!isInvalidGrant) {
+            return OTHER_ERROR;
+        }
+
+        final String subError = errorResponse.getSubError();
+        if (OAuth2SubErrorCode.CLIENT_MISMATCH.equalsIgnoreCase(subError)) {
+            return CLIENT_MISMATCH;
+        }
+        if (OAuth2SubErrorCode.BAD_TOKEN.equalsIgnoreCase(subError)) {
+            return BAD_TOKEN;
+        }
+        if (OAuth2SubErrorCode.TOKEN_EXPIRED.equalsIgnoreCase(subError)) {
+            return TOKEN_EXPIRED;
+        }
+        if (OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED.equalsIgnoreCase(subError)) {
+            return PROTECTION_POLICY_REQUIRED;
+        }
+        if (OAuth2SubErrorCode.CONSENT_REQUIRED.equalsIgnoreCase(subError)) {
+            return CONSENT_REQUIRED;
+        }
+        return OTHER_INVALID_GRANT;
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/foci/FociQueryUtilities.java
@@ -77,7 +77,36 @@ public class FociQueryUtilities {
                                                         @NonNull final String clientId,
                                                         @NonNull final String redirectUri,
                                                         @NonNull final ICacheRecord cacheRecord) throws IOException, ClientException {
-        return tryFociTokenWithGivenClientId(
+        return queryFociMembership(
+                brokerOAuth2TokenCache,
+                clientId,
+                redirectUri,
+                cacheRecord
+        ) == FociQueryOutcome.GRANTED;
+    }
+
+    /**
+     * Queries whether the given client ID can use the cached foci to refresh token, returning a
+     * classified outcome rather than a boolean.
+     *
+     * <p>Equivalent to {@link #tryFociTokenWithGivenClientId(BrokerOAuth2TokenCache, String, String, ICacheRecord)}
+     * in behaviour, including the save-on-success side effect; it differs only in preserving why an
+     * unsuccessful query failed. See {@link FociQueryOutcome} for why that distinction matters.
+     *
+     * @param clientId    String of the given client id.
+     * @param redirectUri redirect url string of the given client id.
+     * @param cacheRecord Foci cache record.
+     * @return the classified outcome; {@link FociQueryOutcome#GRANTED} if the given client id can
+     * use the cached foci token.
+     * @throws ClientException
+     * @throws IOException
+     */
+    @NonNull
+    public static FociQueryOutcome queryFociMembership(@SuppressWarnings(WarningType.rawtype_warning) @NonNull final BrokerOAuth2TokenCache brokerOAuth2TokenCache,
+                                                       @NonNull final String clientId,
+                                                       @NonNull final String redirectUri,
+                                                       @NonNull final ICacheRecord cacheRecord) throws IOException, ClientException {
+        return queryFociMembership(
                 brokerOAuth2TokenCache,
                 clientId, redirectUri,
                 cacheRecord.getRefreshToken(),
@@ -102,7 +131,40 @@ public class FociQueryUtilities {
                                                         @NonNull final RefreshTokenRecord refreshTokenRecord,
                                                         @NonNull final IAccountRecord accountRecord)
             throws ClientException, IOException {
-        final String methodName = ":tryFociTokenWithGivenClientId";
+        return queryFociMembership(
+                brokerOAuth2TokenCache,
+                clientId,
+                redirectUri,
+                refreshTokenRecord,
+                accountRecord
+        ) == FociQueryOutcome.GRANTED;
+    }
+
+    /**
+     * Queries whether the given client ID can use the cached foci to refresh token, returning a
+     * classified outcome rather than a boolean.
+     *
+     * <p>Equivalent to {@link #tryFociTokenWithGivenClientId(OAuth2TokenCache, String, String, RefreshTokenRecord, IAccountRecord)}
+     * in behaviour, including the save-on-success side effect; it differs only in preserving why an
+     * unsuccessful query failed. See {@link FociQueryOutcome} for why that distinction matters.
+     *
+     * @param clientId           String of the given client id.
+     * @param redirectUri        redirect url string of the given client id.
+     * @param accountRecord      account record of request
+     * @param refreshTokenRecord refresh token record of FOCI account
+     * @return the classified outcome; {@link FociQueryOutcome#GRANTED} if the given client id can
+     * use the cached foci token.
+     * @throws ClientException
+     * @throws IOException
+     */
+    @NonNull
+    public static FociQueryOutcome queryFociMembership(@SuppressWarnings(WarningType.rawtype_warning) @NonNull final OAuth2TokenCache brokerOAuth2TokenCache,
+                                                       @NonNull final String clientId,
+                                                       @NonNull final String redirectUri,
+                                                       @NonNull final RefreshTokenRecord refreshTokenRecord,
+                                                       @NonNull final IAccountRecord accountRecord)
+            throws ClientException, IOException {
+        final String methodName = ":queryFociMembership";
         final MicrosoftStsOAuth2Configuration config = new MicrosoftStsOAuth2Configuration();
 
         //Get authority url
@@ -191,7 +253,7 @@ public class FociQueryUtilities {
             );
             brokerOAuth2TokenCacheSave(brokerOAuth2TokenCache, strategy, tokenResult, authorizationRequest);
         }
-        return tokenResult.getSuccess();
+        return FociQueryOutcome.fromTokenResult(tokenResult);
     }
 
     /**

--- a/common4j/src/test/com/microsoft/identity/common/java/foci/FociQueryOutcomeTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/foci/FociQueryOutcomeTest.java
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.java.foci;
+
+import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
+import com.microsoft.identity.common.java.constants.OAuth2SubErrorCode;
+import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
+import com.microsoft.identity.common.java.providers.oauth2.TokenResponse;
+import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+
+public class FociQueryOutcomeTest {
+
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+    /**
+     * Builds an unsuccessful {@link TokenResult} carrying the supplied error response fields.
+     */
+    private static TokenResult errorResult(final int statusCode,
+                                           final String error,
+                                           final String subError) {
+        final TokenErrorResponse errorResponse = new TokenErrorResponse();
+        errorResponse.setStatusCode(statusCode);
+        errorResponse.setError(error);
+        errorResponse.setSubError(subError);
+        return new TokenResult(errorResponse);
+    }
+
+    private static TokenResult invalidGrantResult(final String subError) {
+        return errorResult(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                OAuth2ErrorCode.INVALID_GRANT,
+                subError
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenSuccessful_isGranted() {
+        final TokenResult result = new TokenResult(new TokenResponse());
+
+        Assert.assertEquals(FociQueryOutcome.GRANTED, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    @Test
+    public void fromTokenResult_whenClientMismatch_isClientMismatch() {
+        Assert.assertEquals(
+                FociQueryOutcome.CLIENT_MISMATCH,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.CLIENT_MISMATCH))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenBadToken_isBadToken() {
+        Assert.assertEquals(
+                FociQueryOutcome.BAD_TOKEN,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.BAD_TOKEN))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenTokenExpired_isTokenExpired() {
+        Assert.assertEquals(
+                FociQueryOutcome.TOKEN_EXPIRED,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.TOKEN_EXPIRED))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenProtectionPolicyRequired_isProtectionPolicyRequired() {
+        Assert.assertEquals(
+                FociQueryOutcome.PROTECTION_POLICY_REQUIRED,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenConsentRequired_isConsentRequired() {
+        Assert.assertEquals(
+                FociQueryOutcome.CONSENT_REQUIRED,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.CONSENT_REQUIRED))
+        );
+    }
+
+    /**
+     * The service controls the casing of these strings, so matching must not depend on it.
+     */
+    @Test
+    public void fromTokenResult_whenCasingDiffers_stillClassifies() {
+        final TokenResult result = errorResult(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                "Invalid_Grant",
+                "Client_Mismatch"
+        );
+
+        Assert.assertEquals(FociQueryOutcome.CLIENT_MISMATCH, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    @Test
+    public void fromTokenResult_whenSubErrorIsUnrecognised_isOtherInvalidGrant() {
+        Assert.assertEquals(
+                FociQueryOutcome.OTHER_INVALID_GRANT,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult("some_new_suberror"))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenSubErrorIsAbsent_isOtherInvalidGrant() {
+        Assert.assertEquals(
+                FociQueryOutcome.OTHER_INVALID_GRANT,
+                FociQueryOutcome.fromTokenResult(invalidGrantResult(null))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenThrottled_isOtherError() {
+        final TokenResult result = errorResult(HTTP_TOO_MANY_REQUESTS, "temporarily_unavailable", null);
+
+        Assert.assertEquals(FociQueryOutcome.OTHER_ERROR, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    /**
+     * A membership suberror is only meaningful on an HTTP 400 {@code invalid_grant}; anywhere else
+     * it must not be read as a statement about membership.
+     */
+    @Test
+    public void fromTokenResult_whenClientMismatchOnUnexpectedStatus_isOtherError() {
+        final TokenResult result = errorResult(
+                HttpURLConnection.HTTP_INTERNAL_ERROR,
+                OAuth2ErrorCode.INVALID_GRANT,
+                OAuth2SubErrorCode.CLIENT_MISMATCH
+        );
+
+        Assert.assertEquals(FociQueryOutcome.OTHER_ERROR, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    @Test
+    public void fromTokenResult_whenErrorIsNotInvalidGrant_isOtherError() {
+        final TokenResult result = errorResult(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                "invalid_client",
+                OAuth2SubErrorCode.CLIENT_MISMATCH
+        );
+
+        Assert.assertEquals(FociQueryOutcome.OTHER_ERROR, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    @Test
+    public void fromTokenResult_whenNoErrorResponse_isNoErrorResponse() {
+        Assert.assertEquals(
+                FociQueryOutcome.NO_ERROR_RESPONSE,
+                FociQueryOutcome.fromTokenResult(new TokenResult(null, null))
+        );
+    }
+}

--- a/common4j/src/test/com/microsoft/identity/common/java/foci/FociQueryOutcomeTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/foci/FociQueryOutcomeTest.java
@@ -58,6 +58,14 @@ public class FociQueryOutcomeTest {
         );
     }
 
+    private static TokenResult unauthorizedClientResult(final String subError) {
+        return errorResult(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                OAuth2ErrorCode.UNAUTHORIZED_CLIENT,
+                subError
+        );
+    }
+
     @Test
     public void fromTokenResult_whenSuccessful_isGranted() {
         final TokenResult result = new TokenResult(new TokenResponse());
@@ -89,11 +97,68 @@ public class FociQueryOutcomeTest {
         );
     }
 
+    /**
+     * The service pairs {@code protection_policy_required} with {@code unauthorized_client}, not
+     * {@code invalid_grant} — the same pairing {@code ExceptionAdapter.isIntunePolicyRequiredError}
+     * recognises.
+     */
     @Test
     public void fromTokenResult_whenProtectionPolicyRequired_isProtectionPolicyRequired() {
         Assert.assertEquals(
                 FociQueryOutcome.PROTECTION_POLICY_REQUIRED,
-                FociQueryOutcome.fromTokenResult(invalidGrantResult(OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED))
+                FociQueryOutcome.fromTokenResult(
+                        unauthorizedClientResult(OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenProtectionPolicyRequiredCasingDiffers_stillClassifies() {
+        final TokenResult result = errorResult(
+                HttpURLConnection.HTTP_BAD_REQUEST,
+                "Unauthorized_Client",
+                "Protection_Policy_Required"
+        );
+
+        Assert.assertEquals(
+                FociQueryOutcome.PROTECTION_POLICY_REQUIRED,
+                FociQueryOutcome.fromTokenResult(result)
+        );
+    }
+
+    /**
+     * The {@code unauthorized_client} branch is deliberately narrow: it exists only to reach
+     * {@code protection_policy_required} and must not swallow other suberrors.
+     */
+    @Test
+    public void fromTokenResult_whenUnauthorizedClientWithOtherSubError_isOtherError() {
+        Assert.assertEquals(
+                FociQueryOutcome.OTHER_ERROR,
+                FociQueryOutcome.fromTokenResult(
+                        unauthorizedClientResult(OAuth2SubErrorCode.CLIENT_MISMATCH))
+        );
+    }
+
+    @Test
+    public void fromTokenResult_whenProtectionPolicyRequiredOnUnexpectedStatus_isOtherError() {
+        final TokenResult result = errorResult(
+                HttpURLConnection.HTTP_FORBIDDEN,
+                OAuth2ErrorCode.UNAUTHORIZED_CLIENT,
+                OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED
+        );
+
+        Assert.assertEquals(FociQueryOutcome.OTHER_ERROR, FociQueryOutcome.fromTokenResult(result));
+    }
+
+    /**
+     * Guards the gate in the other direction: the suberror is only honoured on the error code the
+     * service actually pairs it with.
+     */
+    @Test
+    public void fromTokenResult_whenProtectionPolicyRequiredOnInvalidGrant_isOtherInvalidGrant() {
+        Assert.assertEquals(
+                FociQueryOutcome.OTHER_INVALID_GRANT,
+                FociQueryOutcome.fromTokenResult(
+                        invalidGrantResult(OAuth2SubErrorCode.PROTECTION_POLICY_REQUIRED))
         );
     }
 


### PR DESCRIPTION
[AB#3732728](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3732728)

## What

`FociQueryUtilities.tryFociTokenWithGivenClientId` returns only a `boolean`, so
every unsuccessful token exchange collapses into a single "not a family member"
answer. That conflates the one response which actually states non-membership —
HTTP 400 `invalid_grant` with suberror `client_mismatch` — with responses that
say nothing about membership at all:

- the family refresh token used for the exchange was rejected or had expired
- a protection policy or user consent was required
- the request was throttled, or the service returned a 5xx
- the response was unsuccessful but carried no error to inspect

The distinction is discarded at the point of return, so no caller can tell a
verdict from a failure, and a caller that logs or acts on the result reports a
transient failure as a definitive denial.

## Changes

- Add `FociQueryOutcome`, an enum of the distinguishable results, with a static
  `fromTokenResult(TokenResult)` that performs the mapping.
- Add `FociQueryUtilities.queryFociMembership` in both arities, returning the
  outcome. (Java cannot overload on return type, hence the new name.)
- Both existing `tryFociTokenWithGivenClientId` overloads now delegate and
  return `outcome == GRANTED`.

The classification is deliberately strict: anything that is not an HTTP 400
`invalid_grant` is `OTHER_ERROR`, and a successful exchange is `GRANTED`
regardless of anything else. `CLIENT_MISMATCH` is the only value that is a
definitive statement about family membership.

## Compatibility

No behaviour change for existing callers. The boolean overloads keep their
signatures, their return values and their save-on-success side effect; this
only exposes detail that was previously discarded. Adding a caller that
consumes the outcome is out of scope here.

## Testing

`FociQueryOutcomeTest` — 13 unit tests covering each enum value, the
suberror mapping, non-400 and non-`invalid_grant` responses, a null suberror,
and a `TokenResult` with no error response. Pure unit tests, no HTTP mocking.
