### PR TITLE
Fix flow correlation ID unit test isolation, Fixes AB#3751499

### DIFF
--- a/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
+++ b/common/src/test/java/com/microsoft/identity/common/internal/ui/webview/AzureActiveDirectoryWebViewClientTest.java
@@ -264,6 +264,7 @@ public class AzureActiveDirectoryWebViewClientTest {
 
     @Before
     public void setup() throws ClientException {
+        DiagnosticContext.INSTANCE.clear();
         mContext = ApplicationProvider.getApplicationContext();
         mMockWebView = new WebView(mContext);
         mActivity = Robolectric.buildActivity(Activity.class).get();
@@ -2077,23 +2078,23 @@ public class AzureActiveDirectoryWebViewClientTest {
     @Test
     public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowHasNoId() {
         final String fromDiagnosticContext = "33333333-3333-4333-8333-333333333333";
+        final AzureActiveDirectoryWebViewClient webViewClient = newClientWithCorrelationId(null);
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
-        assertEquals(fromDiagnosticContext,
-                newClientWithCorrelationId(null).getFlowCorrelationId());
+        assertEquals(fromDiagnosticContext, webViewClient.getFlowCorrelationId());
     }
 
     @Test
     public void testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowsIdIsEmpty() {
         final String fromDiagnosticContext = "44444444-4444-4444-8444-444444444444";
+        final AzureActiveDirectoryWebViewClient webViewClient = newClientWithCorrelationId("");
         final RequestContext requestContext = new RequestContext();
         requestContext.put(DiagnosticContext.CORRELATION_ID, fromDiagnosticContext);
         DiagnosticContext.INSTANCE.setRequestContext(requestContext);
 
-        assertEquals(fromDiagnosticContext,
-                newClientWithCorrelationId("").getFlowCorrelationId());
+        assertEquals(fromDiagnosticContext, webViewClient.getFlowCorrelationId());
     }
 
     private AzureActiveDirectoryWebViewClient newClientWithCorrelationId(final String correlationId) {


### PR DESCRIPTION
## Summary
- clear `DiagnosticContext` before each `AzureActiveDirectoryWebViewClientTest`
- construct the WebView client before seeding fallback correlation context
- prevent order-dependent first-attempt failures in the flow correlation ID fallback tests

## Validation
- `:common:testLocalDebugUnitTest --tests "com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClientTest.testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowHasNoId" --tests "com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClientTest.testGetFlowCorrelationId_fallsBackToDiagnosticContextWhenTheFlowsIdIsEmpty"`
- `:common:testLocalDebugUnitTest --tests "com.microsoft.identity.common.internal.ui.webview.AzureActiveDirectoryWebViewClientTest"`

## Context
Observed in weekly build. Both tests failed their first attempt with the same stale correlation ID and passed on retry.
## Work Item
- [AB#3751499](https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3751499)

<!-- BEGIN pr-telemetry -->
assistance: agentic-ide
type: test
agent-tool: copilot-chat
agent-model: n/a
work-item: [AB#3751499](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3751499)
<!-- END pr-telemetry -->