### PR TITLE
Bump Kotlin to 2.0.21 with language/API version pinned to 1.9, Fixes AB#3742062

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ vNext
 - [PATCH] Migrate the Native Auth E2E test email provider from 1secmail to authenticated Mail.tm (#3219)
 - [MINOR] Security: validate a PKeyAuth WebView-redirect SubmitUrl (attacker-controllable) as an HTTPS URL same-origin with the challenging endpoint before the device key signs or the WebView submits; flight-gated and ships in shadow mode (CWE-918 / AB#3706623)
 - [MINOR] Reenable the GetCookies WebApps API contract for broker discovery (#3230)
+- [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9, so published metadata stays readable by consumers on Kotlin 1.8 and -Xskip-metadata-version-check is no longer needed (#3238)
 
 Version 24.6.0
 ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -169,6 +169,9 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        // Pinned to 1.9 so published metadata stays readable by consumers still on Kotlin 1.8.
+        languageVersion = "1.9"
+        apiVersion = "1.9"
     }
 
     lintOptions {

--- a/common4j/build.gradle
+++ b/common4j/build.gradle
@@ -347,6 +347,9 @@ afterEvaluate {
 tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         jvmTarget = "1.8"
+        // Pinned to 1.9 so published metadata stays readable by consumers still on Kotlin 1.8.
+        languageVersion = "1.9"
+        apiVersion = "1.9"
     }
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,7 @@ ext {
 
     // Plugins
     gradleVersion = '8.10.0'
-    kotlinVersion = '1.8.0'
+    kotlinVersion = '2.0.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
 

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -58,6 +58,9 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        // Pinned to 1.9 so published metadata stays readable by consumers still on Kotlin 1.8.
+        languageVersion = "1.9"
+        apiVersion = "1.9"
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Bumps Kotlin from 1.8.0 to 2.0.21, with `languageVersion`/`apiVersion` pinned to 1.9 on every module that publishes a consumable artifact.

### Why

Kotlin 1.8 cannot read dependency metadata stamped by a Kotlin 2.0 compiler, which forces `-Xskip-metadata-version-check` onto any module consuming a modern dependency. That flag is module-wide, so it silently disables the check for *every* dependency, not just the intended one. This removes the need for it.

### How it works

- The **2.0.21 compiler** reads dependency metadata up to Kotlin 2.1, so no skip flag is required.
- **`languageVersion`/`apiVersion = 1.9`** keeps the K1 frontend, so this is *not* a K2 migration — no smart-cast/inference/Lombok-interop fallout.
- Emitted metadata is therefore **version 1.9.0**, which consumers still on Kotlin 1.8 can read. No downstream break for MSAL customers, OneAuth, Teams or Outlook.

Verified by inspecting the compiled output: `kotlin.Metadata(mv=[1,9,0])`.

### Validation

- `:common:compileLocalDebugKotlin` — BUILD SUCCESSFUL
- `:common:compileLocalDebugUnitTestKotlin` — BUILD SUCCESSFUL
- `:common:testLocalDebugUnitTest` — 1925 tests, 1786 passed. The 139 failures are all pre-existing and environmental: the `nativeauth.integration` suites require the pipeline-supplied `MOCK_API_URL`, which is empty on a dev box, and one `PackageUtilsTest` failure is Mockito state bleed from `SignUpOAuth2StrategyTest.setup` in the same worker JVM.

### Notes for reviewers

- Test apps and mock apps are deliberately **not** pinned — nothing consumes their metadata. They will compile under K2, so they are the most likely place to see new errors.
- `common/testutils` **is** pinned: it is `maven-publish` + `kotlin-android`, so it emits metadata consumed by the broker/msal/adal automation suites.
- This also aligns the monorepo with the Authenticator app, which is already on Kotlin 2.0.21 and was previously the de-facto source of truth for the Compose/KSP plugin versions while `kotlinVersion` said 1.8.0.

### Work item

- [AB#3742062](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3742062) - Bump Kotlin to 2.0.21 across common, broker, msal, adal and android-complete

<!-- BEGIN pr-telemetry -->
assistance: agentic-ide
type: chore
agent-tool: copilot-chat
agent-model: claude-opus-4.5
work-item: [AB#3742062](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3742062)
<!-- END pr-telemetry -->

