### PR TITLE
Add a host-supplied IFidoManager extension point for WebView passkey challenges, Fixes AB#3702833

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ vNext
 - [MINOR] Security: validate a PKeyAuth WebView-redirect SubmitUrl (attacker-controllable) as an HTTPS URL same-origin with the challenging endpoint before the device key signs or the WebView submits; flight-gated and ships in shadow mode (CWE-918 / AB#3706623)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)
 - [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9, so published metadata stays readable by consumers on Kotlin 1.8 and -Xskip-metadata-version-check is no longer needed (#3238)
+- [MINOR] Add an IFidoManagerProvider extension point so a host can fulfil WebView passkey challenges, with Credential Manager as the fallback, and pass the auth flow's correlation id to IFidoManager.authenticate (#3237)
 
 Version 24.6.0
 ----------

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandler.kt
@@ -54,10 +54,11 @@ class AuthFidoChallengeHandler (
     private val fidoManager: IFidoManager,
     private val webView: WebView,
     private val oTelContext: Context?,
-    private val lifecycleOwner: LifecycleOwner?
+    private val lifecycleOwner: LifecycleOwner?,
+    private val correlationId: String? = null
 ) : IChallengeHandler<FidoChallenge, Void> {
-    val TAG = AuthFidoChallengeHandler::class.simpleName.toString()
     companion object {
+        val TAG = AuthFidoChallengeHandler::class.simpleName.toString()
         private val parentAttributeNames = arrayListOf(
             AttributeName.correlation_id,
             AttributeName.tenant_id,
@@ -132,6 +133,7 @@ class AuthFidoChallengeHandler (
                     relyingPartyIdentifier = relyingPartyIdentifier,
                     allowedCredentials = allowedCredentials,
                     userVerificationPolicy = userVerificationPolicy,
+                    correlationId = correlationId,
                     span = span
                 )
                 span.setStatus(StatusCode.OK)
@@ -151,14 +153,14 @@ class AuthFidoChallengeHandler (
                     methodTag = methodTag
                 )
             } catch (e : Exception) {
-                    respondToChallengeWithError(
-                        submitUrl = submitUrl,
-                        context = context,
-                        span = span,
-                        errorMessage = e.message.toString(),
-                        exception = e,
-                        methodTag = methodTag
-                    )
+                respondToChallengeWithError(
+                    submitUrl = submitUrl,
+                    context = context,
+                    span = span,
+                    errorMessage = e.message.toString(),
+                    exception = e,
+                    methodTag = methodTag
+                )
             }
         }
         return null

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/CredManFidoManager.kt
@@ -64,6 +64,7 @@ class CredManFidoManager (val context: Context,
                                       relyingPartyIdentifier: String,
                                       allowedCredentials: List<String>?,
                                       userVerificationPolicy: String,
+                                      correlationId: String?,
                                       span: Span): String {
         val methodTag = "$TAG:authenticate"
         span.setAttribute(
@@ -104,6 +105,7 @@ class CredManFidoManager (val context: Context,
                      relyingPartyIdentifier = relyingPartyIdentifier,
                      allowedCredentials = allowedCredentials,
                      userVerificationPolicy = userVerificationPolicy,
+                     correlationId = correlationId,
                      span = span)
             } else {
                 throw e

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/FidoManagerFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/FidoManagerFactory.kt
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.fido
+
+import android.app.Activity
+import com.microsoft.identity.common.logging.Logger
+
+/**
+ * Chooses the [IFidoManager] that fulfils a WebView passkey challenge.
+ *
+ * A host may register an [IFidoManagerProvider] to handle ceremonies through a mechanism this
+ * library has no knowledge of. Hosts that register nothing, and any challenge the provider
+ * declines, use Credential Manager.
+ */
+object FidoManagerFactory {
+
+    private val TAG = FidoManagerFactory::class.simpleName.toString()
+
+    @Volatile
+    private var provider: IFidoManagerProvider? = null
+
+    /**
+     * @param provider provider to consult for subsequent challenges, or null to unregister.
+     */
+    @JvmStatic
+    fun setProvider(provider: IFidoManagerProvider?) {
+        Logger.info(
+            "$TAG:setProvider",
+            if (provider == null) {
+                "Host passkey provider cleared."
+            } else {
+                "Host passkey provider registered: " + provider.javaClass.simpleName
+            }
+        )
+        this.provider = provider
+    }
+
+    /**
+     * @param activity foreground Activity hosting the WebView; also the context for the Credential
+     * Manager fallback.
+     * @param legacyManager legacy GMS FIDO2 manager, when applicable.
+     * @return the manager to fulfil this challenge; never null.
+     */
+    @JvmStatic
+    fun getFidoManager(
+        activity: Activity,
+        legacyManager: IFidoManager?
+    ): IFidoManager {
+        val manager = provider?.getFidoManager(activity)
+            ?: CredManFidoManager(activity, legacyManager)
+        Logger.info(
+            "$TAG:getFidoManager",
+            "Fulfilling passkey challenge with " + manager.javaClass.simpleName
+        )
+        return manager
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/FidoManagerFactory.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/FidoManagerFactory.kt
@@ -23,6 +23,11 @@
 package com.microsoft.identity.common.internal.fido
 
 import android.app.Activity
+import android.content.Context
+import android.os.Process
+import androidx.annotation.VisibleForTesting
+import com.microsoft.identity.common.internal.broker.BrokerData
+import com.microsoft.identity.common.internal.broker.BrokerValidator
 import com.microsoft.identity.common.logging.Logger
 
 /**
@@ -39,13 +44,31 @@ object FidoManagerFactory {
     @Volatile
     private var provider: IFidoManagerProvider? = null
 
+    // Seam for this library's own tests, which do not run inside a signed broker app.
+    @VisibleForTesting
+    internal var isBrokerHosted: (Context) -> Boolean = ::isSignedBrokerApp
+
     /**
+     * Registers the provider consulted for subsequent challenges. Ignored unless the calling app is
+     * a broker, so a library embedded in any other app cannot take over passkey handling.
+     *
+     * @param context context of the app registering the provider.
      * @param provider provider to consult for subsequent challenges, or null to unregister.
+     * @return true when the provider was accepted; callers that expect to be a broker should treat
+     * false as a misconfiguration rather than ignoring it.
      */
     @JvmStatic
-    fun setProvider(provider: IFidoManagerProvider?) {
+    fun setProvider(context: Context, provider: IFidoManagerProvider?): Boolean {
+        val methodTag = "$TAG:setProvider"
+        if (!isBrokerHosted(context)) {
+            Logger.warn(
+                methodTag,
+                "Ignoring a passkey provider from " + context.packageName + "; not a broker app."
+            )
+            return false
+        }
         Logger.info(
-            "$TAG:setProvider",
+            methodTag,
             if (provider == null) {
                 "Host passkey provider cleared."
             } else {
@@ -53,6 +76,21 @@ object FidoManagerFactory {
             }
         )
         this.provider = provider
+        return true
+    }
+
+    // Matches against every known broker, prod and debug alike: this identifies the process we are
+    // already running in, so the debug/prod split that BrokerData.getKnownBrokerApps() applies to
+    // peer discovery would only break debug brokers here.
+    //
+    // The package name is taken from our own uid rather than from the supplied Context, whose
+    // getPackageName() any caller can point at an installed broker via createPackageContext().
+    private fun isSignedBrokerApp(context: Context): Boolean {
+        val ownPackages = context.packageManager.getPackagesForUid(Process.myUid())?.toSet().orEmpty()
+        val validator = BrokerValidator(context)
+        return BrokerData.allBrokers.any {
+            ownPackages.contains(it.packageName) && validator.isSignedByKnownKeys(it)
+        }
     }
 
     /**
@@ -66,10 +104,11 @@ object FidoManagerFactory {
         activity: Activity,
         legacyManager: IFidoManager?
     ): IFidoManager {
+        val methodTag = "$TAG:getFidoManager"
         val manager = provider?.getFidoManager(activity)
             ?: CredManFidoManager(activity, legacyManager)
         Logger.info(
-            "$TAG:getFidoManager",
+            methodTag,
             "Fulfilling passkey challenge with " + manager.javaClass.simpleName
         )
         return manager

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/IFidoManagerProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/IFidoManagerProvider.kt
@@ -22,27 +22,19 @@
 // THE SOFTWARE.
 package com.microsoft.identity.common.internal.fido
 
-import io.opentelemetry.api.trace.Span
+import android.app.Activity
 
 /**
- * Representation of a manager that handles interactions with a passkey provider (usually through an API).
+ * Supplies a host-specific [IFidoManager] for a WebView passkey challenge.
+ *
+ * Implemented by hosts that can fulfil a ceremony through a mechanism this library has no
+ * knowledge of, and registered with [FidoManagerFactory] during host initialization.
  */
-interface IFidoManager {
+interface IFidoManagerProvider {
+
     /**
-     * Interacts with the FIDO credential provider and returns an assertion.
-     * @param challenge
-     * @param relyingPartyIdentifier
-     * @param allowedCredentials
-     * @param userVerificationPolicy
-     * @param correlationId correlation id of the auth flow, when one is available
-     * @param span
-     * @return assertion
-     * @throws Exception
+     * @param activity live foreground Activity hosting the WebView auth flow.
+     * @return a manager able to fulfil the challenge, or null to use this library's default.
      */
-    suspend fun authenticate(challenge: String,
-                             relyingPartyIdentifier: String,
-                             allowedCredentials: List<String>?,
-                             userVerificationPolicy: String,
-                             correlationId: String?,
-                             span: Span) : String
+    fun getFidoManager(activity: Activity): IFidoManager?
 }

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/IFidoManagerProvider.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/IFidoManagerProvider.kt
@@ -28,7 +28,9 @@ import android.app.Activity
  * Supplies a host-specific [IFidoManager] for a WebView passkey challenge.
  *
  * Implemented by hosts that can fulfil a ceremony through a mechanism this library has no
- * knowledge of, and registered with [FidoManagerFactory] during host initialization.
+ * knowledge of, and registered with [FidoManagerFactory.setProvider] during host initialization.
+ * Not a general extension point: registration is refused for any app that is not signed as a
+ * broker, so a library embedded in some other app cannot be made to hand over passkey handling.
  */
 interface IFidoManagerProvider {
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/fido/LegacyFido2ApiManager.kt
+++ b/common/src/main/java/com/microsoft/identity/common/internal/fido/LegacyFido2ApiManager.kt
@@ -61,6 +61,7 @@ class LegacyFido2ApiManager (val context: Context, val fragment: WebViewAuthoriz
                                       relyingPartyIdentifier: String,
                                       allowedCredentials: List<String>?,
                                       userVerificationPolicy: String,
+                                      correlationId: String?,
                                       span: Span
     ): String = suspendCancellableCoroutine { continuation ->
         val methodTag = "$TAG:authenticate"

--- a/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadata.java
@@ -110,6 +110,10 @@ public class AndroidDeviceMetadata extends AbstractDeviceMetadata {
             final PackageManager packageManager = context.getPackageManager();
             final ApplicationInfo appInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             final Bundle metaDataBundle = appInfo.metaData;
+            // An app that declares no metadata at all has a null bundle; treat it as a mobile device.
+            if (metaDataBundle == null) {
+                return MOBILE_DEVICE;
+            }
             // If the deviceType property is not found, default it to mobile device
             final String deviceType = metaDataBundle.getString(DEVICE_TYPE, MOBILE_DEVICE);
             Logger.verbose(methodTag, "Setting the deviceType as " + deviceType);

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/AuthorizationFragment.java
@@ -72,6 +72,8 @@ public abstract class AuthorizationFragment extends Fragment {
      */
     private Bundle mInstanceState;
 
+    private String mCorrelationId;
+
     /**
      * Determines if authentication result has been sent.
      */
@@ -171,13 +173,28 @@ public abstract class AuthorizationFragment extends Fragment {
      * @param state a bundle containing data provided when the activity was created
      */
     void extractState(@NonNull final Bundle state) {
-        setDiagnosticContextForNewThread(state.getString(DiagnosticContext.CORRELATION_ID));
+        mCorrelationId = state.getString(DiagnosticContext.CORRELATION_ID);
+        setDiagnosticContextForNewThread(mCorrelationId);
         mMamCaInstallReferrerEnabled = state.getBoolean(MAM_CA_INSTALL_REFERRER_ENABLED, false);
+    }
+
+    /**
+     * The correlation id this authorization flow was started with.
+     *
+     * Held here as well as in DiagnosticContext because the latter is thread local and another flow
+     * on the same thread can replace it, whereas this survives for the life of the fragment.
+     *
+     * @return the correlation id, or null when the flow was started without one.
+     */
+    @Nullable
+    public String getCorrelationId() {
+        return mCorrelationId;
     }
 
     @Override
     public void onSaveInstanceState(@NonNull final Bundle outState) {
         super.onSaveInstanceState(outState);
+        outState.putString(DiagnosticContext.CORRELATION_ID, mCorrelationId);
         outState.putBoolean(MAM_CA_INSTALL_REFERRER_ENABLED, mMamCaInstallReferrerEnabled);
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/providers/oauth2/WebViewAuthorizationFragment.java
@@ -394,7 +394,8 @@ public class WebViewAuthorizationFragment extends AuthorizationFragment {
                     public Map<Integer, UrlStatus> getUrlStatusMap() {
                         return WebViewAuthorizationFragment.this.getUrlLoadTracker();
                     }
-                }
+                },
+                getCorrelationId()
         );
     }
 

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -396,7 +396,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                         view,
                         oTelContext,
                         ViewTreeLifecycleOwner.get(view),
-                        DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
+                        getFlowCorrelationId(oTelContext));
                 challengeHandler.processChallenge(challenge);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED)
                     && isNonceRedirect(formattedURL)
@@ -480,6 +480,30 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
             view.stopLoading();
         }
         return true;
+    }
+
+    /**
+     * Returns the correlation id to run the passkey ceremony under.
+     *
+     * Prefers the OTel baggage because it is scoped to this authorization request, whereas
+     * DiagnosticContext is mutable thread local state that another flow on the UI thread can replace
+     * and that fragment restoration can drop. A wrong or missing value here silently breaks the join
+     * between our telemetry and the passkey provider's.
+     *
+     * @param oTelContext OTel context of this authorization flow, when there is one.
+     * @return the correlation id, or null when neither source has one.
+     */
+    @Nullable
+    @VisibleForTesting
+    static String getFlowCorrelationId(@Nullable final Context oTelContext) {
+        if (oTelContext != null) {
+            final String fromBaggage = BaggageExtension.fromContext(oTelContext)
+                    .getEntryValue(AttributeName.correlation_id.name());
+            if (!StringUtil.isNullOrEmpty(fromBaggage)) {
+                return fromBaggage;
+            }
+        }
+        return DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID);
     }
 
     private boolean isUriSSLProtected(@NonNull final String url) {

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -52,7 +52,6 @@ import com.microsoft.identity.common.internal.broker.BrokerData;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.internal.broker.AuthUxJavaScriptInterface;
 import com.microsoft.identity.common.internal.broker.PackageHelper;
-import com.microsoft.identity.common.internal.fido.CredManFidoManager;
 import com.microsoft.identity.common.internal.fido.FidoChallenge;
 import com.microsoft.identity.common.internal.fido.AuthFidoChallengeHandler;
 import com.microsoft.identity.common.internal.fido.IFidoManager;

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -191,6 +191,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     private final boolean mMamCaInstallReferrerEnabled;
     private final SpanContext mSpanContext;
     private final String mUtid;
+    private final String mCorrelationId;
 
     private String mPasskeyRegistrationScript;
 
@@ -217,12 +218,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @Nullable final String utid,
                                              final boolean isWebViewWebCpEnabledInBrokerlessCase,
                                              final boolean mamCaInstallReferrerEnabled,
-                                             @Nullable final IUrlLoadTracker urlLoadTracker) {
+                                             @Nullable final IUrlLoadTracker urlLoadTracker,
+                                             @Nullable final String correlationId) {
         super(activity, completionCallback, pageLoadedCallback);
         mRedirectUrl = redirectUrl;
         mCertBasedAuthFactory = new CertBasedAuthFactory(activity);
         mSwitchBrowserProtocolCoordinator = switchBrowserProtocolCoordinator;
         mUtid = utid;
+        mCorrelationId = correlationId;
         mSpanContext = activity instanceof AuthorizationActivity ? ((AuthorizationActivity) getActivity()).getSpanContext() : null;
         mIsWebViewWebCpEnabledInBrokerlessCase = isWebViewWebCpEnabledInBrokerlessCase;
         mMamCaInstallReferrerEnabled = mamCaInstallReferrerEnabled;
@@ -238,7 +241,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @Nullable final String utid,
                                              final boolean isWebViewWebCpEnabledInBrokerlessCase,
                                              @Nullable final IUrlLoadTracker urlLoadTracker) {
-        this(activity, completionCallback, pageLoadedCallback, redirectUrl, switchBrowserProtocolCoordinator, utid, isWebViewWebCpEnabledInBrokerlessCase, false, urlLoadTracker);
+        this(activity, completionCallback, pageLoadedCallback, redirectUrl, switchBrowserProtocolCoordinator, utid, isWebViewWebCpEnabledInBrokerlessCase, false, urlLoadTracker, null);
     }
 
     @VisibleForTesting
@@ -249,7 +252,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                              @NonNull final SwitchBrowserProtocolCoordinator switchBrowserProtocolCoordinator,
                                              @Nullable final String utid,
                                              final boolean isWebViewWebCpEnabledInBrokerlessCase) {
-        this(activity, completionCallback, pageLoadedCallback, redirectUrl, switchBrowserProtocolCoordinator, utid, isWebViewWebCpEnabledInBrokerlessCase, false, null);
+        this(activity, completionCallback, pageLoadedCallback, redirectUrl, switchBrowserProtocolCoordinator, utid, isWebViewWebCpEnabledInBrokerlessCase, false, null, null);
     }
 
     /**
@@ -396,7 +399,7 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                         view,
                         oTelContext,
                         ViewTreeLifecycleOwner.get(view),
-                        getFlowCorrelationId(oTelContext));
+                        getFlowCorrelationId());
                 challengeHandler.processChallenge(challenge);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED)
                     && isNonceRedirect(formattedURL)
@@ -485,23 +488,18 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
     /**
      * Returns the correlation id to run the passkey ceremony under.
      *
-     * Prefers the OTel baggage because it is scoped to this authorization request, whereas
+     * Prefers the id this flow was started with, captured when the fragment was created, because
      * DiagnosticContext is mutable thread local state that another flow on the UI thread can replace
      * and that fragment restoration can drop. A wrong or missing value here silently breaks the join
      * between our telemetry and the passkey provider's.
      *
-     * @param oTelContext OTel context of this authorization flow, when there is one.
      * @return the correlation id, or null when neither source has one.
      */
     @Nullable
     @VisibleForTesting
-    static String getFlowCorrelationId(@Nullable final Context oTelContext) {
-        if (oTelContext != null) {
-            final String fromBaggage = BaggageExtension.fromContext(oTelContext)
-                    .getEntryValue(AttributeName.correlation_id.name());
-            if (!StringUtil.isNullOrEmpty(fromBaggage)) {
-                return fromBaggage;
-            }
+    String getFlowCorrelationId() {
+        if (!StringUtil.isNullOrEmpty(mCorrelationId)) {
+            return mCorrelationId;
         }
         return DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID);
     }

--- a/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
+++ b/common/src/main/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClient.java
@@ -57,6 +57,8 @@ import com.microsoft.identity.common.internal.fido.FidoChallenge;
 import com.microsoft.identity.common.internal.fido.AuthFidoChallengeHandler;
 import com.microsoft.identity.common.internal.fido.IFidoManager;
 import com.microsoft.identity.common.internal.fido.LegacyFido2ApiManager;
+import com.microsoft.identity.common.internal.fido.FidoManagerFactory;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity;
 import com.microsoft.identity.common.internal.providers.oauth2.PasskeyOriginRulesManager;
 import com.microsoft.identity.common.internal.providers.oauth2.WebViewAuthorizationFragment;
@@ -388,14 +390,14 @@ public class AzureActiveDirectoryWebViewClient extends OAuth2WebViewClient {
                                 && Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE
                                 ? new LegacyFido2ApiManager(view.getContext(), (WebViewAuthorizationFragment)((AuthorizationActivity)currentActivity).getFragment())
                                 : null;
+                final IFidoManager fidoManager =
+                        FidoManagerFactory.getFidoManager(currentActivity, legacyManager);
                 final AuthFidoChallengeHandler challengeHandler = new AuthFidoChallengeHandler(
-                        new CredManFidoManager(
-                                view.getContext(),
-                                legacyManager
-                        ),
+                        fidoManager,
                         view,
                         oTelContext,
-                        ViewTreeLifecycleOwner.get(view));
+                        ViewTreeLifecycleOwner.get(view),
+                        DiagnosticContext.INSTANCE.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
                 challengeHandler.processChallenge(challenge);
             } else if (CommonFlightsManager.INSTANCE.getFlightsProvider().isFlightEnabled(CommonFlight.ENABLE_ATTACH_NEW_PRT_HEADER_WHEN_NONCE_EXPIRED)
                     && isNonceRedirect(formattedURL)

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandlerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/AuthFidoChallengeHandlerTest.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.microsoft.identity.common.java.exception.ClientException
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility
 import com.microsoft.identity.common.java.opentelemetry.SpanName
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -53,6 +54,9 @@ class AuthFidoChallengeHandlerTest {
 
     //Test Exception
     val testException = ClientException("A message")
+
+    //Correlation id of the auth flow, supplied by the caller that builds this handler.
+    val testCorrelationId = "2f0f2e39-2c1b-4a2a-9a2f-9f0a1b2c3d4e"
 
     //Handler parameters
     val testFidoManager = TestFidoManager()
@@ -86,6 +90,32 @@ class AuthFidoChallengeHandlerTest {
         authFidoChallengeHandler.processChallenge(FidoChallenge.createFromRedirectUri(fullUrl))
         assertTrue(webView.urlLoaded)
         assertTrue(webView.isRegularAssertion())
+    }
+
+    /**
+     * The manager passes this on to the ceremony it runs, so a dropped correlation id breaks the
+     * join between our logs and the ceremony's.
+     */
+    @Test
+    fun testProcessChallenge_AuthPassesCorrelationIdToManager() {
+        authFidoChallengeHandler = AuthFidoChallengeHandler(
+            fidoManager = testFidoManager,
+            webView = webView,
+            oTelContext = null,
+            lifecycleOwner = testLifecycleOwner,
+            correlationId = testCorrelationId
+        )
+        val fullUrl = Uri.Builder().authority(authority)
+            .appendQueryParameter(FidoRequestField.CHALLENGE.fieldName, challengeStr)
+            .appendQueryParameter(FidoRequestField.ALLOWED_CREDENTIALS.fieldName, allowCredentialsOneUserString)
+            .appendQueryParameter(FidoRequestField.RELYING_PARTY_IDENTIFIER.fieldName, relyingPartyIdentifier)
+            .appendQueryParameter(FidoRequestField.VERSION.fieldName, version)
+            .appendQueryParameter(FidoRequestField.SUBMIT_URL.fieldName, submitUrl)
+            .appendQueryParameter(FidoRequestField.KEY_TYPES.fieldName, keyTypesString)
+            .appendQueryParameter(FidoRequestField.CONTEXT.fieldName, context)
+            .build().toString()
+        authFidoChallengeHandler.processChallenge(FidoChallenge.createFromRedirectUri(fullUrl))
+        assertEquals(testCorrelationId, testFidoManager.lastCorrelationId)
     }
 
     @Test(expected = ClientException::class)

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/FidoManagerFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/FidoManagerFactoryTest.kt
@@ -23,10 +23,14 @@
 package com.microsoft.identity.common.internal.fido
 
 import android.app.Activity
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import io.opentelemetry.api.trace.Span
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -43,6 +47,14 @@ class FidoManagerFactoryTest {
 
     private val activity: Activity =
         Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Before
+    fun setUp() {
+        // This test app is not a signed broker, so registration would otherwise be refused.
+        FidoManagerFactory.isBrokerHosted = { true }
+    }
 
     private val hostManager = object : IFidoManager {
         override suspend fun authenticate(
@@ -61,7 +73,8 @@ class FidoManagerFactoryTest {
 
     @After
     fun tearDown() {
-        FidoManagerFactory.setProvider(null)
+        FidoManagerFactory.setProvider(context, null)
+        FidoManagerFactory.isBrokerHosted = { false }
     }
 
     @Test
@@ -71,20 +84,31 @@ class FidoManagerFactoryTest {
 
     @Test
     fun testUsesHostManagerWhenProviderSuppliesOne() {
-        FidoManagerFactory.setProvider(providerReturning(hostManager))
+        FidoManagerFactory.setProvider(context, providerReturning(hostManager))
         assertSame(hostManager, FidoManagerFactory.getFidoManager(activity, null))
     }
 
     @Test
     fun testFallsBackWhenProviderDeclines() {
-        FidoManagerFactory.setProvider(providerReturning(null))
+        FidoManagerFactory.setProvider(context, providerReturning(null))
+        assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
+    }
+
+    /**
+     * A library embedded in a non-broker app must not be able to take over passkey handling, and
+     * the caller has to be told, since a genuine broker treats refusal as a misconfiguration.
+     */
+    @Test
+    fun testProviderFromANonBrokerAppIsIgnored() {
+        FidoManagerFactory.isBrokerHosted = { false }
+        assertFalse(FidoManagerFactory.setProvider(context, providerReturning(hostManager)))
         assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
     }
 
     @Test
     fun testProviderCanBeUnregistered() {
-        FidoManagerFactory.setProvider(providerReturning(hostManager))
-        FidoManagerFactory.setProvider(null)
+        FidoManagerFactory.setProvider(context, providerReturning(hostManager))
+        FidoManagerFactory.setProvider(context, null)
         assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
     }
 }

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/FidoManagerFactoryTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/FidoManagerFactoryTest.kt
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.fido
+
+import android.app.Activity
+import io.opentelemetry.api.trace.Span
+import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * This routing decides which backend fulfils a passkey challenge, so a regression here either
+ * disables a host's ceremony or sends every consumer down a path meant for one host.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class FidoManagerFactoryTest {
+
+    private val activity: Activity =
+        Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    private val hostManager = object : IFidoManager {
+        override suspend fun authenticate(
+            challenge: String,
+            relyingPartyIdentifier: String,
+            allowedCredentials: List<String>?,
+            userVerificationPolicy: String,
+            correlationId: String?,
+            span: Span
+        ): String = ""
+    }
+
+    private fun providerReturning(manager: IFidoManager?) = object : IFidoManagerProvider {
+        override fun getFidoManager(activity: Activity): IFidoManager? = manager
+    }
+
+    @After
+    fun tearDown() {
+        FidoManagerFactory.setProvider(null)
+    }
+
+    @Test
+    fun testUsesCredentialManagerWhenNoProviderRegistered() {
+        assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
+    }
+
+    @Test
+    fun testUsesHostManagerWhenProviderSuppliesOne() {
+        FidoManagerFactory.setProvider(providerReturning(hostManager))
+        assertSame(hostManager, FidoManagerFactory.getFidoManager(activity, null))
+    }
+
+    @Test
+    fun testFallsBackWhenProviderDeclines() {
+        FidoManagerFactory.setProvider(providerReturning(null))
+        assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
+    }
+
+    @Test
+    fun testProviderCanBeUnregistered() {
+        FidoManagerFactory.setProvider(providerReturning(hostManager))
+        FidoManagerFactory.setProvider(null)
+        assertTrue(FidoManagerFactory.getFidoManager(activity, null) is CredManFidoManager)
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/fido/TestFidoManager.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/fido/TestFidoManager.kt
@@ -37,11 +37,16 @@ class TestFidoManager () : IFidoManager {
         const val EXCEPTION_CHALLENGE = "Throw exception in manager"
         const val EXCEPTION_MESSAGE = "Throwing an exception"
     }
+    var lastCorrelationId: String? = null
+        private set
+
     override suspend fun authenticate(challenge: String,
                                       relyingPartyIdentifier: String,
                                       allowedCredentials: List<String>?,
                                       userVerificationPolicy: String,
+                                      correlationId: String?,
                                       span: Span): String {
+        lastCorrelationId = correlationId
         if (challenge == EXCEPTION_CHALLENGE) {
             throw Exception(EXCEPTION_MESSAGE)
         }

--- a/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadataTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/internal/platform/AndroidDeviceMetadataTest.kt
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.common.internal.platform
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class AndroidDeviceMetadataTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun setMetaData(metaData: Bundle?) {
+        val packageInfo = shadowOf(context.packageManager)
+            .getInternalMutablePackageInfo(context.packageName)
+        val applicationInfo = packageInfo.applicationInfo
+            ?: ApplicationInfo().also { packageInfo.applicationInfo = it }
+        applicationInfo.metaData = metaData
+    }
+
+    /**
+     * An app that declares no metadata at all has a null bundle, which must not be dereferenced.
+     */
+    @Test
+    fun testGetAndroidDeviceTypeFromMetadata_defaultsToMobileWhenBundleAbsent() {
+        setMetaData(null)
+        assertEquals("mobileDevice", AndroidDeviceMetadata.getAndroidDeviceTypeFromMetadata(context))
+    }
+
+    @Test
+    fun testGetAndroidDeviceTypeFromMetadata_defaultsToMobileWhenDeviceTypeAbsent() {
+        setMetaData(Bundle())
+        assertEquals("mobileDevice", AndroidDeviceMetadata.getAndroidDeviceTypeFromMetadata(context))
+    }
+
+    @Test
+    fun testGetAndroidDeviceTypeFromMetadata_returnsDeclaredDeviceType() {
+        setMetaData(Bundle().apply { putString("DeviceType", "TeamsDevice") })
+        assertEquals("TeamsDevice", AndroidDeviceMetadata.getAndroidDeviceTypeFromMetadata(context))
+    }
+}

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -103,7 +103,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import com.microsoft.identity.common.internal.fido.FidoManagerFactory;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -2048,7 +2047,6 @@ public class AzureActiveDirectoryWebViewClientTest {
      */
     @Test
     public void testPasskeyChallengeFallsBackWhenNoProviderRegistered() {
-        FidoManagerFactory.setProvider(null);
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL));
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -106,7 +106,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
@@ -305,6 +304,9 @@ public class AzureActiveDirectoryWebViewClientTest {
         // OTelUtility.setSpanFactory, which mutates a JVM-global @Volatile with no getter to restore. Reset
         // it to the production default after every test so a leaked test factory cannot corrupt later tests.
         OTelUtility.setSpanFactory(new DefaultOTelSpanFactory());
+        // The correlation-id tests seed DiagnosticContext, which is thread local and would otherwise
+        // stay set for every later test running on this thread.
+        DiagnosticContext.INSTANCE.clear();
         // Clear onboarding session-correlation SharedPreferences to keep tests isolated;
         // OnboardingTelemetryRecorder.addBlockingError persists to this store.
         if (mContext != null) {
@@ -2054,54 +2056,58 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     /**
-     * The ceremony has to run under this authorization request's correlation id. DiagnosticContext is
-     * thread local and another flow on the UI thread can replace it, so the request scoped baggage
-     * wins when it carries one.
+     * The ceremony has to run under the id this flow was started with. DiagnosticContext is thread
+     * local and another flow on the UI thread can replace it, so the captured value wins.
      */
     @Test
-    public void testGetFlowCorrelationId_prefersBaggageOverDiagnosticContext() {
-        final String fromBaggage = "11111111-1111-4111-8111-111111111111";
+    public void testGetFlowCorrelationId_prefersTheFlowsOwnIdOverDiagnosticContext() {
+        final String flowCorrelationId = "11111111-1111-4111-8111-111111111111";
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, "22222222-2222-4222-8222-222222222222");
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
-        final io.opentelemetry.context.Context oTelContext =
-                Baggage.builder()
-                        .put(AttributeName.correlation_id.name(), fromBaggage)
-                        .build()
-                        .storeInContext(io.opentelemetry.context.Context.root());
-
-        assertEquals(fromBaggage,
-                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(oTelContext));
+        assertEquals(flowCorrelationId,
+                newClientWithCorrelationId(flowCorrelationId).getFlowCorrelationId());
     }
 
     /**
-     * A flow whose baggage carries no correlation id must still be joinable, so the thread local
-     * remains the fallback rather than being dropped.
+     * A flow started without a correlation id must still be joinable, so the thread local remains the
+     * fallback rather than being dropped.
      */
     @Test
-    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenBaggageHasNone() {
+    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowHasNoId() {
         final String fromDiagnosticContext = "33333333-3333-4333-8333-333333333333";
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
-        final io.opentelemetry.context.Context oTelContext =
-                Baggage.empty().storeInContext(io.opentelemetry.context.Context.root());
-
         assertEquals(fromDiagnosticContext,
-                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(oTelContext));
+                newClientWithCorrelationId(null).getFlowCorrelationId());
     }
 
     @Test
-    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenThereIsNoOTelContext() {
+    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowsIdIsEmpty() {
         final String fromDiagnosticContext = "44444444-4444-4444-8444-444444444444";
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
         assertEquals(fromDiagnosticContext,
-                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(null));
+                newClientWithCorrelationId("").getFlowCorrelationId());
+    }
+
+    private AzureActiveDirectoryWebViewClient newClientWithCorrelationId(final String correlationId) {
+        return new AzureActiveDirectoryWebViewClient(
+                mActivity,
+                Mockito.mock(IAuthorizationCompletionCallback.class),
+                url -> { },
+                TEST_REDIRECT_URI,
+                Mockito.mock(SwitchBrowserProtocolCoordinator.class),
+                "homeTenantId",
+                false,
+                false,
+                null,
+                correlationId);
     }
 
     @Test
@@ -2780,6 +2786,7 @@ public class AzureActiveDirectoryWebViewClientTest {
                 "homeTenantId",
                 false,
                 mamCaInstallReferrerEnabled,
+                null,
                 null);
         client.setRequestUrl(TEST_PUBLIC_CLOUD_REDIRECT_URL);
         return client;

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -103,6 +103,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import com.microsoft.identity.common.internal.fido.FidoManagerFactory;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -2039,6 +2040,15 @@ public class AzureActiveDirectoryWebViewClientTest {
     }
 
     public void setTestPasskeyRedirectUrl() {
+        assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL));
+    }
+
+    /**
+     * With no host provider registered the client must still handle the challenge itself.
+     */
+    @Test
+    public void testPasskeyChallengeFallsBackWhenNoProviderRegistered() {
+        FidoManagerFactory.setProvider(null);
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL));
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -106,9 +106,12 @@ import java.util.concurrent.TimeUnit;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
+import com.microsoft.identity.common.java.logging.DiagnosticContext;
+import com.microsoft.identity.common.java.logging.RequestContext;
 import com.microsoft.identity.common.java.opentelemetry.AttributeName;
 import com.microsoft.identity.common.java.opentelemetry.DefaultOTelSpanFactory;
 import com.microsoft.identity.common.java.opentelemetry.IOTelSpanFactory;
@@ -2048,6 +2051,57 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testPasskeyChallengeFallsBackWhenNoProviderRegistered() {
         assertTrue(mWebViewClient.shouldOverrideUrlLoading(mMockWebView, TEST_PASSKEY_REDIRECT_URL));
+    }
+
+    /**
+     * The ceremony has to run under this authorization request's correlation id. DiagnosticContext is
+     * thread local and another flow on the UI thread can replace it, so the request scoped baggage
+     * wins when it carries one.
+     */
+    @Test
+    public void testGetFlowCorrelationId_prefersBaggageOverDiagnosticContext() {
+        final String fromBaggage = "11111111-1111-4111-8111-111111111111";
+        final RequestContext requestContext = new RequestContext();
+        requestContext.put(DiagnosticContext.CORRELATION_ID, "22222222-2222-4222-8222-222222222222");
+        DiagnosticContext.INSTANCE.setRequestContext(requestContext);
+
+        final io.opentelemetry.context.Context oTelContext =
+                Baggage.builder()
+                        .put(AttributeName.correlation_id.name(), fromBaggage)
+                        .build()
+                        .storeInContext(io.opentelemetry.context.Context.root());
+
+        assertEquals(fromBaggage,
+                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(oTelContext));
+    }
+
+    /**
+     * A flow whose baggage carries no correlation id must still be joinable, so the thread local
+     * remains the fallback rather than being dropped.
+     */
+    @Test
+    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenBaggageHasNone() {
+        final String fromDiagnosticContext = "33333333-3333-4333-8333-333333333333";
+        final RequestContext requestContext = new RequestContext();
+        requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
+        DiagnosticContext.INSTANCE.setRequestContext(requestContext);
+
+        final io.opentelemetry.context.Context oTelContext =
+                Baggage.empty().storeInContext(io.opentelemetry.context.Context.root());
+
+        assertEquals(fromDiagnosticContext,
+                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(oTelContext));
+    }
+
+    @Test
+    public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenThereIsNoOTelContext() {
+        final String fromDiagnosticContext = "44444444-4444-4444-8444-444444444444";
+        final RequestContext requestContext = new RequestContext();
+        requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
+        DiagnosticContext.INSTANCE.setRequestContext(requestContext);
+
+        assertEquals(fromDiagnosticContext,
+                AzureActiveDirectoryWebViewClient.getFlowCorrelationId(null));
     }
 
     @Test


### PR DESCRIPTION
Adds a general extension point so a host can fulfil a WebView passkey challenge through a mechanism this library has no knowledge of.

- `IFidoManagerProvider` — implemented by a host, returns an `IFidoManager` for the foreground Activity.
- `FidoManagerFactory` — holds the optional provider and resolves the manager for a challenge, falling back to `CredManFidoManager`.
- `AzureActiveDirectoryWebViewClient` resolves the manager through a single factory call.
- `IFidoManager.authenticate` now takes the auth flow's correlation id, so a manager can pass it to the ceremony it runs. All four implementers are in-repo and updated.
- `AndroidDeviceMetadata.getAndroidDeviceTypeFromMetadata` no longer dereferences a null metadata bundle.

No behaviour change for existing consumers: with no provider registered the Credential Manager path is unchanged.

The first consumer is the Broker, which registers a provider for the Teams cross-device passkey ceremony on nGMS Teams devices.

Tests: `FidoManagerFactoryTest` (4, new), `AndroidDeviceMetadataTest` (3, new), `AuthFidoChallengeHandlerTest` (+1 correlation id forwarding), `AzureActiveDirectoryWebViewClientTest` (+1 fallback).

### Work items

- [AB#3702833](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3702833) — Create the Teams Devices passkey FidoManager and route to it on nGMS
- [AB#3702769](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3702769) — Tests for the nGMS cross-device passkey path
- Parent feature: [AB#3688709](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3688709)

