### PR TITLE
Remove obsolete changelog review guidance, Fixes AB#3751489

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -545,12 +545,9 @@ Flag:
 
 Require:
 - PR summary migration note.
-- Changelog classification (MAJOR/MINOR).
 - Deprecation annotation before removal (unless urgent security fix).
 
 Avoid false positives for private/internal refactors.
-
-See [changelog.txt](../changelog.txt) for the changelog format.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Remove the requirement for Copilot reviews to classify changelog entries as MAJOR or MINOR.
- Remove the obsolete changelog-format reference.
- Keep the existing API compatibility, migration-note, and deprecation guidance unchanged.

## Validation

- `git diff --check`

## Work Item

[AB#3751489](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3751489)