### PR TITLE
Fix Native Auth V2 SSPR OTP error mapping and enforce email-only methods, Fixes AB#3739379

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowController.kt
@@ -99,15 +99,14 @@ class NativeAuthV2FlowController : BaseNativeAuthController() {
 
         try {
             val oAuth2Strategy = createNativeAuthV2Strategy(parameters)
-            val mergedScopes = addDefaultScopes(parameters.scopes)
             val correlationId = parameters.getCorrelationId()
 
             val authChallengeResult = oAuth2Strategy.performAuthorizeChallengeStart(
                 correlationId = correlationId,
                 entryRelation = NativeAuthV2LinkRelation.RESET_PASSWORD.value,
                 scenario = NativeAuthV2FlowScenario.RESET_PASSWORD,
-                scopes = mergedScopes,
-                claimsRequestJson = parameters.claimsRequestJson
+                scopes = emptyList(),
+                claimsRequestJson = null
             )
 
             val initialState = when (authChallengeResult) {
@@ -464,11 +463,11 @@ class NativeAuthV2FlowController : BaseNativeAuthController() {
             }
         }
 
-        val scopes = state.scopesForTokenRequest()
+        val scopes = addDefaultScopes(parameters.scopes)
         val claimsRequestJson = parameters.claimsRequestJson?.takeUnless { it.isBlank() }
-            ?: state.claimsRequestJsonForTokenRequest()?.takeUnless { it.isBlank() }
         val parametersWithScopes = parameters.toBuilder()
             .scopes(scopes)
+            .claimsRequestJson(claimsRequestJson)
             .build()
         val tokenResult = oAuth2Strategy.performTokenRequest(
             code = code,

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowControllerTest.kt
@@ -155,7 +155,7 @@ class NativeAuthV2FlowControllerTest {
     // -----------------------------------------------------------------------------------------
 
     @Test
-    fun testResetPasswordStartRetainsClaimsForTokenRequest() {
+    fun testResetPasswordStartDoesNotSendTokenScopesOrClaims() {
         val claimsRequestJson = """{"access_token":{"xms_cc":{"values":["cp1"]}}}"""
 
         every {
@@ -163,8 +163,8 @@ class NativeAuthV2FlowControllerTest {
                 correlationId = correlationId,
                 entryRelation = any(),
                 scenario = any(),
-                scopes = any(),
-                claimsRequestJson = claimsRequestJson
+                scopes = emptyList(),
+                claimsRequestJson = null
             )
         } returns AuthorizeChallengeApiResult.UnknownError(
             correlationId = correlationId,
@@ -181,8 +181,8 @@ class NativeAuthV2FlowControllerTest {
                 correlationId = correlationId,
                 entryRelation = any(),
                 scenario = any(),
-                scopes = any(),
-                claimsRequestJson = claimsRequestJson
+                scopes = emptyList(),
+                claimsRequestJson = null
             )
         }
     }
@@ -605,9 +605,11 @@ class NativeAuthV2FlowControllerTest {
     }
 
     @Test
-    fun testSignInAfterResetPasswordUsesContinuationStateScopesForTokenRequest() {
+    fun testSignInAfterResetPasswordUsesCallerScopesForTokenRequest() {
         val state = mockContinuationState()
         val flowScopes = listOf("openid", "offline_access", "User.Read")
+        val callerScopes = listOf("Different.Scope")
+        val expectedScopes = callerScopes + "openid" + "offline_access" + "profile"
 
         every { state.scopesForTokenRequest() } returns flowScopes
         every { mockStrategy.performAuthorizeChallengeContinue(state) } returns
@@ -622,13 +624,13 @@ class NativeAuthV2FlowControllerTest {
         )
 
         controller.signInAfterResetPassword(
-            signInAfterResetPasswordParameters(state, listOf("Different.Scope"))
+            signInAfterResetPasswordParameters(state, callerScopes)
         )
 
         verify(exactly = 1) {
             mockStrategy.performTokenRequest(
                 code = "auth-code",
-                scopes = flowScopes,
+                scopes = match { it.toSet() == expectedScopes.toSet() },
                 correlationId = correlationId,
                 claimsRequestJson = null
             )
@@ -639,6 +641,7 @@ class NativeAuthV2FlowControllerTest {
     fun testSignInAfterResetPasswordUsesCallerClaimsForTokenRequest() {
         val state = mockContinuationState()
         val flowScopes = listOf("openid", "offline_access")
+        val expectedScopes = setOf("openid", "offline_access", "profile")
         val claimsRequestJson = """{"access_token":{"xms_cc":{"values":["cp1"]}}}"""
 
         every { state.scopesForTokenRequest() } returns flowScopes
@@ -663,7 +666,7 @@ class NativeAuthV2FlowControllerTest {
         verify(exactly = 1) {
             mockStrategy.performTokenRequest(
                 code = "auth-code",
-                scopes = flowScopes,
+                scopes = match { it.toSet() == expectedScopes },
                 correlationId = correlationId,
                 claimsRequestJson = claimsRequestJson
             )
@@ -671,7 +674,7 @@ class NativeAuthV2FlowControllerTest {
     }
 
     @Test
-    fun testSignInAfterResetPasswordUsesFlowClaimsWhenCallerClaimsAreAbsent() {
+    fun testSignInAfterResetPasswordTreatsBlankCallerClaimsAsAbsentWithoutFallback() {
         val state = mockContinuationState()
         val flowScopes = listOf("openid", "offline_access")
         val flowClaims = """{"id_token":{"auth_time":{"essential":true}}}"""
@@ -681,7 +684,7 @@ class NativeAuthV2FlowControllerTest {
         every { mockStrategy.performAuthorizeChallengeContinue(state) } returns
             AuthorizeChallengeApiResult.AuthorizationCode(correlationId, "auth-code")
         every {
-            mockStrategy.performTokenRequest(any(), any(), any(), flowClaims)
+            mockStrategy.performTokenRequest(any(), any(), any(), null)
         } returns SignInTokenApiResult.UnknownError(
             correlationId = correlationId,
             error = "invalid_grant",
@@ -689,22 +692,28 @@ class NativeAuthV2FlowControllerTest {
             errorCodes = emptyList()
         )
 
-        controller.signInAfterResetPassword(signInAfterResetPasswordParameters(state))
+        controller.signInAfterResetPassword(
+            signInAfterResetPasswordParameters(state, claimsRequestJson = "   ")
+        )
 
         verify(exactly = 1) {
             mockStrategy.performTokenRequest(
                 code = "auth-code",
-                scopes = flowScopes,
+                scopes = match {
+                    it.toSet() == setOf("openid", "offline_access", "profile")
+                },
                 correlationId = correlationId,
-                claimsRequestJson = flowClaims
+                claimsRequestJson = null
             )
         }
     }
 
     @Test
-    fun testSignInAfterResetPasswordUsesContinuationStateScopesForCachePersistenceRequest() {
+    fun testSignInAfterResetPasswordUsesCallerScopesForTokenRequestAndCachePersistence() {
         val state = mockContinuationState()
         val flowScopes = listOf("openid", "offline_access", "User.Read")
+        val callerScopes = listOf("Different.Scope")
+        val tokenScopesSlot = slot<List<String>>()
         val cacheRequestSlot = slot<MicrosoftStsAuthorizationRequest>()
         val stopAfterCapture = RuntimeException("Stop after cache request capture.")
         val mockTokenCache =
@@ -717,7 +726,7 @@ class NativeAuthV2FlowControllerTest {
         every {
             mockStrategy.performTokenRequest(
                 code = any(),
-                scopes = any(),
+                scopes = capture(tokenScopesSlot),
                 correlationId = any(),
                 claimsRequestJson = null
             )
@@ -730,7 +739,7 @@ class NativeAuthV2FlowControllerTest {
             mockTokenCache.saveAndLoadAggregatedAccountData(any(), capture(cacheRequestSlot), any())
         } throws stopAfterCapture
 
-        val parameters = signInAfterResetPasswordParameters(state, listOf("Different.Scope"))
+        val parameters = signInAfterResetPasswordParameters(state, callerScopes)
             .toBuilder()
             .oAuth2TokenCache(mockTokenCache)
             .clientId("client-id")
@@ -743,7 +752,14 @@ class NativeAuthV2FlowControllerTest {
         }
 
         assertEquals("Stop after cache request capture.", thrown.message)
-        assertEquals(flowScopes.joinToString(" "), cacheRequestSlot.captured.scope)
+        assertEquals(
+            setOf("Different.Scope", "openid", "offline_access", "profile"),
+            tokenScopesSlot.captured.toSet()
+        )
+        assertEquals(
+            tokenScopesSlot.captured.toSet(),
+            cacheRequestSlot.captured.scope.split(" ").toSet()
+        )
     }
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
@@ -497,12 +497,13 @@ class NativeAuthV2ResponseParser {
 
         /**
          * Sub-error codes that indicate the user supplied an incorrect one-time code.
-         * `invalidOneTimeCode` is the Native Auth V2 wire value (AADSTS50184); `invalid_oob_value`
-         * is the legacy V1 spelling, tolerated so a mixed-version service response is still
-         * classified as a recoverable code error rather than a terminal one.
+         * `invalidOneTimeCode` is the Native Auth V2 wire value (AADSTS50184) and is the only
+         * spelling MSAL iOS/macOS accepts. `invalid_oob_value` is the legacy V1 spelling, retained
+         * here for back-compat so a V1-shaped response is still classified as a recoverable code
+         * error rather than a terminal one.
          */
         private val INNER_ERROR_INVALID_ONE_TIME_CODE =
-            setOf("invalidOneTimeCode", "invalid_one_time_code", "invalid_oob_value")
+            setOf("invalidOneTimeCode", "invalid_oob_value")
         private val INNER_ERROR_PASSWORD_TOO_WEAK = setOf("passwordTooWeak", "password_too_weak")
         private val INNER_ERROR_INVALID_USERNAME_OR_PASSWORD =
             setOf("invalidUserNameOrPassword", "invalid_username_or_password")

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.java.nativeauth.providers.responses.v2
 
 import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthConstants
 import com.microsoft.identity.common.java.nativeauth.providers.responses.ApiErrorResult
 import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
 
@@ -212,18 +213,22 @@ class NativeAuthV2ResponseParser {
         response: NativeAuthV2HalApiResponse,
         previousState: NativeAuthV2ContinuationState
     ): NativeAuthV2InteractionApiResult {
-        val firstMethod = response.methods.firstOrNull()
-        firstMethod?.links?.get(NativeAuthV2LinkRelation.CHALLENGE.value)
+        val selectedMethod = selectEmailMethod(response)
+        if (selectedMethod == null && response.methods.isNotEmpty()) {
+            return unsupportedChallengeMethodError(response)
+        }
+
+        selectedMethod?.links?.get(NativeAuthV2LinkRelation.CHALLENGE.value)
             ?: response.links[NativeAuthV2LinkRelation.CHALLENGE.value]
             ?: return missingLinkError(response.correlationId, NativeAuthV2LinkRelation.CHALLENGE)
 
-        val successor = NativeAuthV2ContinuationState.next(previousState, response)
+        val successor = NativeAuthV2ContinuationState.next(previousState, response, selectedMethod)
             ?: return missingContinuationTokenError(response.correlationId)
 
         return NativeAuthV2InteractionApiResult.ChallengeRequired(
             correlationId = response.correlationId,
             continuationState = successor,
-            hint = firstMethod?.hint ?: response.challengeTargetLabel
+            hint = selectedMethod?.hint ?: response.challengeTargetLabel
         )
     }
 
@@ -231,8 +236,12 @@ class NativeAuthV2ResponseParser {
         response: NativeAuthV2HalApiResponse,
         previousState: NativeAuthV2ContinuationState
     ): NativeAuthV2InteractionApiResult {
-        val firstMethod = response.methods.firstOrNull()
-        if (firstMethod?.links?.get(NativeAuthV2LinkRelation.VERIFY.value) == null &&
+        val selectedMethod = selectEmailMethod(response)
+        if (selectedMethod == null && response.methods.isNotEmpty()) {
+            return unsupportedChallengeMethodError(response)
+        }
+
+        if (selectedMethod?.links?.get(NativeAuthV2LinkRelation.VERIFY.value) == null &&
             response.links[NativeAuthV2LinkRelation.VERIFY.value] == null
         ) {
             return missingLinkError(response.correlationId, NativeAuthV2LinkRelation.VERIFY)
@@ -243,12 +252,18 @@ class NativeAuthV2ResponseParser {
         if (codeLength <= 0) {
             return invalidFieldError(response.correlationId, CODE_LENGTH_FIELD)
         }
-        val challengeTargetLabel = firstMethod?.hint ?: response.challengeTargetLabel
+        val challengeTargetLabel = selectedMethod?.hint ?: response.challengeTargetLabel
             ?: return missingFieldError(response.correlationId, CHALLENGE_TARGET_LABEL_FIELD)
-        val challengeChannel = firstMethod?.type ?: response.challengeChannel
+        val challengeChannel = selectedMethod?.type ?: response.challengeChannel
             ?: return missingFieldError(response.correlationId, CHALLENGE_CHANNEL_FIELD)
 
-        val successor = NativeAuthV2ContinuationState.next(previousState, response)
+        // V2 SSPR is a code-first, email-only flow. A non-email channel cannot be verified here, so
+        // surface it as an error rather than prompting the user on an unsupported channel.
+        if (!challengeChannel.isEmailChannel()) {
+            return unsupportedChallengeMethodError(response)
+        }
+
+        val successor = NativeAuthV2ContinuationState.next(previousState, response, selectedMethod)
             ?: return missingContinuationTokenError(response.correlationId)
 
         return NativeAuthV2InteractionApiResult.CodeRequired(
@@ -257,6 +272,34 @@ class NativeAuthV2ResponseParser {
             challengeTargetLabel = challengeTargetLabel,
             challengeChannel = challengeChannel,
             codeLength = codeLength
+        )
+    }
+
+    /**
+     * Selects the first email-capable authentication method offered by [response], or `null` when
+     * the response embeds no email method. V2 SSPR only supports email one-time codes, so no
+     * fallback to another channel is attempted.
+     */
+    private fun selectEmailMethod(
+        response: NativeAuthV2HalApiResponse
+    ): NativeAuthV2HalApiResponse.EmbeddedAuthMethod? =
+        response.methods.firstOrNull { it.type.isEmailChannel() }
+
+    private fun String?.isEmailChannel(): Boolean =
+        this?.equals(NativeAuthConstants.ChallengeChannel.EMAIL, ignoreCase = true) == true
+
+    private fun unsupportedChallengeMethodError(
+        response: NativeAuthV2HalApiResponse
+    ): NativeAuthV2InteractionApiResult.UnknownError {
+        Logger.warn(
+            TAG,
+            "Native Auth V2 response did not offer a supported email authentication method."
+        )
+        return NativeAuthV2InteractionApiResult.UnknownError(
+            correlationId = response.correlationId,
+            error = ApiErrorResult.INVALID_STATE,
+            errorDescription = "Native Auth V2 response did not offer a supported email " +
+                    "authentication method. Only email one-time codes are supported."
         )
     }
 
@@ -326,12 +369,13 @@ class NativeAuthV2ResponseParser {
         return when {
             operation == NativeAuthV2Operation.VERIFY &&
                     code in ERROR_INVALID_GRANT &&
-                    innerErrorCode == INNER_ERROR_INVALID_CONTINUATION_TOKEN_V2 ->
+                    innerErrorCode in INNER_ERROR_INVALID_ONE_TIME_CODE ->
+                // The user supplied the wrong one-time code; the app can prompt for a new one.
                 NativeAuthV2InteractionApiResult.InvalidCode(
                     correlationId = correlationId,
                     error = code.orEmpty(),
                     errorDescription = message.orEmpty(),
-                    subError = innerErrorCode,
+                    subError = innerErrorCode.orEmpty(),
                     errorCodes = errorCodes
                 )
 
@@ -362,17 +406,6 @@ class NativeAuthV2ResponseParser {
                     message?.contains(AADSTS_INVALID_USERNAME_OR_PASSWORD) == true ->
                 // Sign-in concern for SSPR; revisit once V2 sign-in lands.
                 unknownInteractionError(correlationId, code, message, errorCodes)
-
-            operation == NativeAuthV2Operation.VERIFY &&
-                    code in ERROR_INVALID_GRANT &&
-                    innerErrorCode == INNER_ERROR_INVALID_OOB_VALUE ->
-                NativeAuthV2InteractionApiResult.InvalidCode(
-                    correlationId = correlationId,
-                    error = code.orEmpty(),
-                    errorDescription = message.orEmpty(),
-                    subError = innerErrorCode.orEmpty(),
-                    errorCodes = errorCodes
-                )
 
             else -> unknownInteractionError(correlationId, code, message, errorCodes)
         }
@@ -461,8 +494,15 @@ class NativeAuthV2ResponseParser {
         private val ERROR_INVALID_GRANT = setOf("invalidGrant", "invalid_grant")
         private val INNER_ERROR_INVALID_CONTINUATION_TOKEN =
             setOf("invalidContinuationToken", "invalid_continuation_token")
-        private const val INNER_ERROR_INVALID_CONTINUATION_TOKEN_V2 = "invalidContinuationToken"
-        private const val INNER_ERROR_INVALID_OOB_VALUE = "invalid_oob_value"
+
+        /**
+         * Sub-error codes that indicate the user supplied an incorrect one-time code.
+         * `invalidOneTimeCode` is the Native Auth V2 wire value (AADSTS50184); `invalid_oob_value`
+         * is the legacy V1 spelling, tolerated so a mixed-version service response is still
+         * classified as a recoverable code error rather than a terminal one.
+         */
+        private val INNER_ERROR_INVALID_ONE_TIME_CODE =
+            setOf("invalidOneTimeCode", "invalid_one_time_code", "invalid_oob_value")
         private val INNER_ERROR_PASSWORD_TOO_WEAK = setOf("passwordTooWeak", "password_too_weak")
         private val INNER_ERROR_INVALID_USERNAME_OR_PASSWORD =
             setOf("invalidUserNameOrPassword", "invalid_username_or_password")

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
@@ -384,7 +384,7 @@ class NativeAuthV2ResponseParser {
                 unknownInteractionError(correlationId, code, message, errorCodes)
 
             operation == NativeAuthV2Operation.UPDATE_PASSWORD &&
-                    innerErrorCode in INNER_ERROR_PASSWORD_TOO_WEAK ->
+                    innerErrorCode in INNER_ERROR_INVALID_PASSWORD ->
                 NativeAuthV2InteractionApiResult.InvalidPassword(
                     correlationId = correlationId,
                     error = code.orEmpty(),
@@ -504,7 +504,20 @@ class NativeAuthV2ResponseParser {
          */
         private val INNER_ERROR_INVALID_ONE_TIME_CODE =
             setOf("invalidOneTimeCode", "invalid_oob_value")
-        private val INNER_ERROR_PASSWORD_TOO_WEAK = setOf("passwordTooWeak", "password_too_weak")
+        private val INNER_ERROR_INVALID_PASSWORD = setOf(
+            "passwordTooWeak",
+            "password_too_weak",
+            "passwordTooShort",
+            "password_too_short",
+            "passwordTooLong",
+            "password_too_long",
+            "passwordIsInvalid",
+            "password_is_invalid",
+            "passwordRecentlyUsed",
+            "password_recently_used",
+            "passwordBanned",
+            "password_banned"
+        )
         private val INNER_ERROR_INVALID_USERNAME_OR_PASSWORD =
             setOf("invalidUserNameOrPassword", "invalid_username_or_password")
         private const val AADSTS_USER_NOT_FOUND = "AADSTS50034"

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParser.kt
@@ -506,17 +506,11 @@ class NativeAuthV2ResponseParser {
             setOf("invalidOneTimeCode", "invalid_oob_value")
         private val INNER_ERROR_INVALID_PASSWORD = setOf(
             "passwordTooWeak",
-            "password_too_weak",
             "passwordTooShort",
-            "password_too_short",
             "passwordTooLong",
-            "password_too_long",
             "passwordIsInvalid",
-            "password_is_invalid",
             "passwordRecentlyUsed",
-            "password_recently_used",
-            "passwordBanned",
-            "password_banned"
+            "passwordBanned"
         )
         private val INNER_ERROR_INVALID_USERNAME_OR_PASSWORD =
             setOf("invalidUserNameOrPassword", "invalid_username_or_password")

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
@@ -207,14 +207,14 @@ class NativeAuthV2ResponseParserTest {
               "action": "verify",
               "codeLength": 6,
               "hint": "top-level-hint",
-              "type": "top-level-type",
+              "type": "sms",
               "_links": {
                 "verify": {"href": "/api/v0.1/auth/top-level/verify"}
               },
               "_embedded": {
                 "methods": [{
                   "hint": "embedded-hint",
-                  "type": "embedded-type",
+                  "type": "email",
                   "_links": {
                     "verify": {"href": "/api/v0.1/auth/embedded/verify"}
                   }
@@ -231,7 +231,7 @@ class NativeAuthV2ResponseParserTest {
         ) as NativeAuthV2InteractionApiResult.CodeRequired
 
         assertEquals("embedded-hint", result.challengeTargetLabel)
-        assertEquals("embedded-type", result.challengeChannel)
+        assertEquals("email", result.challengeChannel)
         assertEquals(
             "/api/v0.1/auth/embedded/verify",
             result.continuationState.href(NativeAuthV2LinkRelation.VERIFY)
@@ -309,7 +309,7 @@ class NativeAuthV2ResponseParserTest {
     fun parseInteraction_whenV2VerificationCodeIsInvalid_returnsInvalidCode() {
         val previousState = previousState()
         val response = responseFrom(
-            """{"error":{"code":"invalidGrant","message":"Code is invalid.","innerError":{"code":"invalidContinuationToken"}}}"""
+            """{"error":{"code":"invalidGrant","message":"Code is invalid.","innerError":{"code":"invalidOneTimeCode"}}}"""
         )
 
         val result = parser.parseInteraction(
@@ -318,7 +318,28 @@ class NativeAuthV2ResponseParserTest {
             NativeAuthV2Operation.VERIFY
         ) as NativeAuthV2InteractionApiResult.InvalidCode
 
-        assertEquals("invalidContinuationToken", result.subError)
+        assertEquals("invalidOneTimeCode", result.subError)
+    }
+
+    @Test
+    fun parseInteraction_whenContinuationTokenIsInvalid_returnsTerminalUnknownError() {
+        val response = responseFrom(
+            """{"error":{"code":"invalidGrant","message":"Continuation token is invalid.","innerError":{"code":"invalidContinuationToken"}}}"""
+        )
+
+        val result = parser.parseInteraction(
+            response,
+            previousState(),
+            NativeAuthV2Operation.VERIFY
+        )
+
+        // An invalid continuation token is SDK-managed state the user cannot recover from by
+        // retyping a code, so it must not be surfaced as a retryable InvalidCode.
+        assertFalse(result is NativeAuthV2InteractionApiResult.InvalidCode)
+        assertTrue(result is NativeAuthV2InteractionApiResult.UnknownError)
+        val error = result as NativeAuthV2InteractionApiResult.UnknownError
+        assertEquals("invalidGrant", error.error)
+        assertEquals("Continuation token is invalid.", error.errorDescription)
     }
 
     @Test
@@ -759,6 +780,7 @@ class NativeAuthV2ResponseParserTest {
               "_embedded": {
                 "methods": [{
                   "hint": "embedded-hint",
+                  "type": "email",
                   "_links": {
                     "challenge": {"href": "/api/v0.1/auth/embedded/challenge"}
                   }
@@ -900,6 +922,134 @@ class NativeAuthV2ResponseParserTest {
         val error = result as NativeAuthV2InteractionApiResult.UnknownError
         assertEquals(ApiErrorResult.INVALID_STATE, error.error)
         assertTrue(error.errorDescription.contains("update"))
+    }
+
+    // endregion
+
+    // region parseInteraction - email-only method enforcement
+
+    @Test
+    fun parseInteraction_whenChallengeOffersNonEmailMethodOnly_returnsUnknownError() {
+        val response = responseFrom(
+            """
+            {
+              "continuationToken": "next-token",
+              "action": "challenge",
+              "_embedded": {
+                "methods": [{
+                  "hint": "+1 (***) ***-1234",
+                  "type": "sms",
+                  "_links": {
+                    "challenge": {"href": "/api/v0.1/auth/sms/challenge"}
+                  }
+                }]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val result = parser.parseInteraction(response, previousState(), NativeAuthV2Operation.CHALLENGE)
+
+        assertTrue(result is NativeAuthV2InteractionApiResult.UnknownError)
+        val error = result as NativeAuthV2InteractionApiResult.UnknownError
+        assertEquals(ApiErrorResult.INVALID_STATE, error.error)
+        assertTrue(error.errorDescription.contains("email"))
+    }
+
+    @Test
+    fun parseInteraction_whenChallengeOffersEmailAfterNonEmailMethod_selectsEmailMethod() {
+        val response = responseFrom(
+            """
+            {
+              "continuationToken": "next-token",
+              "action": "challenge",
+              "_embedded": {
+                "methods": [
+                  {
+                    "hint": "+1 (***) ***-1234",
+                    "type": "sms",
+                    "_links": {
+                      "challenge": {"href": "/api/v0.1/auth/sms/challenge"}
+                    }
+                  },
+                  {
+                    "hint": "u***@contoso.com",
+                    "type": "email",
+                    "_links": {
+                      "challenge": {"href": "/api/v0.1/auth/email/challenge"}
+                    }
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val result = parser.parseInteraction(
+            response,
+            previousState(),
+            NativeAuthV2Operation.CHALLENGE
+        ) as NativeAuthV2InteractionApiResult.ChallengeRequired
+
+        assertEquals("u***@contoso.com", result.hint)
+        assertEquals(
+            "/api/v0.1/auth/email/challenge",
+            result.continuationState.href(NativeAuthV2LinkRelation.CHALLENGE)
+        )
+    }
+
+    @Test
+    fun parseInteraction_whenVerifyOffersNonEmailMethodOnly_returnsUnknownError() {
+        val response = responseFrom(
+            """
+            {
+              "continuationToken": "next-token",
+              "action": "verify",
+              "codeLength": 6,
+              "_embedded": {
+                "methods": [{
+                  "hint": "+1 (***) ***-1234",
+                  "type": "sms",
+                  "_links": {
+                    "verify": {"href": "/api/v0.1/auth/sms/verify"}
+                  }
+                }]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val result = parser.parseInteraction(response, previousState(), NativeAuthV2Operation.CHALLENGE)
+
+        assertTrue(result is NativeAuthV2InteractionApiResult.UnknownError)
+        assertTrue((result as NativeAuthV2InteractionApiResult.UnknownError).errorDescription.contains("email"))
+    }
+
+    @Test
+    fun parseInteraction_whenVerifyTopLevelChannelIsNotEmail_returnsUnknownError() {
+        val response = responseFrom(
+            """{"continuationToken":"t","action":"verify","codeLength":6,"hint":"h","type":"sms","_links":{"verify":{"href":"/x"}}}"""
+        )
+
+        val result = parser.parseInteraction(response, previousState(), NativeAuthV2Operation.CHALLENGE)
+
+        assertTrue(result is NativeAuthV2InteractionApiResult.UnknownError)
+        assertTrue((result as NativeAuthV2InteractionApiResult.UnknownError).errorDescription.contains("email"))
+    }
+
+    @Test
+    fun parseInteraction_whenVerifyChannelIsEmailWithDifferentCasing_returnsCodeRequired() {
+        val response = responseFrom(
+            """{"continuationToken":"t","action":"verify","codeLength":6,"hint":"h","type":"Email","_links":{"verify":{"href":"/x"}}}"""
+        )
+
+        val result = parser.parseInteraction(
+            response,
+            previousState(),
+            NativeAuthV2Operation.CHALLENGE
+        ) as NativeAuthV2InteractionApiResult.CodeRequired
+
+        assertEquals("Email", result.challengeChannel)
     }
 
     // endregion

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
@@ -346,17 +346,11 @@ class NativeAuthV2ResponseParserTest {
     fun parseInteraction_whenPasswordIsInvalid_preservesSubError() {
         val passwordSubErrors = listOf(
             "passwordTooWeak",
-            "password_too_weak",
             "passwordTooShort",
-            "password_too_short",
             "passwordTooLong",
-            "password_too_long",
             "passwordIsInvalid",
-            "password_is_invalid",
             "passwordRecentlyUsed",
-            "password_recently_used",
-            "passwordBanned",
-            "password_banned"
+            "passwordBanned"
         )
 
         passwordSubErrors.forEach { subError ->
@@ -379,6 +373,21 @@ class NativeAuthV2ResponseParserTest {
                 (result as NativeAuthV2InteractionApiResult.InvalidPassword).subError
             )
         }
+    }
+
+    @Test
+    fun parseInteraction_whenPasswordSubErrorUsesLegacySnakeCase_returnsUnknownError() {
+        val response = responseFrom(
+            """{"error":{"code":"invalidRequest","message":"Password is invalid.","innerError":{"code":"password_too_weak"}}}"""
+        )
+
+        val result = parser.parseInteraction(
+            response,
+            previousState(),
+            NativeAuthV2Operation.UPDATE_PASSWORD
+        )
+
+        assertTrue(result is NativeAuthV2InteractionApiResult.UnknownError)
     }
 
     @Test

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ResponseParserTest.kt
@@ -343,33 +343,42 @@ class NativeAuthV2ResponseParserTest {
     }
 
     @Test
-    fun parseInteraction_whenPasswordTooWeak_preservesSubError() {
-        val response = responseFrom(
-            """{"error":{"code":"invalid_request","message":"Password is too weak.","innerError":{"code":"password_too_weak"}}}"""
+    fun parseInteraction_whenPasswordIsInvalid_preservesSubError() {
+        val passwordSubErrors = listOf(
+            "passwordTooWeak",
+            "password_too_weak",
+            "passwordTooShort",
+            "password_too_short",
+            "passwordTooLong",
+            "password_too_long",
+            "passwordIsInvalid",
+            "password_is_invalid",
+            "passwordRecentlyUsed",
+            "password_recently_used",
+            "passwordBanned",
+            "password_banned"
         )
 
-        val result = parser.parseInteraction(
-            response,
-            previousState(),
-            NativeAuthV2Operation.UPDATE_PASSWORD
-        ) as NativeAuthV2InteractionApiResult.InvalidPassword
+        passwordSubErrors.forEach { subError ->
+            val response = responseFrom(
+                """{"error":{"code":"invalidRequest","message":"Password is invalid.","innerError":{"code":"$subError"}}}"""
+            )
 
-        assertEquals("password_too_weak", result.subError)
-    }
+            val result = parser.parseInteraction(
+                response,
+                previousState(),
+                NativeAuthV2Operation.UPDATE_PASSWORD
+            )
 
-    @Test
-    fun parseInteraction_whenV2PasswordTooWeak_preservesSubError() {
-        val response = responseFrom(
-            """{"error":{"code":"invalidRequest","message":"Password is too weak.","innerError":{"code":"passwordTooWeak"}}}"""
-        )
-
-        val result = parser.parseInteraction(
-            response,
-            previousState(),
-            NativeAuthV2Operation.UPDATE_PASSWORD
-        ) as NativeAuthV2InteractionApiResult.InvalidPassword
-
-        assertEquals("passwordTooWeak", result.subError)
+            assertTrue(
+                "Expected InvalidPassword for $subError but was ${result::class.java.simpleName}",
+                result is NativeAuthV2InteractionApiResult.InvalidPassword
+            )
+            assertEquals(
+                subError,
+                (result as NativeAuthV2InteractionApiResult.InvalidPassword).subError
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Completes the Common-side CIAM Native Auth v2 SSPR parity fixes required by MSAL Android.

1. **OTP recoverability**
   - Maps `invalidGrant + invalidOneTimeCode` to retryable `InvalidCode`.
   - Keeps invalid continuation-token failures terminal.

2. **Email OTP selection**
   - Selects the first email-capable authentication method.
   - Rejects unsupported methods and validates initial and resent code results.

3. **Password-policy errors**
   - Maps the supported v2 camelCase password-policy suberrors to retryable `InvalidPassword`.
   - Preserves the original service suberror for MSAL error handling.

4. **Deferred post-reset sign-in inputs**
   - Reset start no longer carries token scopes or claims.
   - Terminal sign-in uses caller-provided scopes and claims consistently for token acquisition and cache persistence, without continuation fallback.

Fixes [AB#3739379](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3739379)
