### PR TITLE
Fixes AB#3731177- #3236 Carry broker power optimization result context

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 vNext
 ----------
+- [MINOR] Carry the executing broker package and battery optimization exemption status across modern MSAL acquire-token-silent success and error results (AB#3731177)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 vNext
 ----------
-- [MINOR] Carry the executing broker package and battery optimization exemption status across modern MSAL acquire-token-silent success and error results (AB#3731177)
+- [MINOR] Carry the executing broker package and battery optimization exemption status across modern MSAL acquire-token-silent success and error results (AB#3731177) (#3236)
 - [MINOR] Add the broker telemetry schema data model, event collector, provider interfaces, and serialization helpers for flight-gated broker execution telemetry (#3095)
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)

--- a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerResult.java
@@ -99,6 +99,7 @@ public class BrokerResult {
         static final String CLI_TELEM_SUB_ERROR_CODE = "cli_telem_suberror_code";
         static final String CLIENT_DATA_INFO = "client_data_info";
         static final String ONBOARDING_BLOB = "onboarding_blob";
+        static final String POWER_OPTIMIZATION_SETTINGS = "power_optimization_settings";
     }
 
     private static final long serialVersionUID = 8606631820514878489L;
@@ -343,6 +344,13 @@ public class BrokerResult {
     @SerializedName(SerializedNames.ONBOARDING_BLOB)
     private final String mOnboardingBlob;
 
+    /**
+     * Battery optimization status measured by the Broker that executed the request.
+     */
+    @Nullable
+    @SerializedName(SerializedNames.POWER_OPTIMIZATION_SETTINGS)
+    private final String mPowerOptimizationSettings;
+
     private BrokerResult(@NonNull final Builder builder) {
         mAccessToken = builder.mAccessToken;
         mIdToken = builder.mIdToken;
@@ -380,6 +388,7 @@ public class BrokerResult {
         mExceptionType = builder.mExceptionType;
         mAadDeviceIdRecord = builder.mAadDeviceIdRecord;
         mOnboardingBlob = builder.mOnboardingBlob;
+        mPowerOptimizationSettings = builder.mPowerOptimizationSettings;
     }
 
     public String getExceptionType() {
@@ -526,6 +535,11 @@ public class BrokerResult {
         return mOnboardingBlob;
     }
 
+    @Nullable
+    public String getPowerOptimizationSettings() {
+        return mPowerOptimizationSettings;
+    }
+
     public static class Builder {
         private String mAccessToken;
         private String mIdToken;
@@ -553,6 +567,7 @@ public class BrokerResult {
         private boolean mServicedFromCache;
         private AadDeviceIdRecord mAadDeviceIdRecord;
         private String mOnboardingBlob;
+        private String mPowerOptimizationSettings;
 
         // Exception parameters
         private String mErrorCode;
@@ -749,6 +764,11 @@ public class BrokerResult {
 
         public Builder onboardingBlob(@Nullable final String onboardingBlob) {
             this.mOnboardingBlob = onboardingBlob;
+            return this;
+        }
+
+        public Builder powerOptimizationSettings(@Nullable final String powerOptimizationSettings) {
+            this.mPowerOptimizationSettings = powerOptimizationSettings;
             return this;
         }
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -665,10 +665,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                     resultBundle.getString(AuthenticationConstants.Broker.BROKER_VERSION)
             );
         }
-        final String brokerPackageName = getBrokerPackageName(
-                resultBundle,
-                brokerResult.getPowerOptimizationSettings()
-        );
+        final String brokerPackageName = getBrokerPackageName(resultBundle);
         if (!StringUtil.isNullOrEmpty(brokerPackageName)) {
             baseException.setBrokerAppPackageName(brokerPackageName);
         }
@@ -1221,10 +1218,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                         resultBundle.getString(AuthenticationConstants.Broker.BROKER_VERSION)
                 );
             }
-            final String brokerPackageName = getBrokerPackageName(
-                    resultBundle,
-                    brokerResult.getPowerOptimizationSettings()
-            );
+            final String brokerPackageName = getBrokerPackageName(resultBundle);
             if (!StringUtil.isNullOrEmpty(brokerPackageName)) {
                 acquireTokenResult.setBrokerAppPackageName(brokerPackageName);
             }
@@ -1242,14 +1236,11 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     }
 
     @Nullable
-    private String getBrokerPackageName(@NonNull final Bundle resultBundle,
-                                        @Nullable final String powerOptimizationSettings) {
-        if (!StringUtil.isNullOrEmpty(powerOptimizationSettings)) {
-            final String activeBrokerPackageName =
-                    resultBundle.getString(ACTIVE_BROKER_PACKAGE_NAME_KEY);
-            if (!StringUtil.isNullOrEmpty(activeBrokerPackageName)) {
-                return activeBrokerPackageName;
-            }
+    private String getBrokerPackageName(@NonNull final Bundle resultBundle) {
+        final String activeBrokerPackageName =
+                resultBundle.getString(ACTIVE_BROKER_PACKAGE_NAME_KEY);
+        if (!StringUtil.isNullOrEmpty(activeBrokerPackageName)) {
+            return activeBrokerPackageName;
         }
 
         return resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME);

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -311,7 +311,6 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         );
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     @NonNull
     public BrokerResult buildBrokerResultFromAuthenticationResult
             (@NonNull final ILocalAuthenticationResult authenticationResult,

--- a/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/result/MsalBrokerResultAdapter.java
@@ -42,6 +42,7 @@ import static com.microsoft.identity.common.adal.internal.AuthenticationConstant
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.HELLO_ERROR_MESSAGE;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.PREFERRED_AUTH_METHOD_CODE;
+import static com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater.ACTIVE_BROKER_PACKAGE_NAME_KEY;
 import static com.microsoft.identity.common.internal.util.GzipUtil.compressString;
 import static com.microsoft.identity.common.java.exception.ClientException.INVALID_BROKER_BUNDLE;
 import static com.microsoft.identity.common.java.util.BrokerProtocolVersionUtil.isFirstVersionOlderOrEqual;
@@ -167,11 +168,35 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
     public Bundle bundleFromAuthenticationResult(@NonNull final ILocalAuthenticationResult authenticationResult,
                                                  @Nullable final String onboardingBlob,
                                                  @Nullable final String negotiatedBrokerProtocolVersion) {
+        return bundleFromAuthenticationResult(
+                authenticationResult,
+                onboardingBlob,
+                negotiatedBrokerProtocolVersion,
+                null
+        );
+    }
+
+    /**
+     * Creates a success bundle with optional Broker battery optimization context.
+     *
+     * @param powerOptimizationSettings The freshly measured Broker status, or null when disabled.
+     */
+    @NonNull
+    public Bundle bundleFromAuthenticationResult(
+            @NonNull final ILocalAuthenticationResult authenticationResult,
+            @Nullable final String onboardingBlob,
+            @Nullable final String negotiatedBrokerProtocolVersion,
+            @Nullable final String powerOptimizationSettings) {
         final String methodTag = TAG + ":bundleFromAuthenticationResult";
         Logger.info(methodTag, "Constructing result bundle from ILocalAuthenticationResult");
 
         final Bundle resultBundle = bundleFromBrokerResult(
-                buildBrokerResultFromAuthenticationResult(authenticationResult, onboardingBlob, negotiatedBrokerProtocolVersion),
+                buildBrokerResultFromAuthenticationResult(
+                        authenticationResult,
+                        onboardingBlob,
+                        negotiatedBrokerProtocolVersion,
+                        powerOptimizationSettings
+                ),
                 negotiatedBrokerProtocolVersion);
         resultBundle.putBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS, true);
 
@@ -278,6 +303,21 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             (@NonNull final ILocalAuthenticationResult authenticationResult,
              @Nullable final String onboardingBlob,
              @Nullable final String negotiatedBrokerProtocolVersion){
+        return buildBrokerResultFromAuthenticationResult(
+                authenticationResult,
+                onboardingBlob,
+                negotiatedBrokerProtocolVersion,
+                null
+        );
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    @NonNull
+    public BrokerResult buildBrokerResultFromAuthenticationResult
+            (@NonNull final ILocalAuthenticationResult authenticationResult,
+             @Nullable final String onboardingBlob,
+             @Nullable final String negotiatedBrokerProtocolVersion,
+             @Nullable final String powerOptimizationSettings){
 
         final IAccountRecord accountRecord = authenticationResult.getAccountRecord();
 
@@ -313,6 +353,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 .extendedExpiresOn(extendedExpiresOn)
                 .cachedAt(Long.parseLong(accessTokenRecord.getCachedAt()))
                 .speRing(authenticationResult.getSpeRing())
+                .powerOptimizationSettings(powerOptimizationSettings)
                 .success(true)
                 .servicedFromCache(authenticationResult.isServicedFromCache());
 
@@ -459,7 +500,8 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                 .cliTelemErrorCode(exception.getCliTelemErrorCode())
                 .cliTelemSubErrorCode(exception.getCliTelemSubErrorCode())
                 .speRing(exception.getSpeRing())
-                .refreshTokenAge(exception.getRefreshTokenAge());
+                .refreshTokenAge(exception.getRefreshTokenAge())
+                .powerOptimizationSettings(exception.getPowerOptimizationSettings());
 
         // Serialize ClientDataInfo (server telemetry from x-ms-clientdata) so it
         // survives the broker IPC boundary on error paths.
@@ -615,6 +657,7 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         if (!StringUtil.isNullOrEmpty(onboardingBlob)) {
             baseException.setOnboardingBlob(onboardingBlob);
         }
+        baseException.setPowerOptimizationSettings(brokerResult.getPowerOptimizationSettings());
 
         // Set broker app info if available
         if (resultBundle.containsKey(AuthenticationConstants.Broker.BROKER_VERSION)) {
@@ -622,10 +665,12 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                     resultBundle.getString(AuthenticationConstants.Broker.BROKER_VERSION)
             );
         }
-        if (resultBundle.containsKey(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)) {
-            baseException.setBrokerAppPackageName(
-                    resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)
-            );
+        final String brokerPackageName = getBrokerPackageName(
+                resultBundle,
+                brokerResult.getPowerOptimizationSettings()
+        );
+        if (!StringUtil.isNullOrEmpty(brokerPackageName)) {
+            baseException.setBrokerAppPackageName(brokerPackageName);
         }
 
         return baseException;
@@ -1161,6 +1206,9 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
             acquireTokenResult.setLocalAuthenticationResult(
                     resultAdapter.authenticationResultFromBrokerResult(brokerResult)
             );
+            acquireTokenResult.setPowerOptimizationSettings(
+                    brokerResult.getPowerOptimizationSettings()
+            );
             // Set broker performance metrics if available
             final BrokerPerformanceMetrics metrics = resultAdapter.getBrokerPerformanceMetricsFromBundle(resultBundle);
             if (metrics != null) {
@@ -1173,10 +1221,12 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
                         resultBundle.getString(AuthenticationConstants.Broker.BROKER_VERSION)
                 );
             }
-            if (resultBundle.containsKey(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)) {
-                acquireTokenResult.setBrokerAppPackageName(
-                        resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME)
-                );
+            final String brokerPackageName = getBrokerPackageName(
+                    resultBundle,
+                    brokerResult.getPowerOptimizationSettings()
+            );
+            if (!StringUtil.isNullOrEmpty(brokerPackageName)) {
+                acquireTokenResult.setBrokerAppPackageName(brokerPackageName);
             }
 
             // Set onboarding telemetry blob if present (best-effort; never fails the result).
@@ -1189,6 +1239,20 @@ public class MsalBrokerResultAdapter implements IBrokerResultAdapter {
         }
 
         throw getBaseExceptionFromBundle(resultBundle);
+    }
+
+    @Nullable
+    private String getBrokerPackageName(@NonNull final Bundle resultBundle,
+                                        @Nullable final String powerOptimizationSettings) {
+        if (!StringUtil.isNullOrEmpty(powerOptimizationSettings)) {
+            final String activeBrokerPackageName =
+                    resultBundle.getString(ACTIVE_BROKER_PACKAGE_NAME_KEY);
+            if (!StringUtil.isNullOrEmpty(activeBrokerPackageName)) {
+                return activeBrokerPackageName;
+            }
+        }
+
+        return resultBundle.getString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME);
     }
 
     @NonNull

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
@@ -458,9 +458,7 @@ class MsalBrokerResultAdapterTests {
     @SneakyThrows
     fun testGetBaseExceptionFromBundle_PrefersActiveBrokerPackageName() {
         val activeBrokerPackageName = "com.microsoft.activebroker"
-        val clientException = ClientException("test_error", "Test error message").apply {
-            powerOptimizationSettings = "NOT_EXEMPT"
-        }
+        val clientException = ClientException("test_error", "Test error message")
         val resultAdapter = MsalBrokerResultAdapter()
         val resultBundle = resultAdapter.bundleFromBaseException(clientException, null).apply {
             putString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME, "com.microsoft.legacybroker")
@@ -787,9 +785,7 @@ class MsalBrokerResultAdapterTests {
         val resultAdapter = MsalBrokerResultAdapter()
         val resultBundle = resultAdapter.bundleFromAuthenticationResult(
             authResult,
-            null,
-            "16.0",
-            "NOT_EXEMPT"
+            "16.0"
         ).apply {
             putString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME, "com.microsoft.legacybroker")
             putString(ACTIVE_BROKER_PACKAGE_NAME_KEY, activeBrokerPackageName)

--- a/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/request/MsalBrokerResultAdapterTests.kt
@@ -24,6 +24,7 @@ package com.microsoft.identity.common.internal.request
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants
 import com.microsoft.identity.common.internal.broker.BrokerResult
+import com.microsoft.identity.common.internal.cache.ActiveBrokerCacheUpdater.Companion.ACTIVE_BROKER_PACKAGE_NAME_KEY
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter.REMOVE_RT_FROM_AAD_RESULT_MSAL_PROTOCOL_VERSION
 import com.microsoft.identity.common.java.cache.CacheRecord
@@ -455,6 +456,41 @@ class MsalBrokerResultAdapterTests {
 
     @Test
     @SneakyThrows
+    fun testGetBaseExceptionFromBundle_PrefersActiveBrokerPackageName() {
+        val activeBrokerPackageName = "com.microsoft.activebroker"
+        val clientException = ClientException("test_error", "Test error message").apply {
+            powerOptimizationSettings = "NOT_EXEMPT"
+        }
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromBaseException(clientException, null).apply {
+            putString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME, "com.microsoft.legacybroker")
+            putString(ACTIVE_BROKER_PACKAGE_NAME_KEY, activeBrokerPackageName)
+        }
+
+        val receivedException = resultAdapter.getBaseExceptionFromBundle(resultBundle)
+
+        assertEquals(activeBrokerPackageName, receivedException.brokerAppPackageName)
+    }
+
+    @Test
+    @SneakyThrows
+    fun testGetBaseExceptionFromBundle_FallsBackToBrokerPackageName() {
+        val brokerPackageName = "com.microsoft.legacybroker"
+        val clientException = ClientException("test_error", "Test error message").apply {
+            powerOptimizationSettings = "UNKNOWN"
+        }
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromBaseException(clientException, null).apply {
+            putString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME, brokerPackageName)
+        }
+
+        val receivedException = resultAdapter.getBaseExceptionFromBundle(resultBundle)
+
+        assertEquals(brokerPackageName, receivedException.brokerAppPackageName)
+    }
+
+    @Test
+    @SneakyThrows
     fun testGetBaseExceptionFromBundle_WithoutBrokerAppInfo() {
         val mockErrorCode = "test_error"
         val mockErrorMessage = "Test error message"
@@ -738,6 +774,89 @@ class MsalBrokerResultAdapterTests {
     }
 
     @Test
+    fun testAcquireTokenResult_PrefersActiveBrokerPackageName() {
+        val activeBrokerPackageName = "com.microsoft.activebroker"
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(
+            cacheRecord,
+            cacheRecords,
+            SdkType.MSAL,
+            false
+        )
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromAuthenticationResult(
+            authResult,
+            null,
+            "16.0",
+            "NOT_EXEMPT"
+        ).apply {
+            putString(AuthenticationConstants.Broker.BROKER_PACKAGE_NAME, "com.microsoft.legacybroker")
+            putString(ACTIVE_BROKER_PACKAGE_NAME_KEY, activeBrokerPackageName)
+        }
+
+        val acquireTokenResult = resultAdapter.getAcquireTokenResultFromResultBundle(resultBundle)
+
+        assertEquals(activeBrokerPackageName, acquireTokenResult.brokerAppPackageName)
+    }
+
+    @Test
+    fun testPowerOptimizationSettings_RoundTripsOnSuccess() {
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(
+            cacheRecord,
+            cacheRecords,
+            SdkType.MSAL,
+            false
+        )
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromAuthenticationResult(
+            authResult,
+            null,
+            "16.0",
+            "NOT_EXEMPT"
+        )
+
+        val acquireTokenResult =
+            resultAdapter.getAcquireTokenResultFromResultBundle(resultBundle)
+
+        assertEquals("NOT_EXEMPT", acquireTokenResult.powerOptimizationSettings)
+    }
+
+    @Test
+    fun testPowerOptimizationSettings_RoundTripsOnFailure() {
+        val sourceException = ClientException("test_error", "Test error").apply {
+            powerOptimizationSettings = "UNKNOWN"
+        }
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromBaseException(sourceException, "16.0")
+
+        val receivedException = resultAdapter.getBaseExceptionFromBundle(resultBundle)
+
+        assertEquals("UNKNOWN", receivedException.powerOptimizationSettings)
+    }
+
+    @Test
+    fun testPowerOptimizationSettings_OmittedForLegacyResult() {
+        val cacheRecord = newCacheRecord()
+        val cacheRecords: MutableList<ICacheRecord> = arrayListOf(cacheRecord)
+        val authResult = LocalAuthenticationResult(
+            cacheRecord,
+            cacheRecords,
+            SdkType.MSAL,
+            false
+        )
+        val resultAdapter = MsalBrokerResultAdapter()
+        val resultBundle = resultAdapter.bundleFromAuthenticationResult(authResult, "16.0")
+
+        val acquireTokenResult =
+            resultAdapter.getAcquireTokenResultFromResultBundle(resultBundle)
+
+        assertNull(acquireTokenResult.powerOptimizationSettings)
+    }
+
+    @Test
     fun testOnboardingBlob_RoundTripsThroughBundle() {
         val blobJson = """{"schema_version":"1.0.0","session_correlation_id":"abc-123","onboarding_mode":"brokered","blocking_errors":["BROKER_INSTALLATION_TRIGGERED"]}"""
         val brokerResult = BrokerResult.Builder()
@@ -823,4 +942,5 @@ class MsalBrokerResultAdapterTests {
 
         assertNull(deserialized.onboardingBlob)
     }
+
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -96,7 +96,7 @@ public class ExceptionAdapter {
                             ((MicrosoftStsAuthorizationResult) authorizationResult).getClientDataInfo()
                     );
                 }
-                return authException;
+                return copyBrokerResultInfo(result, authException);
             }
         } else {
             Logger.warn(
@@ -105,7 +105,17 @@ public class ExceptionAdapter {
             );
         }
 
-        return exceptionFromTokenResult(result.getTokenResult(), commandParameters);
+        return copyBrokerResultInfo(
+                result,
+                exceptionFromTokenResult(result.getTokenResult(), commandParameters)
+        );
+    }
+
+    private static BaseException copyBrokerResultInfo(@NonNull final AcquireTokenResult result,
+                                                      @NonNull final BaseException exception) {
+        exception.setBrokerAppPackageName(result.getBrokerAppPackageName());
+        exception.setPowerOptimizationSettings(result.getPowerOptimizationSettings());
+        return exception;
     }
 
     public static BaseException exceptionFromAuthorizationResult(@NonNull final AuthorizationResult authorizationResult, @Nullable final CommandParameters commandParameters) {

--- a/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/controllers/ExceptionAdapter.java
@@ -96,7 +96,7 @@ public class ExceptionAdapter {
                             ((MicrosoftStsAuthorizationResult) authorizationResult).getClientDataInfo()
                     );
                 }
-                return copyBrokerResultInfo(result, authException);
+                return copyBrokerExecutionInfoToException(result, authException);
             }
         } else {
             Logger.warn(
@@ -105,14 +105,23 @@ public class ExceptionAdapter {
             );
         }
 
-        return copyBrokerResultInfo(
+        return copyBrokerExecutionInfoToException(
                 result,
                 exceptionFromTokenResult(result.getTokenResult(), commandParameters)
         );
     }
 
-    private static BaseException copyBrokerResultInfo(@NonNull final AcquireTokenResult result,
-                                                      @NonNull final BaseException exception) {
+    /**
+     * Copies the executing Broker's package name and power optimization status from an
+     * {@link AcquireTokenResult} to its corresponding exception.
+     *
+     * @param result The result containing Broker execution metadata.
+     * @param exception The exception to enrich with Broker execution metadata.
+     * @return The enriched exception.
+     */
+    private static BaseException copyBrokerExecutionInfoToException(
+            @NonNull final AcquireTokenResult result,
+            @NonNull final BaseException exception) {
         exception.setBrokerAppPackageName(result.getBrokerAppPackageName());
         exception.setPowerOptimizationSettings(result.getPowerOptimizationSettings());
         return exception;

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -354,7 +354,9 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     }
 
     /**
-     * @return The battery optimization status reported by the Broker that executed the request.
+     * @return The battery optimization status reported by the Broker that executed the request:
+     * {@code EXEMPT}, {@code NOT_EXEMPT}, or {@code UNKNOWN}; {@code null} when the Broker does
+     * not provide the status.
      */
     @Nullable
     public String getPowerOptimizationSettings() {

--- a/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/exception/BaseException.java
@@ -107,6 +107,9 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     @Nullable
     private String mBrokerAppPackageName;
 
+    @Nullable
+    private String mPowerOptimizationSettings;
+
     private final List<Map<String, String>> mTelemetry = new ArrayList<>();
 
     private BrokerPerformanceMetrics mBrokerPerformanceMetrics;
@@ -332,6 +335,10 @@ public class BaseException extends Exception implements IErrorInformation, ITele
         this.mBrokerAppPackageName = brokerAppPackageName;
     }
 
+    public void setPowerOptimizationSettings(@Nullable final String powerOptimizationSettings) {
+        this.mPowerOptimizationSettings = powerOptimizationSettings;
+    }
+
     public void setBrokerAppVersion(final String brokerAppVersion) {
         this.mBrokerAppVersion = brokerAppVersion;
     }
@@ -344,5 +351,13 @@ public class BaseException extends Exception implements IErrorInformation, ITele
     @Override
     public String getBrokerAppPackageName() {
         return mBrokerAppPackageName;
+    }
+
+    /**
+     * @return The battery optimization status reported by the Broker that executed the request.
+     */
+    @Nullable
+    public String getPowerOptimizationSettings() {
+        return mPowerOptimizationSettings;
     }
 }

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -53,6 +53,9 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
     @Nullable
     private String mBrokerAppPackageName;
 
+    @Nullable
+    private String mPowerOptimizationSettings;
+
     private BrokerPerformanceMetrics mBrokerPerformanceMetrics;
 
     @Nullable
@@ -135,6 +138,10 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
         this.mBrokerAppPackageName = brokerPackageName;
     }
 
+    public void setPowerOptimizationSettings(@Nullable final String powerOptimizationSettings) {
+        this.mPowerOptimizationSettings = powerOptimizationSettings;
+    }
+
     @Override
     public String getBrokerAppVersion() {
         return mBrokerAppVersion;
@@ -143,6 +150,14 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
     @Override
     public String getBrokerAppPackageName() {
         return mBrokerAppPackageName;
+    }
+
+    /**
+     * @return The battery optimization status reported by the Broker that executed the request.
+     */
+    @Nullable
+    public String getPowerOptimizationSettings() {
+        return mPowerOptimizationSettings;
     }
 
     /**

--- a/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/result/AcquireTokenResult.java
@@ -153,7 +153,9 @@ public class AcquireTokenResult implements IBrokerPerformanceMetricsProvider, IB
     }
 
     /**
-     * @return The battery optimization status reported by the Broker that executed the request.
+     * @return The battery optimization status reported by the Broker that executed the request:
+     * {@code EXEMPT}, {@code NOT_EXEMPT}, or {@code UNKNOWN}; {@code null} when the Broker does
+     * not provide the status.
      */
     @Nullable
     public String getPowerOptimizationSettings() {

--- a/common4j/src/test/com/microsoft/identity/common/java/controllers/ExceptionAdapterTests.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/controllers/ExceptionAdapterTests.java
@@ -51,6 +51,7 @@ import com.microsoft.identity.common.java.providers.microsoft.MicrosoftTokenErro
 import com.microsoft.identity.common.java.providers.oauth2.AuthorizationStatus;
 import com.microsoft.identity.common.java.providers.oauth2.TokenErrorResponse;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.telemetry.ClientDataInfo;
 
 import org.junit.After;
@@ -237,6 +238,23 @@ public class ExceptionAdapterTests {
         assertTrue(exception instanceof UiRequiredException);
         assertEquals(OAuth2ErrorCode.INVALID_GRANT, exception.getErrorCode());
         assertEquals("UI required.", exception.getMessage());
+    }
+
+    @Test
+    public void testExceptionFromAcquireTokenResult_CopiesBrokerPowerOptimizationInfo() {
+        final TokenErrorResponse errorResponse = new TokenErrorResponse();
+        errorResponse.setError(OAuth2ErrorCode.INVALID_GRANT);
+        errorResponse.setErrorDescription("UI required.");
+        final AcquireTokenResult result = new AcquireTokenResult();
+        result.setTokenResult(new TokenResult(null, errorResponse));
+        result.setBrokerAppPackageName("com.microsoft.broker");
+        result.setPowerOptimizationSettings("NOT_EXEMPT");
+
+        final BaseException exception =
+                ExceptionAdapter.exceptionFromAcquireTokenResult(result, null);
+
+        Assert.assertEquals("com.microsoft.broker", exception.getBrokerAppPackageName());
+        Assert.assertEquals("NOT_EXEMPT", exception.getPowerOptimizationSettings());
     }
 
     // -----------------------------------------------------------------------

--- a/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
+++ b/common4j/src/test/com/microsoft/identity/common/java/result/AcquireTokenResultTest.java
@@ -243,4 +243,13 @@ public class AcquireTokenResultTest {
         result.setOnboardingBlob(null);
         Assert.assertNull(result.getOnboardingBlob());
     }
+
+    @Test
+    public void powerOptimizationSettings_RoundTripsThroughSetter() {
+        final AcquireTokenResult result = new AcquireTokenResult();
+
+        result.setPowerOptimizationSettings("NOT_EXEMPT");
+
+        Assert.assertEquals("NOT_EXEMPT", result.getPowerOptimizationSettings());
+    }
 }


### PR DESCRIPTION
## Summary
- add the optional `power_optimization_settings` field to the modern MSAL Broker result contract
- preserve the status and executing Broker package on successful `AcquireTokenResult` and failed `BaseException` paths
- copy both values when a failed `AcquireTokenResult` is converted to an exception
- retain compatibility with older Brokers that omit the additive field

## Cross-repo dependencies
- Broker emission is implemented separately behind `EnableBrokerBatteryOptimizationInfo`
- OneAuth will consume these Common getters and expose the Android-only typed result property in a follow-up

Design document  - https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/26321

## Tracking
[AB#3731177](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3731177)