### PR TITLE
Add Native Auth V2 continuation-state test fixture, Fixes AB#3749428

### DIFF
--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTest.kt
@@ -39,6 +39,18 @@ import java.io.Serializable
 class NativeAuthV2ContinuationStateTest {
 
     @Test
+    fun testFixtureCreatesRepresentativeContinuationState() {
+        val state = NativeAuthV2ContinuationStateTestFactory.create(
+            correlationId = CORRELATION_ID,
+            scopes = SCOPES
+        )
+
+        assertEquals(CORRELATION_ID, state.correlationId)
+        assertEquals(SCOPES, state.scopesForTokenRequest())
+        assertEquals(NativeAuthV2LinkRelation.RESET_PASSWORD, state.entryRelation)
+    }
+
+    @Test
     fun javaSerializationRoundTrip_preservesStateAndRedactsStringRepresentations() {
         val original = createState()
 

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTest.kt
@@ -48,6 +48,7 @@ class NativeAuthV2ContinuationStateTest {
         assertEquals(CORRELATION_ID, state.correlationId)
         assertEquals(SCOPES, state.scopesForTokenRequest())
         assertEquals(NativeAuthV2LinkRelation.RESET_PASSWORD, state.entryRelation)
+        assertEquals(NativeAuthV2FlowScenario.RESET_PASSWORD, state.scenario)
     }
 
     @Test

--- a/common4j/src/testFixtures/kotlin/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTestFactory.kt
+++ b/common4j/src/testFixtures/kotlin/com/microsoft/identity/common/java/nativeauth/providers/responses/v2/NativeAuthV2ContinuationStateTestFactory.kt
@@ -1,0 +1,59 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.nativeauth.providers.responses.v2
+
+import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
+
+/**
+ * Creates representative continuation states for tests in downstream repositories without
+ * exposing or depending on the state's private constructor.
+ */
+object NativeAuthV2ContinuationStateTestFactory {
+
+    @JvmStatic
+    fun create(
+        correlationId: String,
+        scopes: List<String> = listOf("scope")
+    ): NativeAuthV2ContinuationState {
+        val response = NativeAuthV2HalApiResponse.from(
+            halResource = HalResource.from(
+                """
+                {
+                  "continuation_token": "opaque-token",
+                  "reset_password": "/tenant/reset-password"
+                }
+                """.trimIndent()
+            ),
+            statusCode = 200,
+            correlationId = correlationId
+        )
+        val result = NativeAuthV2ResponseParser().parseAuthorizeChallenge(
+            response = response,
+            entryRelation = NativeAuthV2LinkRelation.RESET_PASSWORD,
+            scenario = NativeAuthV2FlowScenario.RESET_PASSWORD,
+            scopes = scopes
+        )
+
+        return (result as AuthorizeChallengeApiResult.ContinuationRequired).continuationState
+    }
+}


### PR DESCRIPTION
## Summary
- add a published common4j test fixture that creates a genuine `NativeAuthV2ContinuationState`
- keep constructor and internal-state knowledge inside common4j
- add focused coverage for the fixture's correlation ID, scopes, and flow metadata

## Why
MSAL Native Auth V2 tests currently reflect over a private common4j constructor and encode its parameter shape. This fixture gives downstream tests a stable construction API so common4j can evolve the opaque state without requiring MSAL test changes.

## Tracking
[AB#3749428](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3749428)


## Validation
- `:common4j:compileKotlin`
- `:common4j:test --tests com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationStateTest`