### PR TITLE
Add Native Auth V2 SMS password reset support, Fixes AB#3754595

### DIFF
--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/NativeAuthV2SelectResetPasswordMethodCommand.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/commands/NativeAuthV2SelectResetPasswordMethodCommand.kt
@@ -1,0 +1,64 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.nativeauth.internal.commands
+
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectResetPasswordMethodCommandParameters
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectResetPasswordMethodCommandResult
+import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
+
+/**
+ * Challenges the V2 reset-password first-factor method explicitly selected by the app.
+ */
+class NativeAuthV2SelectResetPasswordMethodCommand(
+    private val parameters: NativeAuthV2SelectResetPasswordMethodCommandParameters,
+    private val controller: NativeAuthV2FlowController,
+    publicApiId: String
+) : BaseNativeAuthCommand<NativeAuthV2SelectResetPasswordMethodCommandResult>(
+    parameters,
+    controller,
+    publicApiId
+) {
+
+    companion object {
+        private val TAG = NativeAuthV2SelectResetPasswordMethodCommand::class.java.simpleName
+    }
+
+    override fun execute(): NativeAuthV2SelectResetPasswordMethodCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "${TAG}.execute"
+        )
+
+        val result = controller.selectResetPasswordMethod(parameters)
+        Logger.infoWithObject(
+            TAG,
+            parameters.getCorrelationId(),
+            "Returning result: ",
+            result
+        )
+        return result
+    }
+}

--- a/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowController.kt
+++ b/common/src/main/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowController.kt
@@ -27,6 +27,7 @@ import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.BaseSignInTokenCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectMFAMethodCommandParameters
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectResetPasswordMethodCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitMFAChallengeCommandParameters
@@ -44,6 +45,7 @@ import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeA
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResetPasswordSubmitCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResendCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectMFAMethodCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectResetPasswordMethodCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInAfterResetPasswordCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInAfterSignUpCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInStartCommandResult
@@ -116,6 +118,7 @@ class NativeAuthV2FlowController : BaseNativeAuthController() {
          */
         private const val ATTRIBUTE_ALREADY_SUBMITTED_ERROR = "attribute_already_submitted"
         private const val METHOD_TYPE_EMAIL = "email"
+        private const val METHOD_TYPE_SMS = "sms"
     }
 
     // -----------------------------------------------------------------------------------------
@@ -199,36 +202,94 @@ class NativeAuthV2FlowController : BaseNativeAuthController() {
                 else -> return mapInteractionError(startResult)
             }
 
-            val emailMethod = challenge.methods.firstOrNull { it.type == METHOD_TYPE_EMAIL }
-                ?: return INativeAuthCommandResult.APIError(
+            val supportedMethods = challenge.methods.filter {
+                it.type == METHOD_TYPE_EMAIL || it.type == METHOD_TYPE_SMS
+            }
+            if (supportedMethods.isEmpty()) {
+                return INativeAuthCommandResult.APIError(
                     error = UNSUPPORTED_CHALLENGE_METHOD,
-                    errorDescription = "Native Auth V2 password reset requires an email " +
+                    errorDescription = "Native Auth V2 password reset requires an email or SMS " +
                             "authentication method, which the server did not offer.",
                     correlationId = challenge.correlationId
                 )
+            }
 
-            val challengeResult = oAuth2Strategy.performMethodChallenge(
+            if (supportedMethods.size > 1) {
+                return NativeAuthV2CommandResult.ResetPasswordMethodRequired(
+                    correlationId = challenge.correlationId,
+                    continuationState = challenge.continuationState,
+                    authMethods = supportedMethods
+                )
+            }
+
+            return when (val result = challengeResetPasswordMethod(
+                oAuth2Strategy = oAuth2Strategy,
                 state = challenge.continuationState,
-                methodId = emailMethod.id
-            )
-
-            return when (challengeResult) {
-                is NativeAuthV2InteractionApiResult.CodeRequired -> NativeAuthV2CommandResult.CodeRequired(
-                    correlationId = challengeResult.correlationId,
-                    continuationState = challengeResult.continuationState,
-                    codeLength = challengeResult.codeLength,
-                    challengeTargetLabel = challengeResult.challengeTargetLabel,
-                    challengeChannel = challengeResult.challengeChannel
-                )
-                is NativeAuthV2InteractionApiResult.Redirect -> INativeAuthCommandResult.Redirect(
-                    correlationId = challengeResult.correlationId,
-                    redirectReason = challengeResult.redirectReason
-                )
-                else -> mapInteractionError(challengeResult)
+                methodId = supportedMethods.single().id
+            )) {
+                is NativeAuthV2CommandResult.CodeRequired -> result
+                is NativeAuthV2CommandResult.NotImplemented -> result
+                is INativeAuthCommandResult.Redirect -> result
+                is INativeAuthCommandResult.APIError -> result
             }
         } catch (e: Exception) {
             Logger.error(TAG, parameters.getCorrelationId(), "Exception in resetPasswordStart", e)
             throw e
+        }
+    }
+
+    /**
+     * Challenges the reset-password first-factor method the app selected.
+     */
+    fun selectResetPasswordMethod(
+        parameters: NativeAuthV2SelectResetPasswordMethodCommandParameters
+    ): NativeAuthV2SelectResetPasswordMethodCommandResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = parameters.getCorrelationId(),
+            methodName = "$TAG.selectResetPasswordMethod"
+        )
+
+        try {
+            return challengeResetPasswordMethod(
+                oAuth2Strategy = createNativeAuthV2Strategy(parameters),
+                state = parameters.continuationState,
+                methodId = parameters.methodId
+            )
+        } catch (e: Exception) {
+            Logger.error(TAG, parameters.getCorrelationId(), "Exception in selectResetPasswordMethod", e)
+            throw e
+        }
+    }
+
+    private fun challengeResetPasswordMethod(
+        oAuth2Strategy: NativeAuthV2OAuth2Strategy,
+        state: NativeAuthV2ContinuationState,
+        methodId: String
+    ): NativeAuthV2SelectResetPasswordMethodCommandResult {
+        val challengeResult = oAuth2Strategy.performMethodChallenge(
+            state = state,
+            methodId = methodId
+        )
+        val verificationResult = when (challengeResult) {
+            is NativeAuthV2InteractionApiResult.RiskVerificationRequired ->
+                oAuth2Strategy.performRiskVerification(challengeResult.continuationState)
+            else -> challengeResult
+        }
+
+        return when (verificationResult) {
+            is NativeAuthV2InteractionApiResult.CodeRequired -> NativeAuthV2CommandResult.CodeRequired(
+                correlationId = verificationResult.correlationId,
+                continuationState = verificationResult.continuationState,
+                codeLength = verificationResult.codeLength,
+                challengeTargetLabel = verificationResult.challengeTargetLabel,
+                challengeChannel = verificationResult.challengeChannel
+            )
+            is NativeAuthV2InteractionApiResult.Redirect -> INativeAuthCommandResult.Redirect(
+                correlationId = verificationResult.correlationId,
+                redirectReason = verificationResult.redirectReason
+            )
+            else -> mapInteractionError(verificationResult)
         }
     }
 

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/commands/NativeAuthV2CommandsTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/commands/NativeAuthV2CommandsTest.kt
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.nativeauth.internal.commands
 
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectResetPasswordMethodCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitNewPasswordCommandParameters
@@ -30,6 +31,7 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPa
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResendCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResetPasswordSubmitCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResetPasswordStartCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectResetPasswordMethodCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInAfterResetPasswordCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInSubmitCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignUpSubmitCodeCommandResult
@@ -57,6 +59,19 @@ class NativeAuthV2CommandsTest {
 
         assertSame(result, actual)
         verify(exactly = 1) { controller.resetPasswordStart(parameters) }
+    }
+
+    @Test
+    fun selectResetPasswordMethod_executeDelegatesAndReturnsResult() {
+        val parameters = parameters<NativeAuthV2SelectResetPasswordMethodCommandParameters>()
+        val result = mockk<NativeAuthV2SelectResetPasswordMethodCommandResult>()
+        every { controller.selectResetPasswordMethod(parameters) } returns result
+
+        val actual =
+            NativeAuthV2SelectResetPasswordMethodCommand(parameters, controller, API_ID).execute()
+
+        assertSame(result, actual)
+        verify(exactly = 1) { controller.selectResetPasswordMethod(parameters) }
     }
 
     @Test

--- a/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowControllerTest.kt
+++ b/common/src/test/java/com/microsoft/identity/common/nativeauth/internal/controllers/v2/NativeAuthV2FlowControllerTest.kt
@@ -25,6 +25,7 @@ package com.microsoft.identity.common.nativeauth.internal.controllers.v2
 import com.microsoft.identity.common.java.nativeauth.authorities.NativeAuthCIAMAuthority
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectResetPasswordMethodCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitNewPasswordCommandParameters
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordV2StartCommandParameters
@@ -122,6 +123,19 @@ class NativeAuthV2FlowControllerTest {
             .scopes(emptyList())
             .continuationState(state)
             .code(code)
+            .build()
+
+    private fun selectResetPasswordMethodParameters(
+        state: NativeAuthV2ContinuationState,
+        methodId: String
+    ): NativeAuthV2SelectResetPasswordMethodCommandParameters =
+        NativeAuthV2SelectResetPasswordMethodCommandParameters.builder()
+            .authority(mockAuthority)
+            .platformComponents(mockPlatformComponents)
+            .correlationId(correlationId)
+            .scopes(emptyList())
+            .continuationState(state)
+            .methodId(methodId)
             .build()
 
     private fun submitNewPasswordParameters(
@@ -262,6 +276,127 @@ class NativeAuthV2FlowControllerTest {
         result as INativeAuthCommandResult.APIError
         assertEquals(correlationId, result.correlationId)
         assertEquals("unexpected_api_result", result.error)
+    }
+
+    @Test
+    fun testResetPasswordStartReturnsMethodSelectionWhenEmailAndSmsAreOffered() {
+        val state = mockContinuationState()
+        every {
+            mockStrategy.performAuthorizeChallengeStart(
+                correlationId = any(),
+                entryRelation = any(),
+                scenario = any(),
+                scopes = any(),
+                claimsRequestJson = null
+            )
+        } returns AuthorizeChallengeApiResult.ContinuationRequired(
+            correlationId = correlationId,
+            continuationState = state
+        )
+        every {
+            mockStrategy.performResetPasswordStart(username = any(), state = state)
+        } returns NativeAuthV2InteractionApiResult.ChallengeRequired(
+            correlationId = correlationId,
+            continuationState = state,
+            hint = null,
+            methods = listOf(
+                NativeAuthV2AuthMethod("email-1", "email", "u***@contoso.com"),
+                NativeAuthV2AuthMethod("sms-1", "sms", "+X XXX XXX 34")
+            )
+        )
+
+        val result = controller.resetPasswordStart(resetPasswordStartParameters())
+
+        assertTrue(result is NativeAuthV2CommandResult.ResetPasswordMethodRequired)
+        result as NativeAuthV2CommandResult.ResetPasswordMethodRequired
+        assertEquals(listOf("email-1", "sms-1"), result.authMethods.map { it.id })
+        verify(exactly = 0) { mockStrategy.performMethodChallenge(any(), any()) }
+    }
+
+    @Test
+    fun testResetPasswordStartAutomaticallyChallengesSingleSmsMethod() {
+        val challengeState = mockContinuationState()
+        val riskState = mockContinuationState()
+        val verificationState = mockContinuationState()
+        every {
+            mockStrategy.performAuthorizeChallengeStart(
+                correlationId = any(),
+                entryRelation = any(),
+                scenario = any(),
+                scopes = any(),
+                claimsRequestJson = null
+            )
+        } returns AuthorizeChallengeApiResult.ContinuationRequired(
+            correlationId = correlationId,
+            continuationState = challengeState
+        )
+        every {
+            mockStrategy.performResetPasswordStart(username = any(), state = challengeState)
+        } returns NativeAuthV2InteractionApiResult.ChallengeRequired(
+            correlationId = correlationId,
+            continuationState = challengeState,
+            hint = null,
+            methods = listOf(
+                NativeAuthV2AuthMethod("sms-1", "sms", "+X XXX XXX 34")
+            )
+        )
+        every {
+            mockStrategy.performMethodChallenge(challengeState, "sms-1")
+        } returns NativeAuthV2InteractionApiResult.RiskVerificationRequired(
+            correlationId = correlationId,
+            continuationState = riskState
+        )
+        every {
+            mockStrategy.performRiskVerification(riskState)
+        } returns NativeAuthV2InteractionApiResult.CodeRequired(
+            correlationId = correlationId,
+            continuationState = verificationState,
+            challengeTargetLabel = "+X XXX XXX 34",
+            challengeChannel = "sms",
+            codeLength = 6
+        )
+
+        val result = controller.resetPasswordStart(resetPasswordStartParameters())
+
+        assertTrue(result is NativeAuthV2CommandResult.CodeRequired)
+        result as NativeAuthV2CommandResult.CodeRequired
+        assertEquals("sms", result.challengeChannel)
+        assertEquals(6, result.codeLength)
+        verify(exactly = 1) { mockStrategy.performRiskVerification(riskState) }
+    }
+
+    @Test
+    fun testSelectResetPasswordSmsMethodFollowsRiskVerification() {
+        val selectionState = mockContinuationState()
+        val riskState = mockContinuationState()
+        val verificationState = mockContinuationState()
+        every {
+            mockStrategy.performMethodChallenge(selectionState, "sms-1")
+        } returns NativeAuthV2InteractionApiResult.RiskVerificationRequired(
+            correlationId = correlationId,
+            continuationState = riskState
+        )
+        every {
+            mockStrategy.performRiskVerification(riskState)
+        } returns NativeAuthV2InteractionApiResult.CodeRequired(
+            correlationId = correlationId,
+            continuationState = verificationState,
+            challengeTargetLabel = "+X XXX XXX 34",
+            challengeChannel = "sms",
+            codeLength = 6
+        )
+
+        val result = controller.selectResetPasswordMethod(
+            selectResetPasswordMethodParameters(selectionState, "sms-1")
+        )
+
+        assertTrue(result is NativeAuthV2CommandResult.CodeRequired)
+        result as NativeAuthV2CommandResult.CodeRequired
+        assertEquals(verificationState, result.continuationState)
+        assertEquals("+X XXX XXX 34", result.challengeTargetLabel)
+        assertEquals("sms", result.challengeChannel)
+        assertEquals(6, result.codeLength)
+        verify(exactly = 1) { mockStrategy.performRiskVerification(riskState) }
     }
 
     @Test

--- a/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/PublicApiId.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/eststelemetry/PublicApiId.java
@@ -164,7 +164,7 @@ public final class PublicApiId {
     public static final String NATIVE_AUTH_JIT_CHALLENGE_AUTH_METHOD = "255";
     public static final String NATIVE_AUTH_JIT_SUBMIT_CHALLENGE = "256";
 
-    // NativeAuth V2 APIs (260-275)
+    // NativeAuth V2 APIs (260-276)
     //==============================================================================================
     public static final String NATIVE_AUTH_V2_RESET_PASSWORD_START = "260";
     public static final String NATIVE_AUTH_V2_RESET_PASSWORD_SUBMIT_CODE = "261";
@@ -182,6 +182,7 @@ public final class PublicApiId {
     public static final String NATIVE_AUTH_V2_SIGN_UP_SUBMIT_CODE = "273";
     public static final String NATIVE_AUTH_V2_SIGN_IN_SUBMIT_CODE = "274";
     public static final String NATIVE_AUTH_V2_SIGN_IN_RESEND_CODE = "275";
+    public static final String NATIVE_AUTH_V2_RESET_PASSWORD_SELECT_METHOD = "276";
     //endregion
 
     // region WebApps APIs

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/NativeAuthV2SelectResetPasswordMethodCommandParameters.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/commands/parameters/NativeAuthV2SelectResetPasswordMethodCommandParameters.java
@@ -1,0 +1,69 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.common.java.nativeauth.commands.parameters;
+
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Parameters for selecting a V2 reset-password first-factor method.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
+public class NativeAuthV2SelectResetPasswordMethodCommandParameters extends BaseSignInTokenCommandParameters {
+
+    /**
+     * The opaque continuation state containing the server-provided method links.
+     */
+    @NonNull
+    public final NativeAuthV2ContinuationState continuationState;
+
+    /**
+     * The server-issued ID of the selected authentication method.
+     */
+    @NonNull
+    public final String methodId;
+
+    @NonNull
+    @Override
+    public String toUnsanitizedString() {
+        return "NativeAuthV2SelectResetPasswordMethodCommandParameters(methodId=" + methodId
+                + ", authority=" + authority + ", challengeTypes=" + challengeType + ")";
+    }
+
+    @Override
+    public boolean containsPii() {
+        return !toString().equals(toUnsanitizedString());
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return toUnsanitizedString();
+    }
+}

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/INativeAuthCommandResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/INativeAuthCommandResult.kt
@@ -43,6 +43,7 @@ interface INativeAuthCommandResult : ILoggable {
         NativeAuthV2ResetPasswordStartCommandResult, NativeAuthV2ResetPasswordSubmitCodeCommandResult,
         NativeAuthV2SignUpSubmitCodeCommandResult, NativeAuthV2SignInSubmitCodeCommandResult,
         NativeAuthV2ResendCodeCommandResult, NativeAuthV2SubmitNewPasswordCommandResult,
+        NativeAuthV2SelectResetPasswordMethodCommandResult,
         NativeAuthV2SelectMFAMethodCommandResult, NativeAuthV2FlowCompletionCommandResult,
         NativeAuthV2SignUpStartCommandResult, NativeAuthV2SubmitAttributesCommandResult {
             companion object {
@@ -79,6 +80,7 @@ interface INativeAuthCommandResult : ILoggable {
         NativeAuthV2ResetPasswordStartCommandResult, NativeAuthV2ResetPasswordSubmitCodeCommandResult,
         NativeAuthV2SignUpSubmitCodeCommandResult, NativeAuthV2SignInSubmitCodeCommandResult,
         NativeAuthV2ResendCodeCommandResult, NativeAuthV2SubmitNewPasswordCommandResult,
+        NativeAuthV2SelectResetPasswordMethodCommandResult,
         NativeAuthV2SelectMFAMethodCommandResult, NativeAuthV2FlowCompletionCommandResult,
         NativeAuthV2SignUpStartCommandResult, NativeAuthV2SubmitAttributesCommandResult
     {

--- a/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/NativeAuthV2CommandResult.kt
+++ b/common4j/src/main/com/microsoft/identity/common/java/nativeauth/controllers/results/NativeAuthV2CommandResult.kt
@@ -29,6 +29,7 @@ import com.microsoft.identity.common.java.result.ILocalAuthenticationResult
 
 // Per-operation sealed marker interfaces for exhaustive when() dispatch.
 sealed interface NativeAuthV2ResetPasswordStartCommandResult : INativeAuthCommandResult
+sealed interface NativeAuthV2SelectResetPasswordMethodCommandResult : INativeAuthCommandResult
 sealed interface NativeAuthV2SubmitCodeCommandResult : INativeAuthCommandResult
 sealed interface NativeAuthV2ResetPasswordSubmitCodeCommandResult :
     NativeAuthV2SubmitCodeCommandResult
@@ -83,6 +84,7 @@ interface NativeAuthV2CommandResult {
         val challengeTargetLabel: String,
         val challengeChannel: String,
     ) : NativeAuthV2ResetPasswordStartCommandResult,
+        NativeAuthV2SelectResetPasswordMethodCommandResult,
         NativeAuthV2SignInStartCommandResult,
         NativeAuthV2ResendCodeCommandResult,
         NativeAuthV2SignUpStartCommandResult,
@@ -92,6 +94,22 @@ interface NativeAuthV2CommandResult {
 
         override fun toString(): String =
             "NativeAuthV2CommandResult.CodeRequired(correlationId=$correlationId, codeLength=$codeLength, challengeChannel=$challengeChannel)"
+    }
+
+    /**
+     * The reset-password flow offers more than one supported first-factor method. The app must
+     * select one explicitly before the service sends a verification code.
+     */
+    data class ResetPasswordMethodRequired(
+        override val correlationId: String,
+        val continuationState: NativeAuthV2ContinuationState,
+        val authMethods: List<NativeAuthV2AuthMethod>,
+    ) : NativeAuthV2ResetPasswordStartCommandResult {
+        override fun toUnsanitizedString(): String =
+            "NativeAuthV2CommandResult.ResetPasswordMethodRequired(correlationId=$correlationId, authMethods=${authMethods.map { it.toUnsanitizedString() }})"
+
+        override fun toString(): String =
+            "NativeAuthV2CommandResult.ResetPasswordMethodRequired(correlationId=$correlationId, authMethods=${authMethods.map { it.toString() }})"
     }
 
     /**
@@ -405,6 +423,7 @@ interface NativeAuthV2CommandResult {
         val error: String,
         val errorDescription: String,
     ) : NativeAuthV2ResetPasswordStartCommandResult,
+        NativeAuthV2SelectResetPasswordMethodCommandResult,
         NativeAuthV2ResetPasswordSubmitCodeCommandResult,
         NativeAuthV2ResendCodeCommandResult,
         NativeAuthV2SubmitNewPasswordCommandResult,

--- a/common4j/src/test/com/microsoft/identity/common/java/nativeauth/controllers/results/NativeAuthV2CommandResultTest.kt
+++ b/common4j/src/test/com/microsoft/identity/common/java/nativeauth/controllers/results/NativeAuthV2CommandResultTest.kt
@@ -23,6 +23,7 @@
 package com.microsoft.identity.common.java.nativeauth.controllers.results
 
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
 import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -46,6 +47,11 @@ class NativeAuthV2CommandResultTest {
                 6,
                 TARGET,
                 "email"
+            ),
+            NativeAuthV2CommandResult.ResetPasswordMethodRequired(
+                CORRELATION_ID,
+                state,
+                listOf(NativeAuthV2AuthMethod("sms-1", "sms", TARGET))
             ),
             NativeAuthV2CommandResult.IncorrectCode(
                 CORRELATION_ID,


### PR DESCRIPTION
## Summary
- surface reset-password method selection when the service offers both email and SMS
- automatically challenge a single supported method and follow the SMS risk-verification hop
- add the selection command, parameters, result contract, and public API ID

## Testing
- added command, flow-controller, and result-contract unit coverage
- ran the targeted `common` local-debug and `common4j` unit tests

Depends on #3253.

Fixes [AB#3754595](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3754595)